### PR TITLE
[Sprint 26] IPv6 Support for Outbound SMTP

### DIFF
--- a/book/setup.md
+++ b/book/setup.md
@@ -85,7 +85,7 @@ When run without a domain argument, setup will prompt you to enter the domain an
 
 After initial setup, the wizard displays three clearly labeled sections:
 
-- **[DNS]** -- the records you need to add (MX, A, SPF, DKIM, DMARC), with a retry loop so you can press Enter to re-verify after adding records
+- **[DNS]** -- the records you need to add (MX, A, AAAA, SPF, DKIM, DMARC), with a retry loop so you can press Enter to re-verify after adding records
 - **[MCP]** -- configuration snippet for MCP-compatible AI agents (Claude Code, OpenClaw, Codex, OpenCode, etc.)
 - **[Deliverability Improvement (Optional)]** -- PTR record guidance and Gmail filter/whitelist instructions
 
@@ -112,9 +112,10 @@ After the setup wizard displays the required DNS records, add them at your domai
 
 | Type | Name | Value | Where to set |
 |------|------|-------|--------------|
-| A | `agent.yourdomain.com` | Your server IP | Domain registrar |
+| A | `agent.yourdomain.com` | Your server IPv4 | Domain registrar |
+| AAAA | `agent.yourdomain.com` | Your server IPv6 (if available) | Domain registrar |
 | MX | `agent.yourdomain.com` | `10 agent.yourdomain.com.` | Domain registrar |
-| TXT | `agent.yourdomain.com` | `v=spf1 ip4:YOUR_IP -all` | Domain registrar |
+| TXT | `agent.yourdomain.com` | `v=spf1 ip4:YOUR_IP -all` (or `v=spf1 ip4:YOUR_IP ip6:YOUR_IPV6 -all` with IPv6) | Domain registrar |
 | TXT | `dkim._domainkey.agent.yourdomain.com` | `v=DKIM1; k=rsa; p=...` | Domain registrar |
 | TXT | `_dmarc.agent.yourdomain.com` | `v=DMARC1; p=reject` | Domain registrar |
 | PTR | Your server IP | `agent.yourdomain.com.` | VPS provider panel |
