### PR TITLE
[Sprint 2.5] Non-blocking Cleanup

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-clap = { version = "4", features = ["derive"] }
+clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 mail-parser = "0.9"

--- a/docs/sprint.md
+++ b/docs/sprint.md
@@ -236,7 +236,7 @@ aimx send --from catchall@agent.yourdomain.com \
 
 ---
 
-## Sprint 2.5 — Non-blocking Cleanup (Days 5.5–6) [IN PROGRESS]
+## Sprint 2.5 — Non-blocking Cleanup (Days 5.5–6) [DONE]
 
 **Goal:** Address accumulated non-blocking improvements from Sprint 1 and Sprint 2 reviews.
 
@@ -244,18 +244,18 @@ aimx send --from catchall@agent.yourdomain.com \
 
 ### S2.5-1: Ingest Hardening + Testing
 
-- [ ] Add `--data-dir` or `AIMX_DATA_DIR` CLI option to override the hardcoded `/var/lib/aimx/` path *(from Sprint 1 review)*
-- [ ] Add mailbox name validation to prevent `..`, `/`, or empty strings in `create_mailbox` *(from Sprint 1 review)*
-- [ ] Replace hand-rolled `yaml_escape` with `serde_yaml` struct serialization for frontmatter *(from Sprint 1 review)*
-- [ ] Add `\r` to the quoting condition in `yaml_escape` for hardening *(from Sprint 1 review)*
-- [ ] Enhance integration tests to exercise `ingest_email()` with fixture files through the full pipeline *(from Sprint 1 review)*
+- [x] Add `--data-dir` or `AIMX_DATA_DIR` CLI option to override the hardcoded `/var/lib/aimx/` path *(from Sprint 1 review)*
+- [x] Add mailbox name validation to prevent `..`, `/`, or empty strings in `create_mailbox` *(from Sprint 1 review)*
+- [x] Replace hand-rolled `yaml_escape` with `serde_yaml` struct serialization for frontmatter *(from Sprint 1 review)*
+- [x] Add `\r` to the quoting condition in `yaml_escape` for hardening *(from Sprint 1 review)* — Superseded: `yaml_escape` replaced entirely by `serde_yaml` struct serialization
+- [x] Enhance integration tests to exercise `ingest_email()` with fixture files through the full pipeline *(from Sprint 1 review)*
 
 ### S2.5-2: Send Hardening + Testing
 
-- [ ] Escape attachment filenames in MIME headers to prevent malformed headers *(from Sprint 2 review)*
-- [ ] Add integration test for `aimx dkim-keygen` CLI end-to-end *(from Sprint 2 review)*
-- [ ] Refactor duplicated header construction logic in `compose_message()` *(from Sprint 2 review)*
-- [ ] Add test verifying `dkim_selector` config value is used at runtime *(from Sprint 2 review)*
+- [x] Escape attachment filenames in MIME headers to prevent malformed headers *(from Sprint 2 review)*
+- [x] Add integration test for `aimx dkim-keygen` CLI end-to-end *(from Sprint 2 review)*
+- [x] Refactor duplicated header construction logic in `compose_message()` *(from Sprint 2 review)*
+- [x] Add test verifying `dkim_selector` config value is used at runtime *(from Sprint 2 review)*
 
 ---
 
@@ -609,7 +609,7 @@ aimx verify
 |--------|------|-------|------------|--------|
 | 1 | 1–2.5 | Core Pipeline + Idea Validation | `aimx ingest`, basic `aimx send`, mailbox CLI, CI pipeline, test fixtures — testable on VPS | Done |
 | 2 | 3–5 | DKIM + Production Outbound | DKIM signing, threading, attachments — mail passes Gmail checks | Done |
-| 2.5 | 5.5–6 | Non-blocking Cleanup | Ingest/send hardening, test gaps, `--data-dir` CLI option | In Progress |
+| 2.5 | 5.5–6 | Non-blocking Cleanup | Ingest/send hardening, test gaps, `--data-dir` CLI option | Done |
 | 3 | 6–8.5 | MCP Server | All 9 MCP tools — Claude Code can read/send email | Not Started |
 | 4 | 8–10 | Channel Manager + Inbound Trust | Triggers, match filters, DKIM/SPF verification, trust gating | Not Started |
 | 5 | 10.5–12.5 | Setup Wizard | `aimx setup` — one-command setup with preflight + DNS | Not Started |

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,6 +3,10 @@ use clap::{Parser, Subcommand};
 #[derive(Parser)]
 #[command(name = "aimx", about = "SMTP for agents. No middleman.")]
 pub struct Cli {
+    /// Data directory override (default: /var/lib/aimx)
+    #[arg(long, env = "AIMX_DATA_DIR", global = true)]
+    pub data_dir: Option<std::path::PathBuf>,
+
     #[command(subcommand)]
     pub command: Command,
 }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1,9 +1,10 @@
 use crate::config::Config;
 use mail_parser::{MessageParser, MimeHeaders};
