### PR TITLE
Skip recommended packages when installing OpenSMTPD

### DIFF
--- a/docs/manual-setup.md
+++ b/docs/manual-setup.md
@@ -99,7 +99,7 @@ The echo component requires an MTA to receive email and pipe it to `aimx-verify 
 **Install OpenSMTPD:**
 
 ```bash
-sudo apt-get update && sudo apt-get install -y opensmtpd
+sudo apt-get update && sudo apt-get install -y --no-install-recommends opensmtpd
 ```
 
 **Generate a TLS certificate** (self-signed or use Let's Encrypt):
@@ -259,7 +259,7 @@ sudo aimx setup agent.yourdomain.com
 The setup wizard performs these steps automatically:
 
 1. Runs preflight checks (port 25 outbound/inbound, PTR)
-2. Installs OpenSMTPD via `apt-get install opensmtpd`
+2. Installs OpenSMTPD via `apt-get install --no-install-recommends opensmtpd` (skips `opensmtpd-extras`, which pulls in unused MySQL/PostgreSQL/Redis/SQLite client libraries)
 3. Generates a self-signed TLS certificate at `/etc/ssl/aimx/`
 4. Writes `/etc/smtpd.conf` (backs up any existing config)
 5. Restarts OpenSMTPD

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -54,7 +54,7 @@ impl SystemOps for RealSystemOps {
 
     fn install_package(&self, package: &str) -> Result<(), Box<dyn std::error::Error>> {
         let status = std::process::Command::new("sudo")
-            .args(["apt-get", "install", "-y", package])
+            .args(["apt-get", "install", "-y", "--no-install-recommends", package])
             .status()?;
         if !status.success() {
             return Err(format!("Failed to install {package}").into());

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -54,7 +54,13 @@ impl SystemOps for RealSystemOps {
 
     fn install_package(&self, package: &str) -> Result<(), Box<dyn std::error::Error>> {
         let status = std::process::Command::new("sudo")
-            .args(["apt-get", "install", "-y", "--no-install-recommends", package])
+            .args([
+                "apt-get",
+                "install",
+                "-y",
+                "--no-install-recommends",
+                package,
+            ])
             .status()?;
         if !status.success() {
             return Err(format!("Failed to install {package}").into());


### PR DESCRIPTION
## Summary
This PR adds the `--no-install-recommends` flag to the `apt-get install` command for OpenSMTPD to reduce unnecessary dependencies.

## Changes
- Updated the package installation command in `src/setup.rs` to include `--no-install-recommends` flag
- Updated documentation in `docs/manual-setup.md` to reflect the new installation approach and explain the rationale

## Details
The `--no-install-recommends` flag prevents apt from installing recommended packages, which in the case of OpenSMTPD includes `opensmtpd-extras`. This package pulls in unused database client libraries (MySQL, PostgreSQL, Redis, SQLite) that are not needed for the AIMX setup, reducing the installation footprint and improving security by minimizing unnecessary dependencies.

This change applies to both:
1. Manual setup instructions
2. Automated setup wizard in the Rust codebase

https://claude.ai/code/session_01DnviQoymTk33WpVozVH3Ss