@@ -134,7 +135,11 @@ After adding DNS records, verify them manually:
 ```bash
 # A record
 dig +short A agent.yourdomain.com
-# Expected: your server IP
+# Expected: your server IPv4 address
+
+# AAAA record (if your server has IPv6)
+dig +short AAAA agent.yourdomain.com
+# Expected: your server IPv6 address
 
 # MX record
 dig +short MX agent.yourdomain.com
@@ -142,7 +147,7 @@ dig +short MX agent.yourdomain.com
 
 # SPF record
 dig +short TXT agent.yourdomain.com
-# Should include: v=spf1 ip4:YOUR_IP -all
+# Should include: v=spf1 ip4:YOUR_IP -all (or v=spf1 ip4:YOUR_IP ip6:YOUR_IPV6 -all)
 
 # DKIM record
 dig +short TXT dkim._domainkey.agent.yourdomain.com
@@ -217,7 +222,7 @@ After regenerating keys, update the DKIM DNS record with the new public key.
 
 ### Preventing spam classification
 
-1. Ensure all 6 DNS records are correctly set (especially DKIM, SPF, DMARC)
+1. Ensure all DNS records are correctly set (especially DKIM, SPF, DMARC, and AAAA if your server has IPv6)
 2. Set a PTR record at your VPS provider
 3. In Gmail: Settings > Filters > Create filter for `*@agent.yourdomain.com` > Never send to Spam
 4. Alternatively, reply to an email from the domain -- Gmail learns it's not spam

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -74,7 +74,7 @@ All routes expose sensitive communications to third parties, which is absurd whe
 - FR-4: Stop with clear error message if port 25 is blocked. List compatible VPS providers.
 - FR-5: Check reverse DNS (PTR) and warn (non-blocking) if not set.
 - FR-6: Generate 2048-bit RSA DKIM keypair.
-- FR-7: Display required DNS records (MX, A, SPF, DKIM, DMARC, PTR) and wait for user confirmation.
+- FR-7: Display required DNS records (MX, A, AAAA, SPF, DKIM, DMARC, PTR) and wait for user confirmation. Include AAAA record and `ip6:` SPF mechanism when the server has an IPv6 address.
 - FR-8: Verify DNS records are correctly set.
 - FR-9: Create default `catchall` mailbox.
 - FR-10: Display MCP configuration snippet for MCP-compatible AI agents (Claude Code, OpenClaw, Codex, OpenCode, etc.).
@@ -90,7 +90,7 @@ All routes expose sensitive communications to third parties, which is absurd whe
 ### 6.3 Email Sending (`aimx send`)
 - FR-17: Compose RFC 5322 compliant email from provided parameters (from, to, subject, body, attachments).
 - FR-18: Sign message with DKIM (RSA-SHA256) using the domain's private key.
-- FR-19: Deliver signed message directly to the recipient's MX server via SMTP (MX resolution + lettre transport). Return delivery errors immediately — no background queue.
+- FR-19: Deliver signed message directly to the recipient's MX server via SMTP (MX resolution + lettre transport). Support both IPv4 and IPv6 connections (OS decides). Return delivery errors immediately — no background queue.
 - FR-20: Support file attachments by path.
 - FR-21: Set proper In-Reply-To and References headers when replying.
 

--- a/docs/sprint.md
+++ b/docs/sprint.md
@@ -2,8 +2,8 @@
 
 **Sprint cadence:** 2.5 days per sprint
 **Team:** Solo developer with heavy AI augmentation (Claude Code)
-**Total sprints:** 25 (6 original + 2 post-audit hardening + 1 YAML→TOML migration + 2 verifier/setup overhaul + 2 post-Sprint-11 bug fixes + 2 verifier ops + 1 deployment + 1 service rename + 1 setup UX + 5 embedded SMTP + 1 verify cleanup + 1 DKIM permissions fix)
-**Timeline:** ~72.5 calendar days
+**Total sprints:** 26 (6 original + 2 post-audit hardening + 1 YAML→TOML migration + 2 verifier/setup overhaul + 2 post-Sprint-11 bug fixes + 2 verifier ops + 1 deployment + 1 service rename + 1 setup UX + 5 embedded SMTP + 1 verify cleanup + 1 DKIM permissions fix + 1 IPv6 support)
+**Timeline:** ~75.5 calendar days
 **v1 Scope:** Full PRD scope including verifier service. Sprint 1 targets earliest possible idea validation on a real VPS. Sprints 7–8 address findings from post-v1 code review audit. Sprints 10–11 overhaul the verifier service (remove email echo, add EHLO probe) and rewrite the setup flow (root check, MTA conflict detection, install-before-check). Sprints 12–13 fix critical bugs found during post-Sprint-11 debugging: Caddy self-probe loop / XFF SSRF risk in the verifier service, and the preflight chicken-and-egg problem on fresh VPSes. Sprints 14–15 are review-driven operational quality work on the verifier service (request logging, Docker packaging). Sprint 17 renames the verify service to verifier across all code, Docker, CI, and documentation. Sprints 19–23 replace OpenSMTPD with an embedded SMTP server (hand-rolled tokio listener for inbound, lettre + hickory-resolver for outbound) and update all documentation, making aimx a true single-binary solution with no external runtime dependencies and cross-platform Unix support. Sprint 24 cleans up `aimx verify` (EHLO-only checks, sudo requirement, remove `/reach` endpoint, AIMX capitalization).
 
 ---
@@ -242,6 +242,51 @@ Completed sprints 1–21 have been archived for context window efficiency.
 
 ---
 
+## Sprint 26 — IPv6 Support for Outbound SMTP (Days 73–75.5) [IN PROGRESS]
+
+**Goal:** Remove the IPv4-only workaround from outbound delivery and properly support IPv6 across SPF records, DNS guidance, and verification. The IPv4 preference was added in Sprint 25 as a workaround for SPF failures — now that DKIM is fixed, let the OS resolve addresses naturally and ensure SPF covers both address families.
+
+**Dependencies:** Sprint 25
+
+**Testing environment:** Same as Sprint 25. Use `sudo aimx send --from hello@agent.zeroshot.lol --to chua@uzyn.com --subject Hey --body "Test"` to verify delivery works over whichever address family the OS selects.
+
+#### S26-1: Remove IPv4-only outbound restriction
+
+**Context:** `resolve_ipv4()` in `send.rs:95-104` forces all outbound SMTP connections through IPv4 by filtering DNS results for A records only. This was a workaround for SPF failures when connecting over IPv6 (Sprint 25, commit 47168f8). Now that DKIM signing is correct, the restriction should be removed — let the OS decide which address family to use when connecting to MX servers. Remove `resolve_ipv4()` and the `connect_target` override in `try_deliver()`, so `lettre` connects directly to the MX hostname.
+
+**Priority:** P0
+
+- [x] Remove `resolve_ipv4()` function from `send.rs`
+- [x] Remove `connect_target` logic in `try_deliver()` — pass `host` directly to `SmtpTransport::builder_dangerous()`
+- [x] Verify existing tests still pass
+- [ ] Live test: `sudo aimx send --from hello@agent.zeroshot.lol --to chua@uzyn.com --subject Hey --body "Test"` delivers successfully
+
+#### S26-2: Add IPv6 to DNS guidance and SPF record
+
+**Context:** `setup.rs` detects the server IP via `hostname -I` (which returns both IPv4 and IPv6 addresses) but only uses the first address. The generated SPF record (`v=spf1 ip4:{server_ip} -all`) and DNS guidance only cover IPv4. When the OS connects to a recipient MX over IPv6, SPF fails because the server's IPv6 address isn't in the record. Fix: detect both IPv4 and IPv6 addresses from `hostname -I`, generate SPF with both `ip4:` and `ip6:` mechanisms, add an AAAA record to the DNS guidance, and pass both addresses through the setup flow.
+
+**Priority:** P0
+
+- [x] `get_server_ip()` (or new helper) returns both IPv4 and IPv6 addresses from `hostname -I`
+- [x] `generate_dns_records()` produces SPF record with both `ip4:` and `ip6:` when IPv6 is available (e.g., `v=spf1 ip4:X.X.X.X ip6:2001:db8::1 -all`)
+- [x] `generate_dns_records()` includes an AAAA record when IPv6 address is available
+- [x] `display_dns_guidance()` shows the AAAA record to the user
+- [x] Tests updated for dual-stack DNS record generation
+
+#### S26-3: Add `ip6:` support to SPF verification
+
+**Context:** `spf_contains_ip()` in `setup.rs:569-582` only checks `ip4:` mechanisms — this is the open backlog item from Sprint 8. Add `ip6:` mechanism support so that `verify_spf()` correctly validates SPF records containing IPv6 addresses. Also update `verify_all_dns()` to verify SPF against both the server's IPv4 and IPv6 addresses when both are present.
+
+**Priority:** P0
+
+- [x] `spf_contains_ip()` also checks `ip6:` and `+ip6:` prefixes
+- [x] `verify_spf()` can verify against IPv6 addresses
+- [x] `verify_all_dns()` checks SPF for both IPv4 and IPv6 when both are available
+- [x] Unit tests: SPF pass/fail/missing for `ip6:` mechanisms, dual-stack verification
+- [x] Mark Sprint 8 backlog item "Add `ip6:` mechanism support to `spf_contains_ip()`" as triaged
+
+---
+
 ## Summary Table
 
 | Sprint | Days | Focus | Key Output | Status |
@@ -273,6 +318,7 @@ Completed sprints 1–21 have been archived for context window efficiency.
 | 23 | 64–66.5 | Documentation + PRD Update | Update PRD (NFR-1/2/4, FRs), CLAUDE.md, README, book/, clean up backlog | Done |
 | 24 | 67–69.5 | Verify Cleanup + Sudo Requirement | EHLO-only outbound check, remove `/reach` endpoint, `sudo aimx verify`, AIMX capitalization | Done |
 | 25 | 70–72.5 | Fix `aimx send` (Permissions + DKIM Signing) | DKIM key `0o644`, fix DKIM signature verification at Gmail — `aimx send` works end-to-end | Done |
+| 26 | 73–75.5 | IPv6 Support for Outbound SMTP | Remove IPv4-only workaround, dual-stack SPF records, `ip6:` verification | In Progress |
 
 ## Deferred to v2
 
@@ -323,7 +369,7 @@ Concrete items with clear implementation direction. Will be triaged into a clean
 - [x] **(Sprint 6)** Handle multiline (folded) Authentication-Results headers in `extract_auth_result` — _Obsolete: echo removed in Sprint 10 (S10.1)_
 - [x] **(Sprint 6)** Add `Message-ID` and `Date` headers to echo reply (RFC 5322 compliance) — _Obsolete: echo removed in Sprint 10 (S10.1)_
 - [x] **(Sprint 6)** Handle missing catchall mailbox gracefully in `aimx verify` — _Triaged into Sprint 7 (S7.4)_
-- [ ] **(Sprint 8)** Add `ip6:` mechanism support to `spf_contains_ip()` for IPv6 server addresses
+- [x] **(Sprint 8)** Add `ip6:` mechanism support to `spf_contains_ip()` for IPv6 server addresses — _Triaged into Sprint 26, implemented_
 - [x] **(Sprint 8)** Quote data dir path in `generate_smtpd_conf` MDA command to handle paths with spaces — _Obsolete: `generate_smtpd_conf` removed in Sprint 22_
 - [x] **(Sprint 11)** `parse_port25_status` uses `smtpd` substring match which could misidentify non-OpenSMTPD processes — _Obsolete: OpenSMTPD-specific port parsing removed in Sprint 22_
 - [x] **(Sprint 11)** Dead `Fail` branch for PTR in `verify.rs` — _Obsolete: `check_ptr()` is no longer called from `verify.rs`; moved to `setup.rs` where the `Fail` arm is a defensive match on the `PreflightResult` enum_

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -3,7 +3,7 @@ use crate::dkim;
 use colored::Colorize;
 use std::collections::HashMap;
 use std::io::{self, BufRead, Write};
-use std::net::IpAddr;
+use std::net::{IpAddr, Ipv6Addr};
 use std::path::{Path, PathBuf};
 
 #[derive(Debug, PartialEq)]
@@ -207,6 +207,18 @@ pub const DEFAULT_VERIFY_HOST: &str = "https://check.aimx.email";
 
 pub const DEFAULT_CHECK_SERVICE_SMTP_ADDR: &str = "check.aimx.email:25";
 
+fn is_global_ipv6(ip: &Ipv6Addr) -> bool {
+    let segments = ip.segments();
+    // Not link-local (fe80::/10)
+    (segments[0] & 0xffc0) != 0xfe80
+    // Not ULA (fc00::/7)
+    && (segments[0] & 0xfe00) != 0xfc00
+    // Not loopback
+    && !ip.is_loopback()
+    // Not unspecified
+    && !ip.is_unspecified()
+}
+
 #[derive(Debug)]
 pub struct RealNetworkOps {
     pub verify_host: String,
@@ -357,21 +369,24 @@ impl NetworkOps for RealNetworkOps {
     fn get_server_ip(&self) -> Result<IpAddr, Box<dyn std::error::Error>> {
         let output = std::process::Command::new("hostname").arg("-I").output()?;
         let stdout = String::from_utf8_lossy(&output.stdout);
-        let ip_str = stdout
-            .split_whitespace()
-            .next()
-            .ok_or("Could not determine server IP")?;
-        Ok(ip_str.parse()?)
+        for token in stdout.split_whitespace() {
+            if let Ok(ip) = token.parse::<IpAddr>()
+                && ip.is_ipv4()
+            {
+                return Ok(ip);
+            }
+        }
+        Err("Could not determine server IPv4 address".into())
     }
 
     fn get_server_ipv6(&self) -> Result<Option<IpAddr>, Box<dyn std::error::Error>> {
         let output = std::process::Command::new("hostname").arg("-I").output()?;
         let stdout = String::from_utf8_lossy(&output.stdout);
         for token in stdout.split_whitespace() {
-            if let Ok(ip) = token.parse::<IpAddr>()
-                && ip.is_ipv6()
+            if let Ok(IpAddr::V6(ipv6)) = token.parse::<IpAddr>()
+                && is_global_ipv6(&ipv6)
             {
-                return Ok(Some(ip));
+                return Ok(Some(IpAddr::V6(ipv6)));
             }
         }
         Ok(None)
@@ -2478,5 +2493,39 @@ mod tests {
         let results = verify_all_dns(&net, "example.com", &ip, None, "dkim", None);
         assert!(!results.iter().any(|(name, _)| name == "AAAA"));
         assert!(!results.iter().any(|(name, _)| name == "SPF (IPv6)"));
+    }
+
+    // is_global_ipv6 tests
+
+    #[test]
+    fn global_ipv6_accepts_global_unicast() {
+        let ip: Ipv6Addr = "2001:db8::1".parse().unwrap();
+        assert!(is_global_ipv6(&ip));
+    }
+
+    #[test]
+    fn global_ipv6_rejects_link_local() {
+        let ip: Ipv6Addr = "fe80::1".parse().unwrap();
+        assert!(!is_global_ipv6(&ip));
+    }
+
+    #[test]
+    fn global_ipv6_rejects_ula() {
+        let fc: Ipv6Addr = "fc00::1".parse().unwrap();
+        let fd: Ipv6Addr = "fd00::1".parse().unwrap();
+        assert!(!is_global_ipv6(&fc));
+        assert!(!is_global_ipv6(&fd));
+    }
+
+    #[test]
+    fn global_ipv6_rejects_loopback() {
+        let ip: Ipv6Addr = "::1".parse().unwrap();
+        assert!(!is_global_ipv6(&ip));
+    }
+
+    #[test]
+    fn global_ipv6_rejects_unspecified() {
+        let ip: Ipv6Addr = "::".parse().unwrap();
+        assert!(!is_global_ipv6(&ip));
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -36,8 +36,10 @@ pub trait NetworkOps {
     fn check_inbound_port25(&self) -> Result<bool, Box<dyn std::error::Error>>;
     fn check_ptr_record(&self) -> Result<Option<String>, Box<dyn std::error::Error>>;
     fn get_server_ip(&self) -> Result<IpAddr, Box<dyn std::error::Error>>;
+    fn get_server_ipv6(&self) -> Result<Option<IpAddr>, Box<dyn std::error::Error>>;
     fn resolve_mx(&self, domain: &str) -> Result<Vec<String>, Box<dyn std::error::Error>>;
     fn resolve_a(&self, domain: &str) -> Result<Vec<IpAddr>, Box<dyn std::error::Error>>;
+    fn resolve_aaaa(&self, domain: &str) -> Result<Vec<IpAddr>, Box<dyn std::error::Error>>;
     fn resolve_txt(&self, domain: &str) -> Result<Vec<String>, Box<dyn std::error::Error>>;
 }
 
@@ -362,6 +364,19 @@ impl NetworkOps for RealNetworkOps {
         Ok(ip_str.parse()?)
     }
 
+    fn get_server_ipv6(&self) -> Result<Option<IpAddr>, Box<dyn std::error::Error>> {
+        let output = std::process::Command::new("hostname").arg("-I").output()?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        for token in stdout.split_whitespace() {
+            if let Ok(ip) = token.parse::<IpAddr>()
+                && ip.is_ipv6()
+            {
+                return Ok(Some(ip));
+            }
+        }
+        Ok(None)
+    }
+
     fn resolve_mx(&self, domain: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
         let output = std::process::Command::new("dig")
             .args(["+short", "MX", domain])
@@ -378,6 +393,18 @@ impl NetworkOps for RealNetworkOps {
     fn resolve_a(&self, domain: &str) -> Result<Vec<IpAddr>, Box<dyn std::error::Error>> {
         let output = std::process::Command::new("dig")
             .args(["+short", "A", domain])
+            .output()?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let addrs: Vec<IpAddr> = stdout
+            .lines()
+            .filter_map(|l| l.trim().parse().ok())
+            .collect();
+        Ok(addrs)
+    }
+
+    fn resolve_aaaa(&self, domain: &str) -> Result<Vec<IpAddr>, Box<dyn std::error::Error>> {
+        let output = std::process::Command::new("dig")
+            .args(["+short", "AAAA", domain])
             .output()?;
         let stdout = String::from_utf8_lossy(&output.stdout);
         let addrs: Vec<IpAddr> = stdout
@@ -465,15 +492,30 @@ pub struct DnsRecord {
 pub fn generate_dns_records(
     domain: &str,
     server_ip: &str,
+    server_ipv6: Option<&str>,
     dkim_value: &str,
     dkim_selector: &str,
 ) -> Vec<DnsRecord> {
-    vec![
-        DnsRecord {
-            record_type: "A".into(),
+    let spf_value = match server_ipv6 {
+        Some(ipv6) => format!("v=spf1 ip4:{server_ip} ip6:{ipv6} -all"),
+        None => format!("v=spf1 ip4:{server_ip} -all"),
+    };
+
+    let mut records = vec![DnsRecord {
+        record_type: "A".into(),
+        name: domain.into(),
+        value: server_ip.into(),
+    }];
+
+    if let Some(ipv6) = server_ipv6 {
+        records.push(DnsRecord {
+            record_type: "AAAA".into(),
             name: domain.into(),
-            value: server_ip.into(),
-        },
+            value: ipv6.into(),
+        });
+    }
+
+    records.extend([
         DnsRecord {
             record_type: "MX".into(),
             name: domain.into(),
@@ -482,7 +524,7 @@ pub fn generate_dns_records(
         DnsRecord {
             record_type: "TXT".into(),
             name: domain.into(),
-            value: format!("v=spf1 ip4:{server_ip} -all"),
+            value: spf_value,
         },
         DnsRecord {
             record_type: "TXT".into(),
@@ -499,7 +541,9 @@ pub fn generate_dns_records(
             name: server_ip.into(),
             value: format!("{domain}."),
         },
-    ]
+    ]);
+
+    records
 }
 
 #[cfg(test)]
@@ -514,8 +558,14 @@ pub fn format_dns_records(records: &[DnsRecord]) -> String {
     output
 }
 
-pub fn display_dns_guidance(domain: &str, server_ip: &str, dkim_value: &str, dkim_selector: &str) {
-    let records = generate_dns_records(domain, server_ip, dkim_value, dkim_selector);
+pub fn display_dns_guidance(
+    domain: &str,
+    server_ip: &str,
+    server_ipv6: Option<&str>,
+    dkim_value: &str,
+    dkim_selector: &str,
+) {
+    let records = generate_dns_records(domain, server_ip, server_ipv6, dkim_value, dkim_selector);
     let dns_records: Vec<&DnsRecord> = records.iter().filter(|r| r.record_type != "PTR").collect();
     println!("\n{}", "[DNS]".bold());
     println!("Add the following DNS records at your domain registrar:\n");
@@ -566,11 +616,25 @@ pub fn verify_a(net: &dyn NetworkOps, domain: &str, expected_ip: &IpAddr) -> Dns
     }
 }
 
+pub fn verify_aaaa(net: &dyn NetworkOps, domain: &str, expected_ip: &IpAddr) -> DnsVerifyResult {
+    match net.resolve_aaaa(domain) {
+        Ok(addrs) if addrs.contains(expected_ip) => DnsVerifyResult::Pass,
+        Ok(addrs) if !addrs.is_empty() => DnsVerifyResult::Fail(format!(
+            "AAAA record points to {:?}, expected {expected_ip}",
+            addrs
+        )),
+        Ok(_) => DnsVerifyResult::Missing("No AAAA record found".into()),
+        Err(e) => DnsVerifyResult::Fail(format!("AAAA record lookup failed: {e}")),
+    }
+}
+
 fn spf_contains_ip(record: &str, expected_ip: &str) -> bool {
     for token in record.split_whitespace() {
         if let Some(mechanism) = token
             .strip_prefix("ip4:")
             .or_else(|| token.strip_prefix("+ip4:"))
+            .or_else(|| token.strip_prefix("ip6:"))
+            .or_else(|| token.strip_prefix("+ip6:"))
         {
             let ip_part = mechanism.split('/').next().unwrap_or(mechanism);
             if ip_part == expected_ip {
@@ -676,27 +740,44 @@ pub fn verify_all_dns(
     net: &dyn NetworkOps,
     domain: &str,
     server_ip: &IpAddr,
+    server_ipv6: Option<&IpAddr>,
     dkim_selector: &str,
     local_dkim_pubkey: Option<&str>,
 ) -> Vec<(String, DnsVerifyResult)> {
     let ip_str = server_ip.to_string();
-    vec![
+    let mut results = vec![
         ("MX".into(), verify_mx(net, domain)),
         ("A".into(), verify_a(net, domain, server_ip)),
-        ("SPF".into(), verify_spf(net, domain, &ip_str)),
+    ];
+
+    if let Some(ipv6) = server_ipv6 {
+        results.push(("AAAA".into(), verify_aaaa(net, domain, ipv6)));
+    }
+
+    results.push(("SPF".into(), verify_spf(net, domain, &ip_str)));
+
+    if let Some(ipv6) = server_ipv6 {
+        let ipv6_str = ipv6.to_string();
+        results.push(("SPF (IPv6)".into(), verify_spf(net, domain, &ipv6_str)));
+    }
+
+    results.extend([
         (
             "DKIM".into(),
             verify_dkim(net, domain, dkim_selector, local_dkim_pubkey),
         ),
         ("DMARC".into(), verify_dmarc(net, domain)),
-    ]
+    ]);
+
+    results
 }
 
 fn dns_record_for_check<'a>(check: &str, records: &'a [DnsRecord]) -> Option<&'a DnsRecord> {
     match check {
         "A" => records.iter().find(|r| r.record_type == "A"),
+        "AAAA" => records.iter().find(|r| r.record_type == "AAAA"),
         "MX" => records.iter().find(|r| r.record_type == "MX"),
-        "SPF" => records
+        "SPF" | "SPF (IPv6)" => records
             .iter()
             .find(|r| r.record_type == "TXT" && r.value.starts_with("v=spf1")),
         "DKIM" => records
@@ -1089,6 +1170,7 @@ pub fn run_setup(
 
     // Step 7: DNS guidance and verification (section [DNS])
     let server_ip = net.get_server_ip()?;
+    let server_ipv6 = net.get_server_ipv6()?;
     let dkim_value = dkim::dns_record_value(data_dir)?;
 
     let local_dkim_pubkey = dkim_value
@@ -1096,8 +1178,21 @@ pub fn run_setup(
         .map(|s| s.to_string());
 
     let server_ip_str = server_ip.to_string();
-    display_dns_guidance(&domain, &server_ip_str, &dkim_value, &dkim_selector);
-    let dns_records = generate_dns_records(&domain, &server_ip_str, &dkim_value, &dkim_selector);
+    let server_ipv6_str = server_ipv6.map(|ip| ip.to_string());
+    display_dns_guidance(
+        &domain,
+        &server_ip_str,
+        server_ipv6_str.as_deref(),
+        &dkim_value,
+        &dkim_selector,
+    );
+    let dns_records = generate_dns_records(
+        &domain,
+        &server_ip_str,
+        server_ipv6_str.as_deref(),
+        &dkim_value,
+        &dkim_selector,
+    );
 
     // DNS retry loop
     loop {
@@ -1121,6 +1216,7 @@ pub fn run_setup(
             net,
             &domain,
             &server_ip,
+            server_ipv6.as_ref(),
             &dkim_selector,
             local_dkim_pubkey.as_deref(),
         );
@@ -1160,8 +1256,10 @@ mod tests {
         inbound_port25: bool,
         ptr_record: Option<String>,
         server_ip: IpAddr,
+        server_ipv6: Option<IpAddr>,
         mx_records: HashMap<String, Vec<String>>,
         a_records: HashMap<String, Vec<IpAddr>>,
+        aaaa_records: HashMap<String, Vec<IpAddr>>,
         txt_records: HashMap<String, Vec<String>>,
     }
 
@@ -1172,8 +1270,10 @@ mod tests {
                 inbound_port25: true,
                 ptr_record: Some("mail.example.com.".into()),
                 server_ip: "1.2.3.4".parse().unwrap(),
+                server_ipv6: None,
                 mx_records: HashMap::new(),
                 a_records: HashMap::new(),
+                aaaa_records: HashMap::new(),
                 txt_records: HashMap::new(),
             }
         }
@@ -1192,11 +1292,17 @@ mod tests {
         fn get_server_ip(&self) -> Result<IpAddr, Box<dyn std::error::Error>> {
             Ok(self.server_ip)
         }
+        fn get_server_ipv6(&self) -> Result<Option<IpAddr>, Box<dyn std::error::Error>> {
+            Ok(self.server_ipv6)
+        }
         fn resolve_mx(&self, domain: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
             Ok(self.mx_records.get(domain).cloned().unwrap_or_default())
         }
         fn resolve_a(&self, domain: &str) -> Result<Vec<IpAddr>, Box<dyn std::error::Error>> {
             Ok(self.a_records.get(domain).cloned().unwrap_or_default())
+        }
+        fn resolve_aaaa(&self, domain: &str) -> Result<Vec<IpAddr>, Box<dyn std::error::Error>> {
+            Ok(self.aaaa_records.get(domain).cloned().unwrap_or_default())
         }
         fn resolve_txt(&self, domain: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
             Ok(self.txt_records.get(domain).cloned().unwrap_or_default())
@@ -1391,6 +1497,7 @@ mod tests {
         let records = generate_dns_records(
             "agent.example.com",
             "1.2.3.4",
+            None,
             "v=DKIM1; k=rsa; p=ABC123",
             "dkim",
         );
@@ -1405,7 +1512,8 @@ mod tests {
 
         assert_eq!(records[2].record_type, "TXT");
         assert!(records[2].value.contains("v=spf1"));
-        assert!(records[2].value.contains("1.2.3.4"));
+        assert!(records[2].value.contains("ip4:1.2.3.4"));
+        assert!(!records[2].value.contains("ip6:"));
 
         assert_eq!(records[3].record_type, "TXT");
         assert_eq!(records[3].name, "dkim._domainkey.agent.example.com");
@@ -1423,7 +1531,8 @@ mod tests {
 
     #[test]
     fn dns_record_formatting() {
-        let records = generate_dns_records("test.com", "5.6.7.8", "v=DKIM1; k=rsa; p=XYZ", "dkim");
+        let records =
+            generate_dns_records("test.com", "5.6.7.8", None, "v=DKIM1; k=rsa; p=XYZ", "dkim");
         let formatted = format_dns_records(&records);
         assert!(formatted.contains("A"));
         assert!(formatted.contains("MX"));
@@ -1680,7 +1789,7 @@ mod tests {
             vec!["v=DMARC1; p=reject".into()],
         );
 
-        let results = verify_all_dns(&net, "example.com", &ip, "dkim", None);
+        let results = verify_all_dns(&net, "example.com", &ip, None, "dkim", None);
         assert!(results.iter().all(|(_, r)| *r == DnsVerifyResult::Pass));
     }
 
@@ -1692,7 +1801,7 @@ mod tests {
             .insert("example.com".into(), vec!["10 example.com.".into()]);
         // A record missing, SPF missing, etc.
 
-        let results = verify_all_dns(&net, "example.com", &ip, "dkim", None);
+        let results = verify_all_dns(&net, "example.com", &ip, None, "dkim", None);
         let pass_count = results
             .iter()
             .filter(|(_, r)| *r == DnsVerifyResult::Pass)
@@ -2099,7 +2208,8 @@ mod tests {
 
     #[test]
     fn dns_guidance_excludes_ptr() {
-        let records = generate_dns_records("test.com", "1.2.3.4", "v=DKIM1; k=rsa; p=ABC", "dkim");
+        let records =
+            generate_dns_records("test.com", "1.2.3.4", None, "v=DKIM1; k=rsa; p=ABC", "dkim");
         let dns_only: Vec<&DnsRecord> = records.iter().filter(|r| r.record_type != "PTR").collect();
         assert_eq!(dns_only.len(), 5);
         assert!(dns_only.iter().all(|r| r.record_type != "PTR"));
@@ -2150,5 +2260,223 @@ mod tests {
             ..Default::default()
         };
         assert!(!is_already_configured(&sys, "example.com", tmp.path()));
+    }
+
+    // S26-2 — IPv6 DNS record generation tests
+
+    #[test]
+    fn dns_record_generation_with_ipv6() {
+        let records = generate_dns_records(
+            "agent.example.com",
+            "1.2.3.4",
+            Some("2001:db8::1"),
+            "v=DKIM1; k=rsa; p=ABC123",
+            "dkim",
+        );
+        assert_eq!(records.len(), 7);
+
+        assert_eq!(records[0].record_type, "A");
+        assert_eq!(records[0].value, "1.2.3.4");
+
+        assert_eq!(records[1].record_type, "AAAA");
+        assert_eq!(records[1].name, "agent.example.com");
+        assert_eq!(records[1].value, "2001:db8::1");
+
+        assert_eq!(records[2].record_type, "MX");
+
+        assert_eq!(records[3].record_type, "TXT");
+        assert_eq!(records[3].value, "v=spf1 ip4:1.2.3.4 ip6:2001:db8::1 -all");
+    }
+
+    #[test]
+    fn dns_record_generation_without_ipv6() {
+        let records = generate_dns_records(
+            "example.com",
+            "1.2.3.4",
+            None,
+            "v=DKIM1; k=rsa; p=ABC",
+            "dkim",
+        );
+        assert!(!records.iter().any(|r| r.record_type == "AAAA"));
+        let spf = records
+            .iter()
+            .find(|r| r.value.starts_with("v=spf1"))
+            .unwrap();
+        assert_eq!(spf.value, "v=spf1 ip4:1.2.3.4 -all");
+        assert!(!spf.value.contains("ip6:"));
+    }
+
+    #[test]
+    fn dns_guidance_includes_aaaa_with_ipv6() {
+        let records = generate_dns_records(
+            "test.com",
+            "1.2.3.4",
+            Some("2001:db8::1"),
+            "v=DKIM1; k=rsa; p=ABC",
+            "dkim",
+        );
+        let dns_only: Vec<&DnsRecord> = records.iter().filter(|r| r.record_type != "PTR").collect();
+        assert_eq!(dns_only.len(), 6);
+        assert!(dns_only.iter().any(|r| r.record_type == "AAAA"));
+    }
+
+    // S26-3 — ip6: SPF verification tests
+
+    #[test]
+    fn spf_contains_ip_ipv6_pass() {
+        assert!(spf_contains_ip(
+            "v=spf1 ip4:1.2.3.4 ip6:2001:db8::1 -all",
+            "2001:db8::1"
+        ));
+    }
+
+    #[test]
+    fn spf_contains_ip_ipv6_with_plus_prefix() {
+        assert!(spf_contains_ip(
+            "v=spf1 +ip6:2001:db8::1 -all",
+            "2001:db8::1"
+        ));
+    }
+
+    #[test]
+    fn spf_contains_ip_ipv6_missing() {
+        assert!(!spf_contains_ip("v=spf1 ip4:1.2.3.4 -all", "2001:db8::1"));
+    }
+
+    #[test]
+    fn spf_contains_ip_ipv6_wrong_address() {
+        assert!(!spf_contains_ip(
+            "v=spf1 ip6:2001:db8::2 -all",
+            "2001:db8::1"
+        ));
+    }
+
+    #[test]
+    fn spf_contains_ip_ipv6_with_cidr() {
+        assert!(spf_contains_ip(
+            "v=spf1 ip6:2001:db8::1/128 -all",
+            "2001:db8::1"
+        ));
+    }
+
+    #[test]
+    fn spf_contains_ip_ipv4_still_works() {
+        assert!(spf_contains_ip("v=spf1 ip4:1.2.3.4 -all", "1.2.3.4"));
+    }
+
+    #[test]
+    fn spf_contains_ip_dual_stack_both_present() {
+        let record = "v=spf1 ip4:1.2.3.4 ip6:2001:db8::1 -all";
+        assert!(spf_contains_ip(record, "1.2.3.4"));
+        assert!(spf_contains_ip(record, "2001:db8::1"));
+    }
+
+    #[test]
+    fn verify_spf_ipv6_pass() {
+        let mut net = MockNetworkOps::default();
+        net.txt_records.insert(
+            "example.com".into(),
+            vec!["v=spf1 ip4:1.2.3.4 ip6:2001:db8::1 -all".into()],
+        );
+        assert_eq!(
+            verify_spf(&net, "example.com", "2001:db8::1"),
+            DnsVerifyResult::Pass
+        );
+    }
+
+    #[test]
+    fn verify_spf_ipv6_fail() {
+        let mut net = MockNetworkOps::default();
+        net.txt_records
+            .insert("example.com".into(), vec!["v=spf1 ip4:1.2.3.4 -all".into()]);
+        match verify_spf(&net, "example.com", "2001:db8::1") {
+            DnsVerifyResult::Fail(msg) => assert!(msg.contains("does not include")),
+            other => panic!("Expected Fail, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn verify_aaaa_pass() {
+        let ipv6: IpAddr = "2001:db8::1".parse().unwrap();
+        let mut net = MockNetworkOps::default();
+        net.aaaa_records.insert("example.com".into(), vec![ipv6]);
+        assert_eq!(
+            verify_aaaa(&net, "example.com", &ipv6),
+            DnsVerifyResult::Pass
+        );
+    }
+
+    #[test]
+    fn verify_aaaa_missing() {
+        let ipv6: IpAddr = "2001:db8::1".parse().unwrap();
+        let net = MockNetworkOps::default();
+        match verify_aaaa(&net, "example.com", &ipv6) {
+            DnsVerifyResult::Missing(msg) => assert!(msg.contains("No AAAA")),
+            other => panic!("Expected Missing, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn verify_aaaa_wrong_ip() {
+        let expected: IpAddr = "2001:db8::1".parse().unwrap();
+        let actual: IpAddr = "2001:db8::2".parse().unwrap();
+        let mut net = MockNetworkOps::default();
+        net.aaaa_records.insert("example.com".into(), vec![actual]);
+        match verify_aaaa(&net, "example.com", &expected) {
+            DnsVerifyResult::Fail(msg) => assert!(msg.contains("AAAA record points to")),
+            other => panic!("Expected Fail, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn verify_all_dns_with_ipv6() {
+        let ip: IpAddr = "1.2.3.4".parse().unwrap();
+        let ipv6: IpAddr = "2001:db8::1".parse().unwrap();
+        let mut net = MockNetworkOps::default();
+        net.server_ipv6 = Some(ipv6);
+        net.mx_records
+            .insert("example.com".into(), vec!["10 example.com.".into()]);
+        net.a_records.insert("example.com".into(), vec![ip]);
+        net.aaaa_records.insert("example.com".into(), vec![ipv6]);
+        net.txt_records.insert(
+            "example.com".into(),
+            vec!["v=spf1 ip4:1.2.3.4 ip6:2001:db8::1 -all".into()],
+        );
+        net.txt_records.insert(
+            "dkim._domainkey.example.com".into(),
+            vec!["v=DKIM1; k=rsa; p=ABC".into()],
+        );
+        net.txt_records.insert(
+            "_dmarc.example.com".into(),
+            vec!["v=DMARC1; p=reject".into()],
+        );
+
+        let results = verify_all_dns(&net, "example.com", &ip, Some(&ipv6), "dkim", None);
+        assert!(results.iter().all(|(_, r)| *r == DnsVerifyResult::Pass));
+        assert!(results.iter().any(|(name, _)| name == "AAAA"));
+        assert!(results.iter().any(|(name, _)| name == "SPF (IPv6)"));
+    }
+
+    #[test]
+    fn verify_all_dns_without_ipv6_has_no_aaaa() {
+        let ip: IpAddr = "1.2.3.4".parse().unwrap();
+        let mut net = MockNetworkOps::default();
+        net.mx_records
+            .insert("example.com".into(), vec!["10 example.com.".into()]);
+        net.a_records.insert("example.com".into(), vec![ip]);
+        net.txt_records
+            .insert("example.com".into(), vec!["v=spf1 ip4:1.2.3.4 -all".into()]);
+        net.txt_records.insert(
+            "dkim._domainkey.example.com".into(),
+            vec!["v=DKIM1; k=rsa; p=ABC".into()],
+        );
+        net.txt_records.insert(
+            "_dmarc.example.com".into(),
+            vec!["v=DMARC1; p=reject".into()],
+        );
+
+        let results = verify_all_dns(&net, "example.com", &ip, None, "dkim", None);
+        assert!(!results.iter().any(|(name, _)| name == "AAAA"));
+        assert!(!results.iter().any(|(name, _)| name == "SPF (IPv6)"));
     }
 }

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -233,10 +233,16 @@ mod tests {
         fn get_server_ip(&self) -> Result<IpAddr, Box<dyn std::error::Error>> {
             Ok("1.2.3.4".parse().unwrap())
         }
+        fn get_server_ipv6(&self) -> Result<Option<IpAddr>, Box<dyn std::error::Error>> {
+            Ok(None)
+        }
         fn resolve_mx(&self, _domain: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
             Ok(vec![])
         }
         fn resolve_a(&self, _domain: &str) -> Result<Vec<IpAddr>, Box<dyn std::error::Error>> {
+            Ok(vec![])
+        }
+        fn resolve_aaaa(&self, _domain: &str) -> Result<Vec<IpAddr>, Box<dyn std::error::Error>> {
             Ok(vec![])
         }
         fn resolve_txt(&self, _domain: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {


### PR DESCRIPTION
## Summary

- **S26-1**: Remove IPv4-only outbound restriction — already clean on `main` (the `resolve_ipv4()`/`connect_target` workaround from commit 47168f8 was never merged to main). `lettre` connects directly to MX hostnames, letting the OS choose IPv4 or IPv6.
- **S26-2**: Add IPv6 to DNS guidance and SPF record — new `get_server_ipv6()` method on `NetworkOps` trait detects IPv6 from `hostname -I`. `generate_dns_records()` produces AAAA record and `ip6:` SPF mechanism when IPv6 is available. `display_dns_guidance()` shows the AAAA record. `resolve_aaaa()` added to trait for AAAA record verification.
- **S26-3**: Add `ip6:` support to SPF verification — `spf_contains_ip()` now checks `ip6:` and `+ip6:` prefixes. `verify_all_dns()` verifies SPF for both IPv4 and IPv6 addresses when both are present. New `verify_aaaa()` function for AAAA record verification. Closes Sprint 8 backlog item.

17 new unit tests covering dual-stack DNS generation, `ip6:` SPF mechanisms, AAAA record verification, and `verify_all_dns` with/without IPv6. All 351 unit tests + 44 integration tests pass. Updates PRD FR-7 and FR-19 for IPv6 support.

## Test plan

- [x] `cargo test` — 351 unit + 44 integration tests pass
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [ ] Live test: `sudo aimx send` delivers successfully over IPv6 when OS selects it
- [ ] Live test: `sudo aimx setup` shows AAAA record and dual-stack SPF in DNS guidance on a dual-stack server