### PR TITLE
Fix DKIM public key format and prefer IPv4 for outbound SMTP

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -74,7 +74,7 @@ All routes expose sensitive communications to third parties, which is absurd whe
 - FR-4: Stop with clear error message if port 25 is blocked. List compatible VPS providers.
 - FR-5: Check reverse DNS (PTR) and warn (non-blocking) if not set.
 - FR-6: Generate 2048-bit RSA DKIM keypair.
-- FR-7: Display required DNS records (MX, A, SPF, DKIM, DMARC, PTR) and wait for user confirmation.
+- FR-7: Display required DNS records (MX, A, AAAA, SPF, DKIM, DMARC, PTR) and wait for user confirmation. Include AAAA record and `ip6:` SPF mechanism when the server has an IPv6 address.
 - FR-8: Verify DNS records are correctly set.
 - FR-9: Create default `catchall` mailbox.
 - FR-10: Display MCP configuration snippet for MCP-compatible AI agents (Claude Code, OpenClaw, Codex, OpenCode, etc.).
@@ -90,7 +90,7 @@ All routes expose sensitive communications to third parties, which is absurd whe
 ### 6.3 Email Sending (`aimx send`)
 - FR-17: Compose RFC 5322 compliant email from provided parameters (from, to, subject, body, attachments).
 - FR-18: Sign message with DKIM (RSA-SHA256) using the domain's private key.
-- FR-19: Deliver signed message directly to the recipient's MX server via SMTP (MX resolution + lettre transport). Return delivery errors immediately — no background queue.
+- FR-19: Deliver signed message directly to the recipient's MX server via SMTP (MX resolution + lettre transport). Support both IPv4 and IPv6 connections (OS decides). Return delivery errors immediately — no background queue.
 - FR-20: Support file attachments by path.
 - FR-21: Set proper In-Reply-To and References headers when replying.
 

--- a/docs/sprint.md
+++ b/docs/sprint.md
@@ -2,8 +2,8 @@
 
 **Sprint cadence:** 2.5 days per sprint
 **Team:** Solo developer with heavy AI augmentation (Claude Code)
-**Total sprints:** 25 (6 original + 2 post-audit hardening + 1 YAML→TOML migration + 2 verifier/setup overhaul + 2 post-Sprint-11 bug fixes + 2 verifier ops + 1 deployment + 1 service rename + 1 setup UX + 5 embedded SMTP + 1 verify cleanup + 1 DKIM permissions fix)
-**Timeline:** ~72.5 calendar days
+**Total sprints:** 26 (6 original + 2 post-audit hardening + 1 YAML→TOML migration + 2 verifier/setup overhaul + 2 post-Sprint-11 bug fixes + 2 verifier ops + 1 deployment + 1 service rename + 1 setup UX + 5 embedded SMTP + 1 verify cleanup + 1 DKIM permissions fix + 1 IPv6 support)
+**Timeline:** ~75.5 calendar days
 **v1 Scope:** Full PRD scope including verifier service. Sprint 1 targets earliest possible idea validation on a real VPS. Sprints 7–8 address findings from post-v1 code review audit. Sprints 10–11 overhaul the verifier service (remove email echo, add EHLO probe) and rewrite the setup flow (root check, MTA conflict detection, install-before-check). Sprints 12–13 fix critical bugs found during post-Sprint-11 debugging: Caddy self-probe loop / XFF SSRF risk in the verifier service, and the preflight chicken-and-egg problem on fresh VPSes. Sprints 14–15 are review-driven operational quality work on the verifier service (request logging, Docker packaging). Sprint 17 renames the verify service to verifier across all code, Docker, CI, and documentation. Sprints 19–23 replace OpenSMTPD with an embedded SMTP server (hand-rolled tokio listener for inbound, lettre + hickory-resolver for outbound) and update all documentation, making aimx a true single-binary solution with no external runtime dependencies and cross-platform Unix support. Sprint 24 cleans up `aimx verify` (EHLO-only checks, sudo requirement, remove `/reach` endpoint, AIMX capitalization).
 
 ---
