### PR TITLE
[Sprint 4] Channel Manager + Inbound Trust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -49,6 +49,7 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "clap",
+ "glob-match",
  "html2text",
  "mail-auth",
  "mail-parser",
@@ -758,6 +759,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob-match"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9985c9503b412198aa4197559e9a318524ebc4519c229bfa05a535828c950b9d"
 
 [[package]]
 name = "hashbrown"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "shell-escape",
  "tempfile",
  "tokio",
  "uuid",
@@ -1954,6 +1955,12 @@ dependencies = [
  "cpufeatures",
  "digest",
 ]
+
+[[package]]
+name = "shell-escape"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45bb67a18fa91266cc7807181f62f9178a6873bfad7dc788c42e6430db40184f"
 
 [[package]]
 name = "shlex"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ rmcp = { version = "1.3.0", features = ["server", "transport-io"] }
 tokio = { version = "1.51.1", features = ["full"] }
 serde_json = "1.0.149"
 schemars = "1.2.1"
+glob-match = "0.2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ tokio = { version = "1.51.1", features = ["full"] }
 serde_json = "1.0.149"
 schemars = "1.2.1"
 glob-match = "0.2"
+shell-escape = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,5 +1,7 @@
 use crate::config::{MailboxConfig, MatchFilter, OnReceiveRule};
 use crate::ingest::EmailMetadata;
+use shell_escape::escape;
+use std::borrow::Cow;
 use std::path::Path;
 use std::process::Command;
 
@@ -8,15 +10,22 @@ pub struct TriggerContext<'a> {
     pub metadata: &'a EmailMetadata,
 }
 
