### PR TITLE
Fix setup failing when OpenSMTPD was removed but not purged

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -52,12 +52,19 @@ pub struct RealSystemOps;
 
 impl SystemOps for RealSystemOps {
     fn is_package_installed(&self, package: &str) -> bool {
-        std::process::Command::new("dpkg")
+        let output = std::process::Command::new("dpkg")
             .args(["-s", package])
-            .stdout(std::process::Stdio::null())
             .stderr(std::process::Stdio::null())
-            .status()
-            .is_ok_and(|s| s.success())
+            .output();
+        match output {
+            Ok(out) if out.status.success() => {
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                stdout
+                    .lines()
+                    .any(|line| line == "Status: install ok installed")
+            }
+            _ => false,
+        }
     }
 
     fn install_package(&self, package: &str) -> Result<(), Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Summary

- **Bug:** `aimx setup` fails with `"Unit opensmtpd.service not found"` when OpenSMTPD was previously installed then removed via `apt remove opensmtpd` (without `--purge`)
- **Root cause:** `is_package_installed()` trusted the `dpkg -s` exit code alone. After `apt remove`, dpkg still returns success because it retains package metadata with status `deinstall ok config-files` — but the binary and systemd service unit are deleted. Setup skipped reinstallation and then crashed trying to restart a non-existent service.
- **Fix:** Parse the actual `Status:` line from `dpkg -s` output and only treat the package as installed when it reads `Status: install ok installed`

## Test plan

- [x] `cargo test` — all 335 tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Manual: on a system with `apt remove opensmtpd` state, verify `dpkg -s opensmtpd` shows `Status: deinstall ok config-files` and `aimx setup` correctly triggers reinstallation

🤖 Generated with [Claude Code](https://claude.com/claude-code)