### PR TITLE
[Sprint 16] Add Caddy to docker-compose

### DIFF
--- a/docs/sprint.md
+++ b/docs/sprint.md
@@ -2,8 +2,8 @@
 
 **Sprint cadence:** 2.5 days per sprint
 **Team:** Solo developer with heavy AI augmentation (Claude Code)
-**Total sprints:** 15 (6 original + 2 post-audit hardening + 1 YAML→TOML migration + 2 verify/setup overhaul + 2 post-Sprint-11 bug fixes + 2 verify ops)
-**Timeline:** ~42.5 calendar days
+**Total sprints:** 16 (6 original + 2 post-audit hardening + 1 YAML→TOML migration + 2 verify/setup overhaul + 2 post-Sprint-11 bug fixes + 2 verify ops + 1 deployment)
+**Timeline:** ~45.5 calendar days
 **v1 Scope:** Full PRD scope including verify service. Sprint 1 targets earliest possible idea validation on a real VPS. Sprints 7–8 address findings from post-v1 code review audit. Sprints 10–11 overhaul the verify service (remove email echo, add EHLO probe) and rewrite the setup flow (root check, MTA conflict detection, install-before-check). Sprints 12–13 fix critical bugs found during post-Sprint-11 debugging: Caddy self-probe loop / XFF SSRF risk in the verify service, and the preflight chicken-and-egg problem on fresh VPSes. Sprints 14–15 are review-driven operational quality work on the verify service (request logging, Docker packaging).
 
 ---
@@ -1499,6 +1499,31 @@ No GitHub Actions image publishing to ghcr.io in this sprint — not requested. 
 
 ---
 