+fn shell_escape_value(val: &str) -> String {
+    escape(Cow::Borrowed(val)).into_owned()
+}
+
 pub fn substitute_template(command: &str, ctx: &TriggerContext) -> String {
     command
-        .replace("{filepath}", &ctx.filepath.to_string_lossy())
-        .replace("{from}", &ctx.metadata.from)
-        .replace("{to}", &ctx.metadata.to)
-        .replace("{subject}", &ctx.metadata.subject)
-        .replace("{mailbox}", &ctx.metadata.mailbox)
-        .replace("{id}", &ctx.metadata.id)
-        .replace("{date}", &ctx.metadata.date)
+        .replace(
+            "{filepath}",
+            &shell_escape_value(&ctx.filepath.to_string_lossy()),
+        )
+        .replace("{from}", &shell_escape_value(&ctx.metadata.from))
+        .replace("{to}", &shell_escape_value(&ctx.metadata.to))
+        .replace("{subject}", &shell_escape_value(&ctx.metadata.subject))
+        .replace("{mailbox}", &shell_escape_value(&ctx.metadata.mailbox))
+        .replace("{id}", &shell_escape_value(&ctx.metadata.id))
+        .replace("{date}", &shell_escape_value(&ctx.metadata.date))
 }
 
 pub fn matches_filter(filter: &MatchFilter, metadata: &EmailMetadata) -> bool {
@@ -88,7 +97,11 @@ pub fn should_execute_triggers(mailbox_config: &MailboxConfig, metadata: &EmailM
         return metadata.dkim == "pass";
     }
 
-    true
+    eprintln!(
+        "aimx: unknown trust value '{}', denying triggers (fail-closed)",
+        mailbox_config.trust
+    );
+    false
 }
 
 pub fn execute_triggers(mailbox_config: &MailboxConfig, ctx: &TriggerContext) {
@@ -162,7 +175,7 @@ mod tests {
         assert!(result.contains("/var/lib/aimx/catchall/2025-06-01-001.md"));
         assert!(result.contains("alice@gmail.com"));
         assert!(result.contains("agent@test.com"));
-        assert!(result.contains("Hello World"));
+        assert!(result.contains("'Hello World'"));
         assert!(result.contains("catchall"));
         assert!(result.contains("2025-06-01-001"));
         assert!(result.contains("2025-06-01T12:00:00Z"));
@@ -176,9 +189,10 @@ mod tests {
         let filepath = PathBuf::from("/tmp/test.md");
         let ctx = sample_ctx(&filepath, &meta);
 
-        let result = substitute_template("echo '{from}' '{subject}'", &ctx);
-        assert!(result.contains("O'Brien <obrien@test.com>"));
-        assert!(result.contains("Re: \"urgent\" & important"));
+        let result = substitute_template("echo {from} {subject}", &ctx);
+        assert!(result.contains("obrien@test.com"));
+        assert!(result.contains("urgent"));
+        assert!(!result.contains("O'Brien <obrien@test.com>"));
     }
 
     #[test]
@@ -549,7 +563,7 @@ mod tests {
             on_receive: vec![OnReceiveRule {
                 rule_type: "cmd".to_string(),
                 command: format!(
-                    "echo '{{from}} {{subject}}' > {}",
+                    "echo {{from}} {{subject}} > {}",
                     output_file.to_string_lossy()
                 ),
                 r#match: None,
@@ -717,6 +731,91 @@ mod tests {
         assert!(
             marker.exists(),
             "Trigger should fire for DKIM pass with trust=verified"
+        );
+    }
+
+    #[test]
+    fn substitute_template_escapes_shell_metacharacters() {
+        let mut meta = sample_metadata();
+        meta.subject = "$(rm -rf /)".to_string();
+        meta.from = "`curl evil.com`@attacker.com".to_string();
+        let filepath = PathBuf::from("/tmp/test.md");
+        let ctx = sample_ctx(&filepath, &meta);
+
+        let result = substitute_template("echo {from} {subject}", &ctx);
+        assert!(
+            result.contains("'$(rm -rf /)'"),
+            "command substitution should be single-quoted: {result}"
+        );
+        assert!(
+            result.contains("'`curl evil.com`@attacker.com'"),
+            "backtick injection should be single-quoted: {result}"
+        );
+    }
+
+    #[test]
+    fn substitute_template_shell_injection_does_not_execute() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let marker = tmp.path().join("pwned");
+        let mut meta = sample_metadata();
+        meta.subject = format!("$(touch {})", marker.to_string_lossy());
+        let filepath = tmp.path().join("test.md");
+        let ctx = sample_ctx(&filepath, &meta);
+
+        let config = MailboxConfig {
+            address: "*@test.com".to_string(),
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            on_receive: vec![OnReceiveRule {
+                rule_type: "cmd".to_string(),
+                command: "echo {subject}".to_string(),
+                r#match: None,
+            }],
+        };
+
+        execute_triggers(&config, &ctx);
+        assert!(
+            !marker.exists(),
+            "Shell injection should not execute commands"
+        );
+    }
+
+    #[test]
+    fn invalid_trust_value_denies_triggers() {
+        let mut meta = sample_metadata();
+        meta.dkim = "pass".to_string();
+        let config = MailboxConfig {
+            address: "*@test.com".to_string(),
+            trust: "verfied".to_string(),
+            trusted_senders: vec![],
+            on_receive: vec![],
+        };
+        assert!(!should_execute_triggers(&config, &meta));
+    }
+
+    #[test]
+    fn invalid_trust_value_blocks_trigger_execution() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let marker = tmp.path().join("should_not_exist");
+        let meta = sample_metadata();
+        let filepath = tmp.path().join("test.md");
+        let ctx = sample_ctx(&filepath, &meta);
+
+        let config = MailboxConfig {
+            address: "*@test.com".to_string(),
+            trust: "typo".to_string(),
+            trusted_senders: vec![],
+            on_receive: vec![OnReceiveRule {
+                rule_type: "cmd".to_string(),
+                command: format!("touch {}", marker.to_string_lossy()),
+                r#match: None,
+            }],
+        };
+
+        execute_triggers(&config, &ctx);
+        assert!(
+            !marker.exists(),
+            "Trigger should not fire for unknown trust value"
         );
     }
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,0 +1,722 @@
+use crate::config::{MailboxConfig, MatchFilter, OnReceiveRule};
+use crate::ingest::EmailMetadata;
+use std::path::Path;
+use std::process::Command;
+
+pub struct TriggerContext<'a> {
+    pub filepath: &'a Path,
+    pub metadata: &'a EmailMetadata,
+}
+
+pub fn substitute_template(command: &str, ctx: &TriggerContext) -> String {
+    command
+        .replace("{filepath}", &ctx.filepath.to_string_lossy())
+        .replace("{from}", &ctx.metadata.from)
+        .replace("{to}", &ctx.metadata.to)
+        .replace("{subject}", &ctx.metadata.subject)
+        .replace("{mailbox}", &ctx.metadata.mailbox)
+        .replace("{id}", &ctx.metadata.id)
+        .replace("{date}", &ctx.metadata.date)
+}
+
+pub fn matches_filter(filter: &MatchFilter, metadata: &EmailMetadata) -> bool {
+    if let Some(ref from_pattern) = filter.from {
+        let from_addr = extract_email_for_match(&metadata.from);
+        if !glob_match::glob_match(from_pattern, &from_addr) {
+            return false;
+        }
+    }
+
+    if let Some(ref subject_pattern) = filter.subject
+        && !metadata
+            .subject
+            .to_lowercase()
+            .contains(&subject_pattern.to_lowercase())
+    {
+        return false;
+    }
+
+    if let Some(has_attachment) = filter.has_attachment {
+        let email_has_attachment = !metadata.attachments.is_empty();
+        if has_attachment != email_has_attachment {
+            return false;
+        }
+    }
+
+    true
+}
+
+fn extract_email_for_match(from: &str) -> String {
+    if let Some(start) = from.find('<')
+        && let Some(end) = from.find('>')
+    {
+        return from[start + 1..end].to_lowercase();
+    }
+    from.to_lowercase()
+}
+
+pub fn should_fire(rule: &OnReceiveRule, metadata: &EmailMetadata) -> bool {
+    if rule.rule_type != "cmd" {
+        return false;
+    }
+    match &rule.r#match {
+        Some(filter) => matches_filter(filter, metadata),
+        None => true,
+    }
+}
+
+pub fn is_sender_trusted(mailbox_config: &MailboxConfig, from: &str) -> bool {
+    let from_lower = extract_email_for_match(from);
+    for pattern in &mailbox_config.trusted_senders {
+        if glob_match::glob_match(pattern, &from_lower) {
+            return true;
+        }
+    }
+    false
+}
+
+pub fn should_execute_triggers(mailbox_config: &MailboxConfig, metadata: &EmailMetadata) -> bool {
+    if mailbox_config.trust == "none" {
+        return true;
+    }
+
+    if is_sender_trusted(mailbox_config, &metadata.from) {
+        return true;
+    }
+
+    if mailbox_config.trust == "verified" {
+        return metadata.dkim == "pass";
+    }
+
+    true
+}
+
+pub fn execute_triggers(mailbox_config: &MailboxConfig, ctx: &TriggerContext) {
+    if !should_execute_triggers(mailbox_config, ctx.metadata) {
+        return;
+    }
+
+    for rule in &mailbox_config.on_receive {
+        if !should_fire(rule, ctx.metadata) {
+            continue;
+        }
+
+        let expanded = substitute_template(&rule.command, ctx);
+
+        match Command::new("sh").arg("-c").arg(&expanded).output() {
+            Ok(output) => {
+                if !output.status.success() {
+                    let stderr = String::from_utf8_lossy(&output.stderr);
+                    eprintln!(
+                        "aimx: trigger failed (exit {}): {expanded}\n  {stderr}",
+                        output.status.code().unwrap_or(-1)
+                    );
+                }
+            }
+            Err(e) => {
+                eprintln!("aimx: trigger exec error: {expanded}\n  {e}");
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{MatchFilter, OnReceiveRule};
+    use crate::ingest::{AttachmentMeta, EmailMetadata};
+    use std::path::PathBuf;
+
+    fn sample_metadata() -> EmailMetadata {
+        EmailMetadata {
+            id: "2025-06-01-001".to_string(),
+            message_id: "<test@example.com>".to_string(),
+            from: "alice@gmail.com".to_string(),
+            to: "agent@test.com".to_string(),
+            subject: "Hello World".to_string(),
+            date: "2025-06-01T12:00:00Z".to_string(),
+            in_reply_to: "".to_string(),
+            references: "".to_string(),
+            attachments: vec![],
+            mailbox: "catchall".to_string(),
+            read: false,
+            dkim: "none".to_string(),
+            spf: "none".to_string(),
+        }
+    }
+
+    fn sample_ctx<'a>(filepath: &'a Path, metadata: &'a EmailMetadata) -> TriggerContext<'a> {
+        TriggerContext { filepath, metadata }
+    }
+
+    #[test]
+    fn substitute_all_variables() {
+        let meta = sample_metadata();
+        let filepath = PathBuf::from("/var/lib/aimx/catchall/2025-06-01-001.md");
+        let ctx = sample_ctx(&filepath, &meta);
+
+        let result = substitute_template(
+            "echo {filepath} {from} {to} {subject} {mailbox} {id} {date}",
+            &ctx,
+        );
+        assert!(result.contains("/var/lib/aimx/catchall/2025-06-01-001.md"));
+        assert!(result.contains("alice@gmail.com"));
+        assert!(result.contains("agent@test.com"));
+        assert!(result.contains("Hello World"));
+        assert!(result.contains("catchall"));
+        assert!(result.contains("2025-06-01-001"));
+        assert!(result.contains("2025-06-01T12:00:00Z"));
+    }
+
+    #[test]
+    fn substitute_special_characters_in_values() {
+        let mut meta = sample_metadata();
+        meta.from = "O'Brien <obrien@test.com>".to_string();
+        meta.subject = "Re: \"urgent\" & important".to_string();
+        let filepath = PathBuf::from("/tmp/test.md");
+        let ctx = sample_ctx(&filepath, &meta);
+
+        let result = substitute_template("echo '{from}' '{subject}'", &ctx);
+        assert!(result.contains("O'Brien <obrien@test.com>"));
+        assert!(result.contains("Re: \"urgent\" & important"));
+    }
+
+    #[test]
+    fn substitute_no_variables() {
+        let meta = sample_metadata();
+        let filepath = PathBuf::from("/tmp/test.md");
+        let ctx = sample_ctx(&filepath, &meta);
+
+        let result = substitute_template("echo hello", &ctx);
+        assert_eq!(result, "echo hello");
+    }
+
+    #[test]
+    fn match_from_glob_match() {
+        let meta = sample_metadata();
+        let filter = MatchFilter {
+            from: Some("*@gmail.com".to_string()),
+            subject: None,
+            has_attachment: None,
+        };
+        assert!(matches_filter(&filter, &meta));
+    }
+
+    #[test]
+    fn match_from_glob_mismatch() {
+        let meta = sample_metadata();
+        let filter = MatchFilter {
+            from: Some("*@yahoo.com".to_string()),
+            subject: None,
+            has_attachment: None,
+        };
+        assert!(!matches_filter(&filter, &meta));
+    }
+
+    #[test]
+    fn match_from_glob_with_display_name() {
+        let mut meta = sample_metadata();
+        meta.from = "Alice Smith <alice@gmail.com>".to_string();
+        let filter = MatchFilter {
+            from: Some("*@gmail.com".to_string()),
+            subject: None,
+            has_attachment: None,
+        };
+        assert!(matches_filter(&filter, &meta));
+    }
+
+    #[test]
+    fn match_subject_substring() {
+        let meta = sample_metadata();
+        let filter = MatchFilter {
+            from: None,
+            subject: Some("hello".to_string()),
+            has_attachment: None,
+        };
+        assert!(matches_filter(&filter, &meta));
+    }
+
+    #[test]
+    fn match_subject_case_insensitive() {
+        let meta = sample_metadata();
+        let filter = MatchFilter {
+            from: None,
+            subject: Some("HELLO".to_string()),
+            has_attachment: None,
+        };
+        assert!(matches_filter(&filter, &meta));
+    }
+
+    #[test]
+    fn match_subject_mismatch() {
+        let meta = sample_metadata();
+        let filter = MatchFilter {
+            from: None,
+            subject: Some("goodbye".to_string()),
+            has_attachment: None,
+        };
+        assert!(!matches_filter(&filter, &meta));
+    }
+
+    #[test]
+    fn match_has_attachment_true_with_no_attachments() {
+        let meta = sample_metadata();
+        let filter = MatchFilter {
+            from: None,
+            subject: None,
+            has_attachment: Some(true),
+        };
+        assert!(!matches_filter(&filter, &meta));
+    }
+
+    #[test]
+    fn match_has_attachment_true_with_attachments() {
+        let mut meta = sample_metadata();
+        meta.attachments = vec![AttachmentMeta {
+            filename: "file.txt".to_string(),
+            content_type: "text/plain".to_string(),
+            size: 100,
+            path: "attachments/file.txt".to_string(),
+        }];
+        let filter = MatchFilter {
+            from: None,
+            subject: None,
+            has_attachment: Some(true),
+        };
+        assert!(matches_filter(&filter, &meta));
+    }
+
+    #[test]
+    fn match_has_attachment_false_with_no_attachments() {
+        let meta = sample_metadata();
+        let filter = MatchFilter {
+            from: None,
+            subject: None,
+            has_attachment: Some(false),
+        };
+        assert!(matches_filter(&filter, &meta));
+    }
+
+    #[test]
+    fn match_has_attachment_false_with_attachments() {
+        let mut meta = sample_metadata();
+        meta.attachments = vec![AttachmentMeta {
+            filename: "file.txt".to_string(),
+            content_type: "text/plain".to_string(),
+            size: 100,
+            path: "attachments/file.txt".to_string(),
+        }];
+        let filter = MatchFilter {
+            from: None,
+            subject: None,
+            has_attachment: Some(false),
+        };
+        assert!(!matches_filter(&filter, &meta));
+    }
+
+    #[test]
+    fn and_logic_all_match() {
+        let mut meta = sample_metadata();
+        meta.attachments = vec![AttachmentMeta {
+            filename: "file.txt".to_string(),
+            content_type: "text/plain".to_string(),
+            size: 100,
+            path: "attachments/file.txt".to_string(),
+        }];
+        let filter = MatchFilter {
+            from: Some("*@gmail.com".to_string()),
+            subject: Some("hello".to_string()),
+            has_attachment: Some(true),
+        };
+        assert!(matches_filter(&filter, &meta));
+    }
+
+    #[test]
+    fn and_logic_partial_match_from_fails() {
+        let meta = sample_metadata();
+        let filter = MatchFilter {
+            from: Some("*@yahoo.com".to_string()),
+            subject: Some("hello".to_string()),
+            has_attachment: None,
+        };
+        assert!(!matches_filter(&filter, &meta));
+    }
+
+    #[test]
+    fn and_logic_partial_match_subject_fails() {
+        let meta = sample_metadata();
+        let filter = MatchFilter {
+            from: Some("*@gmail.com".to_string()),
+            subject: Some("nonexistent".to_string()),
+            has_attachment: None,
+        };
+        assert!(!matches_filter(&filter, &meta));
+    }
+
+    #[test]
+    fn and_logic_partial_match_attachment_fails() {
+        let meta = sample_metadata();
+        let filter = MatchFilter {
+            from: Some("*@gmail.com".to_string()),
+            subject: Some("hello".to_string()),
+            has_attachment: Some(true),
+        };
+        assert!(!matches_filter(&filter, &meta));
+    }
+
+    #[test]
+    fn should_fire_cmd_no_match_always_fires() {
+        let meta = sample_metadata();
+        let rule = OnReceiveRule {
+            rule_type: "cmd".to_string(),
+            command: "echo test".to_string(),
+            r#match: None,
+        };
+        assert!(should_fire(&rule, &meta));
+    }
+
+    #[test]
+    fn should_fire_non_cmd_type_does_not_fire() {
+        let meta = sample_metadata();
+        let rule = OnReceiveRule {
+            rule_type: "webhook".to_string(),
+            command: "echo test".to_string(),
+            r#match: None,
+        };
+        assert!(!should_fire(&rule, &meta));
+    }
+
+    #[test]
+    fn should_fire_with_matching_filter() {
+        let meta = sample_metadata();
+        let rule = OnReceiveRule {
+            rule_type: "cmd".to_string(),
+            command: "echo test".to_string(),
+            r#match: Some(MatchFilter {
+                from: Some("*@gmail.com".to_string()),
+                subject: None,
+                has_attachment: None,
+            }),
+        };
+        assert!(should_fire(&rule, &meta));
+    }
+
+    #[test]
+    fn should_fire_with_non_matching_filter() {
+        let meta = sample_metadata();
+        let rule = OnReceiveRule {
+            rule_type: "cmd".to_string(),
+            command: "echo test".to_string(),
+            r#match: Some(MatchFilter {
+                from: Some("*@yahoo.com".to_string()),
+                subject: None,
+                has_attachment: None,
+            }),
+        };
+        assert!(!should_fire(&rule, &meta));
+    }
+
+    #[test]
+    fn execute_triggers_success() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let marker = tmp.path().join("triggered");
+        let meta = sample_metadata();
+        let filepath = tmp.path().join("test.md");
+        let ctx = sample_ctx(&filepath, &meta);
+
+        let config = MailboxConfig {
+            address: "*@test.com".to_string(),
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            on_receive: vec![OnReceiveRule {
+                rule_type: "cmd".to_string(),
+                command: format!("touch {}", marker.to_string_lossy()),
+                r#match: None,
+            }],
+        };
+
+        execute_triggers(&config, &ctx);
+        assert!(marker.exists());
+    }
+
+    #[test]
+    fn execute_triggers_multiple_in_order() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let log_file = tmp.path().join("order.log");
+        let meta = sample_metadata();
+        let filepath = tmp.path().join("test.md");
+        let ctx = sample_ctx(&filepath, &meta);
+
+        let config = MailboxConfig {
+            address: "*@test.com".to_string(),
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            on_receive: vec![
+                OnReceiveRule {
+                    rule_type: "cmd".to_string(),
+                    command: format!("echo first >> {}", log_file.to_string_lossy()),
+                    r#match: None,
+                },
+                OnReceiveRule {
+                    rule_type: "cmd".to_string(),
+                    command: format!("echo second >> {}", log_file.to_string_lossy()),
+                    r#match: None,
+                },
+            ],
+        };
+
+        execute_triggers(&config, &ctx);
+        let content = std::fs::read_to_string(&log_file).unwrap();
+        let lines: Vec<&str> = content.trim().lines().collect();
+        assert_eq!(lines, vec!["first", "second"]);
+    }
+
+    #[test]
+    fn execute_triggers_failure_does_not_panic() {
+        let meta = sample_metadata();
+        let filepath = PathBuf::from("/tmp/test.md");
+        let ctx = sample_ctx(&filepath, &meta);
+
+        let config = MailboxConfig {
+            address: "*@test.com".to_string(),
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            on_receive: vec![OnReceiveRule {
+                rule_type: "cmd".to_string(),
+                command: "false".to_string(),
+                r#match: None,
+            }],
+        };
+
+        execute_triggers(&config, &ctx);
+    }
+
+    #[test]
+    fn execute_triggers_no_rules() {
+        let meta = sample_metadata();
+        let filepath = PathBuf::from("/tmp/test.md");
+        let ctx = sample_ctx(&filepath, &meta);
+
+        let config = MailboxConfig {
+            address: "*@test.com".to_string(),
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            on_receive: vec![],
+        };
+
+        execute_triggers(&config, &ctx);
+    }
+
+    #[test]
+    fn execute_triggers_skips_non_matching() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let marker = tmp.path().join("should_not_exist");
+        let meta = sample_metadata();
+        let filepath = tmp.path().join("test.md");
+        let ctx = sample_ctx(&filepath, &meta);
+
+        let config = MailboxConfig {
+            address: "*@test.com".to_string(),
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            on_receive: vec![OnReceiveRule {
+                rule_type: "cmd".to_string(),
+                command: format!("touch {}", marker.to_string_lossy()),
+                r#match: Some(MatchFilter {
+                    from: Some("*@yahoo.com".to_string()),
+                    subject: None,
+                    has_attachment: None,
+                }),
+            }],
+        };
+
+        execute_triggers(&config, &ctx);
+        assert!(!marker.exists());
+    }
+
+    #[test]
+    fn execute_triggers_with_template_variables() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let output_file = tmp.path().join("output.txt");
+        let meta = sample_metadata();
+        let filepath = tmp.path().join("catchall/2025-06-01-001.md");
+        let ctx = sample_ctx(&filepath, &meta);
+
+        let config = MailboxConfig {
+            address: "*@test.com".to_string(),
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            on_receive: vec![OnReceiveRule {
+                rule_type: "cmd".to_string(),
+                command: format!(
+                    "echo '{{from}} {{subject}}' > {}",
+                    output_file.to_string_lossy()
+                ),
+                r#match: None,
+            }],
+        };
+
+        execute_triggers(&config, &ctx);
+        let content = std::fs::read_to_string(&output_file).unwrap();
+        assert!(content.contains("alice@gmail.com"));
+        assert!(content.contains("Hello World"));
+    }
+
+    #[test]
+    fn trust_none_fires_always() {
+        let mut meta = sample_metadata();
+        meta.dkim = "fail".to_string();
+        let config = MailboxConfig {
+            address: "*@test.com".to_string(),
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            on_receive: vec![],
+        };
+        assert!(should_execute_triggers(&config, &meta));
+    }
+
+    #[test]
+    fn trust_verified_blocks_on_dkim_fail() {
+        let mut meta = sample_metadata();
+        meta.dkim = "fail".to_string();
+        let config = MailboxConfig {
+            address: "*@test.com".to_string(),
+            trust: "verified".to_string(),
+            trusted_senders: vec![],
+            on_receive: vec![],
+        };
+        assert!(!should_execute_triggers(&config, &meta));
+    }
+
+    #[test]
+    fn trust_verified_blocks_on_dkim_none() {
+        let meta = sample_metadata();
+        let config = MailboxConfig {
+            address: "*@test.com".to_string(),
+            trust: "verified".to_string(),
+            trusted_senders: vec![],
+            on_receive: vec![],
+        };
+        assert!(!should_execute_triggers(&config, &meta));
+    }
+
+    #[test]
+    fn trust_verified_allows_on_dkim_pass() {
+        let mut meta = sample_metadata();
+        meta.dkim = "pass".to_string();
+        let config = MailboxConfig {
+            address: "*@test.com".to_string(),
+            trust: "verified".to_string(),
+            trusted_senders: vec![],
+            on_receive: vec![],
+        };
+        assert!(should_execute_triggers(&config, &meta));
+    }
+
+    #[test]
+    fn trusted_senders_bypasses_dkim_check() {
+        let mut meta = sample_metadata();
+        meta.dkim = "fail".to_string();
+        let config = MailboxConfig {
+            address: "*@test.com".to_string(),
+            trust: "verified".to_string(),
+            trusted_senders: vec!["*@gmail.com".to_string()],
+            on_receive: vec![],
+        };
+        assert!(should_execute_triggers(&config, &meta));
+    }
+
+    #[test]
+    fn trusted_senders_exact_match() {
+        let mut meta = sample_metadata();
+        meta.dkim = "fail".to_string();
+        let config = MailboxConfig {
+            address: "*@test.com".to_string(),
+            trust: "verified".to_string(),
+            trusted_senders: vec!["alice@gmail.com".to_string()],
+            on_receive: vec![],
+        };
+        assert!(should_execute_triggers(&config, &meta));
+    }
+
+    #[test]
+    fn trusted_senders_no_match_falls_through() {
+        let mut meta = sample_metadata();
+        meta.dkim = "fail".to_string();
+        let config = MailboxConfig {
+            address: "*@test.com".to_string(),
+            trust: "verified".to_string(),
+            trusted_senders: vec!["*@yahoo.com".to_string()],
+            on_receive: vec![],
+        };
+        assert!(!should_execute_triggers(&config, &meta));
+    }
+
+    #[test]
+    fn trusted_senders_with_display_name() {
+        let mut meta = sample_metadata();
+        meta.from = "Alice Smith <alice@gmail.com>".to_string();
+        meta.dkim = "fail".to_string();
+        let config = MailboxConfig {
+            address: "*@test.com".to_string(),
+            trust: "verified".to_string(),
+            trusted_senders: vec!["*@gmail.com".to_string()],
+            on_receive: vec![],
+        };
+        assert!(should_execute_triggers(&config, &meta));
+    }
+
+    #[test]
+    fn trust_verified_trigger_actually_blocked() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let marker = tmp.path().join("should_not_exist");
+        let mut meta = sample_metadata();
+        meta.dkim = "fail".to_string();
+        let filepath = tmp.path().join("test.md");
+        let ctx = sample_ctx(&filepath, &meta);
+
+        let config = MailboxConfig {
+            address: "*@test.com".to_string(),
+            trust: "verified".to_string(),
+            trusted_senders: vec![],
+            on_receive: vec![OnReceiveRule {
+                rule_type: "cmd".to_string(),
+                command: format!("touch {}", marker.to_string_lossy()),
+                r#match: None,
+            }],
+        };
+
+        execute_triggers(&config, &ctx);
+        assert!(
+            !marker.exists(),
+            "Trigger should not have fired for DKIM fail with trust=verified"
+        );
+    }
+
+    #[test]
+    fn trust_verified_trigger_fires_on_pass() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let marker = tmp.path().join("triggered");
+        let mut meta = sample_metadata();
+        meta.dkim = "pass".to_string();
+        let filepath = tmp.path().join("test.md");
+        let ctx = sample_ctx(&filepath, &meta);
+
+        let config = MailboxConfig {
+            address: "*@test.com".to_string(),
+            trust: "verified".to_string(),
+            trusted_senders: vec![],
+            on_receive: vec![OnReceiveRule {
+                rule_type: "cmd".to_string(),
+                command: format!("touch {}", marker.to_string_lossy()),
+                r#match: None,
+            }],
+        };
+
+        execute_triggers(&config, &ctx);
+        assert!(
+            marker.exists(),
+            "Trigger should fire for DKIM pass with trust=verified"
+        );
+    }
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,6 +24,16 @@ pub struct MailboxConfig {
 
     #[serde(default)]
     pub on_receive: Vec<OnReceiveRule>,
+
+    #[serde(default = "default_trust")]
+    pub trust: String,
+
+    #[serde(default)]
+    pub trusted_senders: Vec<String>,
+}
+
+fn default_trust() -> String {
+    "none".to_string()
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -156,6 +166,8 @@ mailboxes:
             MailboxConfig {
                 address: "*@test.com".to_string(),
                 on_receive: vec![],
+                trust: "none".to_string(),
+                trusted_senders: vec![],
             },
         );
 
