### PR TITLE
[Sprint 9] Migrate from YAML to TOML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -61,10 +61,10 @@ dependencies = [
  "schemars",
  "serde",
  "serde_json",
- "serde_yaml",
  "shell-escape",
  "tempfile",
  "tokio",
+ "toml",
  "uuid",
 ]
 
@@ -1825,12 +1825,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "ryu"
-version = "1.0.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
-
-[[package]]
 name = "schemars"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1933,16 +1927,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_yaml"
-version = "0.9.34+deprecated"
+name = "serde_spanned"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
- "indexmap",
- "itoa",
- "ryu",
  "serde",
- "unsafe-libyaml",
 ]
 
 [[package]]
@@ -2257,6 +2247,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "tracing"
 version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2316,12 +2347,6 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "unsafe-libyaml"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "673aac59facbab8a9007c7f6108d11f63b603f7cabff99fabf650fea5c32b861"
 
 [[package]]
 name = "untrusted"
@@ -2714,6 +2739,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2024"
 [dependencies]
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
-serde_yaml = "0.9"
+toml = "0.8"
 mail-parser = "0.9"
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4"] }

--- a/README.md
+++ b/README.md
@@ -25,13 +25,13 @@ Outbound:
 
 - **No daemon.** OpenSMTPD is the only long-running process. `aimx` commands are short-lived.
 - **No IMAP/POP3.** Agents read `.md` files via MCP or filesystem.
-- **Markdown-first.** Emails stored as Markdown with YAML frontmatter -- agents can `cat` and understand immediately.
+- **Markdown-first.** Emails stored as Markdown with TOML frontmatter -- agents can `cat` and understand immediately.
 - **Single binary.** Written in Rust. No runtime dependencies beyond OpenSMTPD.
 
 ## Features
 
 - **Setup wizard** -- preflight checks, OpenSMTPD config, DKIM keygen, DNS guidance, verification
-- **Email delivery** -- EML to Markdown with YAML frontmatter, attachment extraction, mailbox routing
+- **Email delivery** -- EML to Markdown with TOML frontmatter, attachment extraction, mailbox routing
 - **Email sending** -- RFC 5322 composition, DKIM signing (RSA-SHA256), threading support, attachments
 - **MCP server** -- stdio transport for Claude Code and any MCP client: list, read, send, reply, manage mailboxes
 - **Channel manager** -- trigger shell commands on incoming mail with match filters (from, subject, attachments)
@@ -183,51 +183,49 @@ aimx dkim-keygen --selector mykey
 
 ## Configuration
 
-Configuration is stored in `config.yaml` in the data directory (default: `/var/lib/aimx/`).
+Configuration is stored in `config.toml` in the data directory (default: `/var/lib/aimx/`).
 
-### config.yaml reference
+### config.toml reference
 
-```yaml
+```toml
 # Domain for this email server (required)
-domain: agent.yourdomain.com
+domain = "agent.yourdomain.com"
 
 # Data directory (default: /var/lib/aimx)
-data_dir: /var/lib/aimx
+data_dir = "/var/lib/aimx"
 
 # DKIM selector name (default: dkim)
-dkim_selector: dkim
+dkim_selector = "dkim"
 
-# Mailbox definitions
-mailboxes:
-  # Catchall mailbox (receives all unmatched addresses)
-  catchall:
-    address: "*@agent.yourdomain.com"
+# Catchall mailbox (receives all unmatched addresses)
+[mailboxes.catchall]
+address = "*@agent.yourdomain.com"
 
-  # Named mailbox
-  support:
-    address: support@agent.yourdomain.com
+# Named mailbox
+[mailboxes.support]
+address = "support@agent.yourdomain.com"
 
-    # Channel rules: trigger commands on incoming email
-    on_receive:
-      - type: cmd
-        command: 'echo "New email from {from}: {subject}" >> /tmp/email.log'
+# Trust policy (default: none)
+# none: all triggers fire regardless of DKIM/SPF
+# verified: triggers only fire on DKIM-pass emails
+trust = "verified"
 
-      - type: cmd
-        command: 'ntfy pub my-topic "Email from {from}: {subject}"'
-        match:
-          from: "*@gmail.com"        # Glob pattern on sender
-          subject: "urgent"          # Substring match (case-insensitive)
-          has_attachment: true        # Filter on attachment presence
+# Trusted senders bypass DKIM verification (glob patterns)
+trusted_senders = ["*@company.com", "boss@gmail.com"]
 
-    # Trust policy (default: none)
-    # none: all triggers fire regardless of DKIM/SPF
-    # verified: triggers only fire on DKIM-pass emails
-    trust: verified
+# Channel rules: trigger commands on incoming email
+[[mailboxes.support.on_receive]]
+type = "cmd"
+command = 'echo "New email from {from}: {subject}" >> /tmp/email.log'
 
-    # Trusted senders bypass DKIM verification (glob patterns)
-    trusted_senders:
-      - "*@company.com"
-      - "boss@gmail.com"
+[[mailboxes.support.on_receive]]
+type = "cmd"
+command = 'ntfy pub my-topic "Email from {from}: {subject}"'
+
+[mailboxes.support.on_receive.match]
+from = "*@gmail.com"        # Glob pattern on sender
+subject = "urgent"           # Substring match (case-insensitive)
+has_attachment = true        # Filter on attachment presence
 ```
 
 ### Channel manager template variables
@@ -259,7 +257,7 @@ Email is always stored regardless of trust result. Trust only gates trigger exec
 
 ```
 /var/lib/aimx/
-├── config.yaml
+├── config.toml
 ├── dkim/
 │   ├── private.key
 │   └── public.key
@@ -274,24 +272,24 @@ Email is always stored regardless of trust result. Trust only gates trigger exec
 
 ### Email format
 
-Emails are stored as Markdown with YAML frontmatter:
+Emails are stored as Markdown with TOML frontmatter:
 
 ```markdown
----
-id: "2025-01-15-001"
-message_id: "<abc123@example.com>"
-from: "Alice <alice@example.com>"
-to: "support@agent.yourdomain.com"
-subject: "Hello"
-date: "2025-01-15T10:30:00Z"
-in_reply_to: ""
-references: ""
-attachments: []
-mailbox: "support"
-read: false
-dkim: "pass"
-spf: "pass"
----
++++
+id = "2025-01-15-001"
+message_id = "<abc123@example.com>"
+from = "Alice <alice@example.com>"
+to = "support@agent.yourdomain.com"
+subject = "Hello"
+date = "2025-01-15T10:30:00Z"
+in_reply_to = ""
+references = ""
+attachments = []
+mailbox = "support"
+read = false
+dkim = "pass"
+spf = "pass"
++++
 
 Hello, this is the email body in plain text.
 ```

--- a/docs/idea.md
+++ b/docs/idea.md
@@ -63,7 +63,7 @@ Storage:
 
 - **No daemon.** OpenSMTPD is the only long-running process. It calls `aimx ingest` on each incoming message. The MCP server runs in stdio mode, launched on-demand by Claude Code. Nothing else needs to run.
 - **No IMAP/POP3/JMAP.** No mail clients will connect to this. Agents read `.md` files via MCP or filesystem. The mail server's only job is SMTP transport.
-- **`.md` first.** Emails are stored as Markdown with YAML frontmatter, not raw `.eml`. Agents can `cat` an email and understand it immediately. Attachments are extracted to a sibling directory.
+- **`.md` first.** Emails are stored as Markdown with TOML frontmatter, not raw `.eml`. Agents can `cat` an email and understand it immediately. Attachments are extracted to a sibling directory.
 - **DKIM signing in Rust.** Rather than depending on `opensmtpd-filter-dkimsign`, `aimx send` handles DKIM signing natively before handing the message to OpenSMTPD for delivery. Keeps the dependency tree minimal.
 - **Mailboxes are directories.** Creating a mailbox = creating a folder + registering an address. No OS users, no passwords, no database.
 
@@ -158,26 +158,27 @@ Also potentially link it to the website if user wants with a referral code.
 
 ## Email Format (.md)
 