+## Sprint 16 — Add Caddy to docker-compose (Days 43–45.5) [IN PROGRESS]
+
+**Goal:** Make `docker compose up` a single-command deployment for aimx-verify + Caddy, eliminating the need to install and manage Caddy separately on the host. Both services use `network_mode: host` so the Sprint 12 security model (loopback trust + Layer 4 target guard) is fully preserved.
+
+**Dependencies:** Sprint 15 (merged) — Dockerfile, docker-compose, and `.dockerignore` already exist.
+
+### S16.1 — Add Caddy service to docker-compose
+
+*As the maintainer of aimx-verify, I want a single `docker compose up -d` to bring up both the verify service and Caddy so that I don't have to install, configure, or manage Caddy separately on the host.*
+
+**Context:** Sprint 15 shipped docker-compose with only the verify service and documented "run Caddy on the host separately." This works but means the operator manages two deployment systems (Docker for verify, systemd/package for Caddy). Since both can use `network_mode: host` without any security regression — Caddy connects to verify via real loopback, identical to the current setup — bundling them into one compose file simplifies ops with zero tradeoff.
+
+**Priority:** P1
+
+- [ ] Add `caddy` service to `services/verify/docker-compose.yml` using the official `caddy:2` image, `network_mode: host`, `restart: unless-stopped`
+- [ ] Mount the existing `Caddyfile` into the Caddy container (read-only)
+- [ ] Add a named volume `caddy_data` mapped to `/data` for persistent TLS cert storage
+- [ ] Add a named volume `caddy_config` mapped to `/config` for Caddy runtime config
+- [ ] `DOMAIN` environment variable configurable (with default `check.aimx.email` matching the Caddyfile's `{$DOMAIN}` placeholder)
+- [ ] Update the docker-compose header comment to reflect that Caddy is now included
+- [ ] Update `services/verify/README.md` Docker section to document the all-in-one compose deployment, including the `DOMAIN` env var and cert volume
+- [ ] Manually verified: `docker compose up -d --build` brings up both services; `curl http://127.0.0.1:3025/health` returns OK; Caddy logs show it is listening on 443
+
+---
+
 ## Summary Table
 
 | Sprint | Days | Focus | Key Output | Status |
@@ -1520,6 +1545,7 @@ No GitHub Actions image publishing to ghcr.io in this sprint — not requested. 
 | 13 | 34–36.5 | Preflight Flow Fix + PTR Display | Route `aimx preflight` at `/reach`, fix PTR display ordering bug | Done |
 | 14 | 37–39.5 | Request Logging for aimx-verify | Per-request logging for `/probe`, `/reach`, `/health`, and SMTP listener — caller IP, status, elapsed ms | Done |
 | 15 | 40–42.5 | Dockerize aimx-verify | Multi-stage Dockerfile, `docker-compose.yml` with `network_mode: host`, `.dockerignore`, verify README update | Done |
+| 16 | 43–45.5 | Add Caddy to docker-compose | Caddy sibling service in compose (both `network_mode: host`), `DOMAIN` env var, cert volumes, README update | In Progress |
 
 ## Deferred to v2
 

--- a/services/verify/README.md
+++ b/services/verify/README.md
@@ -105,12 +105,22 @@ No MTA, no email sending, no DNS records beyond the A record are needed on the v
 
 A `Dockerfile` and `docker-compose.yml` ship alongside this README for operators who prefer container-based deployments. This path coexists with the systemd path below — pick one.
 
+The compose file brings up **both** the verify service and Caddy in a single command:
+
 ```bash
 cd services/verify
 docker compose up -d --build
 ```
 
-That single command builds the multi-stage image (Rust builder → `debian:bookworm-slim` runtime) and starts the service. The container runs as root so it can bind port 25 without capability fiddling, and because `network_mode: host` shares the host's network namespace, the service binds ports `25` (SMTP listener) and `3025` (HTTP) directly on the host's interfaces — no Docker-side port publishing is involved.
+That single command builds the multi-stage verify image (Rust builder → `debian:bookworm-slim` runtime) and pulls the official `caddy:2` image. The verify container runs as root so it can bind port 25 without capability fiddling. Both containers use `network_mode: host`, sharing the host's network namespace — verify binds `127.0.0.1:3025` (HTTP) and `0.0.0.0:25` (SMTP), while Caddy binds `0.0.0.0:443` (HTTPS) and `0.0.0.0:80` (HTTP redirect). No Docker-side port publishing is involved.
+
+For self-hosted instances, set the domain via environment variable:
+
+```bash
+DOMAIN=check.yourdomain.com docker compose up -d --build
+```
+
+Caddy auto-provisions TLS certificates via ACME (Let's Encrypt). The `caddy_data` volume persists certs across container restarts. Ensure the domain's DNS A record points to the server before starting.
 
 ### Why `network_mode: host`?
 
@@ -123,17 +133,6 @@ The "obvious" docker-compose shape — `ports: "3025:3025"` plus `BIND_ADDR=0.0.
 
 `network_mode: host` avoids this entirely: the container shares the host's network namespace, so `127.0.0.1:3025` inside the container IS the host's loopback, and Caddy running on the host can reverse-proxy to it exactly as it would for a systemd-native deployment. No explicit `ports:` mapping is needed (or allowed — Docker rejects `ports` in host-network mode).
 
-### Caddy is still required
-
-The Docker deployment does **not** bundle Caddy. Run Caddy on the host using the canonical `services/verify/Caddyfile` committed alongside this README:
-
-```bash
-# On the host, not inside the container
-DOMAIN=check.yourdomain.com caddy run --config services/verify/Caddyfile
-```
-
-The compose file's `network_mode: host` means Caddy's `reverse_proxy 127.0.0.1:3025` directive targets the verify container directly.
-
 ### Verifying the deployment
 
 ```bash
@@ -145,26 +144,42 @@ curl http://127.0.0.1:3025/health
 nc 127.0.0.1 25
 # -> 220 check.aimx.email SMTP aimx-verify
 
-# Per-request logs from the container
+# Caddy is proxying
+curl -I https://localhost
+# -> should show Caddy's TLS response (or cert error if DNS isn't pointed yet)
+
+# Per-request logs from both containers
 docker compose logs -f verify
+docker compose logs -f caddy
 ```
 
-From a remote machine (with Caddy + DNS configured), `curl https://check.yourdomain.com/probe` and `curl https://check.yourdomain.com/reach` should return JSON with the caller's real public IP — not `127.0.0.1` or a private Docker bridge address.
+From a remote machine (with DNS configured), `curl https://check.yourdomain.com/probe` and `curl https://check.yourdomain.com/reach` should return JSON with the caller's real public IP — not `127.0.0.1` or a private Docker bridge address.
 
-### Raw `docker run` (without compose)
+### Running without compose
 
-If you prefer not to use docker-compose:
+If you prefer to manage containers individually:
 
 ```bash
+# Verify service
 docker build -t aimx-verify:local services/verify
 docker run -d --name aimx-verify \
   --network host \
   --restart unless-stopped \
   -e RUST_LOG=info \
   aimx-verify:local
+
+# Caddy
+docker run -d --name aimx-caddy \
+  --network host \
+  --restart unless-stopped \
+  -v $(pwd)/services/verify/Caddyfile:/etc/caddy/Caddyfile:ro \
+  -v caddy_data:/data \
+  -v caddy_config:/config \
+  -e DOMAIN=check.yourdomain.com \
+  caddy:2
 ```
 
-Same semantics as the compose shape: host networking, default loopback HTTP bind, Caddy on the host handles TLS + client IP injection.
+Same semantics as the compose shape: host networking, default loopback HTTP bind, Caddy handles TLS + client IP injection.
 
 ## Deployment with systemd
 

--- a/services/verify/docker-compose.yml
+++ b/services/verify/docker-compose.yml
@@ -1,16 +1,18 @@
-# docker-compose for aimx-verify.
+# docker-compose for aimx-verify + Caddy.
 #
-# Deployment shape: `network_mode: host`. The verify service defaults to
-# binding HTTP on 127.0.0.1:3025 and SMTP on 0.0.0.0:25. Sprint 12 added a
-# Layer 3 trust check that only reads the `X-AIMX-Client-IP` header when the
-# TCP peer is loopback — Docker's userland proxy would present peer IPs as
-# the bridge gateway (a private IP), which the Layer 4 target guard rejects.
-# Host networking keeps the service's loopback view identical to a systemd
-# deployment, so Caddy on the host can reverse-proxy to 127.0.0.1:3025
-# without any further fiddling.
+# Deployment shape: both services use `network_mode: host`. The verify service
+# defaults to binding HTTP on 127.0.0.1:3025 and SMTP on 0.0.0.0:25. Caddy
+# terminates TLS on 443 and reverse-proxies to 127.0.0.1:3025, injecting the
+# trusted X-AIMX-Client-IP header.
 #
-# Caddy is NOT part of this compose file. Run Caddy on the host using the
-# canonical `services/verify/Caddyfile` shipped alongside this file.
+# Sprint 12 added a Layer 3 trust check that only reads the X-AIMX-Client-IP
+# header when the TCP peer is loopback — Docker's userland proxy would present
+# peer IPs as the bridge gateway (a private IP), which the Layer 4 target guard
+# rejects. Host networking keeps both services' loopback view identical to a
+# bare-metal deployment, so the trust model works without any fiddling.
+#
+# No `ports:` blocks — `network_mode: host` makes port mapping both
+# unnecessary and incompatible (Docker rejects `ports` with host mode).
 services:
   verify:
     build: .
@@ -27,5 +29,21 @@ services:
       # BIND_ADDR: "127.0.0.1:3025"
       # SMTP_BIND_ADDR: "0.0.0.0:25"
       RUST_LOG: "info"
-    # No `ports:` block — `network_mode: host` makes port mapping both
-    # unnecessary and incompatible (Docker rejects `ports` with host mode).
+
+  caddy:
+    image: caddy:2
+    container_name: aimx-caddy
+    network_mode: host
+    restart: unless-stopped
+    volumes:
+      - ./Caddyfile:/etc/caddy/Caddyfile:ro
+      - caddy_data:/data
+      - caddy_config:/config
+    environment:
+      # Domain for TLS cert provisioning. Default matches the Caddyfile's
+      # {$DOMAIN:check.aimx.email} placeholder. Override for self-hosted:
+      DOMAIN: "${DOMAIN:-check.aimx.email}"
+
+volumes:
+  caddy_data:
+  caddy_config:


### PR DESCRIPTION
## Summary

- Adds a `caddy:2` sibling service to `services/verify/docker-compose.yml` so `docker compose up -d --build` deploys both the verify service and its TLS reverse proxy in one command
- Both services use `network_mode: host`, fully preserving the Sprint 12 loopback trust + Layer 4 target guard security model
- `DOMAIN` env var configurable (defaults to `check.aimx.email`), with `caddy_data` and `caddy_config` named volumes for persistent TLS certs
- README Docker section rewritten to document the all-in-one deployment, including DOMAIN override, verification steps, and running-without-compose instructions

## Story Coverage (S16.1)

- [x] Add `caddy` service using `caddy:2` image, `network_mode: host`, `restart: unless-stopped`
- [x] Mount existing `Caddyfile` into Caddy container (read-only)
- [x] Named volume `caddy_data` mapped to `/data` for persistent TLS cert storage
- [x] Named volume `caddy_config` mapped to `/config` for Caddy runtime config
- [x] `DOMAIN` env var configurable with default `check.aimx.email`
- [x] docker-compose header comment updated to reflect Caddy inclusion
- [x] `services/verify/README.md` Docker section updated with all-in-one compose deployment docs
- [ ] Manual verification (requires Docker host): `docker compose up -d --build` brings up both services

## Test plan

- [x] All 47 existing verify service unit tests pass (`cargo test`)
- [x] `docker-compose.yml` passes YAML validation
- [ ] Manual: `docker compose up -d --build` on a Docker host — verify both containers start
- [ ] Manual: `curl http://127.0.0.1:3025/health` returns OK
- [ ] Manual: Caddy logs show it is listening on 443