@@ -242,6 +242,51 @@ Completed sprints 1–21 have been archived for context window efficiency.
 
 ---
 
+## Sprint 26 — IPv6 Support for Outbound SMTP (Days 73–75.5) [NOT STARTED]
+
+**Goal:** Remove the IPv4-only workaround from outbound delivery and properly support IPv6 across SPF records, DNS guidance, and verification. The IPv4 preference was added in Sprint 25 as a workaround for SPF failures — now that DKIM is fixed, let the OS resolve addresses naturally and ensure SPF covers both address families.
+
+**Dependencies:** Sprint 25
+
+**Testing environment:** Same as Sprint 25. Use `sudo aimx send --from hello@agent.zeroshot.lol --to chua@uzyn.com --subject Hey --body "Test"` to verify delivery works over whichever address family the OS selects.
+
+#### S26-1: Remove IPv4-only outbound restriction
+
+**Context:** `resolve_ipv4()` in `send.rs:95-104` forces all outbound SMTP connections through IPv4 by filtering DNS results for A records only. This was a workaround for SPF failures when connecting over IPv6 (Sprint 25, commit 47168f8). Now that DKIM signing is correct, the restriction should be removed — let the OS decide which address family to use when connecting to MX servers. Remove `resolve_ipv4()` and the `connect_target` override in `try_deliver()`, so `lettre` connects directly to the MX hostname.
+
+**Priority:** P0
+
+- [ ] Remove `resolve_ipv4()` function from `send.rs`
+- [ ] Remove `connect_target` logic in `try_deliver()` — pass `host` directly to `SmtpTransport::builder_dangerous()`
+- [ ] Verify existing tests still pass
+- [ ] Live test: `sudo aimx send --from hello@agent.zeroshot.lol --to chua@uzyn.com --subject Hey --body "Test"` delivers successfully
+
+#### S26-2: Add IPv6 to DNS guidance and SPF record
+
+**Context:** `setup.rs` detects the server IP via `hostname -I` (which returns both IPv4 and IPv6 addresses) but only uses the first address. The generated SPF record (`v=spf1 ip4:{server_ip} -all`) and DNS guidance only cover IPv4. When the OS connects to a recipient MX over IPv6, SPF fails because the server's IPv6 address isn't in the record. Fix: detect both IPv4 and IPv6 addresses from `hostname -I`, generate SPF with both `ip4:` and `ip6:` mechanisms, add an AAAA record to the DNS guidance, and pass both addresses through the setup flow.
+
+**Priority:** P0
+
+- [ ] `get_server_ip()` (or new helper) returns both IPv4 and IPv6 addresses from `hostname -I`
+- [ ] `generate_dns_records()` produces SPF record with both `ip4:` and `ip6:` when IPv6 is available (e.g., `v=spf1 ip4:X.X.X.X ip6:2001:db8::1 -all`)
+- [ ] `generate_dns_records()` includes an AAAA record when IPv6 address is available
+- [ ] `display_dns_guidance()` shows the AAAA record to the user
+- [ ] Tests updated for dual-stack DNS record generation
+
+#### S26-3: Add `ip6:` support to SPF verification
+
+**Context:** `spf_contains_ip()` in `setup.rs:569-582` only checks `ip4:` mechanisms — this is the open backlog item from Sprint 8. Add `ip6:` mechanism support so that `verify_spf()` correctly validates SPF records containing IPv6 addresses. Also update `verify_all_dns()` to verify SPF against both the server's IPv4 and IPv6 addresses when both are present.
+
+**Priority:** P0
+
+- [ ] `spf_contains_ip()` also checks `ip6:` and `+ip6:` prefixes
+- [ ] `verify_spf()` can verify against IPv6 addresses
+- [ ] `verify_all_dns()` checks SPF for both IPv4 and IPv6 when both are available
+- [ ] Unit tests: SPF pass/fail/missing for `ip6:` mechanisms, dual-stack verification
+- [ ] Mark Sprint 8 backlog item "Add `ip6:` mechanism support to `spf_contains_ip()`" as triaged
+
+---
+
 ## Summary Table
 
 | Sprint | Days | Focus | Key Output | Status |