-Incoming `.eml` is parsed and stored as Markdown with YAML frontmatter:
+Incoming `.eml` is parsed and stored as Markdown with TOML frontmatter:
 
 ```markdown
----
-id: "msg-2026-04-09-001"
-message_id: "<abc123@gmail.com>"
-from: "alice@example.com"
-to: "schedule@agent.mydomain.com"
-subject: "Meeting next Thursday"
-date: "2026-04-09T14:32:00+08:00"
-in_reply_to: null
-references: []
-attachments:
-  - filename: "agenda.pdf"
-    content_type: "application/pdf"
-    size: 45230
-    path: "attachments/agenda.pdf"
-mailbox: "schedule"
-read: false
----
++++
+id = "msg-2026-04-09-001"
+message_id = "<abc123@gmail.com>"
+from = "alice@example.com"
+to = "schedule@agent.mydomain.com"
+subject = "Meeting next Thursday"
+date = "2026-04-09T14:32:00+08:00"
+in_reply_to = ""
+references = ""
+mailbox = "schedule"
+read = false
+
+[[attachments]]
+filename = "agenda.pdf"
+content_type = "application/pdf"
+size = 45230
+path = "attachments/agenda.pdf"
++++
 
 Hi, can we schedule a meeting next Thursday at 2pm?
 I've attached the agenda.
@@ -229,7 +230,7 @@ email_mark_unread(mailbox: string, id: string)
 
 ```
 /var/lib/aimx/
-├── config.yaml               # mailbox definitions + channel rules
+├── config.toml               # mailbox definitions + channel rules
 ├── schedule/
 │   ├── 2026-04-09-001.md
 │   ├── 2026-04-09-002.md
@@ -257,40 +258,47 @@ match from any for domain "agent.mydomain.com" action "deliver"
 
 ## Channel Manager
 
-The channel manager triggers actions when emails arrive at specific mailboxes. Rules are defined in `config.yaml`.
+The channel manager triggers actions when emails arrive at specific mailboxes. Rules are defined in `config.toml`.
 
 ### Configuration
 
-```yaml
-domain: agent.mydomain.com
+```toml
+domain = "agent.mydomain.com"
 
-mailboxes:
-  schedule:
-    address: schedule@agent.mydomain.com
-    on_receive:
-      - type: cmd
-        command: 'claude -p "Handle this scheduling request: $(cat {filepath})"'
-  accounting:
-    address: accounting@agent.mydomain.com
-    on_receive:
-      - type: cmd
-        command: 'claude -p "Process this invoice: $(cat {filepath})"'
-        match:
-          has_attachment: true
-      - type: cmd
-        command: 'claude -p "Handle this accounting email: $(cat {filepath})"'
+[mailboxes.schedule]
+address = "schedule@agent.mydomain.com"
 
-  family:
-    address: family@agent.mydomain.com
-    on_receive:
-      - type: cmd
-        command: 'curl -X POST http://localhost:3000/api/family-inbox -d @{filepath}'
+[[mailboxes.schedule.on_receive]]
+type = "cmd"
+command = 'claude -p "Handle this scheduling request: $(cat {filepath})"'
 
-  catchall:
-    address: "*@agent.mydomain.com"
-    on_receive:
-      - type: cmd
-        command: 'ntfy pub agent-mail "New email: {subject} from {from}"'
+[mailboxes.accounting]
+address = "accounting@agent.mydomain.com"
+
+[[mailboxes.accounting.on_receive]]
+type = "cmd"
+command = 'claude -p "Process this invoice: $(cat {filepath})"'
+
+[mailboxes.accounting.on_receive.match]
+has_attachment = true
+
+[[mailboxes.accounting.on_receive]]
+type = "cmd"
+command = 'claude -p "Handle this accounting email: $(cat {filepath})"'
+
+[mailboxes.family]
+address = "family@agent.mydomain.com"
+
+[[mailboxes.family.on_receive]]
+type = "cmd"
+command = 'curl -X POST http://localhost:3000/api/family-inbox -d @{filepath}'
+
+[mailboxes.catchall]
+address = "*@agent.mydomain.com"
+
+[[mailboxes.catchall.on_receive]]
+type = "cmd"
+command = 'ntfy pub agent-mail "New email: {subject} from {from}"'
 ```
 
 ### Supported trigger types
@@ -301,16 +309,15 @@ mailboxes:
 
 Channel triggers execute shell commands on incoming mail. Without verification, anyone can email your agent and trigger actions. Trust policies gate trigger execution on sender authenticity.
 
-During `aimx ingest`, verify the sender's DKIM signature and SPF record using the `mail-auth` crate (same library used for outbound signing). Store the result in frontmatter (`dkim: pass|fail|none`, `spf: pass|fail|none`).
+During `aimx ingest`, verify the sender's DKIM signature and SPF record using the `mail-auth` crate (same library used for outbound signing). Store the result in frontmatter (`dkim = "pass|fail|none"`, `spf = "pass|fail|none"`).
 
-Per-mailbox trust policy in `config.yaml`:
+Per-mailbox trust policy in `config.toml`:
 
-```yaml
-schedule:
-  trust: verified          # only trigger on DKIM-pass emails
-  trusted_senders:         # optional allowlist (always trigger, skip verification)
-    - "*@company.com"
-    - "alice@gmail.com"
+```toml
+[mailboxes.schedule]
+trust = "verified"          # only trigger on DKIM-pass emails
+# optional allowlist (always trigger, skip verification)
+trusted_senders = ["*@company.com", "alice@gmail.com"]
 ```
 
 Trust modes:
@@ -323,11 +330,11 @@ Mail is always stored regardless of trust status. Trust only gates trigger execu
 
 Triggers can be conditionally filtered:
 
-```yaml
-match:
-  from: "*@company.com"
-  subject: "invoice"
-  has_attachment: true
+```toml
+[mailboxes.accounting.on_receive.match]
+from = "*@company.com"
+subject = "invoice"
+has_attachment = true
 ```
 
 All conditions must match (AND logic). If no `match` is specified, the trigger fires on every email to that mailbox.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -81,7 +81,7 @@ All routes expose sensitive communications to third parties, which is absurd whe
 ### 6.2 Email Delivery (`aimx ingest <rcpt>`)
 - FR-11: Accept raw `.eml` from OpenSMTPD via stdin.
 - FR-12: Parse MIME message: extract headers, body (prefer text/plain, fall back to text/html→plaintext), and attachments.
-- FR-13: Generate Markdown file with YAML frontmatter (id, message_id, from, to, subject, date, in_reply_to, references, attachments list, mailbox, read). Set `read: false` on ingest.
+- FR-13: Generate Markdown file with TOML frontmatter (id, message_id, from, to, subject, date, in_reply_to, references, attachments list, mailbox, read). Set `read: false` on ingest.
 - FR-14: Extract attachments to `attachments/` subdirectory within the mailbox folder.
 - FR-15: Route to correct mailbox directory based on RCPT TO local part. Unrecognized addresses go to `catchall`.
 - FR-16: Execute matching channel rules after saving. Trigger failures are logged but do not block delivery.
@@ -100,12 +100,12 @@ All routes expose sensitive communications to third parties, which is absurd whe
 - FR-25: Implement tools: `email_mark_read`, `email_mark_unread`.
 
 ### 6.5 Mailbox Management
-- FR-26: Create mailbox: create directory under `/var/lib/aimx/`, register address in `config.yaml`. No mail server restart required.
+- FR-26: Create mailbox: create directory under `/var/lib/aimx/`, register address in `config.toml`. No mail server restart required.
 - FR-27: List mailboxes with message counts.
 - FR-28: Delete mailbox with confirmation.
 
 ### 6.6 Channel Manager
-- FR-29: Read trigger rules from `config.yaml` per mailbox.
+- FR-29: Read trigger rules from `config.toml` per mailbox.
 - FR-30: Support `cmd` trigger type: execute shell command with template variables (`{filepath}`, `{from}`, `{to}`, `{subject}`, `{mailbox}`, `{id}`, `{date}`).
 - FR-31: Support optional match filters: `from` (glob), `subject` (substring), `has_attachment` (bool). All conditions AND.
 - FR-32: Execute triggers synchronously during delivery. Log failures, never block delivery.
@@ -140,13 +140,13 @@ All routes expose sensitive communications to third parties, which is absurd whe
 - **NFR-4: Linux only.** Target Debian/Ubuntu initially. Other distributions are best-effort.
 - **NFR-5: Minimal resource usage.** aimx ingest must complete in < 1 second for typical emails (< 10MB).
 - **NFR-6: Secure defaults.** Self-signed TLS cert for STARTTLS (generated during setup, no Let's Encrypt needed), DKIM signing on all outbound, DMARC reject policy, SPF strict.
-- **NFR-7: Filesystem-based storage.** No database. Mailboxes are directories. Configuration is YAML.
+- **NFR-7: Filesystem-based storage.** No database. Mailboxes are directories. Configuration is TOML.
 
 ## 8. Technical Considerations
 
 ### Language and Stack
 - **Rust** — single binary, no runtime, strong ecosystem for email/crypto.
-- Key crates: `mail-parser` (MIME parsing), `mail-auth` (DKIM signing), `rmcp` (MCP SDK), `clap` (CLI), `serde`+`serde_yaml` (config).
+- Key crates: `mail-parser` (MIME parsing), `mail-auth` (DKIM signing), `rmcp` (MCP SDK), `clap` (CLI), `serde`+`toml` (config).
 
 ### System Dependencies
 - **OpenSMTPD** — SMTP transport. Installed via `apt`. Configured by `aimx setup` to pipe all incoming mail to `aimx ingest`.
@@ -155,7 +155,7 @@ All routes expose sensitive communications to third parties, which is absurd whe
 ### Storage Layout
 ```
 /var/lib/aimx/
