### PR TITLE
[Sprint 13] Preflight Flow Fix + PTR Display

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -32,7 +32,12 @@ pub trait SystemOps {
 
 pub trait NetworkOps {
     fn check_outbound_port25(&self) -> Result<bool, Box<dyn std::error::Error>>;
+    /// Full SMTP EHLO handshake via `{verify_host}/probe`.
+    /// Used by `aimx setup` (post-install) and `aimx verify`.
     fn check_inbound_port25(&self) -> Result<bool, Box<dyn std::error::Error>>;
+    /// Plain-TCP reachability check via `{verify_host}/reach`.
+    /// Used by `aimx preflight` on a fresh VPS before OpenSMTPD is installed.
+    fn check_inbound_reachable(&self) -> Result<bool, Box<dyn std::error::Error>>;
     fn check_ptr_record(&self) -> Result<Option<String>, Box<dyn std::error::Error>>;
     fn get_server_ip(&self) -> Result<IpAddr, Box<dyn std::error::Error>>;
     fn resolve_mx(&self, domain: &str) -> Result<Vec<String>, Box<dyn std::error::Error>>;
@@ -282,6 +287,21 @@ impl NetworkOps for RealNetworkOps {
         }
     }
 
+    fn check_inbound_reachable(&self) -> Result<bool, Box<dyn std::error::Error>> {
+        let reach_url = format!("{}/reach", self.verify_host);
+        let resp = std::process::Command::new("curl")
+            .args(["-s", "-m", "60", &reach_url])
+            .output();
+
+        match resp {
+            Ok(output) if output.status.success() => {
+                let body = String::from_utf8_lossy(&output.stdout);
+                Ok(body.contains("\"reachable\":true") || body.contains("\"reachable\": true"))
+            }
+            _ => Ok(false),
+        }
+    }
+
     fn check_ptr_record(&self) -> Result<Option<String>, Box<dyn std::error::Error>> {
         let ip = self.get_server_ip()?;
         let output = std::process::Command::new("dig")
@@ -354,14 +374,15 @@ pub const COMPATIBLE_PROVIDERS: &[&str] = &[
 
 #[derive(Debug, PartialEq)]
 pub enum PreflightResult {
-    Pass,
+    /// Check passed. Optional detail string (e.g. PTR value) is displayed inline.
+    Pass(Option<String>),
     Fail(String),
     Warn(String),
 }
 
 pub fn check_outbound(net: &dyn NetworkOps) -> PreflightResult {
     match net.check_outbound_port25() {
-        Ok(true) => PreflightResult::Pass,
+        Ok(true) => PreflightResult::Pass(None),
         Ok(false) => PreflightResult::Fail(
             "Outbound port 25 is blocked. Your VPS provider may restrict SMTP traffic.".into(),
         ),
@@ -369,9 +390,25 @@ pub fn check_outbound(net: &dyn NetworkOps) -> PreflightResult {
     }
 }
 
+/// Full SMTP EHLO handshake via `/probe`. Used by `aimx setup` (post-install)
+/// and `aimx verify` — both run after OpenSMTPD is listening on port 25.
 pub fn check_inbound(net: &dyn NetworkOps) -> PreflightResult {
     match net.check_inbound_port25() {
-        Ok(true) => PreflightResult::Pass,
+        Ok(true) => PreflightResult::Pass(None),
+        Ok(false) => PreflightResult::Fail(
+            "Inbound port 25 is not reachable. Check your firewall and VPS provider settings."
+                .into(),
+        ),
+        Err(e) => PreflightResult::Fail(format!("Inbound port 25 check failed: {e}")),
+    }
+}
+
+/// Plain-TCP reachability check via `/reach`. Used by `aimx preflight` on a
+/// fresh VPS before OpenSMTPD is installed — any listening socket (or the
+/// verify service's TCP connect succeeding) satisfies this check.
+pub fn check_inbound_tcp(net: &dyn NetworkOps) -> PreflightResult {
+    match net.check_inbound_reachable() {
+        Ok(true) => PreflightResult::Pass(None),
         Ok(false) => PreflightResult::Fail(
             "Inbound port 25 is not reachable. Check your firewall and VPS provider settings."
                 .into(),
@@ -382,10 +419,7 @@ pub fn check_inbound(net: &dyn NetworkOps) -> PreflightResult {
 
 pub fn check_ptr(net: &dyn NetworkOps) -> PreflightResult {
     match net.check_ptr_record() {
-        Ok(Some(ptr)) => {
-            println!("  PTR record: {ptr}");
-            PreflightResult::Pass
-        }
+        Ok(Some(ptr)) => PreflightResult::Pass(Some(ptr)),
         Ok(None) => PreflightResult::Warn(
             "No PTR (reverse DNS) record found. Set a PTR record at your VPS provider \
              pointing to your domain. This improves deliverability but is not required."
@@ -396,55 +430,74 @@ pub fn check_ptr(net: &dyn NetworkOps) -> PreflightResult {
 }
 
 pub fn run_preflight(net: &dyn NetworkOps) -> Result<bool, Box<dyn std::error::Error>> {
-    println!("Running preflight checks...\n");
+    let stdout = io::stdout();
+    let stderr = io::stderr();
+    run_preflight_to(net, &mut stdout.lock(), &mut stderr.lock())
+}
+
+/// Testable variant of `run_preflight` that writes to caller-supplied streams.
+/// Both output streams are routed to `out` in tests so ordering can be asserted.
+pub fn run_preflight_to<W: Write, E: Write>(
+    net: &dyn NetworkOps,
+    out: &mut W,
+    err: &mut E,
+) -> Result<bool, Box<dyn std::error::Error>> {
+    writeln!(out, "Running preflight checks...\n")?;
 
     let mut all_pass = true;
 
-    print!("  Outbound port 25... ");
-    io::stdout().flush()?;
+    write!(out, "  Outbound port 25... ")?;
+    out.flush()?;
     match check_outbound(net) {
-        PreflightResult::Pass => println!("PASS"),
+        PreflightResult::Pass(_) => writeln!(out, "PASS")?,
         PreflightResult::Fail(msg) => {
-            println!("FAIL");
-            eprintln!("\n  {msg}");
-            eprintln!("\n  Compatible VPS providers with port 25 open:");
+            writeln!(out, "FAIL")?;
+            writeln!(err, "\n  {msg}")?;
+            writeln!(err, "\n  Compatible VPS providers with port 25 open:")?;
             for p in COMPATIBLE_PROVIDERS {
-                eprintln!("    - {p}");
+                writeln!(err, "    - {p}")?;
             }
             all_pass = false;
         }
-        PreflightResult::Warn(msg) => println!("WARN: {msg}"),
+        PreflightResult::Warn(msg) => writeln!(out, "WARN: {msg}")?,
     }
 
-    print!("  Inbound port 25... ");
-    io::stdout().flush()?;
-    match check_inbound(net) {
-        PreflightResult::Pass => println!("PASS"),
+    // Preflight uses the plain-TCP `/reach` endpoint because it runs on fresh
+    // VPSes before OpenSMTPD is installed — nothing is listening on port 25
+    // yet, so a full EHLO handshake would fail for the wrong reason.
+    write!(out, "  Inbound port 25... ")?;
+    out.flush()?;
+    match check_inbound_tcp(net) {
+        PreflightResult::Pass(_) => writeln!(out, "PASS")?,
         PreflightResult::Fail(msg) => {
-            println!("FAIL");
-            eprintln!("\n  {msg}");
+            writeln!(out, "FAIL")?;
+            writeln!(err, "\n  {msg}")?;
             all_pass = false;
         }
-        PreflightResult::Warn(msg) => println!("WARN: {msg}"),
+        PreflightResult::Warn(msg) => writeln!(out, "WARN: {msg}")?,
     }
 
-    print!("  PTR record... ");
-    io::stdout().flush()?;
+    write!(out, "  PTR record... ")?;
+    out.flush()?;
     match check_ptr(net) {
-        PreflightResult::Pass => println!("PASS"),
+        PreflightResult::Pass(Some(ptr)) => writeln!(out, "PASS ({ptr})")?,
+        PreflightResult::Pass(None) => writeln!(out, "PASS")?,
         PreflightResult::Fail(msg) => {
-            println!("FAIL: {msg}");
+            writeln!(out, "FAIL: {msg}")?;
             all_pass = false;
         }
-        PreflightResult::Warn(msg) => println!("WARN\n  {msg}"),
+        PreflightResult::Warn(msg) => writeln!(out, "WARN\n  {msg}")?,
     }
 
-    println!();
+    writeln!(out)?;
 
     if !all_pass {
-        eprintln!("Preflight checks failed. Please resolve the issues above before proceeding.");
+        writeln!(
+            err,
+            "Preflight checks failed. Please resolve the issues above before proceeding."
+        )?;
     } else {
-        println!("All preflight checks passed.");
+        writeln!(out, "All preflight checks passed.")?;
     }
 
     Ok(all_pass)
@@ -989,7 +1042,7 @@ pub fn run_setup(
     print!("  Outbound port 25... ");
     io::stdout().flush()?;
     match check_outbound(net) {
-        PreflightResult::Pass => println!("PASS"),
+        PreflightResult::Pass(_) => println!("PASS"),
         PreflightResult::Fail(msg) => {
             println!("FAIL");
             eprintln!("\n  {msg}");
@@ -1002,10 +1055,13 @@ pub fn run_setup(
         PreflightResult::Warn(msg) => println!("WARN: {msg}"),
     }
 
+    // Setup runs the inbound check AFTER OpenSMTPD is installed, so the full
+    // EHLO handshake via `/probe` is the right validation — it confirms a real
+    // SMTP server is responding, not just that the port is open.
     print!("  Inbound port 25... ");
     io::stdout().flush()?;
     match check_inbound(net) {
-        PreflightResult::Pass => println!("PASS"),
+        PreflightResult::Pass(_) => println!("PASS"),
         PreflightResult::Fail(msg) => {
             println!("FAIL");
             eprintln!("\n  {msg}");
@@ -1017,7 +1073,8 @@ pub fn run_setup(
     print!("  PTR record... ");
     io::stdout().flush()?;
     match check_ptr(net) {
-        PreflightResult::Pass => println!("PASS"),
+        PreflightResult::Pass(Some(ptr)) => println!("PASS ({ptr})"),
+        PreflightResult::Pass(None) => println!("PASS"),
         PreflightResult::Fail(msg) => {
             println!("FAIL: {msg}");
         }
@@ -1091,6 +1148,7 @@ mod tests {
     struct MockNetworkOps {
         outbound_port25: bool,
         inbound_port25: bool,
+        inbound_reachable: bool,
         ptr_record: Option<String>,
         server_ip: IpAddr,
         mx_records: HashMap<String, Vec<String>>,
@@ -1103,6 +1161,7 @@ mod tests {
             Self {
                 outbound_port25: true,
                 inbound_port25: true,
+                inbound_reachable: true,
                 ptr_record: Some("mail.example.com.".into()),
                 server_ip: "1.2.3.4".parse().unwrap(),
                 mx_records: HashMap::new(),
@@ -1118,6 +1177,9 @@ mod tests {
         }
         fn check_inbound_port25(&self) -> Result<bool, Box<dyn std::error::Error>> {
             Ok(self.inbound_port25)
+        }
+        fn check_inbound_reachable(&self) -> Result<bool, Box<dyn std::error::Error>> {
+            Ok(self.inbound_reachable)
         }
         fn check_ptr_record(&self) -> Result<Option<String>, Box<dyn std::error::Error>> {
             Ok(self.ptr_record.clone())
@@ -1267,7 +1329,7 @@ mod tests {
             outbound_port25: true,
             ..Default::default()
         };
-        assert_eq!(check_outbound(&net), PreflightResult::Pass);
+        assert_eq!(check_outbound(&net), PreflightResult::Pass(None));
     }
 
     #[test]
@@ -1288,7 +1350,7 @@ mod tests {
             inbound_port25: true,
             ..Default::default()
         };
-        assert_eq!(check_inbound(&net), PreflightResult::Pass);
+        assert_eq!(check_inbound(&net), PreflightResult::Pass(None));
     }
 
     #[test]
@@ -1309,7 +1371,10 @@ mod tests {
             ptr_record: Some("mail.example.com.".into()),
             ..Default::default()
         };
-        assert_eq!(check_ptr(&net), PreflightResult::Pass);
+        assert_eq!(
+            check_ptr(&net),
+            PreflightResult::Pass(Some("mail.example.com.".into()))
+        );
     }
 
     #[test]
@@ -1343,8 +1408,10 @@ mod tests {
 
     #[test]
     fn preflight_fails_on_inbound_blocked() {
+        // Preflight uses the /reach path (check_inbound_reachable), so we
+        // block that one to simulate a fresh VPS with port 25 firewalled.
         let net = MockNetworkOps {
-            inbound_port25: false,
+            inbound_reachable: false,
             ..Default::default()
         };
         let result = run_preflight(&net).unwrap();
@@ -2077,5 +2144,247 @@ mod tests {
         let net = RealNetworkOps::default();
         // Just ensure the method is callable (compile check)
         let _ = &net as &dyn NetworkOps;
+    }
+
+    // S13.1 — Route Preflight Inbound at /reach tests
+
+    /// Mock that distinguishes the two inbound check variants and records
+    /// which one was called, so we can pin each caller to the right endpoint.
+    struct TrackingNetworkOps {
+        outbound_port25: bool,
+        inbound_port25: bool,
+        inbound_reachable: bool,
+        ptr_record: Option<String>,
+        port25_called: std::cell::Cell<bool>,
+        reach_called: std::cell::Cell<bool>,
+    }
+
+    impl Default for TrackingNetworkOps {
+        fn default() -> Self {
+            Self {
+                outbound_port25: true,
+                inbound_port25: true,
+                inbound_reachable: true,
+                ptr_record: Some("mail.example.com.".into()),
+                port25_called: std::cell::Cell::new(false),
+                reach_called: std::cell::Cell::new(false),
+            }
+        }
+    }
+
+    impl NetworkOps for TrackingNetworkOps {
+        fn check_outbound_port25(&self) -> Result<bool, Box<dyn std::error::Error>> {
+            Ok(self.outbound_port25)
+        }
+        fn check_inbound_port25(&self) -> Result<bool, Box<dyn std::error::Error>> {
+            self.port25_called.set(true);
+            Ok(self.inbound_port25)
+        }
+        fn check_inbound_reachable(&self) -> Result<bool, Box<dyn std::error::Error>> {
+            self.reach_called.set(true);
+            Ok(self.inbound_reachable)
+        }
+        fn check_ptr_record(&self) -> Result<Option<String>, Box<dyn std::error::Error>> {
+            Ok(self.ptr_record.clone())
+        }
+        fn get_server_ip(&self) -> Result<IpAddr, Box<dyn std::error::Error>> {
+            Ok("1.2.3.4".parse().unwrap())
+        }
+        fn resolve_mx(&self, _domain: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+            Ok(vec![])
+        }
+        fn resolve_a(&self, _domain: &str) -> Result<Vec<IpAddr>, Box<dyn std::error::Error>> {
+            Ok(vec![])
+        }
+        fn resolve_txt(&self, _domain: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+            Ok(vec![])
+        }
+    }
+
+    #[test]
+    fn check_inbound_tcp_pass() {
+        let net = MockNetworkOps {
+            inbound_reachable: true,
+            ..Default::default()
+        };
+        assert_eq!(check_inbound_tcp(&net), PreflightResult::Pass(None));
+    }
+
+    #[test]
+    fn check_inbound_tcp_fail() {
+        let net = MockNetworkOps {
+            inbound_reachable: false,
+            ..Default::default()
+        };
+        match check_inbound_tcp(&net) {
+            PreflightResult::Fail(msg) => assert!(msg.contains("not reachable")),
+            other => panic!("Expected Fail, got {:?}", other),
+        }
+    }
+
+    /// Fresh-VPS scenario: nothing on port 25 to speak EHLO, but the TCP
+    /// reachability check via `/reach` can still pass. Preflight should PASS.
+    #[test]
+    fn preflight_passes_when_reach_ok_even_if_ehlo_would_fail() {
+        let net = TrackingNetworkOps {
+            inbound_port25: false,   // EHLO would fail — no SMTP server yet
+            inbound_reachable: true, // but the TCP-level reach check passes
+            ..Default::default()
+        };
+        let result = run_preflight(&net).unwrap();
+        assert!(result, "preflight should pass on fresh VPS via /reach");
+        assert!(
+            net.reach_called.get(),
+            "preflight must call check_inbound_reachable (/reach)"
+        );
+        assert!(
+            !net.port25_called.get(),
+            "preflight must not call check_inbound_port25 (/probe)"
+        );
+    }
+
+    #[test]
+    fn preflight_fails_when_reach_fails() {
+        let net = TrackingNetworkOps {
+            inbound_reachable: false,
+            ..Default::default()
+        };
+        let result = run_preflight(&net).unwrap();
+        assert!(!result);
+        assert!(net.reach_called.get());
+    }
+
+    /// `aimx setup` runs its inbound check AFTER OpenSMTPD is installed, so
+    /// it must use the full EHLO path via `/probe`, not the plain TCP `/reach`.
+    /// We verify this by constructing a tracking net where the EHLO result
+    /// wins and the reach result is never read.
+    #[test]
+    fn setup_uses_ehlo_not_reach() {
+        let tmp = TempDir::new().unwrap();
+        let sys = MockSystemOps::default();
+        let net = TrackingNetworkOps {
+            inbound_port25: false,
+            inbound_reachable: true,
+            ..Default::default()
+        };
+        // setup will fail at the inbound check, which is expected — we only
+        // care which method was called.
+        let _ = run_setup("example.com", Some(tmp.path()), &sys, &net);
+        assert!(
+            net.port25_called.get(),
+            "aimx setup must call check_inbound_port25 (/probe) for its post-install inbound check"
+        );
+        assert!(
+            !net.reach_called.get(),
+            "aimx setup must not call check_inbound_reachable (/reach)"
+        );
+    }
+
+    // S13.2 — PTR Display Ordering tests
+
+    #[test]
+    fn ptr_pass_carries_value() {
+        let net = MockNetworkOps {
+            ptr_record: Some("vps-198f7320.vps.ovh.net.".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            check_ptr(&net),
+            PreflightResult::Pass(Some("vps-198f7320.vps.ovh.net.".into()))
+        );
+    }
+
+    /// PTR display must appear as a single well-formed line with the value
+    /// inline, not split across an intermediate newline as the old bug did.
+    #[test]
+    fn preflight_ptr_inline_pass() {
+        let net = MockNetworkOps {
+            ptr_record: Some("vps-198f7320.vps.ovh.net.".into()),
+            ..Default::default()
+        };
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let result = run_preflight_to(&net, &mut out, &mut err).unwrap();
+        assert!(result);
+        let stdout = String::from_utf8(out).unwrap();
+
+        // The PTR line must be a single, well-formed line.
+        assert!(
+            stdout.contains("  PTR record... PASS (vps-198f7320.vps.ovh.net.)\n"),
+            "expected inline PTR line, got stdout:\n{stdout}"
+        );
+
+        // The errant `println!("  PTR record: {ptr}")` from the old bug must
+        // NOT appear anywhere in the output.
+        assert!(
+            !stdout.contains("PTR record: vps-198f7320"),
+            "stray PTR line from pre-Sprint-13 bug should not appear:\n{stdout}"
+        );
+    }
+
+    /// Regression test for the exact interleaving symptom that motivated
+    /// Sprint 13: when inbound fails and PTR passes, the stdout sequence
+    /// must be strictly: inbound-FAIL, then PTR-header, then PTR-PASS. The
+    /// PTR line must NOT appear before or inside the inbound block.
+    #[test]
+    fn preflight_no_ptr_interleaving_when_inbound_fails() {
+        let net = MockNetworkOps {
+            inbound_reachable: false,
+            ptr_record: Some("vps-198f7320.vps.ovh.net.".into()),
+            ..Default::default()
+        };
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let result = run_preflight_to(&net, &mut out, &mut err).unwrap();
+        assert!(!result);
+        let stdout = String::from_utf8(out).unwrap();
+
+        // Exactly one line containing "PTR record..." on stdout, and it must
+        // be the final-form "PASS (…)" line — not the intermediate header.
+        let ptr_lines: Vec<&str> = stdout
+            .lines()
+            .filter(|l| l.contains("PTR record"))
+            .collect();
+        assert_eq!(
+            ptr_lines.len(),
+            1,
+            "expected exactly one PTR line on stdout, got {}: {stdout}",
+            ptr_lines.len()
+        );
+        assert_eq!(
+            ptr_lines[0], "  PTR record... PASS (vps-198f7320.vps.ovh.net.)",
+            "PTR line should carry the value inline with PASS"
+        );
+
+        // Inbound FAIL must come before the PTR line on stdout (ordering).
+        let inbound_idx = stdout
+            .find("Inbound port 25... FAIL")
+            .unwrap_or_else(|| panic!("expected 'Inbound port 25... FAIL' in stdout:\n{stdout}"));
+        let ptr_idx = stdout.find("PTR record...").unwrap();
+        assert!(
+            inbound_idx < ptr_idx,
+            "inbound FAIL must appear before PTR line, stdout:\n{stdout}"
+        );
+    }
+
+    #[test]
+    fn preflight_ptr_warn_when_missing() {
+        let net = MockNetworkOps {
+            ptr_record: None,
+            ..Default::default()
+        };
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let result = run_preflight_to(&net, &mut out, &mut err).unwrap();
+        assert!(result, "PTR missing must not fail the overall preflight");
+        let stdout = String::from_utf8(out).unwrap();
+        assert!(
+            stdout.contains("  PTR record... WARN"),
+            "expected WARN marker, got stdout:\n{stdout}"
+        );
+        assert!(
+            stdout.contains("No PTR (reverse DNS) record found"),
+            "expected advisory message, got stdout:\n{stdout}"
+        );
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -215,6 +215,25 @@ impl RealNetworkOps {
             check_service_smtp_addr: smtp_addr,
         })
     }
+
+    /// Shared curl invocation for `/probe` and `/reach` verify-service paths.
+    /// Both endpoints return `{"reachable": bool, ...}`; any curl failure or
+    /// non-success exit maps to `Ok(false)` so preflight displays a FAIL
+    /// advisory rather than an error backtrace.
+    fn curl_reachable(&self, path: &str) -> Result<bool, Box<dyn std::error::Error>> {
+        let url = format!("{}{path}", self.verify_host);
+        let resp = std::process::Command::new("curl")
+            .args(["-s", "-m", "60", &url])
+            .output();
+
+        match resp {
+            Ok(output) if output.status.success() => {
+                let body = String::from_utf8_lossy(&output.stdout);
+                Ok(body.contains("\"reachable\":true") || body.contains("\"reachable\": true"))
+            }
+            _ => Ok(false),
+        }
+    }
 }
 
 pub fn validate_verify_host(verify_host: &str) -> Result<(), Box<dyn std::error::Error>> {
@@ -273,33 +292,11 @@ impl NetworkOps for RealNetworkOps {
     }
 
     fn check_inbound_port25(&self) -> Result<bool, Box<dyn std::error::Error>> {
-        let probe_url = format!("{}/probe", self.verify_host);
-        let resp = std::process::Command::new("curl")
-            .args(["-s", "-m", "60", &probe_url])
-            .output();
-
-        match resp {
-            Ok(output) if output.status.success() => {
-                let body = String::from_utf8_lossy(&output.stdout);
-                Ok(body.contains("\"reachable\":true") || body.contains("\"reachable\": true"))
-            }
-            _ => Ok(false),
-        }
+        self.curl_reachable("/probe")
     }
 
     fn check_inbound_reachable(&self) -> Result<bool, Box<dyn std::error::Error>> {
-        let reach_url = format!("{}/reach", self.verify_host);
-        let resp = std::process::Command::new("curl")
-            .args(["-s", "-m", "60", &reach_url])
-            .output();
-
-        match resp {
-            Ok(output) if output.status.success() => {
-                let body = String::from_utf8_lossy(&output.stdout);
-                Ok(body.contains("\"reachable\":true") || body.contains("\"reachable\": true"))
-            }
-            _ => Ok(false),
-        }
+        self.curl_reachable("/reach")
     }
 
     fn check_ptr_record(&self) -> Result<Option<String>, Box<dyn std::error::Error>> {
@@ -390,10 +387,8 @@ pub fn check_outbound(net: &dyn NetworkOps) -> PreflightResult {
     }
 }
 
-/// Full SMTP EHLO handshake via `/probe`. Used by `aimx setup` (post-install)
-/// and `aimx verify` — both run after OpenSMTPD is listening on port 25.
-pub fn check_inbound(net: &dyn NetworkOps) -> PreflightResult {
-    match net.check_inbound_port25() {
+fn inbound_result(res: Result<bool, Box<dyn std::error::Error>>) -> PreflightResult {
+    match res {
         Ok(true) => PreflightResult::Pass(None),
         Ok(false) => PreflightResult::Fail(
             "Inbound port 25 is not reachable. Check your firewall and VPS provider settings."
@@ -403,18 +398,17 @@ pub fn check_inbound(net: &dyn NetworkOps) -> PreflightResult {
     }
 }
 
+/// Full SMTP EHLO handshake via `/probe`. Used by `aimx setup` (post-install)
+/// and `aimx verify` — both run after OpenSMTPD is listening on port 25.
+pub fn check_inbound(net: &dyn NetworkOps) -> PreflightResult {
+    inbound_result(net.check_inbound_port25())
+}
+
 /// Plain-TCP reachability check via `/reach`. Used by `aimx preflight` on a
 /// fresh VPS before OpenSMTPD is installed — any listening socket (or the
 /// verify service's TCP connect succeeding) satisfies this check.
 pub fn check_inbound_tcp(net: &dyn NetworkOps) -> PreflightResult {
-    match net.check_inbound_reachable() {
-        Ok(true) => PreflightResult::Pass(None),
-        Ok(false) => PreflightResult::Fail(
-            "Inbound port 25 is not reachable. Check your firewall and VPS provider settings."
-                .into(),
-        ),
-        Err(e) => PreflightResult::Fail(format!("Inbound port 25 check failed: {e}")),
-    }
+    inbound_result(net.check_inbound_reachable())
 }
 
 pub fn check_ptr(net: &dyn NetworkOps) -> PreflightResult {
@@ -435,8 +429,9 @@ pub fn run_preflight(net: &dyn NetworkOps) -> Result<bool, Box<dyn std::error::E
     run_preflight_to(net, &mut stdout.lock(), &mut stderr.lock())
 }
 
-/// Testable variant of `run_preflight` that writes to caller-supplied streams.
-/// Both output streams are routed to `out` in tests so ordering can be asserted.
+/// Testable variant of `run_preflight` that writes check progress to `out`
+/// and failure advisories to `err`. Tests supply separate buffers so they can
+/// assert on stdout ordering independently of the error-advisory stream.
 pub fn run_preflight_to<W: Write, E: Write>(
     net: &dyn NetworkOps,
     out: &mut W,
@@ -1392,7 +1387,9 @@ mod tests {
     #[test]
     fn preflight_all_pass() {
         let net = MockNetworkOps::default();
-        let result = run_preflight(&net).unwrap();
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let result = run_preflight_to(&net, &mut out, &mut err).unwrap();
         assert!(result);
     }
 
@@ -1402,7 +1399,9 @@ mod tests {
             outbound_port25: false,
             ..Default::default()
         };
-        let result = run_preflight(&net).unwrap();
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let result = run_preflight_to(&net, &mut out, &mut err).unwrap();
         assert!(!result);
     }
 
@@ -1414,7 +1413,9 @@ mod tests {
             inbound_reachable: false,
             ..Default::default()
         };
-        let result = run_preflight(&net).unwrap();
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let result = run_preflight_to(&net, &mut out, &mut err).unwrap();
         assert!(!result);
     }
 
@@ -1424,7 +1425,9 @@ mod tests {
             ptr_record: None,
             ..Default::default()
         };
-        let result = run_preflight(&net).unwrap();
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let result = run_preflight_to(&net, &mut out, &mut err).unwrap();
         assert!(result);
     }
 
@@ -2231,7 +2234,9 @@ mod tests {
             inbound_reachable: true, // but the TCP-level reach check passes
             ..Default::default()
         };
-        let result = run_preflight(&net).unwrap();
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let result = run_preflight_to(&net, &mut out, &mut err).unwrap();
         assert!(result, "preflight should pass on fresh VPS via /reach");
         assert!(
             net.reach_called.get(),
@@ -2249,7 +2254,9 @@ mod tests {
             inbound_reachable: false,
             ..Default::default()
         };
-        let result = run_preflight(&net).unwrap();
+        let mut out = Vec::new();
+        let mut err = Vec::new();
+        let result = run_preflight_to(&net, &mut out, &mut err).unwrap();
         assert!(!result);
         assert!(net.reach_called.get());
     }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -38,7 +38,7 @@ pub fn run_with_net(net: &dyn NetworkOps) -> Result<(), Box<dyn std::error::Erro
     print!("  Outbound port 25... ");
     std::io::Write::flush(&mut std::io::stdout())?;
     match setup::check_outbound(net) {
-        setup::PreflightResult::Pass => println!("PASS"),
+        setup::PreflightResult::Pass(_) => println!("PASS"),
         setup::PreflightResult::Fail(msg) => {
             println!("FAIL");
             eprintln!("  {msg}");
@@ -47,10 +47,13 @@ pub fn run_with_net(net: &dyn NetworkOps) -> Result<(), Box<dyn std::error::Erro
         setup::PreflightResult::Warn(msg) => println!("WARN: {msg}"),
     }
 
+    // `aimx verify` is a post-setup sanity check — the user already has a
+    // working mail server, so the full EHLO handshake via `/probe` is the
+    // correct validation.
     print!("  Inbound port 25 (EHLO probe)... ");
     std::io::Write::flush(&mut std::io::stdout())?;
     match setup::check_inbound(net) {
-        setup::PreflightResult::Pass => println!("PASS"),
+        setup::PreflightResult::Pass(_) => println!("PASS"),
         setup::PreflightResult::Fail(msg) => {
             println!("FAIL");
             eprintln!("  {msg}");
@@ -62,7 +65,8 @@ pub fn run_with_net(net: &dyn NetworkOps) -> Result<(), Box<dyn std::error::Erro
     print!("  PTR record... ");
     std::io::Write::flush(&mut std::io::stdout())?;
     match setup::check_ptr(net) {
-        setup::PreflightResult::Pass => println!("PASS"),
+        setup::PreflightResult::Pass(Some(ptr)) => println!("PASS ({ptr})"),
+        setup::PreflightResult::Pass(None) => println!("PASS"),
         setup::PreflightResult::Fail(msg) => {
             println!("FAIL: {msg}");
             all_pass = false;
@@ -88,8 +92,29 @@ mod tests {
 
     struct MockNetworkOps {
         outbound: bool,
+        /// Result for `check_inbound_port25` (EHLO via `/probe`). This is the
+        /// variant `aimx verify` should be using.
         inbound: bool,
+        /// Result for `check_inbound_reachable` (plain TCP via `/reach`).
+        /// `aimx verify` must NOT call this; set to the opposite of `inbound`
+        /// in tests that verify `aimx verify` uses the EHLO variant.
+        inbound_reachable: bool,
         ptr: Option<String>,
+        /// Track whether `check_inbound_reachable` was called during the test
+        /// — used to assert `aimx verify` never touches the `/reach` path.
+        reach_called: std::cell::Cell<bool>,
+    }
+
+    impl Default for MockNetworkOps {
+        fn default() -> Self {
+            Self {
+                outbound: true,
+                inbound: true,
+                inbound_reachable: true,
+                ptr: Some("mail.example.com.".into()),
+                reach_called: std::cell::Cell::new(false),
+            }
+        }
     }
 
     impl NetworkOps for MockNetworkOps {
@@ -98,6 +123,10 @@ mod tests {
         }
         fn check_inbound_port25(&self) -> Result<bool, Box<dyn std::error::Error>> {
             Ok(self.inbound)
+        }
+        fn check_inbound_reachable(&self) -> Result<bool, Box<dyn std::error::Error>> {
+            self.reach_called.set(true);
+            Ok(self.inbound_reachable)
         }
         fn check_ptr_record(&self) -> Result<Option<String>, Box<dyn std::error::Error>> {
             Ok(self.ptr.clone())
@@ -118,11 +147,7 @@ mod tests {
 
     #[test]
     fn verify_all_pass() {
-        let net = MockNetworkOps {
-            outbound: true,
-            inbound: true,
-            ptr: Some("mail.example.com.".into()),
-        };
+        let net = MockNetworkOps::default();
         assert!(run_with_net(&net).is_ok());
     }
 
@@ -130,8 +155,7 @@ mod tests {
     fn verify_outbound_fail() {
         let net = MockNetworkOps {
             outbound: false,
-            inbound: true,
-            ptr: Some("mail.example.com.".into()),
+            ..Default::default()
         };
         assert!(run_with_net(&net).is_err());
     }
@@ -139,9 +163,8 @@ mod tests {
     #[test]
     fn verify_inbound_fail() {
         let net = MockNetworkOps {
-            outbound: true,
             inbound: false,
-            ptr: Some("mail.example.com.".into()),
+            ..Default::default()
         };
         assert!(run_with_net(&net).is_err());
     }
@@ -149,9 +172,8 @@ mod tests {
     #[test]
     fn verify_ptr_warn_still_passes() {
         let net = MockNetworkOps {
-            outbound: true,
-            inbound: true,
             ptr: None,
+            ..Default::default()
         };
         assert!(run_with_net(&net).is_ok());
     }
@@ -162,8 +184,27 @@ mod tests {
             outbound: false,
             inbound: false,
             ptr: None,
+            ..Default::default()
         };
         assert!(run_with_net(&net).is_err());
+    }
+
+    /// Regression test for S13.1: `aimx verify` must continue to use the
+    /// EHLO-based `/probe` path (not the plain-TCP `/reach` path). If the
+    /// EHLO path says `inbound: false` but the reach path says
+    /// `inbound_reachable: true`, `aimx verify` should still fail.
+    #[test]
+    fn verify_uses_ehlo_not_reach() {
+        let net = MockNetworkOps {
+            inbound: false,
+            inbound_reachable: true,
+            ..Default::default()
+        };
+        assert!(run_with_net(&net).is_err());
+        assert!(
+            !net.reach_called.get(),
+            "aimx verify must not call check_inbound_reachable (the /reach endpoint)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes two bugs found during post-Sprint-11 debugging of the preflight / verify flow:

- **S13.1 — Preflight chicken-and-egg.** `aimx preflight` is meant to run on a fresh VPS before OpenSMTPD is installed, but its inbound check called `{verify_host}/probe` which does a full SMTP EHLO handshake. On a fresh VPS nothing is listening on port 25, so the handshake failed and preflight reported `Inbound port 25 is not reachable` even when port 25 was actually reachable at the TCP level. Preflight now routes its inbound check at the plain-TCP `/reach` endpoint introduced in Sprint 12. `aimx setup` (post-install) and `aimx verify` continue to use `/probe` for the full EHLO validation — no regression there.
- **S13.2 — PTR display ordering bug.** `check_ptr` was emitting its own `println!(\"  PTR record: {ptr}\")` before returning `PreflightResult::Pass`, which interleaved with the caller's unflushed `print!(\"  PTR record... \")` and produced mangled output when the inbound check failed. `PreflightResult::Pass` now carries `Option<String>`, `check_ptr` returns the PTR value via that payload, and `run_preflight` prints a single well-formed `  PTR record... PASS (<ptr>)` line.

## Changes

- `NetworkOps` trait: new `check_inbound_reachable()` method (calls `/reach`), `check_inbound_port25()` (calls `/probe`) kept unchanged.
- `RealNetworkOps::check_inbound_reachable()` mirrors `check_inbound_port25()` exactly (curl, 60s timeout, parse `\"reachable\":true`) against the new path.
- New `check_inbound_tcp()` helper alongside `check_inbound()`; `run_preflight()` calls the TCP variant, `run_setup()` and `verify::run_with_net()` continue to call the EHLO variant.
- `PreflightResult::Pass` → `Pass(Option<String>)`; all match arms updated across `src/setup.rs` and `src/verify.rs`.
- `check_ptr()` no longer calls `println!` directly — the PTR value is carried back via `Pass(Some(ptr))` and rendered inline by the caller.
- `run_preflight` refactored into `run_preflight_to<W, E>` taking writer streams so output ordering is testable without touching global stdout.
- All `MockNetworkOps` impls in `src/setup.rs` tests and `src/verify.rs` tests extended to implement both methods.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 291 unit tests + 35 integration tests, all pass
- [x] New test: `preflight_passes_when_reach_ok_even_if_ehlo_would_fail` — fresh-VPS scenario
- [x] New test: `setup_uses_ehlo_not_reach` — no regression in setup flow
- [x] New test: `verify_uses_ehlo_not_reach` — no regression in `aimx verify`
- [x] New test: `preflight_ptr_inline_pass` — single well-formed `  PTR record... PASS (<ptr>)` line
- [x] New test: `preflight_no_ptr_interleaving_when_inbound_fails` — regression guard for the interleaving bug
- [x] New test: `preflight_ptr_warn_when_missing` — PTR stays non-blocking

## Notes

- PTR stays advisory: `Warn` on missing, `Pass(Some(_))` on present, never `Fail`. `all_pass` unchanged when PTR is missing.
- Display text kept as `  Inbound port 25...` in preflight — the semantic is still \"is my inbound port 25 reachable,\" just validated at the TCP layer rather than at EHLO.