@@ -181,6 +193,40 @@ mailboxes:
     fn resolve_mailbox_unknown_falls_to_catchall() {
         let config: Config = serde_yaml::from_str(sample_yaml()).unwrap();
         assert_eq!(config.resolve_mailbox("unknown"), "catchall");
+    }
+
+    #[test]
+    fn parse_trust_settings() {
+        let yaml = r#"
+domain: test.com
+mailboxes:
+  secure:
+    address: secure@test.com
+    trust: verified
+    trusted_senders:
+      - "*@company.com"
+      - "boss@gmail.com"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let secure = &config.mailboxes["secure"];
+        assert_eq!(secure.trust, "verified");
+        assert_eq!(secure.trusted_senders.len(), 2);
+        assert_eq!(secure.trusted_senders[0], "*@company.com");
+        assert_eq!(secure.trusted_senders[1], "boss@gmail.com");
+    }
+
+    #[test]
+    fn default_trust_is_none() {
+        let yaml = r#"
+domain: test.com
+mailboxes:
+  catchall:
+    address: "*@test.com"
+"#;
+        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let catchall = &config.mailboxes["catchall"];
+        assert_eq!(catchall.trust, "none");
+        assert!(catchall.trusted_senders.is_empty());
     }
 
     #[test]

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1,7 +1,9 @@
+use crate::channel::{self, TriggerContext};
 use crate::config::Config;
 use mail_parser::{MessageParser, MimeHeaders};
 use serde::Serialize;
 use std::io::Read;