-├── config.yaml
+├── config.toml
 ├── dkim/
 │   ├── private.key
 │   └── public.key
@@ -209,7 +209,7 @@ All routes expose sensitive communications to third parties, which is absurd whe
 | M1: Core Pipeline | Receive and store email as Markdown | `aimx ingest`, EML→MD parser, attachment extraction, mailbox routing |
 | M2: Outbound | Send email with DKIM | `aimx send`, DKIM key generation, DKIM signing, RFC 5322 composition |
 | M3: MCP Server | Agent access via MCP | `aimx mcp` with all email/mailbox tools, stdio transport |
-| M4: Channel Manager | Trigger actions on incoming mail | `cmd` triggers, match filters, config.yaml rules |
+| M4: Channel Manager | Trigger actions on incoming mail | `cmd` triggers, match filters, config.toml rules |
 | M5: Inbound Trust | Gate triggers on sender verification | DKIM/SPF verification during ingest, per-mailbox trust policy, trusted_senders allowlist |
 | M6: Setup Wizard | One-command setup | `aimx setup`, preflight checks, OpenSMTPD config, DNS guidance, verification |
 | M7: Verify Service | Hosted verification endpoint | `check.aimx.email` probe, `verify@aimx.email` endpoint, self-hostable |
@@ -232,5 +232,5 @@ All routes expose sensitive communications to third parties, which is absurd whe
 2. **Email size limits** — Use OpenSMTPD defaults. No separate aimx limit. Trusted environment.
 3. **Mailbox deletion** — Deletes the directory and all emails. No archiving.
 4. **Config hot-reload** — Not needed. `aimx ingest` is short-lived and reads config on each invocation.
-5. **Read/unread tracking** — `read: false` field in YAML frontmatter, set on ingest. `email_mark_read` updates to `read: true`. Self-contained, grepable, no extra files.
+5. **Read/unread tracking** — `read = false` field in TOML frontmatter, set on ingest. `email_mark_read` updates to `read = true`. Self-contained, grepable, no extra files.
 

--- a/docs/sprint.md
+++ b/docs/sprint.md
@@ -939,7 +939,7 @@ One of these is wrong. Research suggests DigitalOcean's current policy is closer
 
 ---
 
-## Sprint 9 — Migrate from YAML to TOML (Days 22–24.5) [NOT STARTED]
+## Sprint 9 — Migrate from YAML to TOML (Days 22–24.5) [IN PROGRESS]
 
 **Goal:** Replace `serde_yaml` (unmaintained) with `toml` for both configuration and email frontmatter, aligning with idiomatic Rust ecosystem conventions.
 
@@ -1008,7 +1008,7 @@ One of these is wrong. Research suggests DigitalOcean's current policy is closer
 | 6 | 13–15.5 | Verify Service + Polish | Hosted probe, status/verify CLI, README | Done |
 | 7 | 16–18.5 | Security Hardening + Critical Fixes | DKIM enforcement, header injection fix, atomic ingest, verify race fix, setup e2e verify | Done |
 | 8 | 19–21.5 | Setup Robustness, CI & Documentation | DNS verification accuracy, data-dir propagation, SPF fix, configurable verify URLs, CI coverage, doc fixes | Done |
-| 9 | 22–24.5 | Migrate from YAML to TOML | Replace serde_yaml with toml crate for config and email frontmatter | Not Started |
+| 9 | 22–24.5 | Migrate from YAML to TOML | Replace serde_yaml with toml crate for config and email frontmatter | In Progress |
 
 ## Deferred to v2
 

--- a/services/verify/README.md
+++ b/services/verify/README.md
@@ -57,10 +57,10 @@ To self-host (replacing `check.aimx.email`):
 2. Point your domain's DNS to the server
 3. Configure a reverse proxy (nginx/caddy) for HTTPS
 4. Run with `BIND_ADDR=127.0.0.1:3025`
