### PR TITLE
[Sprint 24] Verify cleanup + sudo requirement

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What is aimx
 
-Self-hosted email for AI agents. One binary, one setup command. Built-in SMTP server handles inbound; direct SMTP delivery for outbound. aimx handles everything: ingest to Markdown, DKIM signing, MCP server, channel triggers. `aimx serve` is the SMTP daemon; all other commands are short-lived processes.
+Self-hosted email for AI agents. One binary, one setup command. Built-in SMTP server handles inbound; direct SMTP delivery for outbound. AIMX handles everything: ingest to Markdown, DKIM signing, MCP server, channel triggers. `aimx serve` is the SMTP daemon; all other commands are short-lived processes.
 
 ## Build and test commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ Uses `rmcp` crate with `#[tool]` attribute macros on `AimxMcpServer` methods. St
 
 ### Verifier service
 
-Axum HTTP server with `/probe` (EHLO handshake), `/reach` (TCP connect), `/health` endpoints. Runs a concurrent SMTP listener on port 25. Uses `X-AIMX-Client-IP` header from Caddy for caller identification. Deployed via `docker-compose.yml` with `network_mode: host`.
+Axum HTTP server with `/probe` (EHLO handshake) and `/health` endpoints. Runs a concurrent SMTP listener on port 25. Uses `X-AIMX-Client-IP` header from Caddy for caller identification. Deployed via `docker-compose.yml` with `network_mode: host`.
 
 ## Key conventions
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ sudo aimx setup agent.yourdomain.com
 
 # 3. Follow the interactive prompts to add DNS records
 # 4. Verify the setup
-aimx verify
+sudo aimx verify
 
 # 5. Check status
 aimx status
@@ -93,8 +93,8 @@ sudo aimx setup agent.yourdomain.com
 # Check server status
 aimx status
 
-# Check port 25 connectivity
-aimx verify
+# Check port 25 connectivity (requires root)
+sudo aimx verify
 ```
 
 ### Mailbox management
@@ -195,7 +195,7 @@ data_dir = "/var/lib/aimx"
 dkim_selector = "dkim"
 
 # Verifier service base URL (default: https://check.aimx.email)
-# Used by `aimx verify`, `aimx setup`, and `aimx preflight`. Set this only if
+# Used by `aimx verify` and `aimx setup`. Set this only if
 # you are self-hosting the verifier service (see `services/verifier/`). aimx appends
 # `/probe` to this base URL internally.
 # verify_host = "https://verify.yourdomain.com"
@@ -312,10 +312,10 @@ To point aimx at a self-hosted instance, set `verify_host` in `config.toml`:
 verify_host = "https://verify.yourdomain.com"
 ```
 
-Or override it per-invocation with the `--verify-host` flag, which is accepted by `aimx verify`, `aimx setup`, and `aimx preflight`:
+Or override it per-invocation with the `--verify-host` flag, which is accepted by `aimx verify` and `aimx setup`:
 
 ```bash
-aimx verify --verify-host https://verify.yourdomain.com
+sudo aimx verify --verify-host https://verify.yourdomain.com
 ```
 
 Precedence is **CLI flag > config > default** (`https://check.aimx.email`).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# aimx
+# AIMX
 
 > You give your agents an entire server. Why borrow someone else's inbox?
 
@@ -302,11 +302,11 @@ Hello, this is the email body in plain text.
 The verifier service (`services/verifier/`) is a separate deployable service that provides:
 
 1. **Port probe** at `check.aimx.email` -- performs EHLO handshake back to caller's IP on port 25 to verify inbound SMTP reachability
-2. **Port 25 listener** at `check.aimx.email:25` -- accepts TCP connections so aimx clients can test outbound port 25 reachability
+2. **Port 25 listener** at `check.aimx.email:25` -- accepts TCP connections so AIMX clients can test outbound port 25 reachability
 
 No MTA is required on the verifier server. The service is open source and self-hostable. See `services/verifier/README.md` for deployment instructions.
 