+use std::net::IpAddr;
 use std::path::Path;
 
 #[derive(Debug, Clone, Serialize, serde::Deserialize)]
@@ -17,6 +19,14 @@ pub struct EmailMetadata {
     pub attachments: Vec<AttachmentMeta>,
     pub mailbox: String,
     pub read: bool,
+    #[serde(default = "default_auth_result")]
+    pub dkim: String,
+    #[serde(default = "default_auth_result")]
+    pub spf: String,
+}
+
+fn default_auth_result() -> String {
+    "none".to_string()
 }
 
 #[derive(Debug, Clone, Serialize, serde::Deserialize)]
@@ -110,6 +120,8 @@ pub fn ingest_email(
     let filename = format!("{id}.md");
     let filepath = mailbox_dir.join(&filename);
 
+    let (dkim_result, spf_result) = verify_auth(raw, rcpt);
+
     let meta = EmailMetadata {
         id: id.clone(),
         message_id,
@@ -122,12 +134,159 @@ pub fn ingest_email(
         attachments,
         mailbox: mailbox.clone(),
         read: false,
+        dkim: dkim_result,
+        spf: spf_result,
     };
 
     let content = format_markdown(&meta, &body);
     std::fs::write(&filepath, content)?;
 
+    if let Some(mailbox_config) = config.mailboxes.get(&mailbox) {
+        let ctx = TriggerContext {
+            filepath: &filepath,
+            metadata: &meta,
+        };
+        channel::execute_triggers(mailbox_config, &ctx);
+    }
+
     Ok(())
+}
+
+fn verify_auth(raw: &[u8], rcpt: &str) -> (String, String) {
+    let rt = match tokio::runtime::Runtime::new() {
+        Ok(rt) => rt,
+        Err(_) => return ("none".to_string(), "none".to_string()),
+    };
+
+    rt.block_on(async {
+        let dkim_result = verify_dkim_async(raw).await;
+        let spf_result = verify_spf_async(raw, rcpt).await;
+        (dkim_result, spf_result)
+    })
+}
+
+async fn verify_dkim_async(raw: &[u8]) -> String {
+    let auth_msg = match mail_auth::AuthenticatedMessage::parse(raw) {
+        Some(msg) => msg,
+        None => return "none".to_string(),
+    };
+
+    if auth_msg.dkim_headers.is_empty() {
+        return "none".to_string();
+    }
+
+    let resolver = match mail_auth::Resolver::new_system_conf() {
+        Ok(r) => r,
+        Err(_) => match mail_auth::Resolver::new_cloudflare() {
+            Ok(r) => r,
+            Err(_) => return "none".to_string(),
+        },
+    };
+
+    let results = resolver.verify_dkim(&auth_msg).await;
+
+    if results.is_empty() {
+        return "none".to_string();
+    }
+
+    for output in &results {
+        if matches!(output.result(), mail_auth::DkimResult::Pass) {
+            return "pass".to_string();
+        }
+    }
+
+    "fail".to_string()
+}
+
+async fn verify_spf_async(raw: &[u8], rcpt: &str) -> String {
+    let ip = match extract_received_ip(raw) {
+        Some(ip) => ip,
+        None => return "none".to_string(),
+    };
+
+    let sender_domain = rcpt.split('@').nth(1).unwrap_or("");
+    let mail_from = extract_mail_from(raw).unwrap_or_default();
+    let helo_domain = mail_from.split('@').nth(1).unwrap_or(sender_domain);
+
+    if helo_domain.is_empty() {
+        return "none".to_string();
+    }
+
+    let resolver = match mail_auth::Resolver::new_system_conf() {
+        Ok(r) => r,
+        Err(_) => match mail_auth::Resolver::new_cloudflare() {
+            Ok(r) => r,
+            Err(_) => return "none".to_string(),
+        },
+    };
+
+    let spf_output = resolver
+        .verify_spf_sender(ip, helo_domain, helo_domain, &mail_from)
+        .await;
+
+    match spf_output.result() {
+        mail_auth::SpfResult::Pass => "pass".to_string(),
+        mail_auth::SpfResult::Fail => "fail".to_string(),
+        mail_auth::SpfResult::SoftFail => "fail".to_string(),
+        mail_auth::SpfResult::None => "none".to_string(),
+        _ => "fail".to_string(),
+    }
+}
+
+fn extract_received_ip(raw: &[u8]) -> Option<IpAddr> {
+    let header_section = std::str::from_utf8(raw).ok()?;
+    for line in header_section.lines() {
+        if (line.starts_with("Received:") || line.starts_with("received:"))
+            && let Some(ip) = parse_ip_from_received(line)
+        {
+            return Some(ip);
+        }
+    }
+    None
+}
+
+fn parse_ip_from_received(line: &str) -> Option<IpAddr> {
+    let mut chars = line.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '[' {
+            let candidate: String = chars.by_ref().take_while(|&ch| ch != ']').collect();
+            if let Ok(ip) = candidate.parse::<IpAddr>()
+                && !ip.is_loopback()
+            {
+                return Some(ip);
+            }
+        }
+    }
+
+    for word in line.split_whitespace() {
+        let trimmed = word.trim_matches(|c: char| !c.is_ascii_digit() && c != '.' && c != ':');
+        if let Ok(ip) = trimmed.parse::<IpAddr>()
+            && !ip.is_loopback()
+        {
+            return Some(ip);
+        }
+    }
+
+    None
+}
+
+fn extract_mail_from(raw: &[u8]) -> Option<String> {
+    let header_section = std::str::from_utf8(raw).ok()?;
+    for line in header_section.lines() {
+        if line.is_empty() {
+            break;
+        }
+        if line.to_lowercase().starts_with("from:") {
+            let addr = line[5..].trim();
+            if let Some(start) = addr.find('<')
+                && let Some(end) = addr.find('>')
+            {
+                return Some(addr[start + 1..end].to_string());
+            }
+            return Some(addr.to_string());
+        }
+    }
+    None
 }
 
 fn extract_local_part(rcpt: &str) -> &str {
@@ -268,6 +427,8 @@ mod tests {
             MailboxConfig {
                 address: "*@test.com".to_string(),
                 on_receive: vec![],
+                trust: "none".to_string(),
+                trusted_senders: vec![],
             },
         );
         mailboxes.insert(
@@ -275,6 +436,8 @@ mod tests {
             MailboxConfig {
                 address: "alice@test.com".to_string(),
                 on_receive: vec![],
+                trust: "none".to_string(),
+                trusted_senders: vec![],
             },
         );
         Config {
@@ -661,6 +824,8 @@ mod tests {
             attachments: vec![],
             mailbox: "catchall".to_string(),
             read: false,
+            dkim: "none".to_string(),
+            spf: "none".to_string(),
         };
 
         let yaml = serde_yaml::to_string(&meta).unwrap();
@@ -670,5 +835,100 @@ mod tests {
             .get(&serde_yaml::Value::String("from".to_string()))
             .unwrap();
         assert_eq!(from.as_str().unwrap(), "test\n---\ninjected: true");
+    }
+
+    #[test]
+    fn unsigned_email_has_dkim_none_spf_none() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
+
+        let entries: Vec<_> = std::fs::read_dir(tmp.path().join("alice"))
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
+            .collect();
+        let content = std::fs::read_to_string(entries[0].path()).unwrap();
+        let parts: Vec<&str> = content.splitn(3, "---").collect();
+        let yaml_str = parts[1].trim();
+        let parsed: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+        let map = parsed.as_mapping().unwrap();
+
+        let dkim = map
+            .get(&serde_yaml::Value::String("dkim".to_string()))
+            .unwrap()
+            .as_str()
+            .unwrap();
+        assert_eq!(dkim, "none");
+
+        let spf = map
+            .get(&serde_yaml::Value::String("spf".to_string()))
+            .unwrap()
+            .as_str()
+            .unwrap();
+        assert_eq!(spf, "none");
+    }
+
+    #[test]
+    fn parse_ip_from_received_bracketed() {
+        let line = "Received: from mail.example.com (mail.example.com [192.168.1.100])";
+        let ip = parse_ip_from_received(line);
+        assert_eq!(ip, Some("192.168.1.100".parse().unwrap()));
+    }
+
+    #[test]
+    fn parse_ip_from_received_skips_loopback() {
+        let line = "Received: from localhost ([127.0.0.1])";
+        let ip = parse_ip_from_received(line);
+        assert!(ip.is_none());
+    }
+
+    #[test]
+    fn parse_ip_from_received_ipv6() {
+        let line = "Received: from mail.example.com ([2001:db8::1])";
+        let ip = parse_ip_from_received(line);
+        assert_eq!(ip, Some("2001:db8::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn extract_mail_from_basic() {
+        let raw = b"From: sender@example.com\r\nTo: test@test.com\r\n\r\nBody\r\n";
+        let result = extract_mail_from(raw);
+        assert_eq!(result, Some("sender@example.com".to_string()));
+    }
+
+    #[test]
+    fn extract_mail_from_with_display_name() {
+        let raw = b"From: Alice <alice@example.com>\r\nTo: test@test.com\r\n\r\nBody\r\n";
+        let result = extract_mail_from(raw);
+        assert_eq!(result, Some("alice@example.com".to_string()));
+    }
+
+    #[test]
+    fn extract_mail_from_missing() {
+        let raw = b"To: test@test.com\r\n\r\nBody\r\n";
+        let result = extract_mail_from(raw);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn frontmatter_includes_dkim_spf_fields() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
+
+        let entries: Vec<_> = std::fs::read_dir(tmp.path().join("alice"))
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
+            .collect();
+        let content = std::fs::read_to_string(entries[0].path()).unwrap();
+        let parts: Vec<&str> = content.splitn(3, "---").collect();
+        let yaml_str = parts[1].trim();
+        let parsed: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
+        let map = parsed.as_mapping().unwrap();
+
+        assert!(map.contains_key(&serde_yaml::Value::String("dkim".to_string())));
+        assert!(map.contains_key(&serde_yaml::Value::String("spf".to_string())));
     }
 }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -233,9 +233,29 @@ async fn verify_spf_async(raw: &[u8], rcpt: &str) -> String {
     }
 }
 
+fn unfold_headers(raw: &str) -> String {
+    let mut result = String::with_capacity(raw.len());
+    for line in raw.lines() {
+        if line.starts_with(' ') || line.starts_with('\t') {
+            result.push(' ');
+            result.push_str(line.trim());
+        } else {
+            if !result.is_empty() {
+                result.push('\n');
+            }
+            result.push_str(line);
+        }
+    }
+    result
+}
+
 fn extract_received_ip(raw: &[u8]) -> Option<IpAddr> {
     let header_section = std::str::from_utf8(raw).ok()?;
-    for line in header_section.lines() {
+    let unfolded = unfold_headers(header_section);
+    for line in unfolded.lines() {
+        if line.is_empty() {
+            break;
+        }
         if (line.starts_with("Received:") || line.starts_with("received:"))
             && let Some(ip) = parse_ip_from_received(line)
         {
@@ -930,5 +950,33 @@ mod tests {
 
         assert!(map.contains_key(&serde_yaml::Value::String("dkim".to_string())));
         assert!(map.contains_key(&serde_yaml::Value::String("spf".to_string())));
+    }
+
+    #[test]
+    fn extract_received_ip_folded_header() {
+        let raw = b"Received: from mail.example.com (mail.example.com\r\n\t[203.0.113.50]) by mx.local with ESMTP\r\n\r\nBody\r\n";
+        let ip = extract_received_ip(raw);
+        assert_eq!(ip, Some("203.0.113.50".parse().unwrap()));
+    }
+
+    #[test]
+    fn extract_received_ip_folded_with_spaces() {
+        let raw = b"Received: from mail.example.com (mail.example.com\r\n    [198.51.100.25]) by mx.local\r\n\r\nBody\r\n";
+        let ip = extract_received_ip(raw);
+        assert_eq!(ip, Some("198.51.100.25".parse().unwrap()));
+    }
+
+    #[test]
+    fn unfold_headers_preserves_single_line() {
+        let input = "Received: from mail.example.com ([192.168.1.1])";
+        let result = unfold_headers(input);
+        assert_eq!(result, input);
+    }
+
+    #[test]
+    fn unfold_headers_joins_continuation() {
+        let input = "Received: from mail.example.com\n\t([192.168.1.1])";
+        let result = unfold_headers(input);
+        assert!(result.contains("Received: from mail.example.com ([192.168.1.1])"));
     }
 }

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -50,6 +50,8 @@ pub fn create_mailbox(config: &Config, name: &str) -> Result<(), Box<dyn std::er
         MailboxConfig {
             address: format!("{name}@{}", config.domain),
             on_receive: vec![],
+            trust: "none".to_string(),
+            trusted_senders: vec![],
         },
     );
 
@@ -159,6 +161,8 @@ mod tests {
             MailboxConfig {
                 address: "*@test.com".to_string(),
                 on_receive: vec![],
+                trust: "none".to_string(),
+                trusted_senders: vec![],
             },
         );
         Config {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod channel;
 mod cli;
 mod config;
 mod dkim;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -566,6 +566,8 @@ mod tests {
             MailboxConfig {
                 address: "*@test.com".to_string(),
                 on_receive: vec![],
+                trust: "none".to_string(),
+                trusted_senders: vec![],
             },
         );
         mailboxes.insert(
@@ -573,6 +575,8 @@ mod tests {
             MailboxConfig {
                 address: "alice@test.com".to_string(),
                 on_receive: vec![],
+                trust: "none".to_string(),
+                trusted_senders: vec![],
             },
         );
         Config {
@@ -609,6 +613,8 @@ mod tests {
             attachments: vec![],
             mailbox: "alice".to_string(),
             read,
+            dkim: "none".to_string(),
+            spf: "none".to_string(),
         }
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -728,3 +728,246 @@ fn mcp_clean_exit_on_stdin_close() {
     let status = client.child.wait().unwrap();
     assert!(status.success() || status.code() == Some(0));
 }
+
+fn setup_test_env_with_triggers(tmp: &Path, trigger_marker: &Path) -> String {
+    let config_content = format!(
+        r#"domain: agent.example.com
+data_dir: {}
+mailboxes:
+  catchall:
+    address: "*@agent.example.com"
+    on_receive:
+      - type: cmd
+        command: 'touch {}'
+"#,
+        tmp.display(),
+        trigger_marker.display()
+    );
+    std::fs::create_dir_all(tmp.join("catchall")).unwrap();
+    let config_path = tmp.join("config.yaml");
+    std::fs::write(&config_path, &config_content).unwrap();
+    config_path.to_string_lossy().to_string()
+}
+
+#[test]
+fn ingest_trigger_executes_on_delivery() {
+    let tmp = TempDir::new().unwrap();
+    let marker = tmp.path().join("trigger.marker");
+    setup_test_env_with_triggers(tmp.path(), &marker);
+    let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
+
+    Command::cargo_bin("aimx")
+        .unwrap()
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("ingest")
+        .arg("catchall@agent.example.com")
+        .write_stdin(eml)
+        .assert()
+        .success();
+
+    let md_files = find_md_files(&tmp.path().join("catchall"));
+    assert_eq!(md_files.len(), 1);
+    assert!(
+        marker.exists(),
+        "Trigger marker file should have been created"
+    );
+}
+
+#[test]
+fn ingest_failing_trigger_does_not_block_delivery() {
+    let tmp = TempDir::new().unwrap();
+    let config_content = format!(
+        r#"domain: agent.example.com
+data_dir: {}
+mailboxes:
+  catchall:
+    address: "*@agent.example.com"
+    on_receive:
+      - type: cmd
+        command: 'false'
+"#,
+        tmp.path().display()
+    );
+    std::fs::create_dir_all(tmp.path().join("catchall")).unwrap();
+    std::fs::write(tmp.path().join("config.yaml"), &config_content).unwrap();
+
+    let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
+
+    Command::cargo_bin("aimx")
+        .unwrap()
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("ingest")
+        .arg("catchall@agent.example.com")
+        .write_stdin(eml)
+        .assert()
+        .success();
+
+    let md_files = find_md_files(&tmp.path().join("catchall"));
+    assert_eq!(
+        md_files.len(),
+        1,
+        "Email should be saved despite trigger failure"
+    );
+}
+
+#[test]
+fn ingest_trust_verified_blocks_unsigned_trigger() {
+    let tmp = TempDir::new().unwrap();
+    let marker = tmp.path().join("should_not_exist");
+    let config_content = format!(
+        r#"domain: agent.example.com
+data_dir: {}
+mailboxes:
+  catchall:
+    address: "*@agent.example.com"
+    trust: verified
+    on_receive:
+      - type: cmd
+        command: 'touch {}'
+"#,
+        tmp.path().display(),
+        marker.display()
+    );
+    std::fs::create_dir_all(tmp.path().join("catchall")).unwrap();
+    std::fs::write(tmp.path().join("config.yaml"), &config_content).unwrap();
+
+    let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
+
+    Command::cargo_bin("aimx")
+        .unwrap()
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("ingest")
+        .arg("catchall@agent.example.com")
+        .write_stdin(eml)
+        .assert()
+        .success();
+
+    let md_files = find_md_files(&tmp.path().join("catchall"));
+    assert_eq!(md_files.len(), 1, "Email should still be saved");
+    assert!(
+        !marker.exists(),
+        "Trigger should NOT fire for unsigned email with trust=verified"
+    );
+}
+
+#[test]
+fn ingest_trust_none_allows_unsigned_trigger() {
+    let tmp = TempDir::new().unwrap();
+    let marker = tmp.path().join("triggered");
+    let config_content = format!(
+        r#"domain: agent.example.com
+data_dir: {}
+mailboxes:
+  catchall:
+    address: "*@agent.example.com"
+    trust: none
+    on_receive:
+      - type: cmd
+        command: 'touch {}'
+"#,
+        tmp.path().display(),
+        marker.display()
+    );
+    std::fs::create_dir_all(tmp.path().join("catchall")).unwrap();
+    std::fs::write(tmp.path().join("config.yaml"), &config_content).unwrap();
+
+    let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
+
+    Command::cargo_bin("aimx")
+        .unwrap()
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("ingest")
+        .arg("catchall@agent.example.com")
+        .write_stdin(eml)
+        .assert()
+        .success();
+
+    let md_files = find_md_files(&tmp.path().join("catchall"));
+    assert_eq!(md_files.len(), 1);
+    assert!(
+        marker.exists(),
+        "Trigger should fire with trust=none even for unsigned email"
+    );
+}
+
+#[test]
+fn ingest_frontmatter_contains_dkim_spf() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
+
+    Command::cargo_bin("aimx")
+        .unwrap()
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("ingest")
+        .arg("catchall@agent.example.com")
+        .write_stdin(eml)
+        .assert()
+        .success();
+
+    let md_files = find_md_files(&tmp.path().join("catchall"));
+    assert_eq!(md_files.len(), 1);
+
+    let parsed = read_frontmatter(&md_files[0]);
+    let map = parsed.as_mapping().unwrap();
+
+    let dkim = get_yaml_str(map, "dkim");
+    assert!(
+        dkim == "none" || dkim == "pass" || dkim == "fail",
+        "dkim should be pass|fail|none, got: {dkim}"
+    );
+
+    let spf = get_yaml_str(map, "spf");
+    assert!(
+        spf == "none" || spf == "pass" || spf == "fail",
+        "spf should be pass|fail|none, got: {spf}"
+    );
+}
+
+#[test]
+fn ingest_trusted_sender_bypasses_dkim() {
+    let tmp = TempDir::new().unwrap();
+    let marker = tmp.path().join("triggered");
+    let config_content = format!(
+        r#"domain: agent.example.com
+data_dir: {}
+mailboxes:
+  catchall:
+    address: "*@agent.example.com"
+    trust: verified
+    trusted_senders:
+      - "*@example.com"
+    on_receive:
+      - type: cmd
+        command: 'touch {}'
+"#,
+        tmp.path().display(),
+        marker.display()
+    );
+    std::fs::create_dir_all(tmp.path().join("catchall")).unwrap();
+    std::fs::write(tmp.path().join("config.yaml"), &config_content).unwrap();
+
+    let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
+
+    Command::cargo_bin("aimx")
+        .unwrap()
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("ingest")
+        .arg("catchall@agent.example.com")
+        .write_stdin(eml)
+        .assert()
+        .success();
+
+    let md_files = find_md_files(&tmp.path().join("catchall"));
+    assert_eq!(md_files.len(), 1);
+    assert!(
+        marker.exists(),
+        "Trigger should fire for trusted sender even with trust=verified"
+    );
+}


### PR DESCRIPTION
## Summary

- **S4.1 Channel Manager: Trigger Execution** — `on_receive` rules in `config.yaml` execute shell commands on email delivery with template variable substitution (`{filepath}`, `{from}`, `{to}`, `{subject}`, `{mailbox}`, `{id}`, `{date}`). Failures are logged to stderr but never block delivery or cause non-zero exit.

- **S4.2 Match Filters** — Optional `match` block on triggers with `from` (glob pattern), `subject` (case-insensitive substring), and `has_attachment` (bool). All conditions use AND logic. Triggers with no `match` block fire on every email.

- **S4.3 Inbound DKIM/SPF Verification** — During `aimx ingest`, raw email is verified using the `mail-auth` crate against the sender's published DNS records. Results are stored in frontmatter as `dkim: pass|fail|none` and `spf: pass|fail|none`. Verification failure never blocks email storage.

- **S4.4 Trust Policy + Trusted Senders** — Per-mailbox `trust` setting (`none` default, `verified`) gates trigger execution. With `trust: verified`, triggers only fire when `dkim: pass`. `trusted_senders` allowlist (glob patterns) bypasses DKIM check. Email is always stored regardless of trust result.

## Changes

- New `src/channel.rs` module with trigger execution, match filter, and trust policy logic
- Updated `src/ingest.rs` with DKIM/SPF verification during ingest and trigger execution after save
- Updated `src/config.rs` with `trust` and `trusted_senders` fields on `MailboxConfig`
- Added `glob-match` crate dependency for glob pattern matching
- 53 new tests (136 unit + 29 integration = 165 total, up from 112)

## Test plan

- [x] Unit tests: template variable substitution (all variables, special characters)
- [x] Unit tests: match filter (from glob match/mismatch, subject match/mismatch, has_attachment true/false)
- [x] Unit tests: AND logic (partial match does not fire, full match fires)
- [x] Unit tests: trigger execution (success, multiple in order, failure does not panic, no rules, skips non-matching)
- [x] Unit tests: trust gating (none fires always, verified blocks on dkim!=pass, trusted_senders bypasses check)
- [x] Unit tests: DKIM/SPF result parsing (unsigned email produces none, IP extraction from Received headers)
- [x] Unit tests: config parsing (trust settings, default trust is none)
- [x] Integration test: ingest with trigger config → trigger command executed
- [x] Integration test: failing trigger does not affect email delivery
- [x] Integration test: trust=verified blocks unsigned trigger, email still saved
- [x] Integration test: trust=none allows unsigned trigger
- [x] Integration test: trusted_senders bypasses DKIM check
- [x] Integration test: frontmatter contains dkim/spf fields
- [x] All 165 tests pass, clippy clean, fmt clean