+use serde::Serialize;
 use std::io::Read;
 use std::path::Path;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct EmailMetadata {
     pub id: String,
     pub message_id: String,
@@ -13,11 +14,12 @@ pub struct EmailMetadata {
     pub date: String,
     pub in_reply_to: String,
     pub references: String,
-    pub mailbox: String,
     pub attachments: Vec<AttachmentMeta>,
+    pub mailbox: String,
+    pub read: bool,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize)]
 pub struct AttachmentMeta {
     pub filename: String,
     pub content_type: String,
@@ -25,8 +27,14 @@ pub struct AttachmentMeta {
     pub path: String,
 }
 
-pub fn run(rcpt: &str) -> Result<(), Box<dyn std::error::Error>> {
-    let config = Config::load_default()?;
+pub fn run(
+    rcpt: &str,
+    data_dir: Option<&std::path::Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = match data_dir {
+        Some(dir) => Config::load_from_data_dir(dir)?,
+        None => Config::load_default()?,
+    };
     let mut raw = Vec::new();
     std::io::stdin().read_to_end(&mut raw)?;
     ingest_email(&config, rcpt, &raw)
@@ -111,8 +119,9 @@ pub fn ingest_email(
         date,
         in_reply_to,
         references,
-        mailbox: mailbox.clone(),
         attachments,
+        mailbox: mailbox.clone(),
+        read: false,
     };
 
     let content = format_markdown(&meta, &body);
@@ -230,78 +239,19 @@ fn generate_file_id(mailbox_dir: &Path) -> String {
     }
 }
 
-fn yaml_escape(s: &str) -> String {
-    if s.contains(':')
-        || s.contains('#')
-        || s.contains('\'')
-        || s.contains('"')
-        || s.contains('\n')
-        || s.contains('[')
-        || s.contains(']')
-        || s.contains('{')
-        || s.contains('}')
-        || s.contains('&')
-        || s.contains('*')
-        || s.contains('!')
-        || s.contains('|')
-        || s.contains('>')
-        || s.contains('%')
-        || s.contains('@')
-        || s.starts_with(' ')
-        || s.ends_with(' ')
-    {
-        format!(
-            "\"{}\"",
-            s.replace('\\', "\\\\")
-                .replace('"', "\\\"")
-                .replace('\n', "\\n")
-                .replace('\r', "\\r")
-        )
-    } else {
-        s.to_string()
-    }
-}
-
 fn format_markdown(meta: &EmailMetadata, body: &str) -> String {
-    let mut front = String::new();
-    front.push_str("---\n");
-    front.push_str(&format!("id: {}\n", yaml_escape(&meta.id)));
-    front.push_str(&format!("message_id: {}\n", yaml_escape(&meta.message_id)));
-    front.push_str(&format!("from: {}\n", yaml_escape(&meta.from)));
-    front.push_str(&format!("to: {}\n", yaml_escape(&meta.to)));
-    front.push_str(&format!("subject: {}\n", yaml_escape(&meta.subject)));
-    front.push_str(&format!("date: {}\n", yaml_escape(&meta.date)));
-    front.push_str(&format!(
-        "in_reply_to: {}\n",
-        yaml_escape(&meta.in_reply_to)
-    ));
-    front.push_str(&format!("references: {}\n", yaml_escape(&meta.references)));
-
-    if meta.attachments.is_empty() {
-        front.push_str("attachments: []\n");
-    } else {
-        front.push_str("attachments:\n");
-        for att in &meta.attachments {
-            front.push_str(&format!("  - filename: {}\n", yaml_escape(&att.filename)));
-            front.push_str(&format!(
-                "    content_type: {}\n",
-                yaml_escape(&att.content_type)
-            ));
-            front.push_str(&format!("    size: {}\n", att.size));
-            front.push_str(&format!("    path: {}\n", yaml_escape(&att.path)));
-        }
-    }
-
-    front.push_str(&format!("mailbox: {}\n", yaml_escape(&meta.mailbox)));
-    front.push_str("read: false\n");
-    front.push_str("---\n\n");
-    front.push_str(body);
+    let yaml = serde_yaml::to_string(meta).unwrap_or_default();
+    let mut result = String::new();
+    result.push_str("---\n");
+    result.push_str(&yaml);
+    result.push_str("---\n\n");
+    result.push_str(body);
 
     if !body.ends_with('\n') {
-        front.push('\n');
+        result.push('\n');
     }
 
-    front
+    result
 }
 
 #[cfg(test)]
@@ -437,9 +387,32 @@ mod tests {
         assert_eq!(entries.len(), 1);
 
         let content = std::fs::read_to_string(entries[0].path()).unwrap();
-        assert!(content.contains("from: \"sender@example.com\""));
-        assert!(content.contains("subject: Hello"));
-        assert!(content.contains("read: false"));
+
+        let parts: Vec<&str> = content.splitn(3, "---").collect();
+        assert!(parts.len() >= 3);
+        let yaml_str = parts[1].trim();
+        let parsed: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+        let map = parsed.as_mapping().unwrap();
+
+        let from_val = map
+            .get(&serde_yaml::Value::String("from".to_string()))
+            .unwrap()
+            .as_str()
+            .unwrap();
+        assert_eq!(from_val, "sender@example.com");
+
+        let subject_val = map
+            .get(&serde_yaml::Value::String("subject".to_string()))
+            .unwrap()
+            .as_str()
+            .unwrap();
+        assert_eq!(subject_val, "Hello");
+
+        let read_val = map
+            .get(&serde_yaml::Value::String("read".to_string()))
+            .unwrap();
+        assert_eq!(read_val, &serde_yaml::Value::Bool(false));
+
         assert!(content.contains("This is a plain text email."));
     }
 
@@ -561,8 +534,29 @@ mod tests {
             .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
             .collect();
         let md_content = std::fs::read_to_string(entries[0].path()).unwrap();
-        assert!(md_content.contains("filename: notes.txt"));
-        assert!(md_content.contains("path: attachments/notes.txt"));
+        let parts: Vec<&str> = md_content.splitn(3, "---").collect();
+        let yaml_str = parts[1].trim();
+        let parsed: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+        let map = parsed.as_mapping().unwrap();
+        let attachments = map
+            .get(&serde_yaml::Value::String("attachments".to_string()))
+            .unwrap()
+            .as_sequence()
+            .unwrap();
+        assert_eq!(attachments.len(), 1);
+        let att = attachments[0].as_mapping().unwrap();
+        let filename = att
+            .get(&serde_yaml::Value::String("filename".to_string()))
+            .unwrap()
+            .as_str()
+            .unwrap();
+        assert_eq!(filename, "notes.txt");
+        let path_val = att
+            .get(&serde_yaml::Value::String("path".to_string()))
+            .unwrap()
+            .as_str()
+            .unwrap();
+        assert_eq!(path_val, "attachments/notes.txt");
     }
 
     #[test]
@@ -604,7 +598,16 @@ mod tests {
             .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
             .collect();
         let md_content = std::fs::read_to_string(entries[0].path()).unwrap();
-        assert!(md_content.contains("attachments: []"));
+        let parts: Vec<&str> = md_content.splitn(3, "---").collect();
+        let yaml_str = parts[1].trim();
+        let parsed: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+        let map = parsed.as_mapping().unwrap();
+        let attachments = map
+            .get(&serde_yaml::Value::String("attachments".to_string()))
+            .unwrap()
+            .as_sequence()
+            .unwrap();
+        assert!(attachments.is_empty());
     }
 
     #[test]
@@ -645,17 +648,27 @@ mod tests {
     }
 
     #[test]
-    fn yaml_escape_newline_injection() {
-        let escaped = yaml_escape("test\n---\ninjected: true");
-        assert!(!escaped.contains('\n'));
-        assert!(escaped.contains("\\n"));
+    fn serde_yaml_handles_special_characters() {
+        let meta = EmailMetadata {
+            id: "2025-01-01-001".to_string(),
+            message_id: "<test@example.com>".to_string(),
+            from: "test\n---\ninjected: true".to_string(),
+            to: "to@test.com".to_string(),
+            subject: "colons: and #hashes".to_string(),
+            date: "2025-01-01T00:00:00Z".to_string(),
+            in_reply_to: "".to_string(),
+            references: "".to_string(),
+            attachments: vec![],
+            mailbox: "catchall".to_string(),
+            read: false,
+        };
 
-        let yaml_str = format!("subject: {}\n", escaped);
-        let parsed: serde_yaml::Value = serde_yaml::from_str(&yaml_str).unwrap();
-        let val = parsed.as_mapping().unwrap();
-        let subject = val
-            .get(&serde_yaml::Value::String("subject".to_string()))
+        let yaml = serde_yaml::to_string(&meta).unwrap();
+        let parsed: serde_yaml::Value = serde_yaml::from_str(&yaml).unwrap();
+        let map = parsed.as_mapping().unwrap();
+        let from = map
+            .get(&serde_yaml::Value::String("from".to_string()))
             .unwrap();
-        assert_eq!(subject.as_str().unwrap(), "test\n---\ninjected: true");
+        assert_eq!(from.as_str().unwrap(), "test\n---\ninjected: true");
     }
 }

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -3,8 +3,14 @@ use crate::config::{Config, MailboxConfig};
 use std::io::{self, Write};
 use std::path::Path;
 
-pub fn run(cmd: MailboxCommand) -> Result<(), Box<dyn std::error::Error>> {
-    let config = Config::load_default()?;
+pub fn run(
+    cmd: MailboxCommand,
+    data_dir: Option<&std::path::Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let config = match data_dir {
+        Some(dir) => Config::load_from_data_dir(dir)?,
+        None => Config::load_default()?,
+    };
     match cmd {
         MailboxCommand::Create { name } => create(&config, &name),
         MailboxCommand::List => list(&config),
@@ -12,7 +18,25 @@ pub fn run(cmd: MailboxCommand) -> Result<(), Box<dyn std::error::Error>> {
     }
 }
 
+fn validate_mailbox_name(name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    if name.is_empty() {
+        return Err("Mailbox name cannot be empty".into());
+    }
+    if name.contains("..") {
+        return Err("Mailbox name cannot contain '..'".into());
+    }
+    if name.contains('/') || name.contains('\\') {
+        return Err("Mailbox name cannot contain path separators".into());
+    }
+    if name.contains('\0') {
+        return Err("Mailbox name cannot contain null bytes".into());
+    }
+    Ok(())
+}
+
 pub fn create_mailbox(config: &Config, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    validate_mailbox_name(name)?;
+
     if config.mailboxes.contains_key(name) {
         return Err(format!("Mailbox '{name}' already exists").into());
     }
@@ -238,5 +262,49 @@ mod tests {
         let result = list_mailboxes(&config);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].1, 0);
+    }
+
+    #[test]
+    fn create_empty_name_fails() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        setup_config_file(&config);
+
+        let result = create_mailbox(&config, "");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("empty"));
+    }
+
+    #[test]
+    fn create_path_traversal_fails() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        setup_config_file(&config);
+
+        let result = create_mailbox(&config, "../etc");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains(".."));
+    }
+
+    #[test]
+    fn create_with_slash_fails() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        setup_config_file(&config);
+
+        let result = create_mailbox(&config, "foo/bar");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("path separator"));
+    }
+
+    #[test]
+    fn create_with_backslash_fails() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        setup_config_file(&config);
+
+        let result = create_mailbox(&config, "foo\\bar");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("path separator"));
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,16 +7,17 @@ mod send;
 
 use clap::Parser;
 use cli::{Cli, Command};