-To point aimx at a self-hosted instance, set `verify_host` in `config.toml`:
+To point AIMX at a self-hosted instance, set `verify_host` in `config.toml`:
 
 ```toml
 verify_host = "https://verify.yourdomain.com"

--- a/book/channels.md
+++ b/book/channels.md
@@ -7,7 +7,7 @@ Channel rules trigger shell commands when emails arrive at specific mailboxes. C
 When an email is ingested:
 
 1. The email is parsed and saved as a `.md` file
-2. aimx checks the mailbox's `on_receive` rules
+2. AIMX checks the mailbox's `on_receive` rules
 3. Each rule's match filters are evaluated
 4. If the trust policy allows it, the command executes
 5. Trigger failures are logged but **never block delivery**
@@ -124,7 +124,7 @@ Emails from `trusted_senders` always trigger rules, even if DKIM verification fa
 
 ### DKIM/SPF verification
 
-During email ingest, aimx verifies:
+During email ingest, AIMX verifies:
 
 - **DKIM** -- checks the sender's DKIM signature
 - **SPF** -- validates the sending server's IP against the sender domain's SPF record

--- a/book/configuration.md
+++ b/book/configuration.md
@@ -1,6 +1,6 @@
 # Configuration
 
-aimx uses a single TOML configuration file for all settings.
+AIMX uses a single TOML configuration file for all settings.
 
 ## Config file location
 

--- a/book/getting-started.md
+++ b/book/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-This guide walks you through installing aimx and setting up your first agent email address.
+This guide walks you through installing AIMX and setting up your first agent email address.
 
 ## Requirements
 
@@ -11,7 +11,7 @@ This guide walks you through installing aimx and setting up your first agent ema
 
 ### Compatible VPS providers
 
-aimx requires direct SMTP access on port 25. Not all cloud providers allow this.
+AIMX requires direct SMTP access on port 25. Not all cloud providers allow this.
 
 | Provider | Port 25 | Notes |
 |----------|---------|-------|
@@ -93,7 +93,7 @@ aimx send --from catchall@agent.yourdomain.com \
 
 ## Connect your AI agent
 
-Add aimx as an MCP server in your MCP-compatible AI agent (Claude Code, OpenClaw, Codex, OpenCode, etc.):
+Add AIMX as an MCP server in your MCP-compatible AI agent (Claude Code, OpenClaw, Codex, OpenCode, etc.):
 
 ```json
 {

--- a/book/getting-started.md
+++ b/book/getting-started.md
@@ -75,8 +75,8 @@ Follow the on-screen prompts to add the required DNS records at your domain regi
 After DNS records propagate, verify the setup:
 
 ```bash
-# Check port 25 connectivity
-aimx verify
+# Check port 25 connectivity (requires root)
+sudo aimx verify
 
 # Check server status and mailbox counts
 aimx status

--- a/book/index.md
+++ b/book/index.md
@@ -1,10 +1,10 @@
-# aimx User Guide
+# AIMX User Guide
 
 > Your server can receive email. Why are you routing through Gmail?
 
 **SMTP for agents. No middleman.**
 
-aimx is a self-hosted email system for AI agents. One command gives your agents their own email addresses on a domain you control -- no Gmail, no OAuth, no third-party SaaS. Built for Claude Code, OpenClaw, Codex, and any agentic system that needs an email channel.
+AIMX is a self-hosted email system for AI agents. One command gives your agents their own email addresses on a domain you control -- no Gmail, no OAuth, no third-party SaaS. Built for Claude Code, OpenClaw, Codex, and any agentic system that needs an email channel.
 
 ## How it works
 

--- a/book/index.md
+++ b/book/index.md
@@ -43,7 +43,7 @@ sudo cp target/release/aimx /usr/local/bin/
 sudo aimx setup agent.yourdomain.com
 
 # 3. Verify
-aimx verify
+sudo aimx verify
 ```
 
 See the full [Getting Started](getting-started.md) guide for details.

--- a/book/mailboxes.md
+++ b/book/mailboxes.md
@@ -1,6 +1,6 @@
 # Mailboxes & Email
 
-Mailboxes are the core organizational unit in aimx. Each mailbox maps an email address to a directory on disk.
+Mailboxes are the core organizational unit in AIMX. Each mailbox maps an email address to a directory on disk.
 
 ## Concepts
 
@@ -10,7 +10,7 @@ Mailboxes are the core organizational unit in aimx. Each mailbox maps an email a
 
 ### Routing logic
 
-When an email arrives, aimx matches the local part of the recipient address (the part before `@`) against mailbox names in the config. If a mailbox with that exact name exists, the email is delivered there. Otherwise it falls through to the `catchall` mailbox.
+When an email arrives, AIMX matches the local part of the recipient address (the part before `@`) against mailbox names in the config. If a mailbox with that exact name exists, the email is delivered there. Otherwise it falls through to the `catchall` mailbox.
 
 For example, with mailboxes `support` and `catchall` configured:
 - `support@agent.yourdomain.com` -> delivered to the `support` mailbox
@@ -165,13 +165,13 @@ Agents send email using the `email_send` and `email_reply` MCP tools. See [MCP S
 
 ### How sending works
 
-1. aimx composes an RFC 5322 compliant message
+1. AIMX composes an RFC 5322 compliant message
 2. Signs the message with DKIM (RSA-SHA256) using your domain's private key
 3. Delivers the signed message directly to the recipient's MX server via SMTP
 
 ### Reply threading
 
-When replying to an email, aimx sets the `In-Reply-To` and `References` headers so the reply is threaded correctly in the recipient's mail client. Use `--reply-to` with the original message's `Message-ID` value.
+When replying to an email, AIMX sets the `In-Reply-To` and `References` headers so the reply is threaded correctly in the recipient's mail client. Use `--reply-to` with the original message's `Message-ID` value.
 
 The `email_reply` MCP tool handles threading automatically -- it reads the original email and sets the correct headers.
 

--- a/book/mcp.md
+++ b/book/mcp.md
@@ -1,6 +1,6 @@
 # MCP Server
 
-aimx includes a built-in MCP (Model Context Protocol) server that gives AI agents programmatic access to email. Agents can list, read, send, reply to, and manage email through standard MCP tool calls.
+AIMX includes a built-in MCP (Model Context Protocol) server that gives AI agents programmatic access to email. Agents can list, read, send, reply to, and manage email through standard MCP tool calls.
 
 ## Overview
 
@@ -18,7 +18,7 @@ The server runs in stdio mode -- it reads from stdin and writes to stdout. It is
 
 ## Agent integration
 
-Add aimx to any MCP-compatible AI agent (Claude Code, OpenClaw, Codex, OpenCode, etc.). The configuration snippet is the same for all agents that support MCP stdio transport:
+Add AIMX to any MCP-compatible AI agent (Claude Code, OpenClaw, Codex, OpenCode, etc.). The configuration snippet is the same for all agents that support MCP stdio transport:
 
 ```json
 {
@@ -50,7 +50,7 @@ If you use a non-default data directory, pass it via `--data-dir`:
 
 ## MCP tools
 
-aimx exposes 9 MCP tools organized into mailbox management and email operations.
+AIMX exposes 9 MCP tools organized into mailbox management and email operations.
 
 ### Mailbox tools
 

--- a/book/setup.md
+++ b/book/setup.md
@@ -1,6 +1,6 @@
 # Setup
 
-This guide covers every step of setting up aimx in detail -- from prerequisites through production hardening.
+This guide covers every step of setting up AIMX in detail -- from prerequisites through production hardening.
 
 For a shorter walkthrough, see [Getting Started](getting-started.md).
 
@@ -97,7 +97,7 @@ If you've already completed setup and want to re-verify, simply run `aimx setup`
 sudo aimx setup agent.yourdomain.com
 ```
 
-When aimx detects an existing configuration (`aimx serve` running, TLS cert present, DKIM key present), it skips the install/configure steps and proceeds directly to port 25 checks, DNS verification, and the output sections. This makes re-runs a quick verification pass.
+When AIMX detects an existing configuration (`aimx serve` running, TLS cert present, DKIM key present), it skips the install/configure steps and proceeds directly to port 25 checks, DNS verification, and the output sections. This makes re-runs a quick verification pass.
 
 ### DNS retry loop
 
@@ -224,7 +224,7 @@ After regenerating keys, update the DKIM DNS record with the new public key.
 
 ### Firewall
 
-Only port 25 needs to be open for SMTP. No other ports are required by aimx.
+Only port 25 needs to be open for SMTP. No other ports are required by AIMX.
 
 ### File permissions
 
@@ -241,7 +241,7 @@ Back up `/var/lib/aimx/` -- it contains everything: config, DKIM keys, all mailb
 
 ## Verifier service
 
-The verifier service is used during setup to test port 25 reachability. aimx uses a public instance at `check.aimx.email` by default.
+The verifier service is used during setup to test port 25 reachability. AIMX uses a public instance at `check.aimx.email` by default.
 
 ### Self-hosting the verifier service
 
@@ -274,7 +274,7 @@ If you prefer not to use the public instance:
 
 3. Set up a reverse proxy (e.g. Caddy) for HTTPS on the probe endpoint.
 
-4. Point aimx to your instance in `config.toml`:
+4. Point AIMX to your instance in `config.toml`:
    ```toml
    verify_host = "https://verify.yourdomain.com"
    ```

--- a/book/setup.md
+++ b/book/setup.md
@@ -46,16 +46,15 @@ aimx --version
 Before running setup, you can verify port 25 connectivity:
 
 ```bash
-aimx verify
+sudo aimx verify
 ```
 
-When `aimx serve` is running, `aimx verify` performs an outbound port 25 check plus an inbound EHLO handshake probe (no root needed). When nothing is on port 25 (fresh VPS), it tests TCP reachability via a temporary listener (requires root). If port 25 is occupied by another process, verify tells you to stop it before setup.
+`aimx verify` requires root. When `aimx serve` is running, it performs an outbound EHLO handshake plus an inbound EHLO handshake probe. When nothing is on port 25 (fresh VPS), it spawns a temporary listener and runs checks. If port 25 is occupied by another process, verify tells you to stop it before setup.
 
 | Check | What it does | Fix if it fails |
 |-------|-------------|-----------------|
-| Outbound port 25 | Connects to `check.aimx.email` on port 25 to test outbound SMTP | Ask VPS provider to unblock outbound SMTP |
-| Inbound port 25 | Calls the verify service to connect back to your IP on port 25 | Open firewall, ask VPS provider to unblock inbound SMTP |
-| SMTP handshake | Verifies `aimx serve` responds to EHLO (post-setup only) | Check `aimx serve` status and logs |
+| Outbound port 25 | Performs EHLO handshake to `check.aimx.email` on port 25 | Ask VPS provider to unblock outbound SMTP |
+| Inbound port 25 | Calls the verify service to perform EHLO handshake back to your IP on port 25 | Open firewall, ask VPS provider to unblock inbound SMTP |
 
 All checks should show PASS before proceeding with setup.
 
@@ -163,10 +162,10 @@ dig +short -x YOUR_SERVER_IP
 Run the automated verification:
 
 ```bash
-aimx verify
+sudo aimx verify
 ```
 
-This tests outbound port 25 connectivity and inbound SMTP reachability. When `aimx serve` is running, it also performs an EHLO handshake check. On a fresh VPS without `aimx serve`, it uses a plain TCP reach check instead (requires root).
+This tests outbound port 25 connectivity (via EHLO handshake) and inbound SMTP reachability (via EHLO probe). Requires root.
 
 Check server status at any time:
 
@@ -282,13 +281,12 @@ If you prefer not to use the public instance:
 
    Or override it per-invocation with `--verify-host`:
    ```
-   aimx verify --verify-host https://verify.yourdomain.com
+   sudo aimx verify --verify-host https://verify.yourdomain.com
    ```
 
 The verifier service provides:
 - `GET /health` -- health check
 - `GET /probe` -- connects back to caller's IP on port 25, performs EHLO handshake
-- `GET /reach` -- plain TCP connectivity check on port 25
 - Port 25 listener -- accepts TCP connections for outbound port 25 testing
 
 See the [verifier service README](../services/verifier/README.md) for full details.

--- a/book/troubleshooting.md
+++ b/book/troubleshooting.md
@@ -5,15 +5,15 @@ Diagnostic commands and solutions for common issues.
 ## Diagnostic commands
 
 ```bash
-# Check port 25 connectivity (outbound, inbound, PTR)
-# Uses EHLO probe when aimx serve is running; TCP reach on fresh VPS (needs root)
-aimx verify
+# Check port 25 connectivity (outbound + inbound EHLO handshake)
+# Requires root
+sudo aimx verify
 
 # Show server status, configuration, and mailbox counts
 aimx status
 
 # Test against a self-hosted verify service instead of the default
-aimx verify --verify-host https://verify.yourdomain.com
+sudo aimx verify --verify-host https://verify.yourdomain.com
 ```
 
 The `--verify-host` flag is also accepted by `aimx setup`, and overrides the `verify_host` value from `config.toml` for the current invocation.
@@ -25,7 +25,7 @@ The `--verify-host` flag is also accepted by `aimx setup`, and overrides the `ve
 | Verify: outbound port 25 blocked | VPS provider blocks SMTP | Switch providers or request unblock (see [compatible providers](getting-started.md#compatible-vps-providers)) |
 | Verify: inbound port 25 not reachable | Firewall or VPS blocks inbound | `sudo ufw allow 25/tcp`, check VPS firewall settings |
 | DNS records not resolving | Propagation delay | Wait (up to 48h), re-check with `dig` (see [verifying DNS](setup.md#verifying-dns-records)) |
-| `aimx verify` times out | DNS not propagated or verify service down | Run again later; check `curl https://check.aimx.email/health` |
+| `sudo aimx verify` times out | DNS not propagated or verify service down | Run again later; check `curl https://check.aimx.email/health` |
 | Emails landing in spam | Missing DNS records or no PTR | Add all [DNS records](setup.md#dns-configuration), set PTR, use Gmail filter |
 | `aimx serve` not running | Service crashed or not started | Check status and logs (see below) |
 | Emails not delivered to mailbox | `aimx serve` not running or misconfigured | Check service status with `systemctl status aimx` |
@@ -126,13 +126,13 @@ sudo chmod 600 /var/lib/aimx/dkim/private.key
 
 ## How verify works
 
-`aimx verify` auto-detects what is listening on port 25 and adapts its checks:
+`aimx verify` requires root and auto-detects what is listening on port 25:
 
-| Scenario | What happens | Root required? |
-|----------|-------------|----------------|
-| **`aimx serve` running** | Outbound + inbound port check + EHLO handshake | No |
-| **Other process on port 25** (Postfix, Exim, etc.) | Fails — advises to stop the conflicting process | No |
-| **Nothing on port 25** (fresh VPS) | Outbound + inbound TCP reachability via temporary listener | Yes (`sudo aimx verify`) |
+| Scenario | What happens |
+|----------|-------------|
+| **`aimx serve` running** | Outbound EHLO + inbound EHLO probe |
+| **Other process on port 25** (Postfix, Exim, etc.) | Fails -- advises to stop the conflicting process |
+| **Nothing on port 25** (fresh VPS) | Spawns temporary SMTP listener, then runs outbound + inbound EHLO checks |
 
 If verify fails with EHLO probe after setup, the issue is likely in the `aimx serve` configuration rather than firewall/port access. Run `sudo systemctl status aimx` to check.
 
@@ -140,7 +140,7 @@ If verify fails with EHLO probe after setup, the issue is likely in the `aimx se
 
 | Command | Purpose |
 |---------|---------|
-| `aimx verify` | Check port 25 connectivity (auto-detects pre/post setup) |
+| `sudo aimx verify` | Check port 25 connectivity (requires root) |
 | `aimx status` | Show config, mailboxes, and message counts |
 | `aimx mailbox list` | List all mailboxes |
 | `aimx dkim-keygen` | Generate DKIM keypair |

--- a/book/troubleshooting.md
+++ b/book/troubleshooting.md
@@ -32,7 +32,7 @@ The `--verify-host` flag is also accepted by `aimx setup`, and overrides the `ve
 | Channel triggers not firing | Trust policy blocking | Check `trust` setting and DKIM result (see [trust policies](channels.md#trust-policies)) |
 | DKIM verification failing | DNS record mismatch or key regenerated | Ensure DKIM DNS record matches current public key |
 
-## aimx serve diagnostics
+## `aimx serve` diagnostics
 
 ```bash
 # Check if aimx serve is running

--- a/docs/idea.md
+++ b/docs/idea.md
@@ -388,7 +388,7 @@ Written in Rust. Single binary. Minimal dependencies.
 | Component | Role | License |
 |---|---|---|
 | **OpenSMTPD** | SMTP transport (send/receive) | ISC (MIT-equivalent) |
-| **aimx** (this project) | Delivery, .md parsing, MCP, channel manager, DKIM signing, CLI | TBD (permissive) |
+| **AIMX** (this project) | Delivery, .md parsing, MCP, channel manager, DKIM signing, CLI | TBD (permissive) |
 
 ### Why OpenSMTPD
 

--- a/docs/manual-setup.md
+++ b/docs/manual-setup.md
@@ -5,19 +5,18 @@ This guide walks through every step needed to launch aimx, from deploying the ve
 - **Part A** — Deploy the verifier service (done once, before anything else)
 - **Part B** — Set up an aimx mail server (done per server)
 
-The verifier service must be running before any mail server can complete setup, because `aimx setup`, `aimx preflight`, and `aimx verify` all call its HTTP endpoints (to test inbound port 25) and connect to its built-in port 25 listener (to test outbound port 25). `aimx setup` and `aimx verify` use `/probe` (full SMTP EHLO handshake, for post-install validation). `aimx preflight` uses `/reach` (plain TCP connect, works before OpenSMTPD is installed).
+The verifier service must be running before any mail server can complete setup, because `aimx setup` and `aimx verify` both call its HTTP `/probe` endpoint (to test inbound port 25) and connect to its built-in port 25 listener (to test outbound port 25 via EHLO handshake). Both commands use `/probe` (full SMTP EHLO handshake).
 
 ---
 
 ## Part A: Deploy the aimx-verifier Service
 
-The aimx-verifier service provides three functions, all exposed from a single binary:
+The aimx-verifier service provides two functions, all exposed from a single binary:
 
-1. **Port probe** (`GET /probe`) — HTTPS endpoint that opens a TCP connection back to the caller's own IP on port 25 and performs a full SMTP EHLO handshake. Used by `aimx setup` and `aimx verify` to confirm a real SMTP server is responding after OpenSMTPD is installed. The probe always targets the caller's IP; there is no way to probe an arbitrary address.
-2. **Reachability test** (`GET /reach`) — HTTPS endpoint that does a plain TCP connect to the caller's own IP on port 25 with a 10-second timeout. No SMTP handshake. Used by `aimx preflight` to confirm port 25 is reachable on a fresh VPS before OpenSMTPD is installed (any listening socket satisfies this check). Same response shape as `/probe`.
-3. **Port 25 listener** — Built-in TCP listener on `:25` that implements a minimal but correct SMTP exchange: banner → `EHLO`/`HELO` → `250` → `QUIT` → `221 Bye`. Used by aimx clients to test that their outbound port 25 is not blocked by their VPS provider. This is a plain tokio listener built into the `aimx-verifier` binary — **no OpenSMTPD or other MTA is required on the verifier server**.
+1. **Port probe** (`GET /probe`) — HTTPS endpoint that opens a TCP connection back to the caller's own IP on port 25 and performs a full SMTP EHLO handshake. Used by `aimx setup` and `aimx verify` to confirm a real SMTP server is responding. The probe always targets the caller's IP; there is no way to probe an arbitrary address.
+2. **Port 25 listener** — Built-in TCP listener on `:25` that implements a minimal but correct SMTP exchange: banner → `EHLO`/`HELO` → `250` → `QUIT` → `221 Bye`. Used by `aimx` clients to test that their outbound port 25 is not blocked by their VPS provider via EHLO handshake. This is a plain tokio listener built into the `aimx-verifier` binary — **no MTA is required on the verifier server**.
 
-Both `/probe` and `/reach` identify the caller via Caddy's `X-AIMX-Client-IP` header (injected by the canonical `Caddyfile`). Direct exposure of the backend without Caddy is not supported — see the security note in `services/verifier/README.md`.
+`/probe` identifies the caller via Caddy's `X-AIMX-Client-IP` header (injected by the canonical `Caddyfile`). Direct exposure of the backend without Caddy is not supported — see the security note in `services/verifier/README.md`.
 
 ### A1: Prerequisites
 
@@ -150,18 +149,15 @@ nc check.aimx.email 25
 
 The listener implements a minimal but correct SMTP exchange (banner → `EHLO`/`HELO` → `250` → `QUIT` → `221 Bye`). The banner hostname is hardcoded as `check.aimx.email` in the binary even on self-hosted instances — don't be surprised to see it on your own domain.
 
-**Functional `/probe` and `/reach` tests:**
+**Functional `/probe` test:**
 
-Both endpoints always probe the caller's own IP — there is no `?ip=` parameter. To exercise them end-to-end, run `aimx preflight` (which hits `/reach`) or `aimx verify` (which hits `/probe`) from a real mail server with port 25 open. A `PASS` on the "Inbound port 25" line means the verifier service reached back and either (a) completed a plain TCP connect on `/reach` or (b) completed a full EHLO handshake on `/probe`, depending on which command you ran.
+The `/probe` endpoint always probes the caller's own IP — there is no `?ip=` parameter. To exercise it end-to-end, run `sudo aimx verify` (which hits `/probe`) from a real mail server with port 25 open. A `PASS` on the "Inbound port 25" line means the verifier service reached back and completed a full EHLO handshake.
 
-A `curl` from the mail server against either endpoint will also work and is useful for debugging:
+A `curl` from the mail server is useful for debugging:
 
 ```bash
-curl https://check.aimx.email/reach
-# Expected: {"reachable":true,"ip":"<your-server-ip>"}
-
 curl https://check.aimx.email/probe
-# Expected (after OpenSMTPD is installed): {"reachable":true,"ip":"<your-server-ip>"}
+# Expected: {"reachable":true,"ip":"<your-server-ip>"}
 ```
 
 ### A6: Point aimx Mail Servers at Your Verifier Instance
@@ -172,11 +168,10 @@ The default verify host is `https://check.aimx.email`. If you deployed your own 
 verify_host = "https://check.yourdomain.com"
 ```
 
-…or per-invocation with the `--verify-host` flag (accepted by `aimx verify`, `aimx setup`, and `aimx preflight`):
+…or per-invocation with the `--verify-host` flag (accepted by `aimx verify` and `aimx setup`):
 
 ```bash
-aimx verify --verify-host https://check.yourdomain.com
-aimx preflight --verify-host https://check.yourdomain.com
+sudo aimx verify --verify-host https://check.yourdomain.com
 sudo aimx setup agent.yourdomain.com --verify-host https://check.yourdomain.com
 ```
 

--- a/docs/manual-setup.md
+++ b/docs/manual-setup.md
@@ -168,7 +168,7 @@ The default verify host is `https://check.aimx.email`. If you deployed your own 
 verify_host = "https://check.yourdomain.com"
 ```
 
-…or per-invocation with the `--verify-host` flag (accepted by `aimx verify` and `aimx setup`):
+…or per-invocation with the `--verify-host` flag (accepted by `sudo aimx verify` and `sudo aimx setup`):
 
 ```bash
 sudo aimx verify --verify-host https://check.yourdomain.com
@@ -241,31 +241,30 @@ sudo ufw allow 25/tcp
 sudo iptables -A INPUT -p tcp --dport 25 -j ACCEPT
 ```
 
-### B4: Preflight Checks
+### B4: Pre-Setup Verification
 
-Run preflight to confirm your server is ready:
+Run verify to confirm your server is ready before setup:
 
 ```bash
-aimx preflight
+sudo aimx verify
 ```
 
-This checks three things:
+This checks two things:
 
 | Check | What it does | Fix if it fails |
 |-------|-------------|-----------------|
-| Outbound port 25 | Connects to the verifier service host on port 25 | Ask VPS provider to unblock outbound SMTP |
+| Outbound port 25 | EHLO handshake to the verifier service host on port 25 | Ask VPS provider to unblock outbound SMTP |
 | Inbound port 25 | Calls `<verify_host>/probe` to connect back to your IP:25 | Open firewall, ask VPS provider to unblock inbound SMTP |
-| PTR record | Reverse DNS lookup on your IP | Set PTR at your VPS provider's control panel |
 
-All three should show PASS (PTR may show WARN, which is acceptable but should be fixed for deliverability).
+Both should show PASS.
 
 The default verify host is `https://check.aimx.email`. To point at a self-hosted instance instead (see Part A), set `verify_host` in `config.toml` or pass `--verify-host` on the command line:
 
 ```bash
-aimx preflight --verify-host https://check.yourdomain.com
+sudo aimx verify --verify-host https://check.yourdomain.com
 ```
 
-The same flag is accepted by `aimx verify` and `aimx setup`, and takes precedence over the config value.
+The same flag is accepted by `aimx setup`, and takes precedence over the config value.
 
 ### B5: Run Setup Wizard
 
@@ -275,16 +274,15 @@ sudo aimx setup agent.yourdomain.com
 
 The setup wizard performs these steps automatically:
 
-1. Checks for root privileges and scans port 25 for existing MTA conflicts
-2. Installs OpenSMTPD via `apt-get install --no-install-recommends opensmtpd` (skips `opensmtpd-extras`, which pulls in unused MySQL/PostgreSQL/Redis/SQLite client libraries)
-3. Generates a self-signed TLS certificate at `/etc/ssl/aimx/`
-4. Writes `/etc/smtpd.conf` (backs up any existing config) and restarts OpenSMTPD
-5. Runs the three port/PTR checks (outbound 25, inbound 25 via `/probe`, PTR)
-6. Generates the DKIM keypair at `/var/lib/aimx/dkim/`, writes `/var/lib/aimx/config.toml`, and creates the catchall mailbox directory
-7. Displays the DNS records you need to add (see next step)
-8. After you add the records and press Enter, resolves and validates each one
+1. Checks for root privileges and scans port 25 for existing process conflicts
+2. Generates a self-signed TLS certificate at `/etc/ssl/aimx/`
+3. Installs and starts `aimx serve` as a systemd/OpenRC service
+4. Runs port checks (outbound 25, inbound 25 via `/probe`)
+5. Generates the DKIM keypair at `/var/lib/aimx/dkim/`, writes `/var/lib/aimx/config.toml`, and creates the catchall mailbox directory
+6. Displays the DNS records you need to add (see next step)
+7. After you add the records and press Enter, resolves and validates each one
 
-Setup ends after DNS verification. There is no end-to-end email test — run `aimx verify` (or `aimx preflight`) later to re-check port 25 connectivity.
+Setup ends after DNS verification. There is no end-to-end email test — run `sudo aimx verify` later to re-check port 25 connectivity.
 
 ### B6: DNS Configuration
 
@@ -344,10 +342,10 @@ dig +short -x YOUR_SERVER_IP
 **Automated verification:**
 
 ```bash
-aimx verify
+sudo aimx verify
 ```
 
-`aimx verify` runs the same three checks as `aimx preflight`: outbound port 25 (to the verifier service's built-in TCP listener), inbound port 25 (via `/probe`, which connects back to your server), and PTR record. Use whichever command reads better in your workflow — they are functionally equivalent. Neither sends an actual email or waits for an echo reply.
+`aimx verify` runs two checks: outbound port 25 (EHLO handshake to the verifier service's built-in TCP listener) and inbound port 25 (via `/probe`, which connects back to your server). It does not send an actual email or wait for an echo reply.
 
 **Check server status:**
 
@@ -468,7 +466,7 @@ ls -la /var/lib/aimx/dkim/private.key
 
 **Backups:**
 
-The only directory to back up is `/var/lib/aimx/`. It contains everything: config, DKIM keys, all mailboxes and emails. Additionally, back up `/etc/smtpd.conf` if you've customized it beyond what setup generates.
+The only directory to back up is `/var/lib/aimx/`. It contains everything: config, DKIM keys, all mailboxes and emails.
 
 ---
 
@@ -476,20 +474,19 @@ The only directory to back up is `/var/lib/aimx/`. It contains everything: confi
 
 | Problem | Diagnosis | Fix |
 |---------|-----------|-----|
-| Preflight: outbound port 25 blocked | VPS provider blocks SMTP | Switch providers or request unblock (see compatible providers table) |
-| Preflight: inbound port 25 not reachable | Firewall or VPS blocks inbound | `sudo ufw allow 25/tcp`, check VPS firewall settings |
+| Verify: outbound port 25 blocked | VPS provider blocks SMTP | Switch providers or request unblock (see compatible providers table) |
+| Verify: inbound port 25 not reachable | Firewall or VPS blocks inbound | `sudo ufw allow 25/tcp`, check VPS firewall settings |
 | DNS records not resolving | Propagation delay | Wait (up to 48h), re-check with `dig` |
-| `aimx verify` shows inbound FAIL | The verifier service's `/probe` endpoint could not reach your port 25 (firewall, VPS block, OpenSMTPD down, or DNS `A` record not yet resolving) | `sudo systemctl status opensmtpd`, `sudo ufw status`, `dig +short A agent.yourdomain.com`, check VPS firewall |
+| `sudo aimx verify` shows inbound FAIL | The verifier service's `/probe` endpoint could not reach your port 25 (firewall, VPS block, `aimx serve` down, or DNS `A` record not yet resolving) | `sudo systemctl status aimx`, `sudo ufw status`, `dig +short A agent.yourdomain.com`, check VPS firewall |
 | Emails landing in spam | Missing DNS records or no PTR | Add all DNS records, set PTR, use Gmail filter |
-| OpenSMTPD not running | Service crashed or misconfigured | `sudo systemctl status opensmtpd` and `journalctl -u opensmtpd -e` |
-| Emails not being delivered to mailbox | OpenSMTPD MDA misconfigured | Check `/etc/smtpd.conf` has correct `aimx ingest` path |
+| `aimx serve` not running | Service crashed or misconfigured | `sudo systemctl status aimx` and `journalctl -u aimx -e` |
+| Emails not being delivered to mailbox | Ingest misconfigured | Check config and mailbox setup with `aimx status` |
 
 **Useful commands:**
 
 ```bash
-aimx preflight              # Re-run port and PTR checks
+sudo aimx verify            # Re-run port 25 checks
 aimx status                 # Show config, mailboxes, and message counts
-aimx verify                 # Port 25 + PTR check (equivalent to aimx preflight)
-systemctl status opensmtpd  # Check OpenSMTPD service status
-journalctl -u opensmtpd -e  # View OpenSMTPD logs
+sudo systemctl status aimx  # Check aimx serve service status
+journalctl -u aimx -e       # View aimx serve logs
 ```

--- a/docs/manual-setup.md
+++ b/docs/manual-setup.md
@@ -1,9 +1,9 @@
-# aimx Manual Setup & Verification Guide
+# AIMX Manual Setup & Verification Guide
 
-This guide walks through every step needed to launch aimx, from deploying the verification infrastructure to running a production mail server. It is split into two parts:
+This guide walks through every step needed to launch AIMX, from deploying the verification infrastructure to running a production mail server. It is split into two parts:
 
 - **Part A** — Deploy the verifier service (done once, before anything else)
-- **Part B** — Set up an aimx mail server (done per server)
+- **Part B** — Set up an AIMX mail server (done per server)
 
 The verifier service must be running before any mail server can complete setup, because `aimx setup` and `aimx verify` both call its HTTP `/probe` endpoint (to test inbound port 25) and connect to its built-in port 25 listener (to test outbound port 25 via EHLO handshake). Both commands use `/probe` (full SMTP EHLO handshake).
 
@@ -125,7 +125,7 @@ The SMTP listener runs inside the `aimx-verifier` binary — no OpenSMTPD, TLS c
 sudo ufw allow 25/tcp
 ```
 
-If your provider blocks port 25 on the verifier host, the listener will bind successfully but remote aimx clients will not be able to reach it, and their outbound-port-25 check will fail even though their own provider is fine.
+If your provider blocks port 25 on the verifier host, the listener will bind successfully but remote AIMX clients will not be able to reach it, and their outbound-port-25 check will fail even though their own provider is fine.
 
 ### A5: Test the Verifier Service
 
@@ -160,9 +160,9 @@ curl https://check.aimx.email/probe
 # Expected: {"reachable":true,"ip":"<your-server-ip>"}
 ```
 
-### A6: Point aimx Mail Servers at Your Verifier Instance
+### A6: Point AIMX Mail Servers at Your Verifier Instance
 
-The default verify host is `https://check.aimx.email`. If you deployed your own instance in the steps above, tell aimx to use it either via `config.toml`:
+The default verify host is `https://check.aimx.email`. If you deployed your own instance in the steps above, tell AIMX to use it either via `config.toml`:
 
 ```toml
 verify_host = "https://check.yourdomain.com"
@@ -175,13 +175,13 @@ sudo aimx verify --verify-host https://check.yourdomain.com
 sudo aimx setup agent.yourdomain.com --verify-host https://check.yourdomain.com
 ```
 
-Precedence is **CLI flag > `verify_host` in `config.toml` > default** (`https://check.aimx.email`). The value must be a base URL starting with `http://` or `https://`; aimx appends `/probe` internally when calling the probe endpoint, and derives the outbound port 25 target (`host:25`) from the same URL. A trailing slash is accepted and stripped.
+Precedence is **CLI flag > `verify_host` in `config.toml` > default** (`https://check.aimx.email`). The value must be a base URL starting with `http://` or `https://`; AIMX appends `/probe` internally when calling the probe endpoint, and derives the outbound port 25 target (`host:25`) from the same URL. A trailing slash is accepted and stripped.
 
-Because aimx derives the outbound port-25 target from the same `verify_host` URL, the verifier service's HTTP probe and its TCP port-25 listener **must run on the same host** (or at least the same hostname in DNS). Self-hosting on a provider that blocks port 25 on the verifier host will leave aimx clients unable to exercise the outbound check.
+Because AIMX derives the outbound port-25 target from the same `verify_host` URL, the verifier service's HTTP probe and its TCP port-25 listener **must run on the same host** (or at least the same hostname in DNS). Self-hosting on a provider that blocks port 25 on the verifier host will leave AIMX clients unable to exercise the outbound check.
 
 ---
 
-## Part B: Set Up aimx on a Mail Server
+## Part B: Set Up AIMX on a Mail Server
 
 ### B1: Prerequisites
 
@@ -214,7 +214,7 @@ source $HOME/.cargo/env
 sudo apt-get update && sudo apt-get install -y dnsutils openssl curl
 ```
 
-### B2: Build & Install aimx
+### B2: Build & Install AIMX
 
 ```bash
 git clone https://github.com/uzyn/aimx.git
@@ -453,7 +453,7 @@ Available MCP tools: `mailbox_list`, `mailbox_create`, `mailbox_delete`, `email_
 
 **Firewall:**
 
-Only port 25 needs to be open for SMTP. No other ports are required by aimx.
+Only port 25 needs to be open for SMTP. No other ports are required by AIMX.
 
 **File permissions:**
 

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,8 +1,8 @@
-# aimx — Product Requirements Document
+# AIMX — Product Requirements Document
 
 ## 1. Overview
 
-aimx is a self-hosted email system for AI agents. It gives agents their own email addresses on a domain the user controls, with mail stored as Markdown files, MCP integration for agent access, and channel rules to trigger actions on incoming mail. One binary, one setup command, no third parties.
+AIMX is a self-hosted email system for AI agents. It gives agents their own email addresses on a domain the user controls, with mail stored as Markdown files, MCP integration for agent access, and channel rules to trigger actions on incoming mail. One binary, one setup command, no third parties.
 
 **Tagline:** SMTP for agents. No middleman.
 
@@ -27,7 +27,7 @@ All routes expose sensitive communications to third parties, which is absurd whe
 | Zero-to-working-email in one session | Time from `aimx setup` to verified send/receive | < 15 minutes (excluding DNS propagation) |
 | Agent-native email access | MCP tool coverage | All core email operations (list, read, send, reply) available via MCP |
 | Reliable delivery | DKIM/SPF/DMARC pass rate on outbound mail | 100% for correctly configured domains |
-| Minimal operational burden | Long-running processes managed by aimx | 1 (`aimx serve` — the only daemon, managed via systemd/OpenRC) |
+| Minimal operational burden | Long-running processes managed by AIMX | 1 (`aimx serve` — the only daemon, managed via systemd/OpenRC) |
 | Developer adoption | GitHub stars / installs | Establish initial user base; exact target TBD |
 
 ## 4. User Personas
@@ -40,7 +40,7 @@ All routes expose sensitive communications to third parties, which is absurd whe
 ### Agent Framework Developer (secondary)
 - **Description:** Developer building tools/frameworks for AI agents who wants to integrate email as a channel.
 - **Needs:** Standard MCP interface for email. Predictable file-based storage that's easy to read programmatically. Minimal operational overhead.
-- **Context:** Integrating aimx into a larger agent system. Cares about the MCP API surface and file format stability.
+- **Context:** Integrating AIMX into a larger agent system. Cares about the MCP API surface and file format stability.
 
 ## 5. User Stories
 
@@ -138,9 +138,9 @@ All routes expose sensitive communications to third parties, which is absurd whe
 
 ## 7. Non-Functional Requirements
 
-- **NFR-1: Single binary, no runtime dependencies.** The entire aimx tool compiles to one binary. No external packages, no system users, no package manager interaction. The binary is fully self-contained.
+- **NFR-1: Single binary, no runtime dependencies.** The entire AIMX tool compiles to one binary. No external packages, no system users, no package manager interaction. The binary is fully self-contained.
 - **NFR-2: `aimx serve` is the daemon.** `aimx serve` runs as a long-lived SMTP listener process, managed by systemd or OpenRC. All other commands (`ingest`, `send`, `mcp`, `setup`, etc.) remain short-lived.
-- **NFR-3: Permissive licensing.** All aimx code and dependencies must use MIT, Apache-2.0, ISC, or BSD licenses. No GPL/AGPL.
+- **NFR-3: Permissive licensing.** All AIMX code and dependencies must use MIT, Apache-2.0, ISC, or BSD licenses. No GPL/AGPL.
 - **NFR-4: Cross-platform Unix.** Any Unix where Rust compiles and port 25 is available. CI tests Ubuntu, Alpine Linux (musl), and Fedora.
 - **NFR-5: Minimal resource usage.** aimx ingest must complete in < 1 second for typical emails (< 10MB).
 - **NFR-6: Secure defaults.** Self-signed TLS cert for STARTTLS (generated during setup, no Let's Encrypt needed), DKIM signing on all outbound, DMARC reject policy, SPF strict.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -119,9 +119,9 @@ All routes expose sensitive communications to third parties, which is absurd whe
 - FR-37: Mail is always stored regardless of trust result. Trust only gates trigger execution.
 
 ### 6.8 Verifier Service
-- FR-38: Hosted verifier service at `check.aimx.email` exposing an HTTP `/probe` endpoint that identifies the caller via a Caddy-injected `X-AIMX-Client-IP` header and performs a full SMTP EHLO handshake against the caller's IP on port 25 (used by `aimx setup` and `aimx verify` to confirm `aimx serve` is responding after setup). The endpoint applies a target guard that rejects loopback, unspecified, link-local, and RFC 1918 / RFC 4193 ranges so the service cannot be used as a port-scanner proxy. ~~`/reach` (plain TCP connect) was removed — `/probe` (EHLO handshake) is the single endpoint.~~
+- FR-38: Hosted verifier service at `check.aimx.email` exposing an HTTP `/probe` endpoint that identifies the caller via a Caddy-injected `X-AIMX-Client-IP` header and performs a full SMTP EHLO handshake against the caller's IP on port 25 (used by `aimx setup` and `aimx verify` to confirm `aimx serve` is responding after setup). The endpoint applies a target guard that rejects loopback, unspecified, link-local, and RFC 1918 / RFC 4193 ranges so the service cannot be used as a port-scanner proxy. `/probe` (EHLO handshake) is the single endpoint.
 - FR-39: ~~Hosted email endpoint at `verify@aimx.email` that receives test email and sends reply.~~ _Removed: email echo eliminated to avoid backscatter risk and MTA dependency on the verify server. DKIM/SPF verification is handled by DNS record checks during setup instead._
-- FR-39b: Port 25 listener on the verifier service that accepts SMTP connections (responds to EHLO), allowing aimx clients to test outbound port 25 connectivity via EHLO handshake.
+- FR-39b: Port 25 listener on the verifier service that accepts SMTP connections (responds to EHLO), allowing `aimx` clients to test outbound port 25 connectivity via EHLO handshake. _Note: outbound check now performs EHLO handshake directly from the client, not via `/reach`._
 - FR-40: Verifier service is open source and self-hostable. No MTA required on the verifier server.
 
 ### 6.9 CLI Commands

--- a/docs/sprint.md
+++ b/docs/sprint.md
@@ -1,4 +1,4 @@
-# aimx — Sprint Plan
+# AIMX — Sprint Plan
 
 **Sprint cadence:** 2.5 days per sprint
 **Team:** Solo developer with heavy AI augmentation (Claude Code)

--- a/docs/sprint.md
+++ b/docs/sprint.md
@@ -1949,7 +1949,7 @@ No GitHub Actions image publishing to ghcr.io in this sprint — not requested. 
 
 ---
 
-## Sprint 24 — Verify Cleanup + Sudo Requirement (Days 67–69.5) [NOT STARTED]
+## Sprint 24 — Verify Cleanup + Sudo Requirement (Days 67–69.5) [IN PROGRESS]
 
 **Goal:** Simplify `aimx verify` to use EHLO-only checks (no TCP-only reachability), require root, remove the `/reach` endpoint from the verifier service, and fix AIMX capitalization across user-facing output.
 
@@ -2036,7 +2036,7 @@ No GitHub Actions image publishing to ghcr.io in this sprint — not requested. 
 | 21 | 58–60.5 | `aimx serve` Daemon | CLI wiring, signal handling, systemd/OpenRC service files, end-to-end daemon test | Done |
 | 22 | 61–63.5 | Remove OpenSMTPD + Cross-Platform CI | Strip OpenSMTPD from setup/status/verify, Alpine + Fedora CI targets | Done |
 | 23 | 64–66.5 | Documentation + PRD Update | Update PRD (NFR-1/2/4, FRs), CLAUDE.md, README, book/, clean up backlog | Done |
-| 24 | 67–69.5 | Verify Cleanup + Sudo Requirement | EHLO-only outbound check, remove `/reach` endpoint, `sudo aimx verify`, AIMX capitalization | Not Started |
+| 24 | 67–69.5 | Verify Cleanup + Sudo Requirement | EHLO-only outbound check, remove `/reach` endpoint, `sudo aimx verify`, AIMX capitalization | In Progress |
 
 ## Deferred to v2
 

--- a/services/verifier/README.md
+++ b/services/verifier/README.md
@@ -42,7 +42,7 @@ Returns **HTTP 400** if the service is behind a reverse proxy (TCP peer is loopb
 
 ### Port 25 Listener
 
-The service also listens on port 25 (configurable via `SMTP_BIND_ADDR`). When an aimx client connects, it receives a `220` banner, can complete a full EHLO/HELO/QUIT exchange, and receives a `221 Bye` on disconnect. This is a minimal but correct SMTP responder — not a real mail server (no `MAIL FROM`, `RCPT TO`, `DATA`, or `AUTH` support) — used solely as a target for outbound port 25 reachability tests.
+The service also listens on port 25 (configurable via `SMTP_BIND_ADDR`). When an AIMX client connects, it receives a `220` banner, can complete a full EHLO/HELO/QUIT exchange, and receives a `221 Bye` on disconnect. This is a minimal but correct SMTP responder — not a real mail server (no `MAIL FROM`, `RCPT TO`, `DATA`, or `AUTH` support) — used solely as a target for outbound port 25 reachability tests.
 
 ## Caddy Deployment
 
@@ -80,7 +80,7 @@ To self-host (replacing `check.aimx.email`):
 2. Point your domain's DNS to the server.
 3. Install Caddy and drop in the canonical `services/verifier/Caddyfile` (set `DOMAIN` as above).
 4. Run `aimx-verifier` with its default loopback bind (`BIND_ADDR=127.0.0.1:3025`).
-5. In your aimx `config.toml`, set `verify_host` to the base URL of your instance (no path):
+5. In your AIMX `config.toml`, set `verify_host` to the base URL of your instance (no path):
    ```toml
    verify_host = "https://check.yourdomain.com"
    ```

--- a/services/verifier/README.md
+++ b/services/verifier/README.md
@@ -1,10 +1,9 @@
 # aimx-verifier
 
-Verification service for [aimx](https://github.com/uzyn/aimx). Provides two complementary HTTP endpoints plus a built-in port 25 listener:
+Verification service for [AIMX](https://github.com/uzyn/aimx). Provides an HTTP endpoint plus a built-in port 25 listener:
 
-1. **`/probe`** — full SMTP EHLO handshake back to the caller's IP on port 25. Used by `aimx setup` and `aimx verify` to confirm a real SMTP server is responding after OpenSMTPD is installed.
-2. **`/reach`** — plain TCP connect to the caller's IP on port 25 (no SMTP handshake). Used by `aimx preflight` to confirm port 25 is reachable on a fresh VPS before OpenSMTPD is installed.
-3. **Port 25 listener** — built-in TCP listener on port 25 that implements a minimal but correct SMTP exchange (banner → EHLO/HELO → 250 → QUIT → 221 Bye), allowing aimx clients to test outbound port 25 reachability from their end.
+1. **`/probe`** — full SMTP EHLO handshake back to the caller's IP on port 25. Used by `aimx setup` and `aimx verify` to confirm a real SMTP server is responding.
+2. **Port 25 listener** — built-in TCP listener on port 25 that implements a minimal but correct SMTP exchange (banner → EHLO/HELO → 250 → QUIT → 221 Bye), allowing `aimx` clients to test outbound port 25 reachability via EHLO handshake.
 
 No MTA is required on the verifier server.
 
@@ -40,11 +39,6 @@ Connects back to the caller's IP on port 25 and performs a full SMTP EHLO handsh
 Response: `{"reachable": true, "ip": "1.2.3.4"}`
 
 Returns **HTTP 400** if the service is behind a reverse proxy (TCP peer is loopback) and the `X-AIMX-Client-IP` header is missing, unparseable, or points at a loopback/private/link-local address. This indicates a Caddyfile misconfiguration — the proxy should be injecting the header.
-
-#### `GET /reach`
-Connects back to the caller's IP on port 25 with a plain TCP connect (10-second timeout). Does NOT perform any SMTP handshake. Returns `reachable: true` as long as the TCP connection succeeds — any listening socket on port 25 counts. Used by `aimx preflight` to check reachability on a fresh VPS before OpenSMTPD (or any other MTA) is installed. Same response shape and same 400 behavior as `/probe`.
-
-Response: `{"reachable": true, "ip": "1.2.3.4"}`
 
 ### Port 25 Listener
 
@@ -90,7 +84,7 @@ To self-host (replacing `check.aimx.email`):
    ```toml
    verify_host = "https://check.yourdomain.com"
    ```
-   aimx appends `/probe` to this base URL when making HTTP checks. (A future release will also append `/reach` for pre-install preflight.)
+   `aimx` appends `/probe` to this base URL when making HTTP checks.
 
    You can also override it per-invocation:
    ```
@@ -153,7 +147,7 @@ docker compose logs -f verifier
 docker compose logs -f caddy
 ```
 
-From a remote machine (with DNS configured), `curl https://check.yourdomain.com/probe` and `curl https://check.yourdomain.com/reach` should return JSON with the caller's real public IP — not `127.0.0.1` or a private Docker bridge address.
+From a remote machine (with DNS configured), `curl https://check.yourdomain.com/probe` should return JSON with the caller's real public IP — not `127.0.0.1` or a private Docker bridge address.
 
 ### Running without compose
 

--- a/services/verifier/src/main.rs
+++ b/services/verifier/src/main.rs
@@ -22,7 +22,6 @@ const SMTP_LINE_TIMEOUT: Duration = Duration::from_secs(10);
 /// DoS where a peer streams megabytes into a growing `String` buffer before
 /// the per-line timeout fires.
 const SMTP_MAX_LINE_BYTES: u64 = 1024;
-const REACH_TCP_TIMEOUT: Duration = Duration::from_secs(10);
 const PROBE_EHLO_TIMEOUT: Duration = Duration::from_secs(45);
 
 #[derive(Serialize)]
@@ -89,9 +88,9 @@ fn resolve_client_ip(peer: &SocketAddr, headers: &HeaderMap) -> Option<IpAddr> {
 /// Layer 4: reject targets that should never be probed.
 ///
 /// This blocks loopback, unspecified, link-local, RFC 1918 (IPv4 private),
-/// RFC 4193 (IPv6 ULA), and similar ranges. Used by both `/probe` and
-/// `/reach` before any outbound connection is attempted, and also by
-/// `resolve_client_ip` to reject bogus `X-AIMX-Client-IP` values.
+/// RFC 4193 (IPv6 ULA), and similar ranges. Used by `/probe` before any
+/// outbound connection is attempted, and also by `resolve_client_ip` to
+/// reject bogus `X-AIMX-Client-IP` values.
 ///
 /// IPv4-mapped IPv6 addresses are canonicalized to their IPv4 form before
 /// the checks run, so `::ffff:127.0.0.1` and similar are blocked as if the
@@ -145,9 +144,9 @@ fn is_blocked_ipv6(ip: &Ipv6Addr) -> bool {
 }
 
 /// Extension handlers insert into their response so the logging middleware
-/// can include the probe/reach `reachable` outcome in the per-request log
-/// line. Keeping the middleware as the single source of truth for request
-/// logs avoids duplicated log lines per request.
+/// can include the probe `reachable` outcome in the per-request log line.
+/// Keeping the middleware as the single source of truth for request logs
+/// avoids duplicated log lines per request.
 #[derive(Clone, Copy)]
 struct ReachableOutcome(bool);
 
@@ -156,8 +155,8 @@ struct ReachableOutcome(bool);
 /// Emits exactly one `info!` line per HTTP request, containing the method,
 /// path, resolved caller IP (or `unknown` if the Layer 3 trust check
 /// rejected the request before the handler ran), response status, elapsed
-/// ms, and — for `/probe` and `/reach` — the reachable outcome recorded by
-/// the handler via `ReachableOutcome`.
+/// ms, and — for `/probe` — the reachable outcome recorded by the handler
+/// via `ReachableOutcome`.
 async fn log_request(
     ConnectInfo(peer): ConnectInfo<SocketAddr>,
     req: Request,
@@ -226,29 +225,6 @@ async fn probe(
     }))
 }
 
-async fn reach(
-    ConnectInfo(addr): ConnectInfo<SocketAddr>,
-    headers: HeaderMap,
-) -> Result<ProbeBody, StatusCode> {
-    let caller_ip = match resolve_client_ip(&addr, &headers) {
-        Some(ip) => ip,
-        None => return Err(StatusCode::BAD_REQUEST),
-    };
-
-    if is_blocked_target(&caller_ip) {
-        return Ok(ProbeBody(ProbeResponse {
-            reachable: false,
-            ip: caller_ip.to_string(),
-        }));
-    }
-
-    let reachable = check_port25_tcp(&caller_ip).await;
-    Ok(ProbeBody(ProbeResponse {
-        reachable,
-        ip: caller_ip.to_string(),
-    }))
-}
-
 /// Newtype wrapper that converts to a `Json` response and attaches a
 /// `ReachableOutcome` extension so the logging middleware can record the
 /// probe result alongside the standard request metadata.
@@ -263,14 +239,6 @@ impl axum::response::IntoResponse for ProbeBody {
             .insert(ReachableOutcome(reachable));
         response
     }
-}
-
-async fn check_port25_tcp(ip: &IpAddr) -> bool {
-    let addr = SocketAddr::new(*ip, 25);
-    matches!(
-        tokio::time::timeout(REACH_TCP_TIMEOUT, TcpStream::connect(addr)).await,
-        Ok(Ok(_))
-    )
 }
 
 async fn check_port25_ehlo(ip: &IpAddr) -> bool {
@@ -447,7 +415,6 @@ fn main() {
             .route("/", get(health))
             .route("/health", get(health))
             .route("/probe", get(probe))
-            .route("/reach", get(reach))
             .layer(middleware::from_fn(log_request));
 
         let bind_addr = std::env::var("BIND_ADDR").unwrap_or_else(|_| "127.0.0.1:3025".to_string());
@@ -677,13 +644,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn reach_returns_400_on_loopback_without_header() {
-        let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
-        let result = reach(ConnectInfo(addr), empty_headers()).await;
-        assert_eq!(result.err(), Some(StatusCode::BAD_REQUEST));
-    }
-
-    #[tokio::test]
     async fn probe_returns_400_on_loopback_with_private_header() {
         let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
         let headers = headers_with_client_ip("10.0.0.1");
@@ -691,55 +651,8 @@ mod tests {
         assert_eq!(result.err(), Some(StatusCode::BAD_REQUEST));
     }
 
-    #[tokio::test]
-    async fn reach_returns_400_on_loopback_with_private_header() {
-        let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
-        let headers = headers_with_client_ip("10.0.0.1");
-        let result = reach(ConnectInfo(addr), headers).await;
-        assert_eq!(result.err(), Some(StatusCode::BAD_REQUEST));
-    }
-
     // -----------------------------------------------------------------
-    // /reach semantics: TCP-only, no SMTP handshake
-    // -----------------------------------------------------------------
-
-    #[tokio::test]
-    async fn check_port25_tcp_unreachable_host() {
-        let ip: IpAddr = "192.0.2.1".parse().unwrap();
-        let result = check_port25_tcp(&ip).await;
-        assert!(!result);
-    }
-
-    #[tokio::test]
-    async fn check_port25_tcp_listening_socket_returns_true() {
-        // Spawn a dummy TCP listener on a random port. We can't bind port 25
-        // in tests, so we test the inner logic by connecting directly to the
-        // bound address (the helper function is reused).
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let port = listener.local_addr().unwrap().port();
-
-        // Keep it accepting so the connect succeeds.
-        tokio::spawn(async move {
-            loop {
-                let _ = listener.accept().await;
-            }
-        });
-
-        // Verify the plain TCP connect semantics: ANY listening TCP socket
-        // satisfies reachability. No banner or EHLO required.
-        let addr: SocketAddr = format!("127.0.0.1:{port}").parse().unwrap();
-        let ok = tokio::time::timeout(REACH_TCP_TIMEOUT, TcpStream::connect(addr))
-            .await
-            .unwrap()
-            .is_ok();
-        assert!(
-            ok,
-            "plain TCP connect to listening socket should succeed regardless of SMTP"
-        );
-    }
-
-    // -----------------------------------------------------------------
-    // handle_smtp_connection — new correct semantics
+    // handle_smtp_connection
     // -----------------------------------------------------------------
 
     async fn read_line(stream: &mut TcpStream) -> String {
@@ -997,33 +910,17 @@ mod tests {
     }
 
     // -----------------------------------------------------------------
-    // Integration: /probe and /reach handlers resolve IP via header
+    // Integration: /probe handler resolves IP via header
     // -----------------------------------------------------------------
 
     #[tokio::test]
-    async fn reach_resolves_caller_ip_from_header_on_loopback() {
+    async fn probe_resolves_caller_ip_from_header_on_loopback() {
         // Peer is loopback (simulating behind-Caddy request), header carries
-        // a reserved-but-unreachable public-range IP (TEST-NET-1). /reach
-        // should resolve the caller IP from the header — not the peer —
-        // and attempt the TCP connect to that IP, which will fail (since
+        // a reserved-but-unreachable public-range IP (TEST-NET-1). /probe
+        // should resolve the caller IP from the header -- not the peer --
+        // and attempt the EHLO handshake to that IP, which will fail (since
         // 192.0.2.1 is unroutable), yielding reachable: false with the
         // correct ip field.
-        let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
-        let headers = headers_with_client_ip("192.0.2.1");
-        let result = reach(ConnectInfo(addr), headers).await.unwrap();
-        assert_eq!(result.0.ip, "192.0.2.1");
-        assert!(!result.0.reachable);
-    }
-
-    #[tokio::test]
-    async fn probe_resolves_caller_ip_from_header_on_loopback() {
-        // Same test, but against /probe — the spec explicitly asks for header
-        // resolution on /probe in addition to /reach. TEST-NET-1 is
-        // unroutable, so the EHLO handshake fails and we get reachable: false
-        // with the correct ip field. What we're actually asserting is that
-        // the handler resolved the target from the header, not from the
-        // (loopback) peer — if it used the peer the response ip would be
-        // "127.0.0.1".
         let addr: SocketAddr = "127.0.0.1:12345".parse().unwrap();
         let headers = headers_with_client_ip("192.0.2.1");
         let result = probe(ConnectInfo(addr), headers).await.unwrap();
@@ -1263,7 +1160,6 @@ mod tests {
             .route("/", get(health))
             .route("/health", get(health))
             .route("/probe", get(probe))
-            .route("/reach", get(reach))
             .layer(middleware::from_fn(log_request));
 
         let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
@@ -1337,15 +1233,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn log_request_logs_reach_with_reachable_outcome() {
-        // /reach with a public IP in the trusted header — TEST-NET-1 is
+    async fn log_request_logs_probe_with_reachable_outcome() {
+        // /probe with a public IP in the trusted header -- TEST-NET-1 is
         // unroutable so reachable will be false, but the important thing
         // is that `reachable=false` appears in the log line alongside the
         // other fields.
-        let logs = run_http_request("/reach", Some("192.0.2.1")).await;
+        let logs = run_http_request("/probe", Some("192.0.2.1")).await;
         assert!(
-            logs.contains("path=/reach"),
-            "expected /reach path in logs, got: {logs}"
+            logs.contains("path=/probe"),
+            "expected /probe path in logs, got: {logs}"
         );
         assert!(
             logs.contains("caller_ip=192.0.2.1"),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -4,7 +4,7 @@ use clap::{Parser, Subcommand};
 #[command(
     name = "aimx",
     about = "SMTP for agents. No middleman.",
-    long_about = "aimx - Self-hosted email for AI agents.\n\n\
+    long_about = "AIMX - Self-hosted email for AI agents.\n\n\
                    One command to give your AI agents their own email addresses.\n\
                    Incoming mail is parsed to Markdown. Outbound mail is DKIM-signed.\n\
                    MCP is built in. Channel rules trigger agent actions on incoming mail.",

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -375,7 +375,7 @@ impl AimxMcpServer {
 impl ServerHandler for AimxMcpServer {
     fn get_info(&self) -> ServerInfo {
         ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
-            .with_instructions("aimx email server - manage mailboxes and emails for AI agents")
+            .with_instructions("AIMX email server - manage mailboxes and emails for AI agents")
     }
 }
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -69,7 +69,7 @@ async fn run_serve(
         .map_err(|e| format!("Failed to bind to {bind_addr}: {e}"))?;
 
     let actual_addr = listener.local_addr()?;
-    eprintln!("aimx SMTP listener started on {actual_addr}");
+    eprintln!("AIMX SMTP listener started on {actual_addr}");
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
@@ -88,7 +88,7 @@ async fn run_serve(
 
     let in_flight_msg = server.run(listener, shutdown_rx).await;
 
-    eprintln!("aimx SMTP listener shut down");
+    eprintln!("AIMX SMTP listener shut down");
 
     in_flight_msg
 }
@@ -101,7 +101,7 @@ pub mod service {
     pub fn generate_systemd_unit(aimx_path: &str, data_dir: &str) -> String {
         format!(
             "[Unit]\n\
-             Description=aimx SMTP server\n\
+             Description=AIMX SMTP server\n\
              After=network.target\n\
              \n\
              [Service]\n\
@@ -121,7 +121,7 @@ pub mod service {
         format!(
             "#!/sbin/openrc-run\n\
              \n\
-             description=\"aimx SMTP server\"\n\
+             description=\"AIMX SMTP server\"\n\
              command={aimx_path}\n\
              command_args=\"serve --data-dir {data_dir}\"\n\
              supervisor=supervise-daemon\n\

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -231,12 +231,8 @@ impl RealNetworkOps {
         })
     }
 
-    /// Shared curl invocation for `/probe` and `/reach` verify-service paths.
-    /// Both endpoints return `{"reachable": bool, ...}`; any curl failure or
-    /// non-success exit maps to `Ok(false)` so the caller displays a FAIL
-    /// advisory rather than an error backtrace.
-    fn curl_reachable(&self, path: &str) -> Result<bool, Box<dyn std::error::Error>> {
-        let url = format!("{}{path}", self.verify_host);
+    fn curl_probe(&self) -> Result<bool, Box<dyn std::error::Error>> {
+        let url = format!("{}/probe", self.verify_host);
         let resp = std::process::Command::new("curl")
             .args(["-s", "-m", "60", &url])
             .output();
@@ -291,6 +287,7 @@ pub fn derive_smtp_addr_from_verify_host(verify_host: &str) -> String {
 
 impl NetworkOps for RealNetworkOps {
     fn check_outbound_port25(&self) -> Result<bool, Box<dyn std::error::Error>> {
+        use std::io::{BufRead, BufReader, Write};
         use std::net::{TcpStream, ToSocketAddrs};
         use std::time::Duration;
 
@@ -300,14 +297,46 @@ impl NetworkOps for RealNetworkOps {
             return Ok(false);
         }
 
-        match TcpStream::connect_timeout(&addrs[0], Duration::from_secs(10)) {
-            Ok(_) => Ok(true),
-            Err(_) => Ok(false),
+        let stream = match TcpStream::connect_timeout(&addrs[0], Duration::from_secs(10)) {
+            Ok(s) => s,
+            Err(_) => return Ok(false),
+        };
+        stream.set_read_timeout(Some(Duration::from_secs(5)))?;
+        stream.set_write_timeout(Some(Duration::from_secs(5)))?;
+
+        let mut reader = BufReader::new(stream.try_clone()?);
+        let mut writer = stream;
+
+        let mut banner = String::new();
+        if reader.read_line(&mut banner).is_err() || !banner.starts_with("220") {
+            return Ok(false);
         }
+
+        writer.write_all(b"EHLO aimx\r\n")?;
+        writer.flush()?;
+
+        let mut ehlo_resp = String::new();
+        loop {
+            ehlo_resp.clear();
+            if reader.read_line(&mut ehlo_resp).is_err() {
+                return Ok(false);
+            }
+            if ehlo_resp.starts_with("250 ") {
+                break;
+            }
+            if !ehlo_resp.starts_with("250-") {
+                return Ok(false);
+            }
+        }
+
+        let _ = writer.write_all(b"QUIT\r\n");
+        let _ = writer.flush();
+
+        Ok(true)
     }
 
     fn check_inbound_port25(&self) -> Result<bool, Box<dyn std::error::Error>> {
-        self.curl_reachable("/probe")
+        self.curl_probe()
     }
 
     fn check_ptr_record(&self) -> Result<Option<String>, Box<dyn std::error::Error>> {
@@ -945,7 +974,7 @@ pub fn run_setup(
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Step 1: Root check
     if !sys.check_root() {
-        return Err("aimx setup requires root. Run with: sudo aimx setup <domain>".into());
+        return Err("`aimx setup` requires root. Run with: sudo aimx setup <domain>".into());
     }
 
     // Resolve domain: use argument if provided, otherwise prompt interactively
@@ -961,7 +990,7 @@ pub fn run_setup(
         }
     };
 
-    println!("aimx setup for {domain}\n");
+    println!("AIMX setup for {domain}\n");
 
     let data_dir = data_dir.unwrap_or(Path::new("/var/lib/aimx"));
     std::fs::create_dir_all(data_dir)?;
@@ -981,7 +1010,7 @@ pub fn run_setup(
     if already_configured {
         println!(
             "{}",
-            "Existing aimx configuration detected. Skipping install, proceeding to verification."
+            "Existing AIMX configuration detected. Skipping install, proceeding to verification."
                 .green()
         );
     } else {
@@ -989,7 +1018,7 @@ pub fn run_setup(
         match sys.check_port25_occupancy()? {
             Port25Status::Free => {}
             Port25Status::Aimx => {
-                println!("aimx is already running on port 25. Proceeding with setup.");
+                println!("`aimx serve` is already running on port 25. Proceeding with setup.");
             }
             Port25Status::OtherProcess(name) => {
                 return Err(format!(
@@ -1012,7 +1041,7 @@ pub fn run_setup(
 
         println!("Installing aimx service...");
         sys.install_service_file(data_dir)?;
-        println!("{}", "aimx serve started.".green());
+        println!("{}", "`aimx serve` started.".green());
     }
 
     // Step 4-5: Port checks (run on both fresh and re-entrant invocations)
@@ -1049,8 +1078,8 @@ pub fn run_setup(
     if port_failed {
         return Err(
             "Port 25 checks failed. Your VPS provider may block SMTP traffic.\n\
-             aimx serve started but port 25 is not reachable.\n\
-             Fix the issues above and run `aimx setup` again."
+             `aimx serve` started but port 25 is not reachable.\n\
+             Fix the issues above and run `sudo aimx setup` again."
                 .into(),
         );
     }
@@ -1831,7 +1860,7 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
-            err.contains("aimx setup requires root"),
+            err.contains("requires root"),
             "Expected root error, got: {err}"
         );
     }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -756,7 +756,7 @@ pub fn display_dns_verification(
 pub fn display_mcp_section(data_dir: &Path) {
     println!("\n{}", "[MCP]".bold());
     println!(
-        "Add aimx to your MCP-compatible AI agent (Claude Code, OpenClaw, Codex, OpenCode, etc.).\n"
+        "Add AIMX to your MCP-compatible AI agent (Claude Code, OpenClaw, Codex, OpenCode, etc.).\n"
     );
     println!("Configuration snippet:\n");
     println!("{}\n", mcp_config_snippet(data_dir));
@@ -1039,7 +1039,7 @@ pub fn run_setup(
             println!("TLS certificate already exists.");
         }
 
-        println!("Installing aimx service...");
+        println!("Installing AIMX service...");
         sys.install_service_file(data_dir)?;
         println!("{}", "`aimx serve` started.".green());
     }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -6,6 +6,11 @@ pub fn run(
     data_dir: Option<&Path>,
     verify_host: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let sys = setup::RealSystemOps;
+    if !setup::SystemOps::check_root(&sys) {
+        return Err("`aimx verify` requires root. Run with: sudo aimx verify".into());
+    }
+
     let config = match data_dir {
         Some(dir) => Config::load_from_data_dir(dir).ok(),
         None => Config::load_default().ok(),
@@ -136,7 +141,7 @@ pub fn run_with_net(
     net: &dyn NetworkOps,
     port25: &Port25Status,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    println!("aimx verify - Port 25 connectivity check\n");
+    println!("AIMX verify - Port 25 connectivity check\n");
 
     let mut all_pass = true;
 

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -1,13 +1,20 @@
 use crate::config::Config;
-use crate::setup::{self, DEFAULT_VERIFY_HOST, NetworkOps, Port25Status};
+use crate::setup::{self, DEFAULT_VERIFY_HOST, NetworkOps, Port25Status, SystemOps};
 use std::path::Path;
 
 pub fn run(
     data_dir: Option<&Path>,
     verify_host: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let sys = setup::RealSystemOps;
-    if !setup::SystemOps::check_root(&sys) {
+    run_verify(data_dir, verify_host, &setup::RealSystemOps)
+}
+
+pub(crate) fn run_verify(
+    data_dir: Option<&Path>,
+    verify_host: Option<&str>,
+    sys: &dyn SystemOps,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if !sys.check_root() {
         return Err("`aimx verify` requires root. Run with: sudo aimx verify".into());
     }
 
@@ -19,7 +26,7 @@ pub fn run(
     let host = resolve_verify_host(verify_host, config.as_ref(), DEFAULT_VERIFY_HOST);
     let net = setup::RealNetworkOps::from_verify_host(host)?;
 
-    let port25 = detect_port25();
+    let port25 = detect_port25(sys);
 
     if matches!(port25, Port25Status::Free) {
         return run_with_temp_server(&net);
@@ -132,9 +139,8 @@ pub(crate) fn resolve_verify_host(
         .unwrap_or_else(|| default.to_string())
 }
 
-fn detect_port25() -> Port25Status {
-    let sys = setup::RealSystemOps;
-    setup::SystemOps::check_port25_occupancy(&sys).unwrap_or(Port25Status::Free)
+fn detect_port25(sys: &dyn SystemOps) -> Port25Status {
+    sys.check_port25_occupancy().unwrap_or(Port25Status::Free)
 }
 
 pub fn run_with_net(
@@ -236,6 +242,60 @@ mod tests {
         fn resolve_txt(&self, _domain: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
             Ok(vec![])
         }
+    }
+
+    struct MockSystemOps {
+        is_root: bool,
+    }
+
+    impl SystemOps for MockSystemOps {
+        fn write_file(
+            &self,
+            _path: &Path,
+            _content: &str,
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            Ok(())
+        }
+        fn file_exists(&self, _path: &Path) -> bool {
+            false
+        }
+        fn restart_service(&self, _service: &str) -> Result<(), Box<dyn std::error::Error>> {
+            Ok(())
+        }
+        fn is_service_running(&self, _service: &str) -> bool {
+            false
+        }
+        fn generate_tls_cert(
+            &self,
+            _cert_dir: &Path,
+            _domain: &str,
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            Ok(())
+        }
+        fn get_aimx_binary_path(&self) -> Result<std::path::PathBuf, Box<dyn std::error::Error>> {
+            Ok(std::path::PathBuf::from("/usr/local/bin/aimx"))
+        }
+        fn check_root(&self) -> bool {
+            self.is_root
+        }
+        fn check_port25_occupancy(&self) -> Result<Port25Status, Box<dyn std::error::Error>> {
+            Ok(Port25Status::Free)
+        }
+        fn install_service_file(&self, _data_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn verify_requires_root() {
+        let sys = MockSystemOps { is_root: false };
+        let result = run_verify(None, Some("https://check.example.com"), &sys);
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("requires root"),
+            "Expected root error, got: {err}"
+        );
     }
 
     // --- aimx running tests ---


### PR DESCRIPTION
## Summary

- **S24.1**: Switch outbound port 25 check from bare TCP connect to full SMTP EHLO handshake (connect, read 220 banner, send EHLO, read 250, send QUIT) with 10s connect + 5s read/write timeouts
- **S24.2**: Remove `/reach` endpoint from verifier service -- handler, route, `check_port25_tcp()`, all tests, README, and all references across `src/`, `book/`, `docs/`, `CLAUDE.md`
- **S24.3**: Require root for `aimx verify` at entry (reuses `SystemOps::check_root` pattern from `aimx setup`), update all docs to show `sudo aimx verify`
- **S24.4**: Fix AIMX capitalization in user-facing output -- `println`/`eprintln` strings, systemd/OpenRC service descriptions, MCP server instructions, CLI `long_about`

Also renames `curl_reachable()` to `curl_probe()` since it now only serves `/probe`, and cleans up stale `aimx preflight` references.

## Test plan

- [x] Main crate: 321 unit tests + 44 integration tests pass
- [x] Verifier crate: 42 tests pass
- [x] `cargo clippy -- -D warnings` clean on both crates
- [x] `cargo fmt -- --check` clean on both crates
- [ ] Manual VPS validation: `sudo aimx verify` outbound check performs EHLO against `check.aimx.email:25`