@@ -273,6 +318,7 @@ Completed sprints 1–21 have been archived for context window efficiency.
 | 23 | 64–66.5 | Documentation + PRD Update | Update PRD (NFR-1/2/4, FRs), CLAUDE.md, README, book/, clean up backlog | Done |
 | 24 | 67–69.5 | Verify Cleanup + Sudo Requirement | EHLO-only outbound check, remove `/reach` endpoint, `sudo aimx verify`, AIMX capitalization | Done |
 | 25 | 70–72.5 | Fix `aimx send` (Permissions + DKIM Signing) | DKIM key `0o644`, fix DKIM signature verification at Gmail — `aimx send` works end-to-end | Done |
+| 26 | 73–75.5 | IPv6 Support for Outbound SMTP | Remove IPv4-only workaround, dual-stack SPF records, `ip6:` verification | Not Started |
 
 ## Deferred to v2
 
@@ -323,7 +369,7 @@ Concrete items with clear implementation direction. Will be triaged into a clean
 - [x] **(Sprint 6)** Handle multiline (folded) Authentication-Results headers in `extract_auth_result` — _Obsolete: echo removed in Sprint 10 (S10.1)_
 - [x] **(Sprint 6)** Add `Message-ID` and `Date` headers to echo reply (RFC 5322 compliance) — _Obsolete: echo removed in Sprint 10 (S10.1)_
 - [x] **(Sprint 6)** Handle missing catchall mailbox gracefully in `aimx verify` — _Triaged into Sprint 7 (S7.4)_
-- [ ] **(Sprint 8)** Add `ip6:` mechanism support to `spf_contains_ip()` for IPv6 server addresses
+- [ ] **(Sprint 8)** Add `ip6:` mechanism support to `spf_contains_ip()` for IPv6 server addresses — _Triaged into Sprint 26_
 - [x] **(Sprint 8)** Quote data dir path in `generate_smtpd_conf` MDA command to handle paths with spaces — _Obsolete: `generate_smtpd_conf` removed in Sprint 22_
 - [x] **(Sprint 11)** `parse_port25_status` uses `smtpd` substring match which could misidentify non-OpenSMTPD processes — _Obsolete: OpenSMTPD-specific port parsing removed in Sprint 22_
 - [x] **(Sprint 11)** Dead `Fail` branch for PTR in `verify.rs` — _Obsolete: `check_ptr()` is no longer called from `verify.rs`; moved to `setup.rs` where the `Fail` arm is a defensive match on the `PreflightResult` enum_

--- a/src/dkim.rs
+++ b/src/dkim.rs
@@ -1,5 +1,6 @@
-use rsa::pkcs1::{EncodeRsaPrivateKey, EncodeRsaPublicKey};
-use rsa::pkcs8::LineEnding;
+use base64::Engine;
+use rsa::pkcs1::EncodeRsaPrivateKey;
+use rsa::pkcs8::{EncodePublicKey, LineEnding};
 use rsa::{RsaPrivateKey, RsaPublicKey};
 use std::path::Path;
 
@@ -29,7 +30,7 @@ pub fn generate_keypair(data_dir: &Path, force: bool) -> Result<(), Box<dyn std:
     }
 
     let public_key = RsaPublicKey::from(&private_key);
-    let public_pem = public_key.to_pkcs1_pem(LineEnding::LF)?;
+    let public_pem = public_key.to_public_key_pem(LineEnding::LF)?;
     std::fs::write(&public_path, public_pem.as_bytes())?;
 
     Ok(())
@@ -40,10 +41,16 @@ pub fn dns_record_value(data_dir: &Path) -> Result<String, Box<dyn std::error::E
     let pem = std::fs::read_to_string(&public_path)
         .map_err(|_| "DKIM public key not found. Run `aimx dkim-keygen` first.")?;
 
