### PR TITLE
Rename probe_url to verify_host, add --verify-host flag

### DIFF
--- a/docs/guide/configuration.md
+++ b/docs/guide/configuration.md
@@ -30,7 +30,7 @@ The `--data-dir` flag takes precedence over the environment variable.
 | `domain` | string | *(required)* | The email domain (e.g. `agent.yourdomain.com`) |
 | `data_dir` | string | `/var/lib/aimx` | Directory for storing config, keys, and mailboxes |
 | `dkim_selector` | string | `dkim` | DKIM selector name used in DNS records |
-| `probe_url` | string | *(unset)* | Custom verify service URL (defaults to `check.aimx.email`) |
+| `verify_host` | string | `https://check.aimx.email` | Base URL of the verify service used by `aimx verify`, `setup`, and `preflight`. Can be overridden per-invocation with the `--verify-host` flag. |
 
 ### Mailbox settings
 
@@ -87,8 +87,8 @@ data_dir = "/var/lib/aimx"
 # DKIM selector name (default: dkim)
 dkim_selector = "dkim"
 
-# Custom verify service URL (optional)
-# probe_url = "https://verify.yourdomain.com/probe"
+# Custom verify service host (optional)
+# verify_host = "https://verify.yourdomain.com"
 
 # ----------------------------
 # Mailboxes

--- a/docs/guide/setup.md
+++ b/docs/guide/setup.md
@@ -258,7 +258,12 @@ If you prefer not to use the public instance:
 
 4. Point aimx to your instance in `config.toml`:
    ```toml
-   probe_url = "https://verify.yourdomain.com/probe"
+   verify_host = "https://verify.yourdomain.com"
+   ```
+
+   Or override it per-invocation with `--verify-host`:
+   ```
+   aimx verify --verify-host https://verify.yourdomain.com
    ```
 
 The verify service provides:

--- a/docs/guide/troubleshooting.md
+++ b/docs/guide/troubleshooting.md
@@ -13,7 +13,12 @@ aimx status
 
 # Check port 25 connectivity (outbound and inbound)
 aimx verify
+
+# Test against a self-hosted verify service instead of the default
+aimx verify --verify-host https://verify.yourdomain.com
 ```
+
+The `--verify-host` flag is also accepted by `aimx setup` and `aimx preflight`, and overrides the `verify_host` value from `config.toml` for the current invocation.
 
 ## Common issues
 

--- a/services/verify/README.md
+++ b/services/verify/README.md
@@ -46,9 +46,15 @@ To self-host (replacing `check.aimx.email`):
 2. Point your domain's DNS to the server
 3. Configure a reverse proxy (Caddy/nginx) for HTTPS on the HTTP port
 4. Run with `BIND_ADDR=127.0.0.1:3025`
-5. In your aimx `config.toml`, set `probe_url`:
+5. In your aimx `config.toml`, set `verify_host` to the base URL of your instance (no path):
    ```toml