+use std::path::Path;
 
 fn main() {
     let cli = Cli::parse();
 
     let result = match cli.command {
-        Command::Ingest { rcpt } => ingest::run(&rcpt),
-        Command::Send(args) => send::run(args),
-        Command::Mailbox(cmd) => mailbox::run(cmd),
+        Command::Ingest { rcpt } => ingest::run(&rcpt, cli.data_dir.as_deref()),
+        Command::Send(args) => send::run(args, cli.data_dir.as_deref()),
+        Command::Mailbox(cmd) => mailbox::run(cmd, cli.data_dir.as_deref()),
         Command::DkimKeygen { selector, force } => {
-            let config = match config::Config::load_default() {
+            let config = match load_config(cli.data_dir.as_deref()) {
                 Ok(c) => c,
                 Err(e) => {
                     eprintln!("Error loading config: {e}");
@@ -50,5 +51,12 @@ fn main() {
     if let Err(e) = result {
         eprintln!("Error: {e}");
         std::process::exit(1);
+    }
+}
+
+fn load_config(data_dir: Option<&Path>) -> Result<config::Config, Box<dyn std::error::Error>> {
+    match data_dir {
+        Some(dir) => config::Config::load_from_data_dir(dir),
+        None => config::Config::load_default(),
     }
 }

--- a/src/send.rs
+++ b/src/send.rs
@@ -47,6 +47,29 @@ pub struct ComposeResult {
     pub message_id: String,
 }
 
+fn escape_filename(name: &str) -> String {
+    name.replace('\\', "\\\\")
+        .replace('"', "\\\"")
+        .replace('\r', "")
+        .replace('\n', " ")
+}
+
+fn write_common_headers(msg: &mut String, args: &SendArgs, date: &str, message_id: &str) {
+    msg.push_str(&format!("From: {}\r\n", args.from));
+    msg.push_str(&format!("To: {}\r\n", args.to));
+    msg.push_str(&format!("Subject: {}\r\n", args.subject));
+    msg.push_str(&format!("Date: {date}\r\n"));
+    msg.push_str(&format!("Message-ID: {message_id}\r\n"));
+
+    if let Some(ref reply_to) = args.reply_to {
+        let reply_id = normalize_message_id(reply_to);
+        msg.push_str(&format!("In-Reply-To: {reply_id}\r\n"));
+        msg.push_str(&format!("References: {reply_id}\r\n"));
+    }
+
+    msg.push_str("MIME-Version: 1.0\r\n");
+}
+
 pub fn compose_message(args: &SendArgs) -> Result<ComposeResult, Box<dyn std::error::Error>> {
     validate_attachments(&args.attachments)?;
 
@@ -54,115 +77,69 @@ pub fn compose_message(args: &SendArgs) -> Result<ComposeResult, Box<dyn std::er
     let message_id = format!("<{}@{domain}>", Uuid::new_v4());
     let date = Utc::now().to_rfc2822();
 
-    let has_attachments = !args.attachments.is_empty();
-
-    if has_attachments {
-        let boundary = format!("aimx-{}", Uuid::new_v4().simple());
+    if args.attachments.is_empty() {
         let mut msg = String::new();
-
-        msg.push_str(&format!("From: {}\r\n", args.from));
-        msg.push_str(&format!("To: {}\r\n", args.to));
-        msg.push_str(&format!("Subject: {}\r\n", args.subject));
-        msg.push_str(&format!("Date: {date}\r\n"));
-        msg.push_str(&format!("Message-ID: {message_id}\r\n"));
-
-        if let Some(ref reply_to) = args.reply_to {
-            let reply_id = normalize_message_id(reply_to);
-            msg.push_str(&format!("In-Reply-To: {reply_id}\r\n"));
-            msg.push_str(&format!("References: {reply_id}\r\n"));
-        }
-
-        msg.push_str("MIME-Version: 1.0\r\n");
-        msg.push_str(&format!(
-            "Content-Type: multipart/mixed; boundary=\"{boundary}\"\r\n"
-        ));
-        msg.push_str("\r\n");
-
-        msg.push_str(&format!("--{boundary}\r\n"));
+        write_common_headers(&mut msg, args, &date, &message_id);
         msg.push_str("Content-Type: text/plain; charset=utf-8\r\n");
         msg.push_str("\r\n");
         msg.push_str(&args.body);
         msg.push_str("\r\n");
 
-        let mut binary_parts: Vec<Vec<u8>> = Vec::new();
-
-        for path_str in &args.attachments {
-            let path = Path::new(path_str);
-            let filename = path
-                .file_name()
-                .and_then(|n| n.to_str())
-                .unwrap_or("attachment");
-            let content_type = mime_guess::from_path(path)
-                .first_or_octet_stream()
-                .to_string();
-            let file_data = std::fs::read(path)?;
-            let encoded = base64::engine::general_purpose::STANDARD.encode(&file_data);
-
-            let mut part = String::new();
-            part.push_str(&format!("--{boundary}\r\n"));
-            part.push_str(&format!(
-                "Content-Type: {content_type}; name=\"{filename}\"\r\n"
-            ));
-            part.push_str(&format!(
-                "Content-Disposition: attachment; filename=\"{filename}\"\r\n"
-            ));
-            part.push_str("Content-Transfer-Encoding: base64\r\n");
-            part.push_str("\r\n");
-
-            for chunk in encoded.as_bytes().chunks(76) {
-                part.push_str(std::str::from_utf8(chunk).unwrap_or(""));
-                part.push_str("\r\n");
-            }
-
-            binary_parts.push(part.into_bytes());
-        }
-
-        msg.push_str(&format!("--{boundary}--\r\n"));
-
-        let mut result = Vec::new();
-        let closing = format!("--{boundary}--\r\n");
-
-        let msg_bytes = msg.into_bytes();
-        let split_pos = msg_bytes
-            .windows(closing.len())
-            .position(|w| w == closing.as_bytes())
-            .unwrap_or(msg_bytes.len());
-
-        result.extend_from_slice(&msg_bytes[..split_pos]);
-        for part in &binary_parts {
-            result.extend_from_slice(part);
-        }
-        result.extend_from_slice(closing.as_bytes());
-
-        Ok(ComposeResult {
-            message: result,
-            message_id,
-        })
-    } else {
-        let mut msg = String::new();
-        msg.push_str(&format!("From: {}\r\n", args.from));
-        msg.push_str(&format!("To: {}\r\n", args.to));
-        msg.push_str(&format!("Subject: {}\r\n", args.subject));
-        msg.push_str(&format!("Date: {date}\r\n"));
-        msg.push_str(&format!("Message-ID: {message_id}\r\n"));
-
-        if let Some(ref reply_to) = args.reply_to {
-            let reply_id = normalize_message_id(reply_to);
-            msg.push_str(&format!("In-Reply-To: {reply_id}\r\n"));
-            msg.push_str(&format!("References: {reply_id}\r\n"));
-        }
-
-        msg.push_str("MIME-Version: 1.0\r\n");
-        msg.push_str("Content-Type: text/plain; charset=utf-8\r\n");
-        msg.push_str("\r\n");
-        msg.push_str(&args.body);
-        msg.push_str("\r\n");
-
-        Ok(ComposeResult {
+        return Ok(ComposeResult {
             message: msg.into_bytes(),
             message_id,
-        })
+        });
     }
+
+    let boundary = format!("aimx-{}", Uuid::new_v4().simple());
+    let mut msg = String::new();
+    write_common_headers(&mut msg, args, &date, &message_id);
+    msg.push_str(&format!(
+        "Content-Type: multipart/mixed; boundary=\"{boundary}\"\r\n"
+    ));
+    msg.push_str("\r\n");
+
+    msg.push_str(&format!("--{boundary}\r\n"));
+    msg.push_str("Content-Type: text/plain; charset=utf-8\r\n");
+    msg.push_str("\r\n");
+    msg.push_str(&args.body);
+    msg.push_str("\r\n");
+
+    for path_str in &args.attachments {
+        let path = Path::new(path_str);
+        let raw_name = path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("attachment");
+        let safe_name = escape_filename(raw_name);
+        let content_type = mime_guess::from_path(path)
+            .first_or_octet_stream()
+            .to_string();
+        let file_data = std::fs::read(path)?;
+        let encoded = base64::engine::general_purpose::STANDARD.encode(&file_data);
+
+        msg.push_str(&format!("--{boundary}\r\n"));
+        msg.push_str(&format!(
+            "Content-Type: {content_type}; name=\"{safe_name}\"\r\n"
+        ));
+        msg.push_str(&format!(
+            "Content-Disposition: attachment; filename=\"{safe_name}\"\r\n"
+        ));
+        msg.push_str("Content-Transfer-Encoding: base64\r\n");
+        msg.push_str("\r\n");
+
+        for chunk in encoded.as_bytes().chunks(76) {
+            msg.push_str(std::str::from_utf8(chunk).unwrap_or(""));
+            msg.push_str("\r\n");
+        }
+    }
+
+    msg.push_str(&format!("--{boundary}--\r\n"));
+
+    Ok(ComposeResult {
+        message: msg.into_bytes(),
+        message_id,
+    })
 }
 
 fn normalize_message_id(id: &str) -> String {
@@ -214,10 +191,16 @@ pub fn send_with_transport(
     Ok(composed.message_id)
 }
 
-pub fn run(args: SendArgs) -> Result<(), Box<dyn std::error::Error>> {
+pub fn run(
+    args: SendArgs,
+    data_dir: Option<&std::path::Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let transport = SendmailTransport;
 
-    let config = Config::load_default().ok();
+    let config = match data_dir {
+        Some(dir) => Config::load_from_data_dir(dir).ok(),
+        None => Config::load_default().ok(),
+    };
     let private_key = config
         .as_ref()
         .and_then(|c| dkim::load_private_key(&c.data_dir).ok());
@@ -561,5 +544,66 @@ mod tests {
         assert!(text.contains("References: <orig@example.com>"));
         assert!(text.contains("multipart/mixed"));
         assert!(text.contains("filename=\"data.csv\""));
+    }
+
+    #[test]
+    fn attachment_filename_with_quotes_escaped() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let file_path = tmp.path().join("file\"name.txt");
+        std::fs::write(&file_path, "content").unwrap();
+
+        let args = SendArgs {
+            from: "a@b.com".to_string(),
+            to: "c@d.com".to_string(),
+            subject: "test".to_string(),
+            body: "body".to_string(),
+            reply_to: None,
+            attachments: vec![file_path.to_string_lossy().to_string()],
+        };
+
+        let result = compose_message(&args).unwrap();
+        let text = String::from_utf8(result.message).unwrap();
+
+        assert!(text.contains("filename=\"file\\\"name.txt\""));
+        assert!(!text.contains("filename=\"file\"name.txt\""));
+    }
+
+    #[test]
+    fn attachment_filename_with_newline_escaped() {
+        let escaped = super::escape_filename("file\nname.txt");
+        assert!(!escaped.contains('\n'));
+        assert_eq!(escaped, "file name.txt");
+    }
+
+    #[test]
+    fn attachment_filename_with_cr_escaped() {
+        let escaped = super::escape_filename("file\rname.txt");
+        assert!(!escaped.contains('\r'));
+    }
+
+    #[test]
+    fn dkim_selector_config_used() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        crate::dkim::generate_keypair(tmp.path(), false).unwrap();
+        let private_key = crate::dkim::load_private_key(tmp.path()).unwrap();
+
+        let sent = Arc::new(Mutex::new(Vec::new()));
+        let transport = MockTransport {
+            sent: sent.clone(),
+            should_fail: false,
+        };
+
+        let custom_selector = "myselector";
+        let args = test_args();
+        send_with_transport(
+            &args,
+            &transport,
+            Some((&private_key, "example.com", custom_selector)),
+        )
+        .unwrap();
+
+        let messages = sent.lock().unwrap();
+        let text = String::from_utf8(messages[0].clone()).unwrap();
+        assert!(text.contains("s=myselector"));
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -15,6 +15,31 @@ fn setup_test_env(tmp: &Path) -> String {
     config_path.to_string_lossy().to_string()
 }
 
+fn read_frontmatter(md_path: &Path) -> serde_yaml::Value {
+    let content = std::fs::read_to_string(md_path).unwrap();
+    let parts: Vec<&str> = content.splitn(3, "---").collect();
+    assert!(
+        parts.len() >= 3,
+        "Markdown file missing frontmatter delimiters"
+    );
+    serde_yaml::from_str(parts[1].trim()).unwrap()
+}
+
+fn get_yaml_str<'a>(map: &'a serde_yaml::Mapping, key: &str) -> &'a str {
+    map.get(&serde_yaml::Value::String(key.to_string()))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+}
+
+fn find_md_files(dir: &Path) -> Vec<std::path::PathBuf> {
+    std::fs::read_dir(dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| p.extension().is_some_and(|ext| ext == "md"))
+        .collect()
+}
+
 #[test]
 fn help_shows_subcommands() {
     Command::cargo_bin("aimx")
@@ -34,38 +59,279 @@ fn help_shows_subcommands() {
 }
 
 #[test]
-fn ingest_plain_fixture() {
+fn help_shows_data_dir_option() {
+    Command::cargo_bin("aimx")
+        .unwrap()
+        .arg("--help")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("--data-dir"))
+        .stdout(predicate::str::contains("AIMX_DATA_DIR"));
+}
+
+#[test]
+fn ingest_plain_fixture_full_pipeline() {
     let tmp = TempDir::new().unwrap();
-    let _config_path = setup_test_env(tmp.path());
+    setup_test_env(tmp.path());
     let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
 
-    assert!(!eml.is_empty());
+    Command::cargo_bin("aimx")
+        .unwrap()
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("ingest")
+        .arg("catchall@agent.example.com")
+        .write_stdin(eml)
+        .assert()
+        .success();
 
-    let message = mail_parser::MessageParser::default().parse(&eml).unwrap();
-    assert_eq!(message.subject().unwrap(), "Plain text test");
-    assert!(message.body_text(0).is_some());
+    let md_files = find_md_files(&tmp.path().join("catchall"));
+    assert_eq!(md_files.len(), 1);
+
+    let parsed = read_frontmatter(&md_files[0]);
+    let map = parsed.as_mapping().unwrap();
+    assert_eq!(get_yaml_str(map, "from"), "Alice <alice@example.com>");
+    assert_eq!(get_yaml_str(map, "subject"), "Plain text test");
+    assert_eq!(get_yaml_str(map, "message_id"), "plain-001@example.com");
+    assert_eq!(get_yaml_str(map, "mailbox"), "catchall");
+    assert_eq!(
+        map.get(&serde_yaml::Value::String("read".to_string()))
+            .unwrap(),
+        &serde_yaml::Value::Bool(false)
+    );
+
+    let content = std::fs::read_to_string(&md_files[0]).unwrap();
+    assert!(content.contains("This is a plain text email for testing."));
 }
 
 #[test]
-fn ingest_html_fixture() {
+fn ingest_html_fixture_full_pipeline() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
     let eml = std::fs::read("tests/fixtures/html_only.eml").unwrap();
-    let message = mail_parser::MessageParser::default().parse(&eml).unwrap();
-    assert_eq!(message.subject().unwrap(), "HTML only test");
-    assert!(message.body_html(0).is_some());
+
+    Command::cargo_bin("aimx")
+        .unwrap()
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("ingest")
+        .arg("catchall@agent.example.com")
+        .write_stdin(eml)
+        .assert()
+        .success();
+
+    let md_files = find_md_files(&tmp.path().join("catchall"));
+    assert_eq!(md_files.len(), 1);
+
+    let parsed = read_frontmatter(&md_files[0]);
+    let map = parsed.as_mapping().unwrap();
+    assert_eq!(get_yaml_str(map, "subject"), "HTML only test");
+
+    let content = std::fs::read_to_string(&md_files[0]).unwrap();
+    assert!(content.contains("Hello from HTML"));
+    assert!(!content.contains("<html>"));
 }
 
 #[test]
-fn ingest_multipart_fixture() {
+fn ingest_multipart_fixture_full_pipeline() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
     let eml = std::fs::read("tests/fixtures/multipart.eml").unwrap();
-    let message = mail_parser::MessageParser::default().parse(&eml).unwrap();
-    assert_eq!(message.subject().unwrap(), "Multipart test");
-    assert!(message.body_text(0).is_some());
+
+    Command::cargo_bin("aimx")
+        .unwrap()
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("ingest")
+        .arg("catchall@agent.example.com")
+        .write_stdin(eml)
+        .assert()
+        .success();
+
+    let md_files = find_md_files(&tmp.path().join("catchall"));
+    assert_eq!(md_files.len(), 1);
+
+    let content = std::fs::read_to_string(&md_files[0]).unwrap();
+    assert!(content.contains("This is the plain text version."));
+    assert!(!content.contains("<html>"));
 }
 
 #[test]
-fn ingest_attachment_fixture() {
+fn ingest_attachment_fixture_full_pipeline() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
     let eml = std::fs::read("tests/fixtures/with_attachment.eml").unwrap();
-    let message = mail_parser::MessageParser::default().parse(&eml).unwrap();
-    assert_eq!(message.subject().unwrap(), "Email with attachment");
-    assert!(message.attachment_count() > 0);
+
+    Command::cargo_bin("aimx")
+        .unwrap()
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("ingest")
+        .arg("catchall@agent.example.com")
+        .write_stdin(eml)
+        .assert()
+        .success();
+
+    let md_files = find_md_files(&tmp.path().join("catchall"));
+    assert_eq!(md_files.len(), 1);
+
+    let att_path = tmp.path().join("catchall/attachments/readme.txt");
+    assert!(att_path.exists());
+    let att_content = std::fs::read_to_string(&att_path).unwrap();
+    assert!(att_content.contains("This is the content of the attached file."));
+
+    let parsed = read_frontmatter(&md_files[0]);
+    let map = parsed.as_mapping().unwrap();
+    let attachments = map
+        .get(&serde_yaml::Value::String("attachments".to_string()))
+        .unwrap()
+        .as_sequence()
+        .unwrap();
+    assert_eq!(attachments.len(), 1);
+    let att = attachments[0].as_mapping().unwrap();
+    assert_eq!(
+        att.get(&serde_yaml::Value::String("filename".to_string()))
+            .unwrap()
+            .as_str()
+            .unwrap(),
+        "readme.txt"
+    );
+}
+
+#[test]
+fn ingest_routes_to_named_mailbox() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
+
+    Command::cargo_bin("aimx")
+        .unwrap()
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("ingest")
+        .arg("alice@agent.example.com")
+        .write_stdin(eml)
+        .assert()
+        .success();
+
+    let alice_files = find_md_files(&tmp.path().join("alice"));
+    assert_eq!(alice_files.len(), 1);
+
+    let catchall_files = find_md_files(&tmp.path().join("catchall"));
+    assert_eq!(catchall_files.len(), 0);
+}
+
+#[test]
+fn ingest_unknown_routes_to_catchall() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
+
+    Command::cargo_bin("aimx")
+        .unwrap()
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("ingest")
+        .arg("unknown@agent.example.com")
+        .write_stdin(eml)
+        .assert()
+        .success();
+
+    let catchall_files = find_md_files(&tmp.path().join("catchall"));
+    assert_eq!(catchall_files.len(), 1);
+}
+
+#[test]
+fn ingest_via_env_var() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
+
+    Command::cargo_bin("aimx")
+        .unwrap()
+        .env("AIMX_DATA_DIR", tmp.path())
+        .arg("ingest")
+        .arg("catchall@agent.example.com")
+        .write_stdin(eml)
+        .assert()
+        .success();
+
+    let md_files = find_md_files(&tmp.path().join("catchall"));
+    assert_eq!(md_files.len(), 1);
+}
+
+#[test]
+fn dkim_keygen_end_to_end() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+
+    Command::cargo_bin("aimx")
+        .unwrap()
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("dkim-keygen")
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("DKIM keypair generated"))
+        .stdout(predicate::str::contains("_domainkey"));
+
+    assert!(tmp.path().join("dkim/private.key").exists());
+    assert!(tmp.path().join("dkim/public.key").exists());
+
+    let private_pem = std::fs::read_to_string(tmp.path().join("dkim/private.key")).unwrap();
+    assert!(private_pem.contains("BEGIN RSA PRIVATE KEY"));
+
+    let public_pem = std::fs::read_to_string(tmp.path().join("dkim/public.key")).unwrap();
+    assert!(public_pem.contains("BEGIN RSA PUBLIC KEY"));
+}
+
+#[test]
+fn dkim_keygen_no_overwrite() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+
+    Command::cargo_bin("aimx")
+        .unwrap()
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("dkim-keygen")
+        .assert()
+        .success();
+
+    Command::cargo_bin("aimx")
+        .unwrap()
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("dkim-keygen")
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("already exist"));
+}
+
+#[test]
+fn dkim_keygen_force_overwrite() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+
+    Command::cargo_bin("aimx")
+        .unwrap()
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("dkim-keygen")
+        .assert()
+        .success();
+
+    let original = std::fs::read_to_string(tmp.path().join("dkim/private.key")).unwrap();
+
+    Command::cargo_bin("aimx")
+        .unwrap()
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("dkim-keygen")
+        .arg("--force")
+        .assert()
+        .success();
+
+    let new = std::fs::read_to_string(tmp.path().join("dkim/private.key")).unwrap();
+    assert_ne!(original, new);
 }