-5. In your aimx `config.yaml`, set `probe_url` and `verify_address`:
-   ```yaml
-   probe_url: "https://verify.yourdomain.com/probe"
-   verify_address: "verify@yourdomain.com"
+5. In your aimx `config.toml`, set `probe_url` and `verify_address`:
+   ```toml
+   probe_url = "https://verify.yourdomain.com/probe"
+   verify_address = "verify@yourdomain.com"
    ```
 
 For the email echo, additionally:

--- a/src/config.rs
+++ b/src/config.rs
@@ -71,18 +71,18 @@ fn default_dkim_selector() -> String {
 impl Config {
     pub fn load(path: &Path) -> Result<Self, Box<dyn std::error::Error>> {
         let content = std::fs::read_to_string(path)?;
-        let config: Config = serde_yaml::from_str(&content)?;
+        let config: Config = toml::from_str(&content)?;
         Ok(config)
     }
 
     pub fn save(&self, path: &Path) -> Result<(), Box<dyn std::error::Error>> {
-        let content = serde_yaml::to_string(self)?;
+        let content = toml::to_string_pretty(self)?;
         std::fs::write(path, content)?;
         Ok(())
     }
 
     pub fn config_path(data_dir: &Path) -> PathBuf {
-        data_dir.join("config.yaml")
+        data_dir.join("config.toml")
     }
 
     pub fn load_from_data_dir(data_dir: &Path) -> Result<Self, Box<dyn std::error::Error>> {
@@ -111,28 +111,31 @@ mod tests {
     use super::*;
     use tempfile::TempDir;
 
-    fn sample_yaml() -> &'static str {
+    fn sample_toml() -> &'static str {
         r#"
-domain: agent.example.com
-data_dir: /tmp/aimx-test
-mailboxes:
-  catchall:
-    address: "*@agent.example.com"
-  support:
-    address: support@agent.example.com
-    on_receive:
-      - type: cmd
-        command: 'echo "{from}" >> /tmp/log'
-        match:
-          from: "*@gmail.com"
-          subject: urgent
-          has_attachment: true
+domain = "agent.example.com"
+data_dir = "/tmp/aimx-test"
+
+[mailboxes.catchall]
+address = "*@agent.example.com"
+
+[mailboxes.support]
+address = "support@agent.example.com"
+
+[[mailboxes.support.on_receive]]
+type = "cmd"
+command = 'echo "{from}" >> /tmp/log'
+
+[mailboxes.support.on_receive.match]
+from = "*@gmail.com"
+subject = "urgent"
+has_attachment = true
 "#
     }
 
     #[test]
     fn parse_config() {
-        let config: Config = serde_yaml::from_str(sample_yaml()).unwrap();
+        let config: Config = toml::from_str(sample_toml()).unwrap();
         assert_eq!(config.domain, "agent.example.com");
         assert_eq!(config.data_dir, PathBuf::from("/tmp/aimx-test"));
         assert_eq!(config.mailboxes.len(), 2);
@@ -142,7 +145,7 @@ mailboxes:
 
     #[test]
     fn parse_on_receive_rules() {
-        let config: Config = serde_yaml::from_str(sample_yaml()).unwrap();
+        let config: Config = toml::from_str(sample_toml()).unwrap();
         let support = &config.mailboxes["support"];
         assert_eq!(support.on_receive.len(), 1);
         let rule = &support.on_receive[0];
@@ -156,15 +159,15 @@ mailboxes:
 
     #[test]
     fn default_data_dir() {
-        let yaml = "domain: test.com\nmailboxes: {}\n";
-        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let toml_str = "domain = \"test.com\"\n[mailboxes]\n";
+        let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(config.data_dir, PathBuf::from("/var/lib/aimx"));
     }
 
     #[test]
     fn save_and_load_roundtrip() {
         let tmp = TempDir::new().unwrap();
-        let path = tmp.path().join("config.yaml");
+        let path = tmp.path().join("config.toml");
 
         let mut mailboxes = HashMap::new();
         mailboxes.insert(
@@ -193,29 +196,27 @@ mailboxes:
 
     #[test]
     fn resolve_mailbox_known() {
-        let config: Config = serde_yaml::from_str(sample_yaml()).unwrap();
+        let config: Config = toml::from_str(sample_toml()).unwrap();
         assert_eq!(config.resolve_mailbox("support"), "support");
     }
 
     #[test]
     fn resolve_mailbox_unknown_falls_to_catchall() {
-        let config: Config = serde_yaml::from_str(sample_yaml()).unwrap();
+        let config: Config = toml::from_str(sample_toml()).unwrap();
         assert_eq!(config.resolve_mailbox("unknown"), "catchall");
     }
 
     #[test]
     fn parse_trust_settings() {
-        let yaml = r#"
-domain: test.com
-mailboxes:
-  secure:
-    address: secure@test.com
-    trust: verified
-    trusted_senders:
-      - "*@company.com"
-      - "boss@gmail.com"
+        let toml_str = r#"
+domain = "test.com"
+
+[mailboxes.secure]
+address = "secure@test.com"
+trust = "verified"
+trusted_senders = ["*@company.com", "boss@gmail.com"]
 "#;
-        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let config: Config = toml::from_str(toml_str).unwrap();
         let secure = &config.mailboxes["secure"];
         assert_eq!(secure.trust, "verified");
         assert_eq!(secure.trusted_senders.len(), 2);
@@ -225,13 +226,13 @@ mailboxes:
 
     #[test]
     fn default_trust_is_none() {
-        let yaml = r#"
-domain: test.com
-mailboxes:
-  catchall:
-    address: "*@test.com"
+        let toml_str = r#"
+domain = "test.com"
+
+[mailboxes.catchall]
+address = "*@test.com"
 "#;
-        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let config: Config = toml::from_str(toml_str).unwrap();
         let catchall = &config.mailboxes["catchall"];
         assert_eq!(catchall.trust, "none");
         assert!(catchall.trusted_senders.is_empty());
@@ -239,7 +240,7 @@ mailboxes:
 
     #[test]
     fn mailbox_dir() {
-        let config: Config = serde_yaml::from_str(sample_yaml()).unwrap();
+        let config: Config = toml::from_str(sample_toml()).unwrap();
         assert_eq!(
             config.mailbox_dir("support"),
             PathBuf::from("/tmp/aimx-test/support")
@@ -248,13 +249,14 @@ mailboxes:
 
     #[test]
     fn parse_probe_url_and_verify_address() {
-        let yaml = r#"
-domain: test.com
-mailboxes: {}
-probe_url: "https://probe.example.com/check"
-verify_address: "verify@custom.example.com"
+        let toml_str = r#"
+domain = "test.com"
+probe_url = "https://probe.example.com/check"
+verify_address = "verify@custom.example.com"
+
+[mailboxes]
 "#;
-        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(
             config.probe_url.as_deref(),
             Some("https://probe.example.com/check")
@@ -267,8 +269,8 @@ verify_address: "verify@custom.example.com"
 
     #[test]
     fn probe_url_and_verify_address_default_to_none() {
-        let yaml = "domain: test.com\nmailboxes: {}\n";
-        let config: Config = serde_yaml::from_str(yaml).unwrap();
+        let toml_str = "domain = \"test.com\"\n[mailboxes]\n";
+        let config: Config = toml::from_str(toml_str).unwrap();
         assert!(config.probe_url.is_none());
         assert!(config.verify_address.is_none());
     }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -445,11 +445,11 @@ fn create_file_atomic(
 }
 
 fn format_markdown(meta: &EmailMetadata, body: &str) -> String {
-    let yaml = serde_yaml::to_string(meta).expect("EmailMetadata must serialize to YAML");
+    let toml_str = toml::to_string_pretty(meta).expect("EmailMetadata must serialize to TOML");
     let mut result = String::new();
-    result.push_str("---\n");
-    result.push_str(&yaml);
-    result.push_str("---\n\n");
+    result.push_str("+++\n");
+    result.push_str(&toml_str);
+    result.push_str("+++\n\n");
     result.push_str(body);
 
     if !body.ends_with('\n') {
@@ -599,30 +599,20 @@ mod tests {
 
         let content = std::fs::read_to_string(entries[0].path()).unwrap();
 
-        let parts: Vec<&str> = content.splitn(3, "---").collect();
+        let parts: Vec<&str> = content.splitn(3, "+++").collect();
         assert!(parts.len() >= 3);
-        let yaml_str = parts[1].trim();
-        let parsed: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
-        let map = parsed.as_mapping().unwrap();
+        let toml_str = parts[1].trim();
+        let parsed: toml::Value = toml::from_str(toml_str).unwrap();
+        let table = parsed.as_table().unwrap();
 
-        let from_val = map
-            .get(&serde_yaml::Value::String("from".to_string()))
-            .unwrap()
-            .as_str()
-            .unwrap();
+        let from_val = table.get("from").unwrap().as_str().unwrap();
         assert_eq!(from_val, "sender@example.com");
 
-        let subject_val = map
-            .get(&serde_yaml::Value::String("subject".to_string()))
-            .unwrap()
-            .as_str()
-            .unwrap();
+        let subject_val = table.get("subject").unwrap().as_str().unwrap();
         assert_eq!(subject_val, "Hello");
 
-        let read_val = map
-            .get(&serde_yaml::Value::String("read".to_string()))
-            .unwrap();
-        assert_eq!(read_val, &serde_yaml::Value::Bool(false));
+        let read_val = table.get("read").unwrap();
+        assert_eq!(read_val, &toml::Value::Boolean(false));
 
         assert!(content.contains("This is a plain text email."));
     }
@@ -676,7 +666,7 @@ mod tests {
     }
 
     #[test]
-    fn frontmatter_valid_yaml() {
+    fn frontmatter_valid_toml() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
         ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
@@ -688,28 +678,26 @@ mod tests {
             .collect();
         let content = std::fs::read_to_string(entries[0].path()).unwrap();
 
-        let parts: Vec<&str> = content.splitn(3, "---").collect();
+        let parts: Vec<&str> = content.splitn(3, "+++").collect();
         assert!(parts.len() >= 3);
-        let yaml_str = parts[1].trim();
-        let yaml: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
-        let map = yaml.as_mapping().unwrap();
+        let toml_str = parts[1].trim();
+        let parsed: toml::Value = toml::from_str(toml_str).unwrap();
+        let table = parsed.as_table().unwrap();
 
-        assert!(map.contains_key(&serde_yaml::Value::String("id".to_string())));
-        assert!(map.contains_key(&serde_yaml::Value::String("message_id".to_string())));
-        assert!(map.contains_key(&serde_yaml::Value::String("from".to_string())));
-        assert!(map.contains_key(&serde_yaml::Value::String("to".to_string())));
-        assert!(map.contains_key(&serde_yaml::Value::String("subject".to_string())));
-        assert!(map.contains_key(&serde_yaml::Value::String("date".to_string())));
-        assert!(map.contains_key(&serde_yaml::Value::String("in_reply_to".to_string())));
-        assert!(map.contains_key(&serde_yaml::Value::String("references".to_string())));
-        assert!(map.contains_key(&serde_yaml::Value::String("attachments".to_string())));
-        assert!(map.contains_key(&serde_yaml::Value::String("mailbox".to_string())));
-        assert!(map.contains_key(&serde_yaml::Value::String("read".to_string())));
+        assert!(table.contains_key("id"));
+        assert!(table.contains_key("message_id"));
+        assert!(table.contains_key("from"));
+        assert!(table.contains_key("to"));
+        assert!(table.contains_key("subject"));
+        assert!(table.contains_key("date"));
+        assert!(table.contains_key("in_reply_to"));
+        assert!(table.contains_key("references"));
+        assert!(table.contains_key("attachments"));
+        assert!(table.contains_key("mailbox"));
+        assert!(table.contains_key("read"));
 
-        let read_val = map
-            .get(&serde_yaml::Value::String("read".to_string()))
-            .unwrap();
-        assert_eq!(read_val, &serde_yaml::Value::Bool(false));
+        let read_val = table.get("read").unwrap();
+        assert_eq!(read_val, &toml::Value::Boolean(false));
     }
 
     #[test]
@@ -745,28 +733,16 @@ mod tests {
             .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
             .collect();
         let md_content = std::fs::read_to_string(entries[0].path()).unwrap();
-        let parts: Vec<&str> = md_content.splitn(3, "---").collect();
-        let yaml_str = parts[1].trim();
-        let parsed: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
-        let map = parsed.as_mapping().unwrap();
-        let attachments = map
-            .get(&serde_yaml::Value::String("attachments".to_string()))
-            .unwrap()
-            .as_sequence()
-            .unwrap();
+        let parts: Vec<&str> = md_content.splitn(3, "+++").collect();
+        let toml_str = parts[1].trim();
+        let parsed: toml::Value = toml::from_str(toml_str).unwrap();
+        let table = parsed.as_table().unwrap();
+        let attachments = table.get("attachments").unwrap().as_array().unwrap();
         assert_eq!(attachments.len(), 1);
-        let att = attachments[0].as_mapping().unwrap();
-        let filename = att
-            .get(&serde_yaml::Value::String("filename".to_string()))
-            .unwrap()
-            .as_str()
-            .unwrap();
+        let att = attachments[0].as_table().unwrap();
+        let filename = att.get("filename").unwrap().as_str().unwrap();
         assert_eq!(filename, "notes.txt");
-        let path_val = att
-            .get(&serde_yaml::Value::String("path".to_string()))
-            .unwrap()
-            .as_str()
-            .unwrap();
+        let path_val = att.get("path").unwrap().as_str().unwrap();
         assert_eq!(path_val, "attachments/notes.txt");
     }
 
@@ -809,15 +785,11 @@ mod tests {
             .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
             .collect();
         let md_content = std::fs::read_to_string(entries[0].path()).unwrap();
-        let parts: Vec<&str> = md_content.splitn(3, "---").collect();
-        let yaml_str = parts[1].trim();
-        let parsed: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
-        let map = parsed.as_mapping().unwrap();
-        let attachments = map
-            .get(&serde_yaml::Value::String("attachments".to_string()))
-            .unwrap()
-            .as_sequence()
-            .unwrap();
+        let parts: Vec<&str> = md_content.splitn(3, "+++").collect();
+        let toml_str = parts[1].trim();
+        let parsed: toml::Value = toml::from_str(toml_str).unwrap();
+        let table = parsed.as_table().unwrap();
+        let attachments = table.get("attachments").unwrap().as_array().unwrap();
         assert!(attachments.is_empty());
     }
 
@@ -859,11 +831,11 @@ mod tests {
     }
 
     #[test]
-    fn serde_yaml_handles_special_characters() {
+    fn toml_handles_special_characters() {
         let meta = EmailMetadata {
             id: "2025-01-01-001".to_string(),
             message_id: "<test@example.com>".to_string(),
-            from: "test\n---\ninjected: true".to_string(),
+            from: "test\n+++\ninjected: true".to_string(),
             to: "to@test.com".to_string(),
             subject: "colons: and #hashes".to_string(),
             date: "2025-01-01T00:00:00Z".to_string(),
@@ -876,13 +848,11 @@ mod tests {
             spf: "none".to_string(),
         };
 
-        let yaml = serde_yaml::to_string(&meta).unwrap();
-        let parsed: serde_yaml::Value = serde_yaml::from_str(&yaml).unwrap();
-        let map = parsed.as_mapping().unwrap();
-        let from = map
-            .get(&serde_yaml::Value::String("from".to_string()))
-            .unwrap();
-        assert_eq!(from.as_str().unwrap(), "test\n---\ninjected: true");
+        let toml_str = toml::to_string_pretty(&meta).unwrap();
+        let parsed: toml::Value = toml::from_str(&toml_str).unwrap();
+        let table = parsed.as_table().unwrap();
+        let from = table.get("from").unwrap();
+        assert_eq!(from.as_str().unwrap(), "test\n+++\ninjected: true");
     }
 
     #[test]
@@ -897,23 +867,15 @@ mod tests {
             .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
             .collect();
         let content = std::fs::read_to_string(entries[0].path()).unwrap();
-        let parts: Vec<&str> = content.splitn(3, "---").collect();
-        let yaml_str = parts[1].trim();
-        let parsed: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
-        let map = parsed.as_mapping().unwrap();
+        let parts: Vec<&str> = content.splitn(3, "+++").collect();
+        let toml_str = parts[1].trim();
+        let parsed: toml::Value = toml::from_str(toml_str).unwrap();
+        let table = parsed.as_table().unwrap();
 
-        let dkim = map
-            .get(&serde_yaml::Value::String("dkim".to_string()))
-            .unwrap()
-            .as_str()
-            .unwrap();
+        let dkim = table.get("dkim").unwrap().as_str().unwrap();
         assert_eq!(dkim, "none");
 
-        let spf = map
-            .get(&serde_yaml::Value::String("spf".to_string()))
-            .unwrap()
-            .as_str()
-            .unwrap();
+        let spf = table.get("spf").unwrap().as_str().unwrap();
         assert_eq!(spf, "none");
     }
 
@@ -971,13 +933,13 @@ mod tests {
             .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
             .collect();
         let content = std::fs::read_to_string(entries[0].path()).unwrap();
-        let parts: Vec<&str> = content.splitn(3, "---").collect();
-        let yaml_str = parts[1].trim();
-        let parsed: serde_yaml::Value = serde_yaml::from_str(yaml_str).unwrap();
-        let map = parsed.as_mapping().unwrap();
+        let parts: Vec<&str> = content.splitn(3, "+++").collect();
+        let toml_str = parts[1].trim();
+        let parsed: toml::Value = toml::from_str(toml_str).unwrap();
+        let table = parsed.as_table().unwrap();
 
-        assert!(map.contains_key(&serde_yaml::Value::String("dkim".to_string())));
-        assert!(map.contains_key(&serde_yaml::Value::String("spf".to_string())));
+        assert!(table.contains_key("dkim"));
+        assert!(table.contains_key("spf"));
     }
 
     #[test]
@@ -1025,8 +987,8 @@ mod tests {
         assert_eq!(entries.len(), 1);
 
         let content = std::fs::read_to_string(entries[0].path()).unwrap();
-        assert!(content.contains("subject: Test DKIM signed email from Gmail"));
-        assert!(content.contains("from: Test User <testuser@gmail.com>"));
+        assert!(content.contains("subject = \"Test DKIM signed email from Gmail\""));
+        assert!(content.contains("from = \"Test User <testuser@gmail.com>\""));
         assert!(content.contains("CAB1234567890abcdef@mail.gmail.com"));
     }
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -430,12 +430,12 @@ pub fn list_emails(
 }
 
 pub fn parse_frontmatter(content: &str) -> Option<EmailMetadata> {
-    let parts: Vec<&str> = content.splitn(3, "---").collect();
+    let parts: Vec<&str> = content.splitn(3, "+++").collect();
     if parts.len() < 3 {
         return None;
     }
-    let yaml_str = parts[1].trim();
-    serde_yaml::from_str(yaml_str).ok()
+    let toml_str = parts[1].trim();
+    toml::from_str(toml_str).ok()
 }
 
 pub fn filter_emails(
@@ -507,25 +507,25 @@ pub fn set_read_status(config: &Config, mailbox: &str, id: &str, read: bool) -> 
     let content =
         std::fs::read_to_string(&filepath).map_err(|e| format!("Failed to read email: {e}"))?;
 
-    let parts: Vec<&str> = content.splitn(3, "---").collect();
+    let parts: Vec<&str> = content.splitn(3, "+++").collect();
     if parts.len() < 3 {
         return Err("Invalid email format.".to_string());
     }
 
-    let yaml_str = parts[1].trim();
+    let toml_str = parts[1].trim();
     let mut meta: EmailMetadata =
-        serde_yaml::from_str(yaml_str).map_err(|e| format!("Failed to parse frontmatter: {e}"))?;
+        toml::from_str(toml_str).map_err(|e| format!("Failed to parse frontmatter: {e}"))?;
 
     meta.read = read;
 
-    let yaml = serde_yaml::to_string(&meta)
+    let new_toml = toml::to_string_pretty(&meta)
         .map_err(|e| format!("Failed to serialize frontmatter: {e}"))?;
     let body = parts[2];
 
     let mut result = String::new();
-    result.push_str("---\n");
-    result.push_str(&yaml);
-    result.push_str("---");
+    result.push_str("+++\n");
+    result.push_str(&new_toml);
+    result.push_str("+++");
     result.push_str(body);
 
     std::fs::write(&filepath, result).map_err(|e| format!("Failed to write email: {e}"))?;
@@ -602,8 +602,8 @@ mod tests {
 
     fn create_test_email(dir: &std::path::Path, id: &str, meta: &EmailMetadata) {
         std::fs::create_dir_all(dir).unwrap();
-        let yaml = serde_yaml::to_string(meta).unwrap();
-        let content = format!("---\n{yaml}---\n\nThis is the body of email {id}.\n");
+        let toml_str = toml::to_string_pretty(meta).unwrap();
+        let content = format!("+++\n{toml_str}+++\n\nThis is the body of email {id}.\n");
         std::fs::write(dir.join(format!("{id}.md")), content).unwrap();
     }
 
@@ -628,8 +628,8 @@ mod tests {
     #[test]
     fn parse_frontmatter_valid() {
         let meta = sample_meta("2025-06-01-001", "sender@example.com", "Hello", false);
-        let yaml = serde_yaml::to_string(&meta).unwrap();
-        let content = format!("---\n{yaml}---\n\nBody text.\n");
+        let toml_str = toml::to_string_pretty(&meta).unwrap();
+        let content = format!("+++\n{toml_str}+++\n\nBody text.\n");
 
         let parsed = parse_frontmatter(&content).unwrap();
         assert_eq!(parsed.id, "2025-06-01-001");

--- a/src/status.rs
+++ b/src/status.rs
@@ -90,7 +90,7 @@ fn gather_recent_activity(config: &Config) -> Vec<RecentEmail> {
                 None => continue,
             };
 
-            let meta: EmailMetadata = match serde_yaml::from_str(&fm) {
+            let meta: EmailMetadata = match toml::from_str(&fm) {
                 Ok(m) => m,
                 Err(_) => continue,
             };
@@ -150,7 +150,7 @@ fn is_unread(path: &Path) -> bool {
         None => return false,
     };
 
-    match serde_yaml::from_str::<EmailMetadata>(&frontmatter) {
+    match toml::from_str::<EmailMetadata>(&frontmatter) {
         Ok(meta) => !meta.read,
         Err(_) => false,
     }
@@ -158,12 +158,12 @@ fn is_unread(path: &Path) -> bool {
 
 fn extract_frontmatter(content: &str) -> Option<String> {
     let trimmed = content.trim_start();
-    if !trimmed.starts_with("---") {
+    if !trimmed.starts_with("+++") {
         return None;
     }
 
     let after_first = &trimmed[3..];
-    let end = after_first.find("---")?;
+    let end = after_first.find("+++")?;
     Some(after_first[..end].to_string())
 }
 
@@ -313,10 +313,10 @@ mod tests {
 
     #[test]
     fn extract_frontmatter_valid() {
-        let content = "---\nid: test\nread: false\n---\nBody here";
+        let content = "+++\nid = \"test\"\nread = false\n+++\nBody here";
         let fm = extract_frontmatter(content).unwrap();
-        assert!(fm.contains("id: test"));
-        assert!(fm.contains("read: false"));
+        assert!(fm.contains("id = \"test\""));
+        assert!(fm.contains("read = false"));
     }
 
     #[test]
@@ -326,7 +326,7 @@ mod tests {
 
     #[test]
     fn extract_frontmatter_no_end_marker() {
-        assert!(extract_frontmatter("---\nid: test\nno end").is_none());
+        assert!(extract_frontmatter("+++\nid = \"test\"\nno end").is_none());
     }
 
     #[test]
@@ -348,8 +348,8 @@ mod tests {
     fn count_messages_with_emails() {
         let tmp = tempfile::TempDir::new().unwrap();
 
-        let unread_content = "---\nid: \"001\"\nmessage_id: \"<a@b>\"\nfrom: \"a@b\"\nto: \"c@d\"\nsubject: \"Test\"\ndate: \"2025-01-01\"\nin_reply_to: \"\"\nreferences: \"\"\nattachments: []\nmailbox: \"catchall\"\nread: false\ndkim: \"none\"\nspf: \"none\"\n---\nBody";
-        let read_content = "---\nid: \"002\"\nmessage_id: \"<a@b>\"\nfrom: \"a@b\"\nto: \"c@d\"\nsubject: \"Test\"\ndate: \"2025-01-01\"\nin_reply_to: \"\"\nreferences: \"\"\nattachments: []\nmailbox: \"catchall\"\nread: true\ndkim: \"none\"\nspf: \"none\"\n---\nBody";
+        let unread_content = "+++\nid = \"001\"\nmessage_id = \"<a@b>\"\nfrom = \"a@b\"\nto = \"c@d\"\nsubject = \"Test\"\ndate = \"2025-01-01\"\nin_reply_to = \"\"\nreferences = \"\"\nattachments = []\nmailbox = \"catchall\"\nread = false\ndkim = \"none\"\nspf = \"none\"\n+++\nBody";
+        let read_content = "+++\nid = \"002\"\nmessage_id = \"<a@b>\"\nfrom = \"a@b\"\nto = \"c@d\"\nsubject = \"Test\"\ndate = \"2025-01-01\"\nin_reply_to = \"\"\nreferences = \"\"\nattachments = []\nmailbox = \"catchall\"\nread = true\ndkim = \"none\"\nspf = \"none\"\n+++\nBody";
 
         std::fs::write(tmp.path().join("2025-01-01-001.md"), unread_content).unwrap();
         std::fs::write(tmp.path().join("2025-01-01-002.md"), read_content).unwrap();
@@ -365,7 +365,7 @@ mod tests {
     fn is_unread_true() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.md");
-        let content = "---\nid: \"001\"\nmessage_id: \"<a@b>\"\nfrom: \"a@b\"\nto: \"c@d\"\nsubject: \"Test\"\ndate: \"2025-01-01\"\nin_reply_to: \"\"\nreferences: \"\"\nattachments: []\nmailbox: \"catchall\"\nread: false\ndkim: \"none\"\nspf: \"none\"\n---\nBody";
+        let content = "+++\nid = \"001\"\nmessage_id = \"<a@b>\"\nfrom = \"a@b\"\nto = \"c@d\"\nsubject = \"Test\"\ndate = \"2025-01-01\"\nin_reply_to = \"\"\nreferences = \"\"\nattachments = []\nmailbox = \"catchall\"\nread = false\ndkim = \"none\"\nspf = \"none\"\n+++\nBody";
         std::fs::write(&path, content).unwrap();
         assert!(is_unread(&path));
     }
@@ -374,7 +374,7 @@ mod tests {
     fn is_unread_false() {
         let tmp = tempfile::TempDir::new().unwrap();
         let path = tmp.path().join("test.md");
-        let content = "---\nid: \"001\"\nmessage_id: \"<a@b>\"\nfrom: \"a@b\"\nto: \"c@d\"\nsubject: \"Test\"\ndate: \"2025-01-01\"\nin_reply_to: \"\"\nreferences: \"\"\nattachments: []\nmailbox: \"catchall\"\nread: true\ndkim: \"none\"\nspf: \"none\"\n---\nBody";
+        let content = "+++\nid = \"001\"\nmessage_id = \"<a@b>\"\nfrom = \"a@b\"\nto = \"c@d\"\nsubject = \"Test\"\ndate = \"2025-01-01\"\nin_reply_to = \"\"\nreferences = \"\"\nattachments = []\nmailbox = \"catchall\"\nread = true\ndkim = \"none\"\nspf = \"none\"\n+++\nBody";
         std::fs::write(&path, content).unwrap();
         assert!(!is_unread(&path));
     }
@@ -477,7 +477,7 @@ mod tests {
         let catchall = data_dir.join("catchall");
         std::fs::create_dir_all(&catchall).unwrap();
 
-        let email_content = "---\nid: \"2025-01-15-001\"\nmessage_id: \"<a@b>\"\nfrom: \"alice@example.com\"\nto: \"c@d\"\nsubject: \"Test email\"\ndate: \"2025-01-15T10:30:00Z\"\nin_reply_to: \"\"\nreferences: \"\"\nattachments: []\nmailbox: \"catchall\"\nread: false\ndkim: \"none\"\nspf: \"none\"\n---\nBody here";
+        let email_content = "+++\nid = \"2025-01-15-001\"\nmessage_id = \"<a@b>\"\nfrom = \"alice@example.com\"\nto = \"c@d\"\nsubject = \"Test email\"\ndate = \"2025-01-15T10:30:00Z\"\nin_reply_to = \"\"\nreferences = \"\"\nattachments = []\nmailbox = \"catchall\"\nread = false\ndkim = \"none\"\nspf = \"none\"\n+++\nBody here";
         std::fs::write(catchall.join("2025-01-15-001.md"), email_content).unwrap();
 
         let mut mailboxes = std::collections::HashMap::new();

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -106,7 +106,7 @@ fn list_md_files(dir: &Path) -> Vec<String> {
 }
 
 fn print_verification_result(content: &str) {
-    let parts: Vec<&str> = content.splitn(3, "---").collect();
+    let parts: Vec<&str> = content.splitn(3, "+++").collect();
     if parts.len() >= 3 {
         let body = parts[2].trim();
         if !body.is_empty() {
@@ -145,7 +145,7 @@ mod tests {
 
     #[test]
     fn print_verification_result_does_not_panic() {
-        let content = "---\nid: test\n---\nDKIM: pass\nSPF: pass\n";
+        let content = "+++\nid = \"test\"\n+++\nDKIM: pass\nSPF: pass\n";
         print_verification_result(content);
     }
 
@@ -166,14 +166,14 @@ mod tests {
 
     #[test]
     fn resolve_verify_address_uses_default() {
-        let config: Config = serde_yaml::from_str("domain: test.com\nmailboxes: {}\n").unwrap();
+        let config: Config = toml::from_str("domain = \"test.com\"\n[mailboxes]\n").unwrap();
         assert_eq!(resolve_verify_address(&config), "verify@aimx.email");
     }
 
     #[test]
     fn resolve_verify_address_uses_custom() {
-        let config: Config = serde_yaml::from_str(
-            "domain: test.com\nmailboxes: {}\nverify_address: verify@custom.example.com\n",
+        let config: Config = toml::from_str(
+            "domain = \"test.com\"\nverify_address = \"verify@custom.example.com\"\n[mailboxes]\n",
         )
         .unwrap();
         assert_eq!(resolve_verify_address(&config), "verify@custom.example.com");
@@ -184,10 +184,10 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         // Create config but no catchall directory
         let config_content = format!(
-            "domain: test.com\ndata_dir: {}\nmailboxes:\n  catchall:\n    address: \"*@test.com\"\n",
+            "domain = \"test.com\"\ndata_dir = \"{}\"\n\n[mailboxes.catchall]\naddress = \"*@test.com\"\n",
             tmp.path().display()
         );
-        std::fs::write(tmp.path().join("config.yaml"), config_content).unwrap();
+        std::fs::write(tmp.path().join("config.toml"), config_content).unwrap();
 
         let result = run(Some(tmp.path()));
         assert!(result.is_err());

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -7,30 +7,28 @@ use tempfile::TempDir;
 
 fn setup_test_env(tmp: &Path) -> String {
     let config_content = format!(
-        "domain: agent.example.com\ndata_dir: {}\nmailboxes:\n  catchall:\n    address: \"*@agent.example.com\"\n  alice:\n    address: alice@agent.example.com\n",
+        "domain = \"agent.example.com\"\ndata_dir = \"{}\"\n\n[mailboxes.catchall]\naddress = \"*@agent.example.com\"\n\n[mailboxes.alice]\naddress = \"alice@agent.example.com\"\n",
         tmp.display()
     );
     std::fs::create_dir_all(tmp.join("catchall")).unwrap();
     std::fs::create_dir_all(tmp.join("alice")).unwrap();
-    let config_path = tmp.join("config.yaml");
+    let config_path = tmp.join("config.toml");
     std::fs::write(&config_path, &config_content).unwrap();
     config_path.to_string_lossy().to_string()
 }
 
-fn read_frontmatter(md_path: &Path) -> serde_yaml::Value {
+fn read_frontmatter(md_path: &Path) -> toml::Value {
     let content = std::fs::read_to_string(md_path).unwrap();
-    let parts: Vec<&str> = content.splitn(3, "---").collect();
+    let parts: Vec<&str> = content.splitn(3, "+++").collect();
     assert!(
         parts.len() >= 3,
         "Markdown file missing frontmatter delimiters"
     );
-    serde_yaml::from_str(parts[1].trim()).unwrap()
+    toml::from_str(parts[1].trim()).unwrap()
 }
 
-fn get_yaml_str<'a>(map: &'a serde_yaml::Mapping, key: &str) -> &'a str {
-    map.get(&serde_yaml::Value::String(key.to_string()))
-        .and_then(|v| v.as_str())
-        .unwrap_or("")
+fn get_toml_str<'a>(table: &'a toml::Table, key: &str) -> &'a str {
+    table.get(key).and_then(|v| v.as_str()).unwrap_or("")
 }
 
 fn find_md_files(dir: &Path) -> Vec<std::path::PathBuf> {
@@ -91,16 +89,12 @@ fn ingest_plain_fixture_full_pipeline() {
     assert_eq!(md_files.len(), 1);
 
     let parsed = read_frontmatter(&md_files[0]);
-    let map = parsed.as_mapping().unwrap();
-    assert_eq!(get_yaml_str(map, "from"), "Alice <alice@example.com>");
-    assert_eq!(get_yaml_str(map, "subject"), "Plain text test");
-    assert_eq!(get_yaml_str(map, "message_id"), "plain-001@example.com");
-    assert_eq!(get_yaml_str(map, "mailbox"), "catchall");
-    assert_eq!(
-        map.get(&serde_yaml::Value::String("read".to_string()))
-            .unwrap(),
-        &serde_yaml::Value::Bool(false)
-    );
+    let table = parsed.as_table().unwrap();
+    assert_eq!(get_toml_str(table, "from"), "Alice <alice@example.com>");
+    assert_eq!(get_toml_str(table, "subject"), "Plain text test");
+    assert_eq!(get_toml_str(table, "message_id"), "plain-001@example.com");
+    assert_eq!(get_toml_str(table, "mailbox"), "catchall");
+    assert_eq!(table.get("read").unwrap(), &toml::Value::Boolean(false));
 
     let content = std::fs::read_to_string(&md_files[0]).unwrap();
     assert!(content.contains("This is a plain text email for testing."));
@@ -126,8 +120,8 @@ fn ingest_html_fixture_full_pipeline() {
     assert_eq!(md_files.len(), 1);
 
     let parsed = read_frontmatter(&md_files[0]);
-    let map = parsed.as_mapping().unwrap();
-    assert_eq!(get_yaml_str(map, "subject"), "HTML only test");
+    let table = parsed.as_table().unwrap();
+    assert_eq!(get_toml_str(table, "subject"), "HTML only test");
 
     let content = std::fs::read_to_string(&md_files[0]).unwrap();
     assert!(content.contains("Hello from HTML"));
@@ -183,21 +177,11 @@ fn ingest_attachment_fixture_full_pipeline() {
     assert!(att_content.contains("This is the content of the attached file."));
 
     let parsed = read_frontmatter(&md_files[0]);
-    let map = parsed.as_mapping().unwrap();
-    let attachments = map
-        .get(&serde_yaml::Value::String("attachments".to_string()))
-        .unwrap()
-        .as_sequence()
-        .unwrap();
+    let table = parsed.as_table().unwrap();
+    let attachments = table.get("attachments").unwrap().as_array().unwrap();
     assert_eq!(attachments.len(), 1);
-    let att = attachments[0].as_mapping().unwrap();
-    assert_eq!(
-        att.get(&serde_yaml::Value::String("filename".to_string()))
-            .unwrap()
-            .as_str()
-            .unwrap(),
-        "readme.txt"
-    );
+    let att = attachments[0].as_table().unwrap();
+    assert_eq!(att.get("filename").unwrap().as_str().unwrap(), "readme.txt");
 }
 
 #[test]
@@ -541,7 +525,7 @@ fn mcp_mailbox_delete_catchall_error() {
 fn create_email_file(dir: &Path, id: &str, from: &str, subject: &str, read: bool) {
     std::fs::create_dir_all(dir).unwrap();
     let content = format!(
-        "---\nid: {id}\nmessage_id: \"<{id}@test.com>\"\nfrom: {from}\nto: alice@test.com\nsubject: {subject}\ndate: '2025-06-01T12:00:00Z'\nin_reply_to: ''\nreferences: ''\nattachments: []\nmailbox: alice\nread: {read}\n---\n\nBody of {id}.\n"
+        "+++\nid = \"{id}\"\nmessage_id = \"<{id}@test.com>\"\nfrom = \"{from}\"\nto = \"alice@test.com\"\nsubject = \"{subject}\"\ndate = \"2025-06-01T12:00:00Z\"\nin_reply_to = \"\"\nreferences = \"\"\nattachments = []\nmailbox = \"alice\"\nread = {read}\ndkim = \"none\"\nspf = \"none\"\n+++\n\nBody of {id}.\n"
     );
     std::fs::write(dir.join(format!("{id}.md")), content).unwrap();
 }
@@ -654,7 +638,7 @@ fn mcp_email_mark_read_unread() {
     assert!(text.contains("marked as read"));
 
     let content = std::fs::read_to_string(tmp.path().join("alice/2025-06-01-001.md")).unwrap();
-    assert!(content.contains("read: true"));
+    assert!(content.contains("read = true"));
 
     let resp = client.call_tool(
         "email_mark_unread",
@@ -664,7 +648,7 @@ fn mcp_email_mark_read_unread() {
     assert!(text.contains("marked as unread"));
 
     let content = std::fs::read_to_string(tmp.path().join("alice/2025-06-01-001.md")).unwrap();
-    assert!(content.contains("read: false"));
+    assert!(content.contains("read = false"));
 
     client.shutdown();
 }
@@ -731,20 +715,21 @@ fn mcp_clean_exit_on_stdin_close() {
 
 fn setup_test_env_with_triggers(tmp: &Path, trigger_marker: &Path) -> String {
     let config_content = format!(
-        r#"domain: agent.example.com
-data_dir: {}
-mailboxes:
-  catchall:
-    address: "*@agent.example.com"
-    on_receive:
-      - type: cmd
-        command: 'touch {}'
+        r#"domain = "agent.example.com"
+data_dir = "{}"
+
+[mailboxes.catchall]
+address = "*@agent.example.com"
+
+[[mailboxes.catchall.on_receive]]
+type = "cmd"
+command = "touch {}"
 "#,
         tmp.display(),
         trigger_marker.display()
     );
     std::fs::create_dir_all(tmp.join("catchall")).unwrap();
-    let config_path = tmp.join("config.yaml");
+    let config_path = tmp.join("config.toml");
     std::fs::write(&config_path, &config_content).unwrap();
     config_path.to_string_lossy().to_string()
 }
@@ -778,19 +763,20 @@ fn ingest_trigger_executes_on_delivery() {
 fn ingest_failing_trigger_does_not_block_delivery() {
     let tmp = TempDir::new().unwrap();
     let config_content = format!(
-        r#"domain: agent.example.com
-data_dir: {}
-mailboxes:
-  catchall:
-    address: "*@agent.example.com"
-    on_receive:
-      - type: cmd
-        command: 'false'
+        r#"domain = "agent.example.com"
+data_dir = "{}"
+
+[mailboxes.catchall]
+address = "*@agent.example.com"
+
+[[mailboxes.catchall.on_receive]]
+type = "cmd"
+command = "false"
 "#,
         tmp.path().display()
     );
     std::fs::create_dir_all(tmp.path().join("catchall")).unwrap();
-    std::fs::write(tmp.path().join("config.yaml"), &config_content).unwrap();
+    std::fs::write(tmp.path().join("config.toml"), &config_content).unwrap();
 
     let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
 
@@ -817,21 +803,22 @@ fn ingest_trust_verified_blocks_unsigned_trigger() {
     let tmp = TempDir::new().unwrap();
     let marker = tmp.path().join("should_not_exist");
     let config_content = format!(
-        r#"domain: agent.example.com
-data_dir: {}
-mailboxes:
-  catchall:
-    address: "*@agent.example.com"
-    trust: verified
-    on_receive:
-      - type: cmd
-        command: 'touch {}'
+        r#"domain = "agent.example.com"
+data_dir = "{}"
+
+[mailboxes.catchall]
+address = "*@agent.example.com"
+trust = "verified"
+
+[[mailboxes.catchall.on_receive]]
+type = "cmd"
+command = "touch {}"
 "#,
         tmp.path().display(),
         marker.display()
     );
     std::fs::create_dir_all(tmp.path().join("catchall")).unwrap();
-    std::fs::write(tmp.path().join("config.yaml"), &config_content).unwrap();
+    std::fs::write(tmp.path().join("config.toml"), &config_content).unwrap();
 
     let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
 
@@ -858,21 +845,22 @@ fn ingest_trust_none_allows_unsigned_trigger() {
     let tmp = TempDir::new().unwrap();
     let marker = tmp.path().join("triggered");
     let config_content = format!(
-        r#"domain: agent.example.com
-data_dir: {}
-mailboxes:
-  catchall:
-    address: "*@agent.example.com"
-    trust: none
-    on_receive:
-      - type: cmd
-        command: 'touch {}'
+        r#"domain = "agent.example.com"
+data_dir = "{}"
+
+[mailboxes.catchall]
+address = "*@agent.example.com"
+trust = "none"
+
+[[mailboxes.catchall.on_receive]]
+type = "cmd"
+command = "touch {}"
 "#,
         tmp.path().display(),
         marker.display()
     );
     std::fs::create_dir_all(tmp.path().join("catchall")).unwrap();
-    std::fs::write(tmp.path().join("config.yaml"), &config_content).unwrap();
+    std::fs::write(tmp.path().join("config.toml"), &config_content).unwrap();
 
     let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
 
@@ -914,15 +902,15 @@ fn ingest_frontmatter_contains_dkim_spf() {
     assert_eq!(md_files.len(), 1);
 
     let parsed = read_frontmatter(&md_files[0]);
-    let map = parsed.as_mapping().unwrap();
+    let table = parsed.as_table().unwrap();
 
-    let dkim = get_yaml_str(map, "dkim");
+    let dkim = get_toml_str(table, "dkim");
     assert!(
         dkim == "none" || dkim == "pass" || dkim == "fail",
         "dkim should be pass|fail|none, got: {dkim}"
     );
 
-    let spf = get_yaml_str(map, "spf");
+    let spf = get_toml_str(table, "spf");
     assert!(
         spf == "none" || spf == "pass" || spf == "fail",
         "spf should be pass|fail|none, got: {spf}"
@@ -934,23 +922,23 @@ fn ingest_trusted_sender_bypasses_dkim() {
     let tmp = TempDir::new().unwrap();
     let marker = tmp.path().join("triggered");
     let config_content = format!(
-        r#"domain: agent.example.com
-data_dir: {}
-mailboxes:
-  catchall:
-    address: "*@agent.example.com"
-    trust: verified
-    trusted_senders:
-      - "*@example.com"
-    on_receive:
-      - type: cmd
-        command: 'touch {}'
+        r#"domain = "agent.example.com"
+data_dir = "{}"
+
+[mailboxes.catchall]
+address = "*@agent.example.com"
+trust = "verified"
+trusted_senders = ["*@example.com"]
+
+[[mailboxes.catchall.on_receive]]
+type = "cmd"
+command = "touch {}"
 "#,
         tmp.path().display(),
         marker.display()
     );
     std::fs::create_dir_all(tmp.path().join("catchall")).unwrap();
-    std::fs::write(tmp.path().join("config.yaml"), &config_content).unwrap();
+    std::fs::write(tmp.path().join("config.toml"), &config_content).unwrap();
 
     let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
 


### PR DESCRIPTION
## Summary

- **S9.1 - Config migration**: Replace `serde_yaml` with `toml` crate in `Cargo.toml`. `Config::load()` reads `config.toml` via `toml::from_str`, `Config::save()` writes via `toml::to_string_pretty`. All references to `config.yaml` updated to `config.toml` throughout code, tests, and docs.
- **S9.2 - Frontmatter migration**: Email `.md` files now use `+++` delimiters with TOML format instead of `---` with YAML. All frontmatter serialization (`ingest.rs`) and parsing (`mcp.rs`, `status.rs`, `verify.rs`) migrated. All `serde_yaml::Value`/`Mapping` test assertions replaced with `toml::Value`/`Table` equivalents.
- **Zero remaining `serde_yaml` imports** in the codebase. All 293 tests pass (258 unit + 35 integration). `cargo clippy -- -D warnings` and `cargo fmt -- --check` clean.

## Test plan

- [x] All 258 unit tests pass (`cargo test --bin aimx`)
- [x] All 35 integration tests pass (`cargo test --test integration`)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Config roundtrip: save + load produces identical Config struct
- [x] Email ingest produces `.md` files with `+++` TOML frontmatter
- [x] MCP email_mark_read/unread correctly parses and rewrites TOML frontmatter
- [x] Status command correctly counts read/unread from TOML frontmatter
- [x] Verify command correctly extracts body from `+++` delimited files
- [x] No `serde_yaml` references remain in source, test, or Cargo files