### PR TITLE
[Sprint 19] Embedded SMTP Receiver

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,6 +59,8 @@ dependencies = [
  "predicates",
  "rmcp",
  "rsa",
+ "rustls",
+ "rustls-pemfile",
  "rustls-pki-types",
  "schemars",
  "serde",
@@ -66,6 +68,7 @@ dependencies = [
  "shell-escape",
  "tempfile",
  "tokio",
+ "tokio-rustls",
  "toml",
  "uuid",
 ]
@@ -175,6 +178,28 @@ name = "autocfg"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
+name = "aws-lc-rs"
+version = "1.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+dependencies = [
+ "aws-lc-sys",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.39.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+dependencies = [
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
 
 [[package]]
 name = "base64"
@@ -316,6 +341,15 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
+
+[[package]]
+name = "cmake"
+version = "0.1.58"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -530,6 +564,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dunce"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,6 +658,12 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
+
+[[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -1828,6 +1874,7 @@ version = "0.23.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring",
@@ -1835,6 +1882,15 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -1852,6 +1908,7 @@ version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -1997,6 +2054,16 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "signature"
@@ -2231,6 +2298,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,10 @@ base64 = "0.22"
 mail-auth = "0.7"
 mime_guess = "2"
 rmcp = { version = "1.3.0", features = ["server", "transport-io"] }
-tokio = { version = "1.51.1", features = ["rt-multi-thread", "macros", "io-util", "io-std"] }
+tokio = { version = "1.51.1", features = ["rt-multi-thread", "macros", "io-util", "io-std", "net", "time", "sync", "signal"] }
+tokio-rustls = "0.26"
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "std"] }
+rustls-pemfile = "2"
 serde_json = "1.0.149"
 schemars = "1.2.1"
 glob-match = "0.2"

--- a/docs/sprint.md
+++ b/docs/sprint.md
@@ -1639,7 +1639,7 @@ No GitHub Actions image publishing to ghcr.io in this sprint — not requested. 
 
 ---
 
-## Sprint 19 — Embedded SMTP Receiver (Days 52–54.5) [NOT STARTED]
+## Sprint 19 — Embedded SMTP Receiver (Days 52–54.5) [IN PROGRESS]
 
 **Goal:** Build a hand-rolled tokio-based SMTP listener that accepts inbound email and calls `ingest_email()` in-process. No CLI wiring yet — this sprint produces the library code that `aimx serve` will use.
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod mailbox;
 mod mcp;
 mod send;
 mod setup;
+pub mod smtp;
 mod status;
 mod verify;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,7 +7,8 @@ mod mailbox;
 mod mcp;
 mod send;
 mod setup;
-pub mod smtp;
+#[allow(dead_code)]
+mod smtp;
 mod status;
 mod verify;
 

--- a/src/smtp/mod.rs
+++ b/src/smtp/mod.rs
@@ -1,0 +1,156 @@
+mod session;
+#[cfg(test)]
+mod tests;
+mod tls;
+
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::net::TcpListener;
+use tokio::sync::Semaphore;
+
+use crate::config::Config;
+
+pub const DEFAULT_MAX_MESSAGE_SIZE: usize = 25 * 1024 * 1024; // 25 MB
+pub const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(300); // 5 min
+pub const DEFAULT_TOTAL_TIMEOUT: Duration = Duration::from_secs(600); // 10 min
+pub const DEFAULT_MAX_CONNECTIONS: usize = 100;
+pub const DEFAULT_MAX_COMMANDS_BEFORE_DATA: usize = 50;
+
+pub struct SmtpServer {
+    config: Arc<Config>,
+    tls_acceptor: Option<Arc<tokio_rustls::TlsAcceptor>>,
+    max_message_size: usize,
+    idle_timeout: Duration,
+    total_timeout: Duration,
+    max_connections: usize,
+    max_commands_before_data: usize,
+}
+
+impl SmtpServer {
+    pub fn new(config: Config) -> Self {
+        Self {
+            config: Arc::new(config),
+            tls_acceptor: None,
+            max_message_size: DEFAULT_MAX_MESSAGE_SIZE,
+            idle_timeout: DEFAULT_IDLE_TIMEOUT,
+            total_timeout: DEFAULT_TOTAL_TIMEOUT,
+            max_connections: DEFAULT_MAX_CONNECTIONS,
+            max_commands_before_data: DEFAULT_MAX_COMMANDS_BEFORE_DATA,
+        }
+    }
+
+    pub fn with_tls(
+        mut self,
+        cert_path: &std::path::Path,
+        key_path: &std::path::Path,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let acceptor = tls::build_tls_acceptor(cert_path, key_path)?;
+        self.tls_acceptor = Some(Arc::new(acceptor));
+        Ok(self)
+    }
+
+    pub fn with_max_message_size(mut self, size: usize) -> Self {
+        self.max_message_size = size;
+        self
+    }
+
+    pub fn with_max_connections(mut self, max: usize) -> Self {
+        self.max_connections = max;
+        self
+    }
+
+    pub fn with_timeouts(mut self, idle: Duration, total: Duration) -> Self {
+        self.idle_timeout = idle;
+        self.total_timeout = total;
+        self
+    }
+
+    pub fn with_max_commands_before_data(mut self, max: usize) -> Self {
+        self.max_commands_before_data = max;
+        self
+    }
+
+    pub async fn run(
+        &self,
+        listener: TcpListener,
+        mut shutdown: tokio::sync::watch::Receiver<bool>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let semaphore = Arc::new(Semaphore::new(self.max_connections));
+        let hostname = self.config.domain.clone();
+
+        loop {
+            tokio::select! {
+                result = listener.accept() => {
+                    let (stream, peer_addr) = match result {
+                        Ok(v) => v,
+                        Err(e) => {
+                            eprintln!("Accept error: {e}");
+                            continue;
+                        }
+                    };
+
+                    let permit = match semaphore.clone().try_acquire_owned() {
+                        Ok(p) => p,
+                        Err(_) => {
+                            Self::reject_connection(stream, peer_addr).await;
+                            continue;
+                        }
+                    };
+
+                    let config = Arc::clone(&self.config);
+                    let tls_acceptor = self.tls_acceptor.clone();
+                    let hostname = hostname.clone();
+                    let max_message_size = self.max_message_size;
+                    let idle_timeout = self.idle_timeout;
+                    let total_timeout = self.total_timeout;
+                    let max_commands = self.max_commands_before_data;
+
+                    tokio::spawn(async move {
+                        let _permit = permit;
+                        let params = session::SessionParams {
+                            config,
+                            tls_acceptor,
+                            hostname,
+                            peer_addr,
+                            max_message_size,
+                            idle_timeout,
+                            total_timeout,
+                            max_commands_before_data: max_commands,
+                        };
+                        let session = session::SmtpSession::new(params);
+                        if let Err(e) = session.handle(stream).await {
+                            eprintln!("[{peer_addr}] Session error: {e}");
+                        }
+                    });
+                }
+                _ = shutdown.changed() => {
+                    break;
+                }
+            }
+        }
+
+        drop(listener);
+
+        let grace_start = tokio::time::Instant::now();
+        let grace_period = Duration::from_secs(30);
+        while semaphore.available_permits() < self.max_connections {
+            if grace_start.elapsed() >= grace_period {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        Ok(())
+    }
+
+    async fn reject_connection(stream: tokio::net::TcpStream, addr: SocketAddr) {
+        use tokio::io::AsyncWriteExt;
+        let mut stream = stream;
+        let _ = stream
+            .write_all(b"421 Too many connections, try again later\r\n")
+            .await;
+        let _ = stream.shutdown().await;
+        eprintln!("[{addr}] Rejected: connection limit reached");
+    }
+}

--- a/src/smtp/session.rs
+++ b/src/smtp/session.rs
@@ -7,6 +7,8 @@ use tokio_rustls::TlsAcceptor;
 
 use crate::config::Config;
 
+const MAX_COMMAND_LINE_LENGTH: usize = 1024;
+
 #[derive(Debug, Clone, Copy, PartialEq)]
 enum State {
     Connected,
@@ -14,6 +16,12 @@ enum State {
     MailFrom,
     RcptTo,
     Data,
+}
+
+enum CommandLoopExit {
+    Done,
+    StarttlsUpgrade,
+    Err(Box<dyn std::error::Error + Send + Sync>),
 }
 
 pub struct SessionParams {
@@ -38,6 +46,8 @@ struct SessionState {
     tls_active: bool,
     ehlo_hostname: String,
     command_count: usize,
+    total_bytes: usize,
+    message_count: usize,
 }
 
 impl SessionState {
@@ -49,6 +59,8 @@ impl SessionState {
             tls_active: false,
             ehlo_hostname: String::new(),
             command_count: 0,
+            total_bytes: 0,
+            message_count: 0,
         }
     }
 
@@ -83,33 +95,35 @@ impl SmtpSession {
         .await;
 
         let duration = connection_start.elapsed();
-        let rcpt_count = session_state.forward_paths.len();
         match &result {
             Ok(Ok(_)) => {
                 eprintln!(
-                    "[{}] Connection closed ehlo={} rcpts={} duration={:.1}s result=ok",
+                    "[{}] Connection closed ehlo={} messages={} bytes={} duration={:.1}s result=ok",
                     self.params.peer_addr,
                     session_state.ehlo_hostname,
-                    rcpt_count,
+                    session_state.message_count,
+                    session_state.total_bytes,
                     duration.as_secs_f64()
                 );
             }
             Ok(Err(e)) => {
                 eprintln!(
-                    "[{}] Connection error ehlo={} rcpts={} duration={:.1}s result=error: {}",
+                    "[{}] Connection error ehlo={} messages={} bytes={} duration={:.1}s result=error: {}",
                     self.params.peer_addr,
                     session_state.ehlo_hostname,
-                    rcpt_count,
+                    session_state.message_count,
+                    session_state.total_bytes,
                     duration.as_secs_f64(),
                     e
                 );
             }
             Err(_) => {
                 eprintln!(
-                    "[{}] Connection timeout ehlo={} rcpts={} duration={:.1}s result=timeout",
+                    "[{}] Connection timeout ehlo={} messages={} bytes={} duration={:.1}s result=timeout",
                     self.params.peer_addr,
                     session_state.ehlo_hostname,
-                    rcpt_count,
+                    session_state.message_count,
+                    session_state.total_bytes,
                     duration.as_secs_f64()
                 );
             }
@@ -129,20 +143,18 @@ impl SmtpSession {
         let mut reader = BufReader::new(reader);
         writer.write_all(banner.as_bytes()).await?;
 
-        let result = self
+        match self
             .command_loop(&mut reader, &mut writer, session_state, total_deadline)
-            .await;
-
-        if let Err(ref e) = result
-            && e.to_string() == "STARTTLS_UPGRADE"
+            .await
         {
-            let inner = reader.into_inner().unsplit(writer);
-            return self
-                .handle_tls_upgrade(inner, session_state, total_deadline)
-                .await;
+            CommandLoopExit::StarttlsUpgrade => {
+                let inner = reader.into_inner().unsplit(writer);
+                self.handle_tls_upgrade(inner, session_state, total_deadline)
+                    .await
+            }
+            CommandLoopExit::Done => Ok(()),
+            CommandLoopExit::Err(e) => Err(e),
         }
-
-        result
     }
 
     async fn handle_tls_upgrade(
@@ -151,7 +163,11 @@ impl SmtpSession {
         session_state: &mut SessionState,
         total_deadline: tokio::time::Instant,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        let acceptor = self.params.tls_acceptor.as_ref().unwrap();
+        let acceptor = self
+            .params
+            .tls_acceptor
+            .as_ref()
+            .expect("TLS acceptor must exist during STARTTLS upgrade");
         let tls_stream = match acceptor.accept(stream).await {
             Ok(s) => s,
             Err(e) => {
@@ -166,8 +182,13 @@ impl SmtpSession {
         let (reader, mut writer) = tokio::io::split(tls_stream);
         let mut reader = BufReader::new(reader);
 
-        self.command_loop(&mut reader, &mut writer, session_state, total_deadline)
+        match self
+            .command_loop(&mut reader, &mut writer, session_state, total_deadline)
             .await
+        {
+            CommandLoopExit::Done | CommandLoopExit::StarttlsUpgrade => Ok(()),
+            CommandLoopExit::Err(e) => Err(e),
+        }
     }
 
     async fn command_loop<R, W>(
@@ -176,7 +197,7 @@ impl SmtpSession {
         writer: &mut W,
         session_state: &mut SessionState,
         total_deadline: tokio::time::Instant,
-    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+    ) -> CommandLoopExit
     where
         R: AsyncRead + Unpin,
         W: AsyncWrite + Unpin,
@@ -185,25 +206,38 @@ impl SmtpSession {
         loop {
             line_buf.clear();
             let read_result = tokio::time::timeout(self.params.idle_timeout, async {
-                tokio::time::timeout_at(total_deadline, reader.read_line(&mut line_buf)).await
+                tokio::time::timeout_at(
+                    total_deadline,
+                    bounded_read_line(reader, &mut line_buf, MAX_COMMAND_LINE_LENGTH),
+                )
+                .await
             })
             .await;
 
-            let bytes_read = match read_result {
-                Ok(Ok(Ok(n))) => n,
-                Ok(Ok(Err(e))) => return Err(format!("Read error: {e}").into()),
+            let line_result = match read_result {
+                Ok(Ok(r)) => r,
                 Ok(Err(_)) => {
                     let _ = writer.write_all(b"421 Connection timed out\r\n").await;
-                    return Ok(());
+                    return CommandLoopExit::Done;
                 }
                 Err(_) => {
                     let _ = writer.write_all(b"421 Idle timeout exceeded\r\n").await;
-                    return Ok(());
+                    return CommandLoopExit::Done;
                 }
             };
 
-            if bytes_read == 0 {
-                return Ok(());
+            match line_result {
+                ReadLineResult::TooLong => {
+                    if writer.write_all(b"500 Line too long\r\n").await.is_err() {
+                        return CommandLoopExit::Done;
+                    }
+                    continue;
+                }
+                ReadLineResult::Eof => return CommandLoopExit::Done,
+                ReadLineResult::Err(e) => {
+                    return CommandLoopExit::Err(format!("Read error: {e}").into());
+                }
+                ReadLineResult::Ok(_) => {}
             }
 
             let line = line_buf.trim_end();
@@ -215,8 +249,8 @@ impl SmtpSession {
             if session_state.state != State::Data
                 && session_state.command_count > self.params.max_commands_before_data
             {
-                writer.write_all(b"421 Too many commands\r\n").await?;
-                return Ok(());
+                let _ = writer.write_all(b"421 Too many commands\r\n").await;
+                return CommandLoopExit::Done;
             }
 
             let (cmd, args) = parse_command(line);
@@ -229,13 +263,21 @@ impl SmtpSession {
                     if let Some(resp) = self.handle_data_precheck(session_state) {
                         resp
                     } else {
-                        writer
+                        if writer
                             .write_all(b"354 Start mail input; end with <CRLF>.<CRLF>\r\n")
-                            .await?;
+                            .await
+                            .is_err()
+                        {
+                            return CommandLoopExit::Done;
+                        }
                         session_state.state = State::Data;
-                        let result = self
+                        let result = match self
                             .receive_data(reader, session_state, total_deadline)
-                            .await?;
+                            .await
+                        {
+                            Ok(r) => r,
+                            Err(e) => return CommandLoopExit::Err(e),
+                        };
                         session_state.reset_transaction();
                         result
                     }
@@ -243,8 +285,8 @@ impl SmtpSession {
                 "RSET" => self.handle_rset(session_state),
                 "NOOP" => "250 OK\r\n".to_string(),
                 "QUIT" => {
-                    writer.write_all(b"221 Bye\r\n").await?;
-                    return Ok(());
+                    let _ = writer.write_all(b"221 Bye\r\n").await;
+                    return CommandLoopExit::Done;
                 }
                 "STARTTLS" => {
                     if self.params.tls_acceptor.is_none() {
@@ -252,14 +294,16 @@ impl SmtpSession {
                     } else if session_state.tls_active {
                         "503 TLS already active\r\n".to_string()
                     } else {
-                        writer.write_all(b"220 Ready to start TLS\r\n").await?;
-                        return Err("STARTTLS_UPGRADE".into());
+                        let _ = writer.write_all(b"220 Ready to start TLS\r\n").await;
+                        return CommandLoopExit::StarttlsUpgrade;
                     }
                 }
                 _ => "500 Unrecognized command\r\n".to_string(),
             };
 
-            writer.write_all(response.as_bytes()).await?;
+            if writer.write_all(response.as_bytes()).await.is_err() {
+                return CommandLoopExit::Done;
+            }
         }
     }
 
@@ -349,24 +393,51 @@ impl SmtpSession {
     {
         let mut data = Vec::new();
         let mut line_buf = String::new();
+        let data_line_limit = self.params.max_message_size + 1024;
 
         loop {
             line_buf.clear();
             let read_result = tokio::time::timeout(self.params.idle_timeout, async {
-                tokio::time::timeout_at(total_deadline, reader.read_line(&mut line_buf)).await
+                tokio::time::timeout_at(
+                    total_deadline,
+                    bounded_read_line(reader, &mut line_buf, data_line_limit),
+                )
+                .await
             })
             .await;
 
-            let bytes_read = match read_result {
-                Ok(Ok(Ok(n))) => n,
-                Ok(Ok(Err(e))) => return Err(format!("Read error during DATA: {e}").into()),
+            let line_result = match read_result {
+                Ok(Ok(r)) => r,
                 Ok(Err(_)) | Err(_) => {
                     return Ok("421 Timeout during DATA\r\n".to_string());
                 }
             };
 
-            if bytes_read == 0 {
-                return Ok("451 Client disconnected during DATA\r\n".to_string());
+            match line_result {
+                ReadLineResult::TooLong => {
+                    // Drain remaining DATA lines
+                    loop {
+                        line_buf.clear();
+                        match tokio::time::timeout(
+                            self.params.idle_timeout,
+                            bounded_read_line(reader, &mut line_buf, data_line_limit),
+                        )
+                        .await
+                        {
+                            Ok(ReadLineResult::Ok(_)) if line_buf.trim_end() == "." => break,
+                            Ok(ReadLineResult::Eof) | Err(_) => break,
+                            _ => continue,
+                        }
+                    }
+                    return Ok("552 Message exceeds maximum size\r\n".to_string());
+                }
+                ReadLineResult::Eof => {
+                    return Ok("451 Client disconnected during DATA\r\n".to_string());
+                }
+                ReadLineResult::Err(e) => {
+                    return Err(format!("Read error during DATA: {e}").into());
+                }
+                ReadLineResult::Ok(_) => {}
             }
 
             // RFC 5321: reject bare LF (lines must end with CRLF)
@@ -386,21 +457,17 @@ impl SmtpSession {
             }
 
             if data.len() > self.params.max_message_size {
-                // Consume remaining DATA to avoid desync
                 loop {
                     line_buf.clear();
                     match tokio::time::timeout(
                         self.params.idle_timeout,
-                        reader.read_line(&mut line_buf),
+                        bounded_read_line(reader, &mut line_buf, data_line_limit),
                     )
                     .await
                     {
-                        Ok(Ok(n)) if n > 0 => {
-                            if line_buf.trim_end() == "." {
-                                break;
-                            }
-                        }
-                        _ => break,
+                        Ok(ReadLineResult::Ok(_)) if line_buf.trim_end() == "." => break,
+                        Ok(ReadLineResult::Eof) | Err(_) => break,
+                        _ => continue,
                     }
                 }
                 return Ok("552 Message exceeds maximum size\r\n".to_string());
@@ -413,11 +480,12 @@ impl SmtpSession {
     async fn deliver_message(
         &self,
         data: &[u8],
-        session_state: &SessionState,
+        session_state: &mut SessionState,
     ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
-        let mut all_ok = true;
         let config = Arc::clone(&self.params.config);
         let data = data.to_vec();
+        let mut succeeded = 0usize;
+        let mut failed = 0usize;
 
         for rcpt in &session_state.forward_paths {
             let config = Arc::clone(&config);
@@ -425,37 +493,108 @@ impl SmtpSession {
             let rcpt_owned = rcpt.clone();
             let peer = self.params.peer_addr;
 
-            // Run ingest in a blocking thread since it creates its own
-            // tokio runtime for DKIM/SPF verification.
             let result = tokio::task::spawn_blocking(move || {
                 crate::ingest::ingest_email(&config, &rcpt_owned, &data).map_err(|e| e.to_string())
             })
             .await;
 
             match result {
-                Ok(Ok(())) => {}
+                Ok(Ok(())) => succeeded += 1,
                 Ok(Err(e)) => {
                     eprintln!("[{peer}] Ingest failed for {rcpt}: {e}");
-                    all_ok = false;
+                    failed += 1;
                 }
                 Err(e) => {
                     eprintln!("[{peer}] Ingest task panicked for {rcpt}: {e}");
-                    all_ok = false;
+                    failed += 1;
                 }
             }
         }
 
-        if all_ok {
-            let size = data.len();
-            let rcpt_count = session_state.forward_paths.len();
-            eprintln!(
-                "[{}] Message accepted from={} rcpts={} size={}",
-                self.params.peer_addr, session_state.reverse_path, rcpt_count, size
-            );
+        let size = data.len();
+        let rcpt_count = session_state.forward_paths.len();
+        if succeeded > 0 {
+            session_state.message_count += 1;
+            session_state.total_bytes += size;
+            if failed > 0 {
+                eprintln!(
+                    "[{}] Message partially accepted from={} rcpts={} succeeded={} failed={} size={}",
+                    self.params.peer_addr,
+                    session_state.reverse_path,
+                    rcpt_count,
+                    succeeded,
+                    failed,
+                    size
+                );
+            } else {
+                eprintln!(
+                    "[{}] Message accepted from={} rcpts={} size={}",
+                    self.params.peer_addr, session_state.reverse_path, rcpt_count, size
+                );
+            }
             Ok("250 OK message accepted\r\n".to_string())
         } else {
+            eprintln!(
+                "[{}] Message rejected from={} rcpts={} all_failed size={}",
+                self.params.peer_addr, session_state.reverse_path, rcpt_count, size
+            );
             Ok("451 Temporary failure, please retry\r\n".to_string())
         }
+    }
+}
+
+enum ReadLineResult {
+    Ok(usize),
+    TooLong,
+    Eof,
+    Err(String),
+}
+
+async fn bounded_read_line<R: AsyncBufReadExt + Unpin>(
+    reader: &mut R,
+    buf: &mut String,
+    max_len: usize,
+) -> ReadLineResult {
+    loop {
+        let available = match reader.fill_buf().await {
+            Ok([]) => return ReadLineResult::Eof,
+            Ok(b) => b,
+            Err(e) => return ReadLineResult::Err(e.to_string()),
+        };
+        if let Some(newline_pos) = available.iter().position(|&b| b == b'\n') {
+            let line_len = buf.len() + newline_pos + 1;
+            if line_len > max_len {
+                reader.consume(newline_pos + 1);
+                return ReadLineResult::TooLong;
+            }
+            let chunk = &available[..newline_pos + 1];
+            buf.push_str(&String::from_utf8_lossy(chunk));
+            reader.consume(newline_pos + 1);
+            return ReadLineResult::Ok(line_len);
+        }
+        // No newline in the buffer yet
+        if buf.len() + available.len() > max_len {
+            let n = available.len();
+            reader.consume(n);
+            // Drain until newline or EOF
+            loop {
+                let rest = match reader.fill_buf().await {
+                    Ok([]) => return ReadLineResult::TooLong,
+                    Ok(b) => b,
+                    Err(_) => return ReadLineResult::TooLong,
+                };
+                if let Some(pos) = rest.iter().position(|&b| b == b'\n') {
+                    reader.consume(pos + 1);
+                    return ReadLineResult::TooLong;
+                }
+                let rn = rest.len();
+                reader.consume(rn);
+            }
+        }
+        let chunk = String::from_utf8_lossy(available).to_string();
+        let n = available.len();
+        buf.push_str(&chunk);
+        reader.consume(n);
     }
 }
 

--- a/src/smtp/session.rs
+++ b/src/smtp/session.rs
@@ -1,0 +1,517 @@
+use std::net::SocketAddr;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader};
+use tokio_rustls::TlsAcceptor;
+
+use crate::config::Config;
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+enum State {
+    Connected,
+    Greeted,
+    MailFrom,
+    RcptTo,
+    Data,
+}
+
+pub struct SessionParams {
+    pub config: Arc<Config>,
+    pub tls_acceptor: Option<Arc<TlsAcceptor>>,
+    pub hostname: String,
+    pub peer_addr: SocketAddr,
+    pub max_message_size: usize,
+    pub idle_timeout: Duration,
+    pub total_timeout: Duration,
+    pub max_commands_before_data: usize,
+}
+
+pub struct SmtpSession {
+    params: SessionParams,
+}
+
+struct SessionState {
+    state: State,
+    reverse_path: String,
+    forward_paths: Vec<String>,
+    tls_active: bool,
+    ehlo_hostname: String,
+    command_count: usize,
+}
+
+impl SessionState {
+    fn new() -> Self {
+        Self {
+            state: State::Connected,
+            reverse_path: String::new(),
+            forward_paths: Vec::new(),
+            tls_active: false,
+            ehlo_hostname: String::new(),
+            command_count: 0,
+        }
+    }
+
+    fn reset_transaction(&mut self) {
+        self.reverse_path.clear();
+        self.forward_paths.clear();
+        if self.state != State::Connected {
+            self.state = State::Greeted;
+        }
+    }
+}
+
+impl SmtpSession {
+    pub fn new(params: SessionParams) -> Self {
+        Self { params }
+    }
+
+    pub async fn handle(
+        self,
+        stream: tokio::net::TcpStream,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let connection_start = Instant::now();
+        let total_deadline = tokio::time::Instant::now() + self.params.total_timeout;
+
+        let mut session_state = SessionState::new();
+        let banner = format!("220 {} ESMTP aimx\r\n", self.params.hostname);
+
+        let result = tokio::time::timeout_at(total_deadline, async {
+            self.run_session(stream, &mut session_state, &banner, total_deadline)
+                .await
+        })
+        .await;
+
+        let duration = connection_start.elapsed();
+        let rcpt_count = session_state.forward_paths.len();
+        match &result {
+            Ok(Ok(_)) => {
+                eprintln!(
+                    "[{}] Connection closed ehlo={} rcpts={} duration={:.1}s result=ok",
+                    self.params.peer_addr,
+                    session_state.ehlo_hostname,
+                    rcpt_count,
+                    duration.as_secs_f64()
+                );
+            }
+            Ok(Err(e)) => {
+                eprintln!(
+                    "[{}] Connection error ehlo={} rcpts={} duration={:.1}s result=error: {}",
+                    self.params.peer_addr,
+                    session_state.ehlo_hostname,
+                    rcpt_count,
+                    duration.as_secs_f64(),
+                    e
+                );
+            }
+            Err(_) => {
+                eprintln!(
+                    "[{}] Connection timeout ehlo={} rcpts={} duration={:.1}s result=timeout",
+                    self.params.peer_addr,
+                    session_state.ehlo_hostname,
+                    rcpt_count,
+                    duration.as_secs_f64()
+                );
+            }
+        }
+
+        result.unwrap_or(Ok(()))
+    }
+
+    async fn run_session(
+        &self,
+        stream: tokio::net::TcpStream,
+        session_state: &mut SessionState,
+        banner: &str,
+        total_deadline: tokio::time::Instant,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let (reader, mut writer) = tokio::io::split(stream);
+        let mut reader = BufReader::new(reader);
+        writer.write_all(banner.as_bytes()).await?;
+
+        let result = self
+            .command_loop(&mut reader, &mut writer, session_state, total_deadline)
+            .await;
+
+        if let Err(ref e) = result
+            && e.to_string() == "STARTTLS_UPGRADE"
+        {
+            let inner = reader.into_inner().unsplit(writer);
+            return self
+                .handle_tls_upgrade(inner, session_state, total_deadline)
+                .await;
+        }
+
+        result
+    }
+
+    async fn handle_tls_upgrade(
+        &self,
+        stream: tokio::net::TcpStream,
+        session_state: &mut SessionState,
+        total_deadline: tokio::time::Instant,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        let acceptor = self.params.tls_acceptor.as_ref().unwrap();
+        let tls_stream = match acceptor.accept(stream).await {
+            Ok(s) => s,
+            Err(e) => {
+                eprintln!("[{}] TLS handshake failed: {}", self.params.peer_addr, e);
+                return Err(format!("TLS handshake failed: {e}").into());
+            }
+        };
+        session_state.tls_active = true;
+        session_state.state = State::Connected;
+        session_state.reset_transaction();
+
+        let (reader, mut writer) = tokio::io::split(tls_stream);
+        let mut reader = BufReader::new(reader);
+
+        self.command_loop(&mut reader, &mut writer, session_state, total_deadline)
+            .await
+    }
+
+    async fn command_loop<R, W>(
+        &self,
+        reader: &mut BufReader<R>,
+        writer: &mut W,
+        session_state: &mut SessionState,
+        total_deadline: tokio::time::Instant,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>>
+    where
+        R: AsyncRead + Unpin,
+        W: AsyncWrite + Unpin,
+    {
+        let mut line_buf = String::new();
+        loop {
+            line_buf.clear();
+            let read_result = tokio::time::timeout(self.params.idle_timeout, async {
+                tokio::time::timeout_at(total_deadline, reader.read_line(&mut line_buf)).await
+            })
+            .await;
+
+            let bytes_read = match read_result {
+                Ok(Ok(Ok(n))) => n,
+                Ok(Ok(Err(e))) => return Err(format!("Read error: {e}").into()),
+                Ok(Err(_)) => {
+                    let _ = writer.write_all(b"421 Connection timed out\r\n").await;
+                    return Ok(());
+                }
+                Err(_) => {
+                    let _ = writer.write_all(b"421 Idle timeout exceeded\r\n").await;
+                    return Ok(());
+                }
+            };
+
+            if bytes_read == 0 {
+                return Ok(());
+            }
+
+            let line = line_buf.trim_end();
+            if line.is_empty() {
+                continue;
+            }
+
+            session_state.command_count += 1;
+            if session_state.state != State::Data
+                && session_state.command_count > self.params.max_commands_before_data
+            {
+                writer.write_all(b"421 Too many commands\r\n").await?;
+                return Ok(());
+            }
+
+            let (cmd, args) = parse_command(line);
+            let response = match cmd.as_str() {
+                "EHLO" => self.handle_ehlo(args, session_state),
+                "HELO" => self.handle_helo(args, session_state),
+                "MAIL" => self.handle_mail_from(args, session_state),
+                "RCPT" => self.handle_rcpt_to(args, session_state),
+                "DATA" => {
+                    if let Some(resp) = self.handle_data_precheck(session_state) {
+                        resp
+                    } else {
+                        writer
+                            .write_all(b"354 Start mail input; end with <CRLF>.<CRLF>\r\n")
+                            .await?;
+                        session_state.state = State::Data;
+                        let result = self
+                            .receive_data(reader, session_state, total_deadline)
+                            .await?;
+                        session_state.reset_transaction();
+                        result
+                    }
+                }
+                "RSET" => self.handle_rset(session_state),
+                "NOOP" => "250 OK\r\n".to_string(),
+                "QUIT" => {
+                    writer.write_all(b"221 Bye\r\n").await?;
+                    return Ok(());
+                }
+                "STARTTLS" => {
+                    if self.params.tls_acceptor.is_none() {
+                        "502 STARTTLS not available\r\n".to_string()
+                    } else if session_state.tls_active {
+                        "503 TLS already active\r\n".to_string()
+                    } else {
+                        writer.write_all(b"220 Ready to start TLS\r\n").await?;
+                        return Err("STARTTLS_UPGRADE".into());
+                    }
+                }
+                _ => "500 Unrecognized command\r\n".to_string(),
+            };
+
+            writer.write_all(response.as_bytes()).await?;
+        }
+    }
+
+    fn handle_ehlo(&self, args: &str, session_state: &mut SessionState) -> String {
+        if args.is_empty() {
+            return "501 EHLO requires domain argument\r\n".to_string();
+        }
+        session_state.ehlo_hostname = args.to_string();
+        session_state.state = State::Greeted;
+        session_state.reset_transaction();
+
+        let mut response = format!("250-{} Hello {}\r\n", self.params.hostname, args);
+        response.push_str(&format!("250-SIZE {}\r\n", self.params.max_message_size));
+        response.push_str("250-8BITMIME\r\n");
+        response.push_str("250-PIPELINING\r\n");
+        if self.params.tls_acceptor.is_some() && !session_state.tls_active {
+            response.push_str("250-STARTTLS\r\n");
+        }
+        response.push_str("250 SMTPUTF8\r\n");
+        response
+    }
+
+    fn handle_helo(&self, args: &str, session_state: &mut SessionState) -> String {
+        if args.is_empty() {
+            return "501 HELO requires domain argument\r\n".to_string();
+        }
+        session_state.ehlo_hostname = args.to_string();
+        session_state.state = State::Greeted;
+        session_state.reset_transaction();
+        format!("250 {} Hello {}\r\n", self.params.hostname, args)
+    }
+
+    fn handle_mail_from(&self, args: &str, session_state: &mut SessionState) -> String {
+        if session_state.state == State::Connected {
+            return "503 Send EHLO/HELO first\r\n".to_string();
+        }
+        if session_state.state == State::MailFrom || session_state.state == State::RcptTo {
+            return "503 MAIL FROM already given\r\n".to_string();
+        }
+        let upper = args.to_uppercase();
+        if !upper.starts_with("FROM:") {
+            return "501 Syntax: MAIL FROM:<address>\r\n".to_string();
+        }
+        let addr = extract_angle_addr(&args[5..]);
+        session_state.reverse_path = addr;
+        session_state.state = State::MailFrom;
+        "250 OK\r\n".to_string()
+    }
+
+    fn handle_rcpt_to(&self, args: &str, session_state: &mut SessionState) -> String {
+        if session_state.state == State::Connected || session_state.state == State::Greeted {
+            return "503 Send MAIL FROM first\r\n".to_string();
+        }
+        let upper = args.to_uppercase();
+        if !upper.starts_with("TO:") {
+            return "501 Syntax: RCPT TO:<address>\r\n".to_string();
+        }
+        let addr = extract_angle_addr(&args[3..]);
+        if addr.is_empty() {
+            return "501 Syntax: RCPT TO:<address>\r\n".to_string();
+        }
+        session_state.forward_paths.push(addr);
+        session_state.state = State::RcptTo;
+        "250 OK\r\n".to_string()
+    }
+
+    fn handle_data_precheck(&self, session_state: &SessionState) -> Option<String> {
+        if session_state.state != State::RcptTo {
+            return Some("503 Send RCPT TO first\r\n".to_string());
+        }
+        None
+    }
+
+    fn handle_rset(&self, session_state: &mut SessionState) -> String {
+        session_state.reset_transaction();
+        "250 OK\r\n".to_string()
+    }
+
+    async fn receive_data<R>(
+        &self,
+        reader: &mut BufReader<R>,
+        session_state: &mut SessionState,
+        total_deadline: tokio::time::Instant,
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>>
+    where
+        R: AsyncRead + Unpin,
+    {
+        let mut data = Vec::new();
+        let mut line_buf = String::new();
+
+        loop {
+            line_buf.clear();
+            let read_result = tokio::time::timeout(self.params.idle_timeout, async {
+                tokio::time::timeout_at(total_deadline, reader.read_line(&mut line_buf)).await
+            })
+            .await;
+
+            let bytes_read = match read_result {
+                Ok(Ok(Ok(n))) => n,
+                Ok(Ok(Err(e))) => return Err(format!("Read error during DATA: {e}").into()),
+                Ok(Err(_)) | Err(_) => {
+                    return Ok("421 Timeout during DATA\r\n".to_string());
+                }
+            };
+
+            if bytes_read == 0 {
+                return Ok("451 Client disconnected during DATA\r\n".to_string());
+            }
+
+            // RFC 5321: reject bare LF (lines must end with CRLF)
+            if line_buf.ends_with('\n') && !line_buf.ends_with("\r\n") {
+                return Ok("500 Bare LF not allowed (RFC 5321)\r\n".to_string());
+            }
+
+            if line_buf.trim_end() == "." {
+                break;
+            }
+
+            // Dot-stuffing: remove leading dot per RFC 5321 section 4.5.2
+            if line_buf.starts_with("..") {
+                data.extend_from_slice(&line_buf.as_bytes()[1..]);
+            } else {
+                data.extend_from_slice(line_buf.as_bytes());
+            }
+
+            if data.len() > self.params.max_message_size {
+                // Consume remaining DATA to avoid desync
+                loop {
+                    line_buf.clear();
+                    match tokio::time::timeout(
+                        self.params.idle_timeout,
+                        reader.read_line(&mut line_buf),
+                    )
+                    .await
+                    {
+                        Ok(Ok(n)) if n > 0 => {
+                            if line_buf.trim_end() == "." {
+                                break;
+                            }
+                        }
+                        _ => break,
+                    }
+                }
+                return Ok("552 Message exceeds maximum size\r\n".to_string());
+            }
+        }
+
+        self.deliver_message(&data, session_state).await
+    }
+
+    async fn deliver_message(
+        &self,
+        data: &[u8],
+        session_state: &SessionState,
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        let mut all_ok = true;
+        let config = Arc::clone(&self.params.config);
+        let data = data.to_vec();
+
+        for rcpt in &session_state.forward_paths {
+            let config = Arc::clone(&config);
+            let data = data.clone();
+            let rcpt_owned = rcpt.clone();
+            let peer = self.params.peer_addr;
+
+            // Run ingest in a blocking thread since it creates its own
+            // tokio runtime for DKIM/SPF verification.
+            let result = tokio::task::spawn_blocking(move || {
+                crate::ingest::ingest_email(&config, &rcpt_owned, &data).map_err(|e| e.to_string())
+            })
+            .await;
+
+            match result {
+                Ok(Ok(())) => {}
+                Ok(Err(e)) => {
+                    eprintln!("[{peer}] Ingest failed for {rcpt}: {e}");
+                    all_ok = false;
+                }
+                Err(e) => {
+                    eprintln!("[{peer}] Ingest task panicked for {rcpt}: {e}");
+                    all_ok = false;
+                }
+            }
+        }
+
+        if all_ok {
+            let size = data.len();
+            let rcpt_count = session_state.forward_paths.len();
+            eprintln!(
+                "[{}] Message accepted from={} rcpts={} size={}",
+                self.params.peer_addr, session_state.reverse_path, rcpt_count, size
+            );
+            Ok("250 OK message accepted\r\n".to_string())
+        } else {
+            Ok("451 Temporary failure, please retry\r\n".to_string())
+        }
+    }
+}
+
+fn parse_command(line: &str) -> (String, &str) {
+    let line = line.trim();
+    if let Some(pos) = line.find(' ') {
+        let cmd = line[..pos].to_uppercase();
+        let args = line[pos + 1..].trim();
+        (cmd, args)
+    } else {
+        (line.to_uppercase(), "")
+    }
+}
+
+fn extract_angle_addr(s: &str) -> String {
+    let s = s.trim();
+    if let Some(start) = s.find('<')
+        && let Some(end) = s.find('>')
+    {
+        return s[start + 1..end].trim().to_string();
+    }
+    s.to_string()
+}
+
+#[cfg(test)]
+mod unit_tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_command_with_args() {
+        let (cmd, args) = parse_command("EHLO example.com");
+        assert_eq!(cmd, "EHLO");
+        assert_eq!(args, "example.com");
+    }
+
+    #[test]
+    fn test_parse_command_no_args() {
+        let (cmd, args) = parse_command("QUIT");
+        assert_eq!(cmd, "QUIT");
+        assert_eq!(args, "");
+    }
+
+    #[test]
+    fn test_parse_command_case_insensitive() {
+        let (cmd, _) = parse_command("ehlo test.com");
+        assert_eq!(cmd, "EHLO");
+    }
+
+    #[test]
+    fn test_extract_angle_addr() {
+        assert_eq!(extract_angle_addr("<user@example.com>"), "user@example.com");
+        assert_eq!(
+            extract_angle_addr(" <user@example.com> "),
+            "user@example.com"
+        );
+        assert_eq!(extract_angle_addr("<>"), "");
+        assert_eq!(extract_angle_addr("user@example.com"), "user@example.com");
+    }
+}

--- a/src/smtp/tests.rs
+++ b/src/smtp/tests.rs
@@ -1,0 +1,824 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::net::TcpStream;
+
+use crate::config::{Config, MailboxConfig};
+use crate::smtp::SmtpServer;
+
+fn test_config(data_dir: &std::path::Path) -> Config {
+    let mut mailboxes = HashMap::new();
+    mailboxes.insert(
+        "catchall".to_string(),
+        MailboxConfig {
+            address: "*@test.local".to_string(),
+            on_receive: vec![],
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+        },
+    );
+    mailboxes.insert(
+        "alice".to_string(),
+        MailboxConfig {
+            address: "alice@test.local".to_string(),
+            on_receive: vec![],
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+        },
+    );
+    Config {
+        domain: "test.local".to_string(),
+        data_dir: data_dir.to_path_buf(),
+        dkim_selector: "dkim".to_string(),
+        mailboxes,
+        verify_host: None,
+    }
+}
+
+struct TestClient {
+    reader: BufReader<tokio::io::ReadHalf<TcpStream>>,
+    writer: tokio::io::WriteHalf<TcpStream>,
+}
+
+impl TestClient {
+    async fn connect(port: u16) -> Self {
+        let stream = TcpStream::connect(format!("127.0.0.1:{port}"))
+            .await
+            .unwrap();
+        let (reader, writer) = tokio::io::split(stream);
+        Self {
+            reader: BufReader::new(reader),
+            writer,
+        }
+    }
+
+    async fn read_line(&mut self) -> String {
+        let mut buf = String::new();
+        tokio::time::timeout(Duration::from_secs(5), self.reader.read_line(&mut buf))
+            .await
+            .expect("read timeout")
+            .expect("read error");
+        buf
+    }
+
+    async fn read_response(&mut self) -> String {
+        let mut response = String::new();
+        loop {
+            let line = self.read_line().await;
+            let is_last = line.len() >= 4 && line.as_bytes()[3] == b' ';
+            response.push_str(&line);
+            if is_last || line.is_empty() {
+                break;
+            }
+        }
+        response
+    }
+
+    async fn send(&mut self, cmd: &str) {
+        self.writer
+            .write_all(format!("{cmd}\r\n").as_bytes())
+            .await
+            .unwrap();
+    }
+
+    async fn send_and_read(&mut self, cmd: &str) -> String {
+        self.send(cmd).await;
+        self.read_response().await
+    }
+}
+
+async fn start_server(config: Config) -> (u16, tokio::sync::watch::Sender<bool>) {
+    let server = SmtpServer::new(config);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+    tokio::spawn(async move {
+        server.run(listener, shutdown_rx).await.unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (port, shutdown_tx)
+}
+
+async fn start_server_with_size_limit(
+    config: Config,
+    max_size: usize,
+) -> (u16, tokio::sync::watch::Sender<bool>) {
+    let server = SmtpServer::new(config).with_max_message_size(max_size);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+    tokio::spawn(async move {
+        server.run(listener, shutdown_rx).await.unwrap();
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    (port, shutdown_tx)
+}
+
+fn test_email() -> &'static str {
+    "From: sender@example.com\r\nTo: alice@test.local\r\nSubject: Test\r\nDate: Mon, 01 Jan 2024 00:00:00 +0000\r\nMessage-ID: <test@example.com>\r\n\r\nHello World\r\n"
+}
+
+// --- S19.1: SMTP state machine tests ---
+
+#[tokio::test]
+async fn test_ehlo_response() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+
+    let banner = client.read_line().await;
+    assert!(banner.starts_with("220 "));
+
+    let resp = client.send_and_read("EHLO client.example.com").await;
+    assert!(resp.contains("250"));
+    assert!(resp.contains("SIZE"));
+    assert!(resp.contains("8BITMIME"));
+
+    client.send_and_read("QUIT").await;
+}
+
+#[tokio::test]
+async fn test_helo_response() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    let resp = client.send_and_read("HELO client.example.com").await;
+    assert!(resp.starts_with("250 "));
+
+    client.send_and_read("QUIT").await;
+}
+
+#[tokio::test]
+async fn test_full_mail_transaction() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    let resp = client.send_and_read("EHLO client.example.com").await;
+    assert!(resp.contains("250"));
+
+    let resp = client.send_and_read("MAIL FROM:<sender@example.com>").await;
+    assert!(resp.starts_with("250 "));
+
+    let resp = client.send_and_read("RCPT TO:<alice@test.local>").await;
+    assert!(resp.starts_with("250 "));
+
+    let resp = client.send_and_read("DATA").await;
+    assert!(resp.starts_with("354"));
+
+    client.send(test_email()).await;
+    let resp = client.send_and_read(".").await;
+    assert!(resp.starts_with("250 "));
+
+    let resp = client.send_and_read("QUIT").await;
+    assert!(resp.starts_with("221"));
+
+    let alice_dir = tmp.path().join("alice");
+    assert!(alice_dir.exists());
+    let entries: Vec<_> = std::fs::read_dir(&alice_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
+        .collect();
+    assert_eq!(entries.len(), 1);
+}
+
+#[tokio::test]
+async fn test_multi_recipient() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    client.send_and_read("EHLO client.example.com").await;
+    client.send_and_read("MAIL FROM:<sender@example.com>").await;
+    client.send_and_read("RCPT TO:<alice@test.local>").await;
+    client.send_and_read("RCPT TO:<catchall@test.local>").await;
+
+    let resp = client.send_and_read("DATA").await;
+    assert!(resp.starts_with("354"));
+
+    client.send(test_email()).await;
+    let resp = client.send_and_read(".").await;
+    assert!(resp.starts_with("250"));
+
+    client.send_and_read("QUIT").await;
+
+    let alice_mds: Vec<_> = std::fs::read_dir(tmp.path().join("alice"))
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
+        .collect();
+    let catchall_mds: Vec<_> = std::fs::read_dir(tmp.path().join("catchall"))
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
+        .collect();
+    assert_eq!(alice_mds.len(), 1);
+    assert_eq!(catchall_mds.len(), 1);
+}
+
+#[tokio::test]
+async fn test_unrecognized_command() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    let resp = client.send_and_read("BOGUS").await;
+    assert!(resp.starts_with("500"));
+}
+
+#[tokio::test]
+async fn test_out_of_sequence_mail() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    let resp = client.send_and_read("MAIL FROM:<test@test.com>").await;
+    assert!(resp.starts_with("503"));
+}
+
+#[tokio::test]
+async fn test_out_of_sequence_rcpt() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    client.send_and_read("EHLO test.com").await;
+
+    let resp = client.send_and_read("RCPT TO:<test@test.com>").await;
+    assert!(resp.starts_with("503"));
+}
+
+#[tokio::test]
+async fn test_out_of_sequence_data() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    client.send_and_read("EHLO test.com").await;
+    client.send_and_read("MAIL FROM:<test@test.com>").await;
+
+    let resp = client.send_and_read("DATA").await;
+    assert!(resp.starts_with("503"));
+}
+
+#[tokio::test]
+async fn test_noop() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    let resp = client.send_and_read("NOOP").await;
+    assert!(resp.starts_with("250"));
+}
+
+#[tokio::test]
+async fn test_rset() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    client.send_and_read("EHLO test.com").await;
+    client.send_and_read("MAIL FROM:<test@test.com>").await;
+
+    let resp = client.send_and_read("RSET").await;
+    assert!(resp.starts_with("250"));
+
+    let resp = client.send_and_read("RCPT TO:<test@test.com>").await;
+    assert!(resp.starts_with("503"));
+}
+
+#[tokio::test]
+async fn test_quit() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    let resp = client.send_and_read("QUIT").await;
+    assert!(resp.starts_with("221"));
+}
+
+#[tokio::test]
+async fn test_ehlo_without_domain() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    let resp = client.send_and_read("EHLO").await;
+    assert!(resp.starts_with("501"));
+}
+
+#[tokio::test]
+async fn test_double_mail_from() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    client.send_and_read("EHLO test.com").await;
+    client.send_and_read("MAIL FROM:<a@test.com>").await;
+    let resp = client.send_and_read("MAIL FROM:<b@test.com>").await;
+    assert!(resp.starts_with("503"));
+}
+
+// --- S19.1: Size limit tests ---
+
+#[tokio::test]
+async fn test_message_size_limit() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server_with_size_limit(config, 100).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    client.send_and_read("EHLO test.com").await;
+    client.send_and_read("MAIL FROM:<sender@test.com>").await;
+    client.send_and_read("RCPT TO:<alice@test.local>").await;
+    client.send_and_read("DATA").await;
+
+    let large_body = "X".repeat(200);
+    client
+        .send(&format!(
+            "From: sender@test.com\r\nTo: alice@test.local\r\nSubject: Big\r\n\r\n{large_body}"
+        ))
+        .await;
+    let resp = client.send_and_read(".").await;
+    assert!(resp.starts_with("552"), "Expected 552 but got: {resp}");
+}
+
+// --- S19.1: Timeout tests ---
+
+#[tokio::test]
+async fn test_idle_timeout() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let server =
+        SmtpServer::new(config).with_timeouts(Duration::from_millis(200), Duration::from_secs(10));
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+    tokio::spawn(async move {
+        server.run(listener, shutdown_rx).await.unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    tokio::time::sleep(Duration::from_millis(300)).await;
+
+    let resp = client.read_line().await;
+    assert!(
+        resp.contains("421") || resp.is_empty(),
+        "Expected timeout response, got: {resp}"
+    );
+}
+
+// --- S19.2: STARTTLS tests ---
+
+#[tokio::test]
+async fn test_starttls_advertised_in_ehlo() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+
+    let (cert_path, key_path) = super::tls::generate_test_certs(tmp.path()).unwrap();
+
+    let server = SmtpServer::new(config)
+        .with_tls(&cert_path, &key_path)
+        .unwrap();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+    tokio::spawn(async move {
+        server.run(listener, shutdown_rx).await.unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    let resp = client.send_and_read("EHLO test.com").await;
+    assert!(
+        resp.contains("STARTTLS"),
+        "EHLO response should advertise STARTTLS: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_starttls_not_available_without_tls() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    client.send_and_read("EHLO test.com").await;
+    let resp = client.send_and_read("STARTTLS").await;
+    assert!(
+        resp.starts_with("502"),
+        "Should reject STARTTLS without TLS config: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_plain_connection_works_without_starttls() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    client.send_and_read("EHLO test.com").await;
+    client.send_and_read("MAIL FROM:<sender@test.com>").await;
+    client.send_and_read("RCPT TO:<alice@test.local>").await;
+    client.send_and_read("DATA").await;
+    client.send(test_email()).await;
+    let resp = client.send_and_read(".").await;
+    assert!(
+        resp.starts_with("250"),
+        "Plain connection should work: {resp}"
+    );
+
+    client.send_and_read("QUIT").await;
+}
+
+#[tokio::test]
+async fn test_starttls_upgrade() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+
+    let (cert_path, key_path) = super::tls::generate_test_certs(tmp.path()).unwrap();
+
+    let server = SmtpServer::new(config)
+        .with_tls(&cert_path, &key_path)
+        .unwrap();
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+    tokio::spawn(async move {
+        server.run(listener, shutdown_rx).await.unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    let stream = TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .unwrap();
+    let (reader, mut writer) = tokio::io::split(stream);
+    let mut reader = BufReader::new(reader);
+    let mut buf = String::new();
+
+    // Read banner
+    reader.read_line(&mut buf).await.unwrap();
+    assert!(buf.starts_with("220"));
+
+    // Send EHLO
+    writer.write_all(b"EHLO test.com\r\n").await.unwrap();
+    buf.clear();
+    loop {
+        reader.read_line(&mut buf).await.unwrap();
+        if buf.contains("250 ") {
+            break;
+        }
+    }
+
+    // Send STARTTLS
+    writer.write_all(b"STARTTLS\r\n").await.unwrap();
+    buf.clear();
+    reader.read_line(&mut buf).await.unwrap();
+    assert!(buf.starts_with("220"), "Expected 220 Ready for TLS: {buf}");
+
+    // Upgrade to TLS
+    let inner = reader.into_inner().unsplit(writer);
+
+    let mut root_store = rustls::RootCertStore::empty();
+    let cert_pem = std::fs::read(&cert_path).unwrap();
+    let certs: Vec<_> = rustls_pemfile::certs(&mut std::io::BufReader::new(cert_pem.as_slice()))
+        .collect::<Result<Vec<_>, _>>()
+        .unwrap();
+    for cert in &certs {
+        root_store.add(cert.clone()).unwrap();
+    }
+
+    let tls_config = rustls::ClientConfig::builder()
+        .with_root_certificates(root_store)
+        .with_no_client_auth();
+    let connector = tokio_rustls::TlsConnector::from(Arc::new(tls_config));
+    let server_name = rustls_pki_types::ServerName::try_from("localhost").unwrap();
+    let tls_stream = connector.connect(server_name, inner).await.unwrap();
+
+    let (tls_reader, mut tls_writer) = tokio::io::split(tls_stream);
+    let mut tls_reader = BufReader::new(tls_reader);
+
+    // After TLS, send EHLO again and complete a mail transaction
+    tls_writer.write_all(b"EHLO test.com\r\n").await.unwrap();
+    buf.clear();
+    loop {
+        tls_reader.read_line(&mut buf).await.unwrap();
+        if buf.contains("250 ") {
+            break;
+        }
+    }
+    assert!(
+        !buf.contains("STARTTLS"),
+        "STARTTLS should not be in post-upgrade EHLO: {buf}"
+    );
+
+    tls_writer
+        .write_all(b"MAIL FROM:<sender@test.com>\r\n")
+        .await
+        .unwrap();
+    buf.clear();
+    tls_reader.read_line(&mut buf).await.unwrap();
+    assert!(buf.starts_with("250"));
+
+    tls_writer
+        .write_all(b"RCPT TO:<alice@test.local>\r\n")
+        .await
+        .unwrap();
+    buf.clear();
+    tls_reader.read_line(&mut buf).await.unwrap();
+    assert!(buf.starts_with("250"));
+
+    tls_writer.write_all(b"DATA\r\n").await.unwrap();
+    buf.clear();
+    tls_reader.read_line(&mut buf).await.unwrap();
+    assert!(buf.starts_with("354"));
+
+    tls_writer.write_all(test_email().as_bytes()).await.unwrap();
+    tls_writer.write_all(b".\r\n").await.unwrap();
+    buf.clear();
+    tls_reader.read_line(&mut buf).await.unwrap();
+    assert!(
+        buf.starts_with("250"),
+        "Expected 250 after DATA over TLS: {buf}"
+    );
+
+    tls_writer.write_all(b"QUIT\r\n").await.unwrap();
+    buf.clear();
+    tls_reader.read_line(&mut buf).await.unwrap();
+    assert!(buf.starts_with("221"));
+}
+
+// --- S19.3: Ingest integration tests ---
+
+#[tokio::test]
+async fn test_ingest_creates_markdown_file() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    client.send_and_read("EHLO test.com").await;
+    client.send_and_read("MAIL FROM:<sender@example.com>").await;
+    client.send_and_read("RCPT TO:<alice@test.local>").await;
+    client.send_and_read("DATA").await;
+    client.send(test_email()).await;
+    let resp = client.send_and_read(".").await;
+    assert!(resp.starts_with("250"), "Expected 250: {resp}");
+
+    client.send_and_read("QUIT").await;
+
+    let alice_dir = tmp.path().join("alice");
+    let md_files: Vec<_> = std::fs::read_dir(&alice_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
+        .collect();
+    assert_eq!(md_files.len(), 1);
+
+    let content = std::fs::read_to_string(md_files[0].path()).unwrap();
+    assert!(content.contains("+++"));
+    assert!(content.contains("subject = \"Test\""));
+    assert!(content.contains("Hello World"));
+}
+
+#[tokio::test]
+async fn test_ingest_failure_returns_451() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = Config {
+        domain: "test.local".to_string(),
+        data_dir: PathBuf::from("/nonexistent/path/that/does/not/exist"),
+        dkim_selector: "dkim".to_string(),
+        mailboxes: HashMap::new(),
+        verify_host: None,
+    };
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    client.send_and_read("EHLO test.com").await;
+    client.send_and_read("MAIL FROM:<sender@test.com>").await;
+    client.send_and_read("RCPT TO:<alice@test.local>").await;
+    client.send_and_read("DATA").await;
+    client.send(test_email()).await;
+    let resp = client.send_and_read(".").await;
+    assert!(
+        resp.starts_with("451"),
+        "Expected 451 on ingest failure: {resp}"
+    );
+
+    drop(tmp);
+}
+
+// --- S19.4: Connection hardening tests ---
+
+#[tokio::test]
+async fn test_connection_limit() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let server = SmtpServer::new(config).with_max_connections(2);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+    tokio::spawn(async move {
+        server.run(listener, shutdown_rx).await.unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    // Open 2 connections (at the limit)
+    let mut c1 = TestClient::connect(port).await;
+    c1.read_line().await;
+    let mut c2 = TestClient::connect(port).await;
+    c2.read_line().await;
+
+    // Third connection should be rejected
+    let mut c3 = TestClient::connect(port).await;
+    let resp = c3.read_line().await;
+    assert!(
+        resp.starts_with("421"),
+        "Expected 421 for connection limit: {resp}"
+    );
+
+    // Close one connection, then new one should work
+    c1.send_and_read("QUIT").await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let mut c4 = TestClient::connect(port).await;
+    let banner = c4.read_line().await;
+    assert!(
+        banner.starts_with("220"),
+        "Expected 220 after freeing a slot: {banner}"
+    );
+    c4.send_and_read("QUIT").await;
+    c2.send_and_read("QUIT").await;
+}
+
+#[tokio::test]
+async fn test_command_flood_limit() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let server = SmtpServer::new(config).with_max_commands_before_data(5);
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let (_shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+
+    tokio::spawn(async move {
+        server.run(listener, shutdown_rx).await.unwrap();
+    });
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    for _ in 0..5 {
+        let resp = client.send_and_read("NOOP").await;
+        assert!(resp.starts_with("250"));
+    }
+
+    let resp = client.send_and_read("NOOP").await;
+    assert!(
+        resp.contains("421"),
+        "Expected 421 for command flood: {resp}"
+    );
+}
+
+#[tokio::test]
+async fn test_bare_lf_rejected_in_data() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+
+    let stream = TcpStream::connect(format!("127.0.0.1:{port}"))
+        .await
+        .unwrap();
+    let (reader, mut writer) = tokio::io::split(stream);
+    let mut reader = BufReader::new(reader);
+    let mut buf = String::new();
+
+    // Read banner
+    reader.read_line(&mut buf).await.unwrap();
+
+    writer.write_all(b"EHLO test.com\r\n").await.unwrap();
+    buf.clear();
+    loop {
+        reader.read_line(&mut buf).await.unwrap();
+        if buf.contains("250 ") {
+            break;
+        }
+    }
+
+    writer
+        .write_all(b"MAIL FROM:<test@test.com>\r\n")
+        .await
+        .unwrap();
+    buf.clear();
+    reader.read_line(&mut buf).await.unwrap();
+
+    writer
+        .write_all(b"RCPT TO:<alice@test.local>\r\n")
+        .await
+        .unwrap();
+    buf.clear();
+    reader.read_line(&mut buf).await.unwrap();
+
+    writer.write_all(b"DATA\r\n").await.unwrap();
+    buf.clear();
+    reader.read_line(&mut buf).await.unwrap();
+
+    // Send data with bare LF (no CR)
+    writer
+        .write_all(b"Subject: test\nBare LF line\r\n.\r\n")
+        .await
+        .unwrap();
+    buf.clear();
+    reader.read_line(&mut buf).await.unwrap();
+    assert!(buf.starts_with("500"), "Expected 500 for bare LF: {buf}");
+}
+
+// --- Multiple transactions per connection ---
+
+#[tokio::test]
+async fn test_multiple_transactions_per_connection() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    client.send_and_read("EHLO test.com").await;
+
+    // First message
+    client.send_and_read("MAIL FROM:<sender@test.com>").await;
+    client.send_and_read("RCPT TO:<alice@test.local>").await;
+    client.send_and_read("DATA").await;
+    client.send(test_email()).await;
+    let resp = client.send_and_read(".").await;
+    assert!(resp.starts_with("250"));
+
+    // Second message
+    client.send_and_read("MAIL FROM:<sender2@test.com>").await;
+    client.send_and_read("RCPT TO:<alice@test.local>").await;
+    client.send_and_read("DATA").await;
+    client.send(test_email()).await;
+    let resp = client.send_and_read(".").await;
+    assert!(resp.starts_with("250"));
+
+    client.send_and_read("QUIT").await;
+
+    let alice_dir = tmp.path().join("alice");
+    let md_files: Vec<_> = std::fs::read_dir(&alice_dir)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
+        .collect();
+    assert_eq!(md_files.len(), 2);
+}
+
+use std::sync::Arc;

--- a/src/smtp/tls.rs
+++ b/src/smtp/tls.rs
@@ -1,0 +1,77 @@
+use std::fs;
+use std::io::BufReader;
+use std::path::Path;
+use std::sync::Arc;
+use tokio_rustls::TlsAcceptor;
+
+pub fn build_tls_acceptor(
+    cert_path: &Path,
+    key_path: &Path,
+) -> Result<TlsAcceptor, Box<dyn std::error::Error>> {
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+
+    let cert_pem = fs::read(cert_path)
+        .map_err(|e| format!("Failed to read TLS cert at {}: {e}", cert_path.display()))?;
+    let key_pem = fs::read(key_path)
+        .map_err(|e| format!("Failed to read TLS key at {}: {e}", key_path.display()))?;
+
+    let certs: Vec<_> = rustls_pemfile::certs(&mut BufReader::new(cert_pem.as_slice()))
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("Failed to parse TLS certificate: {e}"))?;
+
+    if certs.is_empty() {
+        return Err("No certificates found in cert file".into());
+    }
+
+    let key = rustls_pemfile::private_key(&mut BufReader::new(key_pem.as_slice()))
+        .map_err(|e| format!("Failed to parse TLS private key: {e}"))?
+        .ok_or("No private key found in key file")?;
+
+    let config = rustls::ServerConfig::builder()
+        .with_no_client_auth()
+        .with_single_cert(certs, key)
+        .map_err(|e| format!("TLS configuration error: {e}"))?;
+
+    Ok(TlsAcceptor::from(Arc::new(config)))
+}
+
+#[cfg(test)]
+pub fn generate_test_certs(
+    dir: &Path,
+) -> Result<(std::path::PathBuf, std::path::PathBuf), Box<dyn std::error::Error>> {
+    use std::io::Write;
+    use std::process::Command;
+
+    let cert_path = dir.join("cert.pem");
+    let key_path = dir.join("key.pem");
+
+    // Generate with proper end-entity extensions (no CA:TRUE) so rustls accepts it
+    let output = Command::new("openssl")
+        .args([
+            "req",
+            "-x509",
+            "-newkey",
+            "rsa:2048",
+            "-keyout",
+            key_path.to_str().unwrap(),
+            "-out",
+            cert_path.to_str().unwrap(),
+            "-days",
+            "1",
+            "-nodes",
+            "-subj",
+            "/CN=localhost",
+            "-addext",
+            "basicConstraints=critical,CA:FALSE",
+            "-addext",
+            "subjectAltName=DNS:localhost",
+        ])
+        .output()?;
+
+    if !output.status.success() {
+        std::io::stderr().write_all(&output.stderr)?;
+        return Err("Failed to generate test certificates with openssl".into());
+    }
+
+    Ok((cert_path, key_path))
+}


### PR DESCRIPTION
## Summary

- Hand-rolled tokio-based SMTP listener that accepts inbound email and calls `ingest_email()` in-process, replacing the need for OpenSMTPD's listener role
- Full SMTP state machine: EHLO/HELO, MAIL FROM, RCPT TO, DATA, QUIT, RSET, NOOP with proper RFC 5321 error codes and sequencing
- STARTTLS support via `tokio-rustls` with configurable cert/key paths; plain connections still accepted for backward compatibility
- Connection hardening: concurrent connection limit (100), command flood limit (50 before DATA), bare LF rejection, connection logging with peer IP/duration/result

### Stories implemented

**S19.1 — SMTP Protocol State Machine (P0)**
- [x] SMTP state machine handles all required commands with correct response codes
- [x] Proper error responses: 500 (unrecognized), 503 (out-of-sequence), 552 (oversized)
- [x] Per-connection timeout: 5 min idle, 10 min total
- [x] Message size limit: 25 MB default (configurable)
- [x] Multi-recipient support: multiple RCPT TO collected and each delivered independently
- [x] Graceful connection teardown on timeout or client disconnect
- [x] Unit tests for every SMTP command (valid and invalid sequences)
- [x] Unit test for timeout behavior and size limit enforcement

**S19.2 — STARTTLS Support (P0)**
- [x] STARTTLS advertised in EHLO capabilities list
- [x] STARTTLS command upgrades connection to TLS using `tokio-rustls`
- [x] TLS certs loaded from configurable paths
- [x] Plain (non-TLS) connections still accepted and fully functional
- [x] Invalid/missing cert paths produce clear startup error
- [x] Unit test: STARTTLS upgrade with test certificates
- [x] Unit test: plain connection works without STARTTLS

**S19.3 — Ingest Pipeline Integration (P0)**
- [x] On DATA completion, calls `ingest_email()` for each recipient (via `spawn_blocking`)
- [x] Successful ingest returns 250 to the sending MTA
- [x] Failed ingest returns 451 (temporary failure) for MTA retry
- [x] Ingest failure logged but does not crash the listener
- [x] Config loaded once at startup and shared across connections (Arc)
- [x] Integration test: start listener, send fixture email via SMTP, verify .md file created

**S19.4 — Connection Hardening (P1)**
- [x] Concurrent connection limit (default: 100) — 421 when exceeded
- [x] Per-connection command limit (50 before DATA) — prevents command flooding
- [x] Reject bare LF in DATA (RFC 5321 CRLF requirement)
- [x] Log each connection: peer IP, EHLO hostname, recipient count, message size, duration, result
- [x] Unit test: connection limit enforcement
- [x] Unit test: command flood triggers limit

## Test plan

- [x] All 323 unit tests pass (including 24 new SMTP tests + 4 parse/helper tests)
- [x] All 34 integration tests pass (no regressions)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Verifier service tests unaffected (47 pass)