### PR DESCRIPTION
## Summary

- **S2.5-1 Ingest Hardening:** Added `--data-dir` / `AIMX_DATA_DIR` CLI option to override default data path. Added mailbox name validation to reject `..`, `/`, `\`, empty, and null byte names. Replaced hand-rolled `yaml_escape` with `serde_yaml` struct serialization for frontmatter generation, eliminating edge cases. Added full-pipeline integration tests exercising `ingest_email()` with all fixture `.eml` files via CLI subprocess.
- **S2.5-2 Send Hardening:** Added `escape_filename()` to sanitize attachment filenames in MIME headers (quotes, newlines, carriage returns). Refactored duplicated header construction into `write_common_headers()`. Added end-to-end integration tests for `aimx dkim-keygen` CLI. Added test verifying custom `dkim_selector` config value is used in DKIM signing.

## Changes

| File | Change |
|------|--------|
| `Cargo.toml` | Added clap `env` feature for `AIMX_DATA_DIR` env var support |
| `src/cli.rs` | Added `--data-dir` global option with `AIMX_DATA_DIR` env |
| `src/main.rs` | Thread `data_dir` option through to all subcommand handlers |
| `src/ingest.rs` | Replace `yaml_escape` + manual frontmatter with `serde_yaml` struct serialization; accept `data_dir` override |
| `src/mailbox.rs` | Add `validate_mailbox_name()` with path traversal checks; accept `data_dir` override |
| `src/send.rs` | Add `escape_filename()`, extract `write_common_headers()`, accept `data_dir` override |
| `tests/integration.rs` | 12 tests total: full-pipeline ingest for all 4 fixtures, routing, env var, dkim-keygen e2e |

## Test results

- **64 unit tests** passing (8 new)
- **12 integration tests** passing (7 new)
- `cargo clippy -- -D warnings` clean
- `cargo fmt -- --check` clean

## Test plan

- [x] All existing tests pass (no regressions)
- [x] `--data-dir` flag overrides default data directory
- [x] `AIMX_DATA_DIR` env var overrides default data directory
- [x] Mailbox name validation rejects `..`, `/`, `\`, empty, null bytes
- [x] Frontmatter generated by serde_yaml is valid YAML with correct field values
- [x] Special characters in email fields (newlines, colons, hashes, @) are handled correctly by serde_yaml
- [x] Attachment filenames with quotes/newlines/CR are escaped in MIME headers
- [x] `dkim-keygen` CLI generates keys and outputs DNS record
- [x] Custom `dkim_selector` value appears in DKIM signature (`s=` parameter)
- [x] Full pipeline integration: fixture .eml -> CLI ingest -> .md file with correct frontmatter and body