-    let b64 = pem
-        .lines()
-        .filter(|l| !l.starts_with("-----"))
-        .collect::<String>();
+    let public_key = if pem.contains("BEGIN RSA PUBLIC KEY") {
+        use rsa::pkcs1::DecodeRsaPublicKey;
+        RsaPublicKey::from_pkcs1_pem(&pem)?
+    } else {
+        use rsa::pkcs8::DecodePublicKey;
+        RsaPublicKey::from_public_key_pem(&pem)?
+    };
+
+    let spki_der = public_key.to_public_key_der()?;
+    let b64 = base64::engine::general_purpose::STANDARD.encode(spki_der.as_ref());
 
     Ok(format!("v=DKIM1; k=rsa; p={b64}"))
 }
@@ -144,7 +151,7 @@ mod tests {
         let private_key: RsaPrivateKey =
             rsa::pkcs1::DecodeRsaPrivateKey::from_pkcs1_pem(&private_pem).unwrap();
         let public_key: rsa::RsaPublicKey =
-            rsa::pkcs1::DecodeRsaPublicKey::from_pkcs1_pem(&public_pem).unwrap();
+            rsa::pkcs8::DecodePublicKey::from_public_key_pem(&public_pem).unwrap();
 
         assert_eq!(private_key.size() * 8, DKIM_KEY_BITS);
         assert_eq!(public_key.size() * 8, DKIM_KEY_BITS);

--- a/src/send.rs
+++ b/src/send.rs
@@ -92,6 +92,17 @@ impl MailTransport for LettreTransport {
 }
 
 impl LettreTransport {
+    fn resolve_ipv4(host: &str) -> Option<std::net::Ipv4Addr> {
+        use std::net::ToSocketAddrs;
+        format!("{host}:25")
+            .to_socket_addrs()
+            .ok()?
+            .find_map(|addr| match addr {
+                std::net::SocketAddr::V4(v4) => Some(*v4.ip()),
+                _ => None,
+            })
+    }
+
     fn try_deliver(
         &self,
         host: &str,
@@ -105,7 +116,14 @@ impl LettreTransport {
             .build_rustls()
             .map_err(|e| format!("TLS configuration error: {e}"))?;
 
-        let transport = lettre::SmtpTransport::builder_dangerous(host)
+        let connect_target = Self::resolve_ipv4(host)
+            .map(|ip| ip.to_string())
+            .unwrap_or_else(|| host.to_string());
+
+        let transport = lettre::SmtpTransport::builder_dangerous(&connect_target)
+            .hello_name(lettre::transport::smtp::extension::ClientId::Domain(
+                host.to_string(),
+            ))
             .port(25)
             .tls(lettre::transport::smtp::client::Tls::Opportunistic(
                 tls_params,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -269,7 +269,7 @@ fn dkim_keygen_end_to_end() {
     assert!(private_pem.contains("BEGIN RSA PRIVATE KEY"));
 
     let public_pem = std::fs::read_to_string(tmp.path().join("dkim/public.key")).unwrap();
-    assert!(public_pem.contains("BEGIN RSA PUBLIC KEY"));
+    assert!(public_pem.contains("BEGIN PUBLIC KEY"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- **DKIM key format**: Public key was generated in PKCS#1 format (`BEGIN RSA PUBLIC KEY`) but DKIM RFC 6376 requires SPKI format (`BEGIN PUBLIC KEY`). Gmail rejected with "invalid public key". Fixed `generate_keypair()` and `dns_record_value()` to use SPKI, with backward-compat auto-conversion for existing PKCS#1 keys on disk.
- **IPv4 preference**: Outbound SMTP defaulted to IPv6, which most SPF records don't cover. Added `resolve_ipv4()` to prefer IPv4 connections, matching standard email delivery practice.

## Test plan
- [x] All 378 tests pass (334 unit + 44 integration)
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Live test: `sudo aimx send` to Gmail — SPF pass, DKIM pass, DMARC pass
- [x] `dns_record_value()` auto-converts existing PKCS#1 keys to SPKI format
- [x] New keypairs generated in SPKI format (`BEGIN PUBLIC KEY`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)