-   probe_url = "https://verify.yourdomain.com/probe"
+   verify_host = "https://verify.yourdomain.com"
+   ```
+   aimx appends `/probe` to this base URL when making the HTTP check.
+
+   You can also override it per-invocation:
+   ```
+   aimx verify --verify-host https://verify.yourdomain.com
    ```
 
 No MTA, no email sending, no DNS records needed on the verify server -- it only needs:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -41,16 +41,28 @@ pub enum Command {
     Setup {
         /// Domain to configure (e.g. agent.example.com)
         domain: String,
+
+        /// Override the verify service host (e.g. https://verify.example.com)
+        #[arg(long)]
+        verify_host: Option<String>,
     },
 
     /// Show server status, mailbox counts, and configuration
     Status,
 
     /// Run preflight checks (port 25, PTR) without installing anything
-    Preflight,
+    Preflight {
+        /// Override the verify service host (e.g. https://verify.example.com)
+        #[arg(long)]
+        verify_host: Option<String>,
+    },
 
     /// Check port 25 connectivity (outbound, inbound EHLO, PTR)
-    Verify,
+    Verify {
+        /// Override the verify service host (e.g. https://verify.example.com)
+        #[arg(long)]
+        verify_host: Option<String>,
+    },
 
     /// Generate DKIM keypair for email signing
     DkimKeygen {

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,7 +18,7 @@ pub struct Config {
     pub mailboxes: HashMap<String, MailboxConfig>,
 
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub probe_url: Option<String>,
+    pub verify_host: Option<String>,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
@@ -182,7 +182,7 @@ has_attachment = true
             data_dir: tmp.path().to_path_buf(),
             dkim_selector: "dkim".to_string(),
             mailboxes,
-            probe_url: None,
+            verify_host: None,
         };
 
         config.save(&path).unwrap();
@@ -244,25 +244,25 @@ address = "*@test.com"
     }
 
     #[test]
-    fn parse_probe_url() {
+    fn parse_verify_host() {
         let toml_str = r#"
 domain = "test.com"
-probe_url = "https://probe.example.com/check"
+verify_host = "https://verify.example.com"
 
 [mailboxes]
 "#;
         let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(
-            config.probe_url.as_deref(),
-            Some("https://probe.example.com/check")
+            config.verify_host.as_deref(),
+            Some("https://verify.example.com")
         );
     }
 
     #[test]
-    fn probe_url_defaults_to_none() {
+    fn verify_host_defaults_to_none() {
         let toml_str = "domain = \"test.com\"\n[mailboxes]\n";
         let config: Config = toml::from_str(toml_str).unwrap();
-        assert!(config.probe_url.is_none());
+        assert!(config.verify_host.is_none());
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -272,4 +272,19 @@ verify_host = "https://verify.example.com"
         let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(config.domain, "test.com");
     }
+
+    #[test]
+    fn legacy_probe_url_field_silently_ignored() {
+        // Pre-rename configs used `probe_url`; serde drops unknown fields so those
+        // configs still load, but `verify_host` is left unset (falls back to default).
+        let toml_str = r#"
+domain = "test.com"
+probe_url = "https://old.example.com/probe"
+
+[mailboxes]
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.domain, "test.com");
+        assert!(config.verify_host.is_none());
+    }
 }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -491,7 +491,7 @@ mod tests {
             data_dir: tmp.to_path_buf(),
             dkim_selector: "dkim".to_string(),
             mailboxes,
-            probe_url: None,
+            verify_host: None,
         }
     }
 

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -170,7 +170,7 @@ mod tests {
             data_dir: tmp.to_path_buf(),
             dkim_selector: "dkim".to_string(),
             mailboxes,
-            probe_url: None,
+            verify_host: None,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,25 +35,24 @@ fn main() {
             Ok(rt) => rt.block_on(mcp::run(cli.data_dir.as_deref())),
             Err(e) => Err(format!("Failed to create runtime: {e}").into()),
         },
-        Command::Setup { domain } => {
+        Command::Setup {
+            domain,
+            verify_host,
+        } => {
             let sys = setup::RealSystemOps;
-            let probe_url = load_config(cli.data_dir.as_deref())
-                .ok()
-                .and_then(|c| c.probe_url)
-                .unwrap_or_else(|| setup::DEFAULT_PROBE_URL.to_string());
-            let net = setup::RealNetworkOps::from_probe_url(probe_url);
+            let host = resolve_verify_host(verify_host.as_deref(), cli.data_dir.as_deref());
+            let net = setup::RealNetworkOps::from_verify_host(host);
             setup::run_setup(&domain, cli.data_dir.as_deref(), &sys, &net)
         }
         Command::Status => status::run(cli.data_dir.as_deref()),
-        Command::Preflight => {
-            let probe_url = load_config(cli.data_dir.as_deref())
-                .ok()
-                .and_then(|c| c.probe_url)
-                .unwrap_or_else(|| setup::DEFAULT_PROBE_URL.to_string());
-            let net = setup::RealNetworkOps::from_probe_url(probe_url);
+        Command::Preflight { verify_host } => {
+            let host = resolve_verify_host(verify_host.as_deref(), cli.data_dir.as_deref());
+            let net = setup::RealNetworkOps::from_verify_host(host);
             setup::run_preflight_command(&net)
         }
-        Command::Verify => verify::run(cli.data_dir.as_deref()),
+        Command::Verify { verify_host } => {
+            verify::run(cli.data_dir.as_deref(), verify_host.as_deref())
+        }
     };
 
     if let Err(e) = result {
@@ -67,4 +66,14 @@ fn load_config(data_dir: Option<&Path>) -> Result<config::Config, Box<dyn std::e
         Some(dir) => config::Config::load_from_data_dir(dir),
         None => config::Config::load_default(),
     }
+}
+
+fn resolve_verify_host(cli_override: Option<&str>, data_dir: Option<&Path>) -> String {
+    if let Some(host) = cli_override {
+        return host.to_string();
+    }
+    load_config(data_dir)
+        .ok()
+        .and_then(|c| c.verify_host)
+        .unwrap_or_else(|| setup::DEFAULT_VERIFY_HOST.to_string())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,8 +16,14 @@ use std::path::Path;
 
 fn main() {
     let cli = Cli::parse();
+    if let Err(e) = dispatch(cli) {
+        eprintln!("Error: {e}");
+        std::process::exit(1);
+    }
+}
 
-    let result = match cli.command {
+fn dispatch(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
+    match cli.command {
         Command::Ingest { rcpt } => ingest::run(&rcpt, cli.data_dir.as_deref()),
         Command::Send(args) => send::run(args, cli.data_dir.as_deref()),
         Command::Mailbox(cmd) => mailbox::run(cmd, cli.data_dir.as_deref()),
@@ -31,33 +37,27 @@ fn main() {
             };
             dkim::run_keygen(&config.data_dir, &config.domain, &selector, force)
         }
-        Command::Mcp => match tokio::runtime::Runtime::new() {
-            Ok(rt) => rt.block_on(mcp::run(cli.data_dir.as_deref())),
-            Err(e) => Err(format!("Failed to create runtime: {e}").into()),
-        },
+        Command::Mcp => {
+            let rt = tokio::runtime::Runtime::new()
+                .map_err(|e| format!("Failed to create runtime: {e}"))?;
+            rt.block_on(mcp::run(cli.data_dir.as_deref()))
+        }
         Command::Setup {
             domain,
             verify_host,
         } => {
             let sys = setup::RealSystemOps;
-            let host = resolve_verify_host(verify_host.as_deref(), cli.data_dir.as_deref());
-            let net = setup::RealNetworkOps::from_verify_host(host);
+            let net = build_network_ops(verify_host.as_deref(), cli.data_dir.as_deref())?;
             setup::run_setup(&domain, cli.data_dir.as_deref(), &sys, &net)
         }
         Command::Status => status::run(cli.data_dir.as_deref()),
         Command::Preflight { verify_host } => {
-            let host = resolve_verify_host(verify_host.as_deref(), cli.data_dir.as_deref());
-            let net = setup::RealNetworkOps::from_verify_host(host);
+            let net = build_network_ops(verify_host.as_deref(), cli.data_dir.as_deref())?;
             setup::run_preflight_command(&net)
         }
         Command::Verify { verify_host } => {
             verify::run(cli.data_dir.as_deref(), verify_host.as_deref())
         }
-    };
-
-    if let Err(e) = result {
-        eprintln!("Error: {e}");
-        std::process::exit(1);
     }
 }
 
@@ -68,12 +68,12 @@ fn load_config(data_dir: Option<&Path>) -> Result<config::Config, Box<dyn std::e
     }
 }
 
-fn resolve_verify_host(cli_override: Option<&str>, data_dir: Option<&Path>) -> String {
-    if let Some(host) = cli_override {
-        return host.to_string();
-    }
-    load_config(data_dir)
-        .ok()
-        .and_then(|c| c.verify_host)
-        .unwrap_or_else(|| setup::DEFAULT_VERIFY_HOST.to_string())
+fn build_network_ops(
+    cli_override: Option<&str>,
+    data_dir: Option<&Path>,
+) -> Result<setup::RealNetworkOps, Box<dyn std::error::Error>> {
+    let config = load_config(data_dir).ok();
+    let host =
+        verify::resolve_verify_host(cli_override, config.as_ref(), setup::DEFAULT_VERIFY_HOST);
+    setup::RealNetworkOps::from_verify_host(host)
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -589,7 +589,7 @@ mod tests {
             data_dir: tmp.to_path_buf(),
             dkim_selector: "dkim".to_string(),
             mailboxes,
-            probe_url: None,
+            verify_host: None,
         }
     }
 

--- a/src/send.rs
+++ b/src/send.rs
@@ -820,7 +820,7 @@ mod tests {
             data_dir: tmp.path().to_path_buf(),
             dkim_selector: "dkim".to_string(),
             mailboxes,
-            probe_url: None,
+            verify_host: None,
         };
         config
             .save(&crate::config::Config::config_path(tmp.path()))

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -185,6 +185,7 @@ pub const DEFAULT_VERIFY_HOST: &str = "https://check.aimx.email";
 
 pub const DEFAULT_CHECK_SERVICE_SMTP_ADDR: &str = "check.aimx.email:25";
 
+#[derive(Debug)]
 pub struct RealNetworkOps {
     pub verify_host: String,
     pub check_service_smtp_addr: String,
@@ -200,28 +201,51 @@ impl Default for RealNetworkOps {
 }
 
 impl RealNetworkOps {
-    pub fn from_verify_host(verify_host: String) -> Self {
+    pub fn from_verify_host(verify_host: String) -> Result<Self, Box<dyn std::error::Error>> {
         let trimmed = verify_host.trim_end_matches('/').to_string();
+        validate_verify_host(&trimmed)?;
         let smtp_addr = derive_smtp_addr_from_verify_host(&trimmed);
-        Self {
+        Ok(Self {
             verify_host: trimmed,
             check_service_smtp_addr: smtp_addr,
-        }
+        })
     }
 }
 
+pub fn validate_verify_host(verify_host: &str) -> Result<(), Box<dyn std::error::Error>> {
+    if verify_host.is_empty() {
+        return Err("verify-host cannot be empty".into());
+    }
+    if !verify_host.starts_with("http://") && !verify_host.starts_with("https://") {
+        return Err(format!(
+            "verify-host must start with http:// or https:// (got: {verify_host})"
+        )
+        .into());
+    }
+    Ok(())
+}
+
 pub fn derive_smtp_addr_from_verify_host(verify_host: &str) -> String {
-    // Extract host from URL like "https://check.aimx.email"
+    // Extract authority (host[:port]) from URL like "https://check.aimx.email:3025/probe"
     let without_scheme = verify_host
         .strip_prefix("https://")
         .or_else(|| verify_host.strip_prefix("http://"))
         .unwrap_or(verify_host);
-    let host = without_scheme.split('/').next().unwrap_or(without_scheme);
-    // Strip port if present
-    let host = if host.contains(':') {
-        host.split(':').next().unwrap_or(host)
-    } else {
-        host
+    let authority = without_scheme.split('/').next().unwrap_or(without_scheme);
+
+    // Bracketed IPv6 literal: [::1] or [::1]:3025
+    if let Some(rest) = authority.strip_prefix('[')
+        && let Some(end) = rest.find(']')
+    {
+        let ipv6 = &rest[..end];
+        return format!("[{ipv6}]:25");
+    }
+
+    // Hostname or IPv4: strip :port if present (rsplit handles hosts safely since
+    // non-IPv6 hosts have at most one colon — the port separator).
+    let host = match authority.rsplit_once(':') {
+        Some((h, _port)) => h,
+        None => authority,
     };
     format!("{host}:25")
 }
@@ -1197,16 +1221,44 @@ mod tests {
 
     #[test]
     fn real_network_ops_custom_verify_host() {
-        let net = RealNetworkOps::from_verify_host("https://verify.custom.example.com".to_string());
+        let net = RealNetworkOps::from_verify_host("https://verify.custom.example.com".to_string())
+            .unwrap();
         assert_eq!(net.verify_host, "https://verify.custom.example.com");
         assert_eq!(net.check_service_smtp_addr, "verify.custom.example.com:25");
     }
 
     #[test]
     fn real_network_ops_from_verify_host_strips_trailing_slash() {
-        let net = RealNetworkOps::from_verify_host("https://check.aimx.email/".to_string());
+        let net =
+            RealNetworkOps::from_verify_host("https://check.aimx.email/".to_string()).unwrap();
         assert_eq!(net.verify_host, "https://check.aimx.email");
         assert_eq!(net.check_service_smtp_addr, "check.aimx.email:25");
+    }
+
+    #[test]
+    fn from_verify_host_rejects_empty() {
+        let err = RealNetworkOps::from_verify_host(String::new()).unwrap_err();
+        assert!(err.to_string().contains("cannot be empty"));
+    }
+
+    #[test]
+    fn from_verify_host_rejects_bare_hostname() {
+        let err = RealNetworkOps::from_verify_host("check.aimx.email".to_string()).unwrap_err();
+        assert!(err.to_string().contains("http://"));
+    }
+
+    #[test]
+    fn from_verify_host_rejects_non_http_scheme() {
+        let err =
+            RealNetworkOps::from_verify_host("ftp://verify.example.com".to_string()).unwrap_err();
+        assert!(err.to_string().contains("http://"));
+    }
+
+    #[test]
+    fn from_verify_host_rejects_only_slashes() {
+        // trailing-slash strip reduces "/" to empty
+        let err = RealNetworkOps::from_verify_host("/".to_string()).unwrap_err();
+        assert!(err.to_string().contains("cannot be empty"));
     }
 
     #[test]
@@ -1980,8 +2032,32 @@ mod tests {
     }
 
     #[test]
+    fn derive_smtp_addr_from_ipv6_literal_with_port() {
+        assert_eq!(
+            derive_smtp_addr_from_verify_host("https://[::1]:3025"),
+            "[::1]:25"
+        );
+    }
+
+    #[test]
+    fn derive_smtp_addr_from_ipv6_literal_without_port() {
+        assert_eq!(
+            derive_smtp_addr_from_verify_host("https://[2001:db8::1]"),
+            "[2001:db8::1]:25"
+        );
+    }
+
+    #[test]
+    fn derive_smtp_addr_from_ipv6_literal_with_path() {
+        assert_eq!(
+            derive_smtp_addr_from_verify_host("https://[::1]:8080/probe"),
+            "[::1]:25"
+        );
+    }
+
+    #[test]
     fn real_network_ops_from_verify_host() {
-        let net = RealNetworkOps::from_verify_host("https://check.aimx.email".to_string());
+        let net = RealNetworkOps::from_verify_host("https://check.aimx.email".to_string()).unwrap();
         assert_eq!(net.verify_host, "https://check.aimx.email");
         assert_eq!(net.check_service_smtp_addr, "check.aimx.email:25");
     }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -181,40 +181,41 @@ pub fn parse_port25_status(ss_output: &str) -> Result<Port25Status, Box<dyn std:
     Ok(Port25Status::OtherMta("unknown".to_string()))
 }
 
-pub const DEFAULT_PROBE_URL: &str = "https://check.aimx.email/probe";
+pub const DEFAULT_VERIFY_HOST: &str = "https://check.aimx.email";
 
 pub const DEFAULT_CHECK_SERVICE_SMTP_ADDR: &str = "check.aimx.email:25";
 
 pub struct RealNetworkOps {
-    pub probe_url: String,
+    pub verify_host: String,
     pub check_service_smtp_addr: String,
 }
 
 impl Default for RealNetworkOps {
     fn default() -> Self {
         Self {
-            probe_url: DEFAULT_PROBE_URL.to_string(),
+            verify_host: DEFAULT_VERIFY_HOST.to_string(),
             check_service_smtp_addr: DEFAULT_CHECK_SERVICE_SMTP_ADDR.to_string(),
         }
     }
 }
 
 impl RealNetworkOps {
-    pub fn from_probe_url(probe_url: String) -> Self {
-        let smtp_addr = derive_smtp_addr_from_probe_url(&probe_url);
+    pub fn from_verify_host(verify_host: String) -> Self {
+        let trimmed = verify_host.trim_end_matches('/').to_string();
+        let smtp_addr = derive_smtp_addr_from_verify_host(&trimmed);
         Self {
-            probe_url,
+            verify_host: trimmed,
             check_service_smtp_addr: smtp_addr,
         }
     }
 }
 
-pub fn derive_smtp_addr_from_probe_url(probe_url: &str) -> String {
-    // Extract host from URL like "https://check.aimx.email/probe"
-    let without_scheme = probe_url
+pub fn derive_smtp_addr_from_verify_host(verify_host: &str) -> String {
+    // Extract host from URL like "https://check.aimx.email"
+    let without_scheme = verify_host
         .strip_prefix("https://")
-        .or_else(|| probe_url.strip_prefix("http://"))
-        .unwrap_or(probe_url);
+        .or_else(|| verify_host.strip_prefix("http://"))
+        .unwrap_or(verify_host);
     let host = without_scheme.split('/').next().unwrap_or(without_scheme);
     // Strip port if present
     let host = if host.contains(':') {
@@ -243,8 +244,9 @@ impl NetworkOps for RealNetworkOps {
     }
 
     fn check_inbound_port25(&self) -> Result<bool, Box<dyn std::error::Error>> {
+        let probe_url = format!("{}/probe", self.verify_host);
         let resp = std::process::Command::new("curl")
-            .args(["-s", "-m", "60", &self.probe_url])
+            .args(["-s", "-m", "60", &probe_url])
             .output();
 
         match resp {
@@ -844,7 +846,7 @@ pub fn finalize_setup(
             data_dir: data_dir.to_path_buf(),
             dkim_selector: dkim_selector.to_string(),
             mailboxes,
-            probe_url: None,
+            verify_host: None,
         };
         cfg.save(&config_path)?;
         cfg
@@ -1188,17 +1190,23 @@ mod tests {
     }
 
     #[test]
-    fn real_network_ops_default_probe_url() {
+    fn real_network_ops_default_verify_host() {
         let net = RealNetworkOps::default();
-        assert_eq!(net.probe_url, DEFAULT_PROBE_URL);
+        assert_eq!(net.verify_host, DEFAULT_VERIFY_HOST);
     }
 
     #[test]
-    fn real_network_ops_custom_probe_url() {
-        let net =
-            RealNetworkOps::from_probe_url("https://probe.custom.example.com/check".to_string());
-        assert_eq!(net.probe_url, "https://probe.custom.example.com/check");
-        assert_eq!(net.check_service_smtp_addr, "probe.custom.example.com:25");
+    fn real_network_ops_custom_verify_host() {
+        let net = RealNetworkOps::from_verify_host("https://verify.custom.example.com".to_string());
+        assert_eq!(net.verify_host, "https://verify.custom.example.com");
+        assert_eq!(net.check_service_smtp_addr, "verify.custom.example.com:25");
+    }
+
+    #[test]
+    fn real_network_ops_from_verify_host_strips_trailing_slash() {
+        let net = RealNetworkOps::from_verify_host("https://check.aimx.email/".to_string());
+        assert_eq!(net.verify_host, "https://check.aimx.email");
+        assert_eq!(net.check_service_smtp_addr, "check.aimx.email:25");
     }
 
     #[test]
@@ -1950,7 +1958,7 @@ mod tests {
     #[test]
     fn derive_smtp_addr_from_https_url() {
         assert_eq!(
-            derive_smtp_addr_from_probe_url("https://check.aimx.email/probe"),
+            derive_smtp_addr_from_verify_host("https://check.aimx.email"),
             "check.aimx.email:25"
         );
     }
@@ -1958,23 +1966,23 @@ mod tests {
     #[test]
     fn derive_smtp_addr_from_http_url() {
         assert_eq!(
-            derive_smtp_addr_from_probe_url("http://probe.custom.example.com/check"),
-            "probe.custom.example.com:25"
+            derive_smtp_addr_from_verify_host("http://verify.custom.example.com"),
+            "verify.custom.example.com:25"
         );
     }
 
     #[test]
     fn derive_smtp_addr_from_url_with_port() {
         assert_eq!(
-            derive_smtp_addr_from_probe_url("https://check.aimx.email:3025/probe"),
+            derive_smtp_addr_from_verify_host("https://check.aimx.email:3025"),
             "check.aimx.email:25"
         );
     }
 
     #[test]
-    fn real_network_ops_from_probe_url() {
-        let net = RealNetworkOps::from_probe_url("https://check.aimx.email/probe".to_string());
-        assert_eq!(net.probe_url, "https://check.aimx.email/probe");
+    fn real_network_ops_from_verify_host() {
+        let net = RealNetworkOps::from_verify_host("https://check.aimx.email".to_string());
+        assert_eq!(net.verify_host, "https://check.aimx.email");
         assert_eq!(net.check_service_smtp_addr, "check.aimx.email:25");
     }
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -405,7 +405,7 @@ mod tests {
             data_dir: data_dir.to_path_buf(),
             dkim_selector: "dkim".to_string(),
             mailboxes,
-            probe_url: None,
+            verify_host: None,
         };
 
         let info = gather_status(&config);
@@ -495,7 +495,7 @@ mod tests {
             data_dir: data_dir.to_path_buf(),
             dkim_selector: "dkim".to_string(),
             mailboxes,
-            probe_url: None,
+            verify_host: None,
         };
 
         let activity = gather_recent_activity(&config);

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,21 +1,33 @@
 use crate::config::Config;
-use crate::setup::{self, DEFAULT_PROBE_URL, NetworkOps};
+use crate::setup::{self, DEFAULT_VERIFY_HOST, NetworkOps};
 use std::path::Path;
 
-pub fn run(data_dir: Option<&Path>) -> Result<(), Box<dyn std::error::Error>> {
+pub fn run(
+    data_dir: Option<&Path>,
+    host_override: Option<&str>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let config = match data_dir {
         Some(dir) => Config::load_from_data_dir(dir).ok(),
         None => Config::load_default().ok(),
     };
 
-    let probe_url = config
-        .as_ref()
-        .and_then(|c| c.probe_url.clone())
-        .unwrap_or_else(|| DEFAULT_PROBE_URL.to_string());
-
-    let net = setup::RealNetworkOps::from_probe_url(probe_url);
+    let verify_host = resolve_verify_host(host_override, config.as_ref(), DEFAULT_VERIFY_HOST);
+    let net = setup::RealNetworkOps::from_verify_host(verify_host);
 
     run_with_net(&net)
+}
+
+pub fn resolve_verify_host(
+    host_override: Option<&str>,
+    config: Option<&Config>,
+    default: &str,
+) -> String {
+    if let Some(host) = host_override {
+        return host.to_string();
+    }
+    config
+        .and_then(|c| c.verify_host.clone())
+        .unwrap_or_else(|| default.to_string())
 }
 
 pub fn run_with_net(net: &dyn NetworkOps) -> Result<(), Box<dyn std::error::Error>> {
@@ -173,5 +185,44 @@ mod tests {
     #[test]
     fn default_check_service_smtp_addr() {
         assert_eq!(DEFAULT_CHECK_SERVICE_SMTP_ADDR, "check.aimx.email:25");
+    }
+
+    fn cfg_with_verify_host(host: Option<&str>) -> Config {
+        let toml_str = match host {
+            Some(h) => format!("domain = \"test.com\"\nverify_host = \"{h}\"\n[mailboxes]\n"),
+            None => "domain = \"test.com\"\n[mailboxes]\n".to_string(),
+        };
+        toml::from_str(&toml_str).unwrap()
+    }
+
+    #[test]
+    fn resolve_host_prefers_cli_override_over_config_and_default() {
+        let config = cfg_with_verify_host(Some("https://config.example.com"));
+        let resolved = resolve_verify_host(
+            Some("https://cli.example.com"),
+            Some(&config),
+            "https://default.example.com",
+        );
+        assert_eq!(resolved, "https://cli.example.com");
+    }
+
+    #[test]
+    fn resolve_host_uses_config_when_no_cli_override() {
+        let config = cfg_with_verify_host(Some("https://config.example.com"));
+        let resolved = resolve_verify_host(None, Some(&config), "https://default.example.com");
+        assert_eq!(resolved, "https://config.example.com");
+    }
+
+    #[test]
+    fn resolve_host_falls_back_to_default_when_config_missing_field() {
+        let config = cfg_with_verify_host(None);
+        let resolved = resolve_verify_host(None, Some(&config), "https://default.example.com");
+        assert_eq!(resolved, "https://default.example.com");
+    }
+
+    #[test]
+    fn resolve_host_falls_back_to_default_when_no_config() {
+        let resolved = resolve_verify_host(None, None, "https://default.example.com");
+        assert_eq!(resolved, "https://default.example.com");
     }
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -4,25 +4,25 @@ use std::path::Path;
 
 pub fn run(
     data_dir: Option<&Path>,
-    host_override: Option<&str>,
+    verify_host: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let config = match data_dir {
         Some(dir) => Config::load_from_data_dir(dir).ok(),
         None => Config::load_default().ok(),
     };
 
-    let verify_host = resolve_verify_host(host_override, config.as_ref(), DEFAULT_VERIFY_HOST);
-    let net = setup::RealNetworkOps::from_verify_host(verify_host);
+    let host = resolve_verify_host(verify_host, config.as_ref(), DEFAULT_VERIFY_HOST);
+    let net = setup::RealNetworkOps::from_verify_host(host)?;
 
     run_with_net(&net)
 }
 
-pub fn resolve_verify_host(
-    host_override: Option<&str>,
+pub(crate) fn resolve_verify_host(
+    cli_override: Option<&str>,
     config: Option<&Config>,
     default: &str,
 ) -> String {
-    if let Some(host) = host_override {
+    if let Some(host) = cli_override {
         return host.to_string();
     }
     config


### PR DESCRIPTION
## Summary
- Rename config key `probe_url` → `verify_host`. The default is now a base URL (`https://check.aimx.email`) with no `/probe` suffix — aimx appends `/probe` internally when making the HTTP check.
- Add `--verify-host <URL>` flag to `aimx verify`, `aimx setup`, and `aimx preflight`, with precedence **CLI flag > config > default**.
- No legacy `probe_url` support: the project is pre-launch, so the old key is dropped entirely (any stale `probe_url` in a user config is silently ignored by serde and falls back to the default).

## Motivation
`probe_url` leaked an implementation detail (the `/probe` endpoint path) and forced users overriding it to know the exact route. `verify_host` describes *where* the verify service lives, not which endpoint.

## Test plan
- [x] `cargo fmt` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 273 unit + 35 integration tests pass, including four new precedence tests for `resolve_verify_host` and a new trailing-slash-strip test (`real_network_ops_from_verify_host_strips_trailing_slash`)
- [x] `aimx verify --help`, `aimx setup --help`, `aimx preflight --help` all show the new `--verify-host` flag
- [x] Smoke: `aimx verify --verify-host https://localhost` produces a different outbound-check error than the default (proves the flag flows through to `RealNetworkOps`)
- [x] Smoke: trailing-slash input (`https://check.aimx.email/`) produces identical behavior to the no-slash form