### PR TITLE
Expand documentation with routing logic and command clarifications

### DIFF
--- a/book/index.md
+++ b/book/index.md
@@ -26,7 +26,7 @@ Outbound:
 
 - **[Setup wizard](setup.md)** -- interactive setup, OpenSMTPD configuration, DKIM key generation, colorized DNS/MCP/deliverability output, re-entrant verification
 - **[Markdown email](mailboxes.md)** -- incoming email parsed to Markdown with TOML frontmatter, attachment extraction, per-mailbox routing
-- **[MCP server](mcp.md)** -- stdio transport for Claude Code, OpenClaw, Codex, OpenCode, and any MCP-compatible agent: list, read, send, reply, manage mailboxes
+- **[MCP Server](mcp.md)** -- stdio transport for Claude Code, OpenClaw, Codex, OpenCode, and any MCP-compatible agent: list, read, send, reply, manage mailboxes
 - **[Channel rules](channels.md)** -- trigger shell commands on incoming mail with match filters (from, subject, attachments)
 - **[DKIM signing](setup.md#dkim-key-management)** -- native RSA-SHA256 signing for outbound mail
 - **[Inbound trust](channels.md#trust-policies)** -- DKIM/SPF verification, per-mailbox trust policies, trusted sender allowlists

--- a/book/mailboxes.md
+++ b/book/mailboxes.md
@@ -8,6 +8,15 @@ Mailboxes are the core organizational unit in aimx. Each mailbox maps an email a
 - **Catchall.** The `catchall` mailbox (created by default during setup) receives email for any unrecognized address at your domain.
 - **No restart required.** Mailbox changes take effect immediately -- `aimx ingest` reads the config on each invocation.
 
+### Routing logic
+
+When an email arrives, aimx matches the local part of the recipient address (the part before `@`) against mailbox names in the config. If a mailbox with that exact name exists, the email is delivered there. Otherwise it falls through to the `catchall` mailbox.
+
+For example, with mailboxes `support` and `catchall` configured:
+- `support@agent.yourdomain.com` -> delivered to the `support` mailbox
+- `billing@agent.yourdomain.com` -> delivered to the `catchall` mailbox (no `billing` mailbox exists)
+- `anything@agent.yourdomain.com` -> delivered to the `catchall` mailbox
+
 ## Managing mailboxes
 
 ### Create a mailbox

--- a/book/mcp.md
+++ b/book/mcp.md
@@ -176,7 +176,8 @@ Updates `read = false` in the email's frontmatter.
 | Framework | Integration method |
 |-----------|-------------------|
 | Claude Code | MCP stdio mode via `~/.claude/settings.json` |
-| OpenClaw | MCP integration or [channel rules](channels.md) via shell |
+| OpenClaw | MCP stdio mode or [channel rules](channels.md) via shell |
+| OpenCode | MCP stdio mode |
 | Codex | [Channel rules](channels.md) via shell command |
 | Any MCP client | Standard MCP stdio transport |
 

--- a/book/setup.md
+++ b/book/setup.md
@@ -61,10 +61,12 @@ This checks port 25 connectivity without installing anything:
 
 | Check | What it does | Fix if it fails |
 |-------|-------------|-----------------|
-| Outbound port 25 | Connects to a well-known MX server on port 25 | Ask VPS provider to unblock outbound SMTP |
-| Inbound port 25 | Calls `check.aimx.email/reach` to connect back to your IP on port 25 | Open firewall, ask VPS provider to unblock inbound SMTP |
+| Outbound port 25 | Connects to `check.aimx.email` on port 25 to test outbound SMTP | Ask VPS provider to unblock outbound SMTP |
+| Inbound port 25 | Calls `check.aimx.email/reach` to connect back to your IP on port 25 (plain TCP) | Open firewall, ask VPS provider to unblock inbound SMTP |
 
 Both checks should show PASS before proceeding with setup.
+
+> **Preflight vs Verify:** `aimx preflight` runs *before* OpenSMTPD is installed -- it uses a plain TCP reachability check (`/reach`). `aimx verify` runs *after* setup -- it performs a full SMTP EHLO handshake (`/probe`) to confirm your mail server responds correctly. Use `preflight` to validate your VPS, and `verify` to validate your running setup.
 
 ## Setup wizard
 

--- a/book/troubleshooting.md
+++ b/book/troubleshooting.md
@@ -126,14 +126,27 @@ If permissions are wrong:
 sudo chmod 600 /var/lib/aimx/dkim/private.key
 ```
 
+## Preflight vs Verify
+
+Both commands check port 25 connectivity, but they serve different purposes:
+
+| Command | When to use | What it checks |
+|---------|-------------|----------------|
+| `sudo aimx preflight` | **Before setup** on a fresh VPS | Plain TCP reachability via `/reach` -- does not require a running mail server. Requires root to bind port 25. |
+| `aimx verify` | **After setup** with a running mail server | Full SMTP EHLO handshake via `/probe` -- confirms OpenSMTPD responds correctly. Does not require root. |
+
+If `aimx verify` fails but `aimx preflight` passed earlier, the issue is likely in your OpenSMTPD configuration rather than firewall/port access.
+
 ## Useful commands reference
 
 | Command | Purpose |
 |---------|---------|
-| `sudo aimx preflight` | Check port 25 connectivity |
+| `sudo aimx preflight` | Check port 25 connectivity (pre-setup) |
 | `aimx status` | Show config, mailboxes, and message counts |
-| `aimx verify` | Full connectivity verification |
+| `aimx verify` | Full connectivity verification (post-setup) |
 | `aimx mailbox list` | List all mailboxes |
+| `aimx dkim-keygen` | Generate DKIM keypair |
+| `aimx dkim-keygen --force` | Regenerate DKIM keys (update DNS record after) |
 | `aimx --data-dir /path status` | Use a custom data directory |
 | `sudo systemctl status opensmtpd` | Check OpenSMTPD service |
 | `journalctl -u opensmtpd -e` | View OpenSMTPD logs |


### PR DESCRIPTION
## Summary
This PR expands the documentation with clearer explanations of key concepts and commands, particularly around email routing logic and the distinction between preflight and verify operations.

## Key changes

- **Added routing logic section** to `mailboxes.md` explaining how aimx matches recipient addresses to mailboxes and falls back to catchall
- **Clarified preflight vs verify distinction** across multiple docs (`troubleshooting.md`, `setup.md`) with a detailed comparison table showing when to use each command and what they check
- **Enhanced command reference** in `troubleshooting.md` with:
  - Clarified purpose descriptions for `preflight` and `verify` (pre-setup vs post-setup)
  - Added `dkim-keygen` and `dkim-keygen --force` commands with descriptions
- **Updated setup.md** with more precise descriptions of what the outbound and inbound port 25 checks do
- **Fixed framework integration details** in `mcp.md` (OpenClaw uses MCP stdio mode, added OpenCode)
- **Minor capitalization fix** in `index.md` (MCP server → MCP Server)

## Notable details

The preflight vs verify clarification is the most significant addition, addressing a common source of confusion:
- `preflight` uses plain TCP reachability check (`/reach`) and requires root, runs before OpenSMTPD setup
- `verify` performs full SMTP EHLO handshake (`/probe`) and doesn't require root, runs after setup is complete

This helps users understand that if verify fails but preflight passed, the issue is likely in OpenSMTPD configuration rather than firewall/port access.

https://claude.ai/code/session_01NCPgDQiyPSGBYShvLyTc22