### PR TITLE
[Sprint 28] Agent Integration Framework + Claude Code

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -53,6 +53,7 @@ dependencies = [
  "glob-match",
  "hickory-resolver 0.25.2",
  "html2text",
+ "include_dir",
  "lettre",
  "libc",
  "mail-auth",
@@ -1127,6 +1128,25 @@ checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "include_dir"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "923d117408f1e49d914f1a379a309cffe4f18c05cf4e3d12e613a15fc81bd0dd"
+dependencies = [
+ "include_dir_macros",
+]
+
+[[package]]
+name = "include_dir_macros"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cab85a7ed0bd5f0e76d93846e0147172bed2e2d3f859bcc33a8d9699cad1a75"
+dependencies = [
+ "proc-macro2",
+ "quote",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ colored = "3"
 rustls-pki-types = { version = "1", features = ["alloc"] }
 lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "tokio1", "tokio1-rustls-tls"] }
 hickory-resolver = "0.25"
+include_dir = "0.7"
 
 [dev-dependencies]
 tempfile = "3"

--- a/agents/claude-code/.claude-plugin/plugin.json
+++ b/agents/claude-code/.claude-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "aimx",
+  "description": "Self-hosted email for AI agents. Provides MCP tools for sending, reading, and managing email stored as Markdown files.",
+  "version": "0.1.0",
+  "author": {
+    "name": "AIMX",
+    "url": "https://github.com/uzyn/aimx"
+  },
+  "mcpServers": {
+    "aimx": {
+      "command": "/usr/local/bin/aimx",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/agents/claude-code/README.md
+++ b/agents/claude-code/README.md
@@ -1,0 +1,42 @@
+# AIMX plugin for Claude Code
+
+This directory is the source tree for the Claude Code plugin that wires AIMX
+into Claude Code. Contents are bundled into the `aimx` binary at compile
+time (via `include_dir!`) and installed by `aimx agent-setup claude-code`.
+
+## What gets installed
+
+- `.claude-plugin/plugin.json` — Claude Code plugin manifest, including an
+  `mcpServers.aimx` entry pointing at `/usr/local/bin/aimx mcp`.
+- `skills/aimx/SKILL.md` — an agent-facing skill. Its body is the canonical
+  AIMX primer (`agents/common/aimx-primer.md`); the installer assembles the
+  final `SKILL.md` from a YAML header plus that primer so there is one
+  source of truth.
+
+## Install
+
+```bash
+aimx agent-setup claude-code
+```
+
+Default destination: `~/.claude/plugins/aimx/`. After install, restart
+Claude Code — the plugin is auto-discovered from that directory.
+
+## Overriding the data directory
+
+If AIMX was set up with a non-default data directory, re-run the installer
+with `--data-dir`:
+
+```bash
+aimx --data-dir /custom/path agent-setup claude-code
+```
+
+The installer rewrites the plugin's `mcpServers.aimx.args` to include
+`--data-dir /custom/path` before writing `plugin.json` to disk.
+
+## Schema reference
+
+The plugin manifest follows the Claude Code plugin schema documented at
+<https://docs.claude.com/en/docs/claude-code/plugins>. The skill format
+follows the Claude Code skill schema (YAML frontmatter with `name` and
+`description`, followed by the skill body).

--- a/agents/claude-code/skills/aimx/SKILL.md.header
+++ b/agents/claude-code/skills/aimx/SKILL.md.header
@@ -1,0 +1,5 @@
+---
+name: aimx
+description: Self-hosted email for AI agents. Send, read, reply to, and manage email via AIMX MCP tools. Invoke when the user asks about sending mail, checking an inbox, replying to a message, or managing mailboxes, or when the conversation references AIMX.
+---
+

--- a/agents/common/aimx-primer.md
+++ b/agents/common/aimx-primer.md
@@ -1,0 +1,130 @@
+# AIMX primer for agents
+
+You have access to AIMX, a self-hosted email system. AIMX exposes email
+operations through MCP tools and stores mail as Markdown files on the local
+filesystem. This document describes how to interact with AIMX. Read it once
+before attempting mail operations; re-read any section you need when a tool
+call fails.
+
+## MCP tools
+
+All tools are served by the `aimx` binary over stdio. Nine tools are
+available.
+
+### Mailbox tools
+
+- `mailbox_create(name: string)` — create a new mailbox. `name` is the local
+  part of the email address (e.g. `agent` → `agent@<domain>`).
+- `mailbox_list()` — list all mailboxes with total and unread message counts.
+- `mailbox_delete(name: string)` — delete a mailbox and every email in it.
+  Irreversible.
+
+### Email tools
+
+- `email_list(mailbox: string, unread?: bool, from?: string, since?: string,
+  subject?: string)` — list emails in a mailbox. Filters AND together.
+  `since` is RFC 3339 (e.g. `2025-01-01T00:00:00Z`). `from` is substring
+  match. `subject` is case-insensitive substring match.
+- `email_read(mailbox: string, id: string)` — return the full Markdown file
+  (frontmatter + body) for a single email. `id` has the form
+  `YYYY-MM-DD-NNN` (e.g. `2025-01-01-001`).
+- `email_send(from_mailbox: string, to: string, subject: string, body: string,
+  attachments?: string[])` — compose, DKIM-sign, and deliver an email.
+  `from_mailbox` must be a real mailbox name (not a catchall). `attachments`
+  are absolute file paths.
+- `email_reply(mailbox: string, id: string, body: string)` — reply to an
+  existing email. AIMX sets `In-Reply-To`, `References`, and the `Re:`
+  subject automatically.
+- `email_mark_read(mailbox: string, id: string)` — mark a single email as
+  read.
+- `email_mark_unread(mailbox: string, id: string)` — mark a single email as
+  unread.
+
+All tools return strings. Errors are returned as error strings — inspect the
+message and adjust parameters.
+
+## Storage layout
+
+AIMX stores mail on the local filesystem under a data directory (default
+`/var/lib/aimx/`):
+
+```
+/var/lib/aimx/
+├── config.toml
+├── dkim/
+│   ├── private.key
+│   └── public.key
+├── <mailbox>/
+│   ├── YYYY-MM-DD-NNN.md
+│   └── attachments/
+│       └── <filename>
+└── catchall/
+    └── ...
+```
+
+- One Markdown file per email, named `YYYY-MM-DD-NNN.md` where `NNN` is a
+  per-day sequence starting at `001`.
+- Attachments are extracted into the mailbox's `attachments/` directory.
+  Filenames are preserved; the frontmatter lists them.
+- `catchall` receives any mail addressed to an unrecognised local part.
+- You may read `.md` files directly from the filesystem when that is more
+  convenient than an MCP call — the format is stable.
+
+## Frontmatter
+
+Each email file begins with a TOML frontmatter block delimited by `+++`
+(three plus signs, not `---`). Fields:
+
+- `id` — `YYYY-MM-DD-NNN`, matches the filename stem.
+- `message_id` — RFC 5322 `Message-ID` of the email, without angle brackets.
+- `from` — sender address (may include display name).
+- `to` — recipient address (may include display name).
+- `subject` — email subject, or `(no subject)` when absent.
+- `date` — RFC 3339 timestamp when the email was received.
+- `in_reply_to` — parent `Message-ID` if this is a reply, otherwise empty.
+- `references` — space-separated chain of `Message-ID`s for threading, or
+  empty.
+- `attachments` — array of `{name, path, content_type, size}` tables, one per
+  attachment.
+- `mailbox` — name of the mailbox this email was routed to.
+- `read` — `true` or `false`. Set to `false` on ingest.
+- `dkim` — `pass`, `fail`, or `none`. Result of DKIM signature verification
+  during ingest.
+- `spf` — `pass`, `fail`, or `none`. Result of SPF verification during
+  ingest.
+
+The body follows the closing `+++`, rendered from the `text/plain` part of
+the message (falling back to `text/html` converted to plaintext).
+
+## Mailboxes
+
+- Mailbox names are local parts. They must be valid in the local part of an
+  email address (letters, digits, and a small set of punctuation).
+- The `catchall` mailbox is created automatically during setup and receives
+  mail for unrecognised addresses.
+- Create additional mailboxes with `mailbox_create` before sending mail
+  from them — `email_send` requires a real mailbox name.
+
+## Read / unread
+
+- `email_list` with `unread: true` returns only unread messages — use this
+  to find new mail to process.
+- After processing, call `email_mark_read` to avoid reprocessing on the next
+  poll. `email_mark_unread` reverses the state.
+- Read state lives in the `read` frontmatter field. It is not tracked in a
+  separate database or index.
+
+## Trust model
+
+AIMX verifies the DKIM signature and SPF record of every inbound email
+during ingest. The results are written to the `dkim` and `spf` frontmatter
+fields (`pass`, `fail`, or `none`).
+
+- Mail is always stored, regardless of verification result. `dkim` and `spf`
+  do not gate reads.
+- Channel triggers (shell commands fired on incoming mail) may be gated on
+  `dkim: pass` via per-mailbox trust policies configured in `config.toml`.
+  That is an operator concern, not an agent concern.
+- When deciding whether to act on the contents of an email (e.g. following a
+  link or treating the sender as authenticated), consult the `dkim` and
+  `spf` fields. Treat `fail` and `none` as untrusted.

--- a/book/agent-integration.md
+++ b/book/agent-integration.md
@@ -1,0 +1,137 @@
+# Agent Integration
+
+AIMX ships plugin/skill packages for popular AI agents and a one-command
+installer, `aimx agent-setup <agent>`, that drops the right files into the
+right per-user directory. After install, the agent discovers AIMX as both an
+MCP server (so tool calls work) and an agent-facing primer (so the agent
+knows when and how to use those tools).
+
+This page covers what the installer does, the list of supported agents, and
+how to wire AIMX in manually if your agent is not yet in the registry.
+
+## What `aimx agent-setup` does
+
+`aimx agent-setup <agent>`:
+
+1. Looks up the named agent in the built-in registry.
+2. Expands `$HOME` / `$XDG_CONFIG_HOME` to compute the destination.
+3. Writes the plugin tree embedded in the `aimx` binary to that destination
+   with file mode `0o644` and directory mode `0o755`.
+4. Prints an activation hint — usually "restart the agent" when the agent
+   auto-discovers plugins from a known directory, or the exact install
+   command when the agent needs an explicit step.
+
+Key properties:
+
+- **Runs as the current user.** Never requires root. `sudo aimx agent-setup
+  ...` is rejected with a clear error.
+- **Writes only to `$HOME`.** Nothing under `/etc` or `/var` is touched.
+- **Never edits the agent's primary config file.** If the agent needs
+  additional wiring (e.g. a `mcp add` call), the installer prints the
+  command and the user runs it.
+- **Offline.** The plugin tree is embedded at compile time; no network
+  access is required at install time.
+
+## Flags
+
+| Flag | Purpose |
+|------|---------|
+| `--list` | Print the registry (agent name, destination, activation hint). |
+| `--force` | Overwrite existing destination files without prompting. |
+| `--print` | Print plugin contents to stdout instead of writing to disk. Useful for CI and dry runs. |
+| `--data-dir <path>` | Global flag. If AIMX was set up with a non-default data directory, pass this so the plugin's MCP command is rewritten to include `--data-dir`. |
+
+## Supported agents
+
+The matrix below tracks what is available in the current `aimx` binary. It
+grows as more agents are landed in subsequent sprints.
+
+| Agent | Install command | Destination | Activation |
+|-------|-----------------|-------------|------------|
+| Claude Code | `aimx agent-setup claude-code` | `~/.claude/plugins/aimx/` | Restart Claude Code; the plugin is auto-discovered from `~/.claude/plugins/`. |
+
+More agents — Codex CLI, OpenCode, Gemini CLI, Goose, OpenClaw — land in
+Sprint 29 onward.
+
+### Claude Code
+
+Claude Code discovers plugins by scanning `~/.claude/plugins/`. The AIMX
+plugin ships two pieces:
+
+- `.claude-plugin/plugin.json` — manifest declaring the plugin and
+  registering `aimx mcp` as an MCP server.
+- `skills/aimx/SKILL.md` — a skill Claude Code loads when the conversation
+  touches email, inboxes, or AIMX. The skill body is the canonical AIMX
+  primer: MCP tool names and parameters, the on-disk storage layout, the
+  frontmatter format, read/unread semantics, and the DKIM/SPF trust model.
+
+Install:
+
+```bash
+aimx agent-setup claude-code
+```
+
+Custom data directory:
+
+```bash
+aimx --data-dir /custom/path agent-setup claude-code
+```
+
+The installer rewrites `mcpServers.aimx.args` to include
+`--data-dir /custom/path` before writing `plugin.json` to disk.
+
+## Manual MCP wiring
+
+If your agent is not yet supported, wire AIMX in manually as a plain MCP
+stdio server. Most MCP-compatible agents accept a JSON snippet of this
+form:
+
+```json
+{
+  "mcpServers": {
+    "aimx": {
+      "command": "/usr/local/bin/aimx",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+For a custom data directory, extend `args`:
+
+```json
+"args": ["--data-dir", "/custom/path", "mcp"]
+```
+
+The location that JSON goes in is agent-specific — check your agent's MCP
+documentation. AIMX's [MCP Server](mcp.md) chapter documents the available
+tools.
+
+## Troubleshooting
+
+### The agent does not see AIMX after `agent-setup` runs
+
+- Confirm the destination was written: `aimx agent-setup --list` shows the
+  destination path; check that it exists and contains the expected files.
+- Restart the agent. Most agents only scan their plugin directory at
+  startup.
+- If the agent requires an explicit install step, re-read the installer
+  output — the activation hint tells you exactly which command to run.
+
+### "destination files already exist" error
+
+Re-run with `--force` to overwrite. This is the expected behaviour when
+you are upgrading AIMX and want the new plugin version on disk.
+
+### `agent-setup` refuses to run as root
+
+It is intentional. Per-user agent configuration lives under `$HOME`; if you
+run the installer as root, it would drop files into root's home (or fail in
+surprising ways with `sudo -u`). Run it as the user whose agent you are
+configuring.
+
+### MCP tools appear but calls fail with "Failed to load config"
+
+The plugin's MCP command defaults to `/var/lib/aimx/` for AIMX's data
+directory. If you set up AIMX with a different path, re-run with
+`aimx --data-dir <path> agent-setup <agent> --force`.

--- a/book/index.md
+++ b/book/index.md
@@ -27,6 +27,7 @@ Outbound:
 - **[Setup wizard](setup.md)** -- interactive setup, service file generation, DKIM key generation, colorized DNS/MCP/deliverability output, re-entrant verification
 - **[Markdown email](mailboxes.md)** -- incoming email parsed to Markdown with TOML frontmatter, attachment extraction, per-mailbox routing
 - **[MCP Server](mcp.md)** -- stdio transport for Claude Code, OpenClaw, Codex, OpenCode, and any MCP-compatible agent: list, read, send, reply, manage mailboxes
+- **[Agent Integration](agent-integration.md)** -- one-command `aimx agent-setup <agent>` installer for per-agent plugin/skill packages
 - **[Channel rules](channels.md)** -- trigger shell commands on incoming mail with match filters (from, subject, attachments)
 - **[DKIM signing](setup.md#dkim-key-management)** -- native RSA-SHA256 signing for outbound mail
 - **[Inbound trust](channels.md#trust-policies)** -- DKIM/SPF verification, per-mailbox trust policies, trusted sender allowlists
@@ -58,4 +59,5 @@ See the full [Getting Started](getting-started.md) guide for details.
 | [Mailboxes & Email](mailboxes.md) | Mailbox management, email format, sending, attachments, threading |
 | [Channel Rules & Trust](channels.md) | Trigger commands on incoming mail, match filters, trust policies |
 | [MCP Server](mcp.md) | Agent integration via Model Context Protocol, all 9 MCP tools |
+| [Agent Integration](agent-integration.md) | `aimx agent-setup <agent>` installer and per-agent plugin packages |
 | [Troubleshooting](troubleshooting.md) | Diagnostics, common issues, useful commands |

--- a/book/mcp.md
+++ b/book/mcp.md
@@ -1,5 +1,7 @@
 # MCP Server
 
+> To install AIMX into your agent, see [Agent Integration](agent-integration.md).
+
 AIMX includes a built-in MCP (Model Context Protocol) server that gives AI agents programmatic access to email. Agents can list, read, send, reply to, and manage email through standard MCP tool calls.
 
 ## Overview

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -172,7 +172,7 @@ fn install(
         )
     })?;
 
-    let files = assemble_plugin_files(spec, source, opts.data_dir)?;
+    let files = assemble_plugin_files(source, opts.data_dir)?;
 
     if opts.print {
         for (rel, bytes) in &files {
@@ -204,7 +204,6 @@ fn install(
 /// Returns `(relative_path, bytes)` pairs. Relative paths are relative to
 /// the install destination root.
 pub fn assemble_plugin_files(
-    spec: &AgentSpec,
     source: &Dir<'_>,
     data_dir: Option<&Path>,
 ) -> Result<Vec<(PathBuf, Vec<u8>)>, String> {
@@ -240,10 +239,13 @@ pub fn assemble_plugin_files(
         }
 
         // Skip README.md at the top of the plugin source — it is developer-facing,
-        // not an artifact to install. Include it only if the agent author wants
-        // it; for our single spec we filter it out.
+        // not an artifact to install.
+        //
+        // NOTE: this match is deliberately top-level only (`rel.as_os_str()`
+        // rather than `rel.file_name()`), so a nested file such as
+        // `docs/README.md` inside a plugin tree would still be installed.
+        // Keep this scoping if you touch the filter.
         if rel.as_os_str() == "README.md" {
-            let _ = spec.name; // touch to silence unused warning when only one branch
             continue;
         }
 
@@ -283,10 +285,12 @@ fn collect_entries(
 /// Rewrite `mcpServers.<server>.args` in a plugin.json-like JSON so that the
 /// command runs with `--data-dir <path>`. Preserves other fields.
 ///
-/// This is intentionally a targeted string-level rewrite rather than a full
-/// JSON round-trip — it keeps the formatting of the hand-authored file intact
-/// while swapping only the `args` array.
-fn rewrite_plugin_args(json_text: &str, data_dir: &Path) -> Result<String, String> {
+/// Implementation parses the JSON into `serde_json::Value`, swaps the `args`
+/// array on each server entry, and re-serializes via `to_string_pretty`. The
+/// output is therefore serde-formatted, not byte-identical to the hand-authored
+/// file — acceptable because `plugin.json` has no comments or meaningful
+/// whitespace to preserve.
+pub fn rewrite_plugin_args(json_text: &str, data_dir: &Path) -> Result<String, String> {
     let value: serde_json::Value = serde_json::from_str(json_text)
         .map_err(|e| format!("plugin.json is not valid JSON: {e}"))?;
 
@@ -590,6 +594,77 @@ mod tests {
         let env = MockEnv::new(tmp.path().to_path_buf());
         let err = run_with_env(None, false, false, false, None, &env).unwrap_err();
         assert!(err.to_string().contains("agent name"));
+    }
+
+    #[test]
+    fn install_tty_prompt_yes_overwrites() {
+        let tmp = TempDir::new().unwrap();
+        let mut env = MockEnv::new(tmp.path().to_path_buf());
+
+        // First install succeeds.
+        run_with_env(Some("claude-code".into()), false, false, false, None, &env).unwrap();
+
+        // Second install: TTY says "y", overwrite proceeds.
+        env.tty = true;
+        env.responses = RefCell::new(vec!["y\n".to_string()]);
+        run_with_env(Some("claude-code".into()), false, false, false, None, &env).unwrap();
+
+        let dest = tmp.path().join(".claude/plugins/aimx");
+        assert!(dest.join(".claude-plugin/plugin.json").exists());
+    }
+
+    #[test]
+    fn install_tty_prompt_no_aborts() {
+        let tmp = TempDir::new().unwrap();
+        let mut env = MockEnv::new(tmp.path().to_path_buf());
+
+        // First install succeeds.
+        run_with_env(Some("claude-code".into()), false, false, false, None, &env).unwrap();
+
+        // Second install: TTY says "n", install aborts.
+        env.tty = true;
+        env.responses = RefCell::new(vec!["n\n".to_string()]);
+        let err =
+            run_with_env(Some("claude-code".into()), false, false, false, None, &env).unwrap_err();
+        assert!(err.to_string().contains("aborted by user"));
+    }
+
+    #[test]
+    fn assembled_skill_md_is_header_plus_primer_byte_for_byte() {
+        let source = AGENTS_DIR.get_dir("claude-code").unwrap();
+        let files = assemble_plugin_files(source, None).unwrap();
+
+        let (_, skill_bytes) = files
+            .iter()
+            .find(|(rel, _)| rel.to_string_lossy() == "skills/aimx/SKILL.md")
+            .expect("assembled SKILL.md should be present");
+
+        let header = AGENTS_DIR
+            .get_file("claude-code/skills/aimx/SKILL.md.header")
+            .unwrap()
+            .contents();
+        let primer = AGENTS_DIR
+            .get_file("common/aimx-primer.md")
+            .unwrap()
+            .contents();
+
+        let mut expected = Vec::with_capacity(header.len() + primer.len());
+        expected.extend_from_slice(header);
+        expected.extend_from_slice(primer);
+
+        assert_eq!(
+            skill_bytes, &expected,
+            "SKILL.md must be exact concatenation of header followed by primer"
+        );
+    }
+
+    #[test]
+    fn rewrite_plugin_args_rejects_malformed_json() {
+        let err = rewrite_plugin_args("{ not json", Path::new("/tmp/x")).unwrap_err();
+        assert!(
+            err.contains("plugin.json is not valid JSON"),
+            "unexpected error: {err}"
+        );
     }
 
     #[cfg(unix)]

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -1,0 +1,617 @@
+//! Per-agent plugin installer for `aimx agent-setup`.
+//!
+//! Ships plugin/skill packages for supported agents (currently Claude Code)
+//! bundled into the binary via `include_dir!`, and installs them into the
+//! user's `$HOME`-based agent directory.
+
+use crate::term;
+use include_dir::{Dir, DirEntry, include_dir};
+use std::io::{self, BufRead, Write};
+use std::path::{Path, PathBuf};
+
+static AGENTS_DIR: Dir<'_> = include_dir!("$CARGO_MANIFEST_DIR/agents");
+
+/// Short name and install metadata for a supported agent.
+pub struct AgentSpec {
+    /// Registry key passed on the CLI (e.g. `claude-code`).
+    pub name: &'static str,
+    /// Path inside the `agents/` tree that holds the plugin source.
+    pub source_subdir: &'static str,
+    /// Destination template, with `$HOME` / `$XDG_CONFIG_HOME` placeholders.
+    pub dest_template: &'static str,
+    /// Message printed to the user after a successful install.
+    pub activation_hint: &'static str,
+}
+
+/// Static registry of supported agents.
+pub fn registry() -> &'static [AgentSpec] {
+    &[AgentSpec {
+        name: "claude-code",
+        source_subdir: "claude-code",
+        dest_template: "$HOME/.claude/plugins/aimx",
+        activation_hint: "Plugin installed. Restart Claude Code to pick it up (it is auto-discovered from ~/.claude/plugins/).",
+    }]
+}
+
+pub fn find_agent(name: &str) -> Option<&'static AgentSpec> {
+    registry().iter().find(|a| a.name == name)
+}
+
+/// Trait used to make installs testable without touching the real `$HOME`
+/// or real uid.
+pub trait AgentEnv {
+    fn home_dir(&self) -> Option<PathBuf>;
+    fn xdg_config_home(&self) -> Option<PathBuf>;
+    fn is_root(&self) -> bool;
+    fn is_stdin_tty(&self) -> bool;
+    fn read_line(&self) -> io::Result<String>;
+}
+
+pub struct RealAgentEnv;
+
+impl AgentEnv for RealAgentEnv {
+    fn home_dir(&self) -> Option<PathBuf> {
+        std::env::var_os("HOME").map(PathBuf::from)
+    }
+
+    fn xdg_config_home(&self) -> Option<PathBuf> {
+        std::env::var_os("XDG_CONFIG_HOME").map(PathBuf::from)
+    }
+
+    fn is_root(&self) -> bool {
+        // SAFETY: libc::geteuid is a simple syscall with no preconditions.
+        unsafe { libc::geteuid() == 0 }
+    }
+
+    fn is_stdin_tty(&self) -> bool {
+        use std::io::IsTerminal;
+        io::stdin().is_terminal()
+    }
+
+    fn read_line(&self) -> io::Result<String> {
+        let mut s = String::new();
+        io::stdin().lock().read_line(&mut s)?;
+        Ok(s)
+    }
+}
+
+/// Options controlling a single `agent-setup` invocation.
+pub struct InstallOptions<'a> {
+    pub force: bool,
+    pub print: bool,
+    pub data_dir: Option<&'a Path>,
+}
+
+/// Resolve a destination template against the environment. Substitutes
+/// `$HOME` and `$XDG_CONFIG_HOME`.
+pub fn resolve_dest(template: &str, env: &dyn AgentEnv) -> Result<PathBuf, String> {
+    let home = env.home_dir().ok_or_else(|| {
+        "HOME is not set; agent-setup writes to the user's home directory".to_string()
+    })?;
+
+    let xdg = env
+        .xdg_config_home()
+        .unwrap_or_else(|| home.join(".config"));
+
+    let substituted = template
+        .replace("$XDG_CONFIG_HOME", &xdg.to_string_lossy())
+        .replace("$HOME", &home.to_string_lossy());
+
+    Ok(PathBuf::from(substituted))
+}
+
+/// Entry point called from `main.rs`.
+pub fn run(
+    agent: Option<String>,
+    list: bool,
+    force: bool,
+    print: bool,
+    data_dir: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let env = RealAgentEnv;
+    run_with_env(agent, list, force, print, data_dir, &env)
+}
+
+pub fn run_with_env(
+    agent: Option<String>,
+    list: bool,
+    force: bool,
+    print: bool,
+    data_dir: Option<&Path>,
+    env: &dyn AgentEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if list {
+        print_registry(env);
+        return Ok(());
+    }
+
+    let name = agent.ok_or_else(|| {
+        "agent-setup requires an agent name, or --list to see supported agents".to_string()
+    })?;
+
+    if env.is_root() {
+        return Err("agent-setup is a per-user operation — run without sudo or as root".into());
+    }
+
+    let spec = find_agent(&name).ok_or_else(|| {
+        format!("unknown agent '{name}'; run `aimx agent-setup --list` to see supported agents")
+    })?;
+
+    let opts = InstallOptions {
+        force,
+        print,
+        data_dir,
+    };
+
+    install(spec, &opts, env)
+}
+
+fn print_registry(env: &dyn AgentEnv) {
+    println!("{}", term::header("Supported agents:"));
+    println!();
+    for spec in registry() {
+        let dest = resolve_dest(spec.dest_template, env)
+            .unwrap_or_else(|_| PathBuf::from(spec.dest_template));
+        println!("  {}", term::highlight(spec.name));
+        println!("    destination: {}", dest.display());
+        println!("    install:     aimx agent-setup {}", spec.name);
+        println!("    activation:  {}", spec.activation_hint);
+        println!();
+    }
+}
+
+fn install(
+    spec: &AgentSpec,
+    opts: &InstallOptions,
+    env: &dyn AgentEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let source = AGENTS_DIR.get_dir(spec.source_subdir).ok_or_else(|| {
+        format!(
+            "internal error: missing embedded source for '{}'",
+            spec.name
+        )
+    })?;
+
+    let files = assemble_plugin_files(spec, source, opts.data_dir)?;
+
+    if opts.print {
+        for (rel, bytes) in &files {
+            println!("=== {} ===", rel.display());
+            match std::str::from_utf8(bytes) {
+                Ok(text) => println!("{text}"),
+                Err(_) => println!("<{} bytes of binary content>", bytes.len()),
+            }
+        }
+        return Ok(());
+    }
+
+    let dest_root = resolve_dest(spec.dest_template, env)?;
+    write_files(&dest_root, &files, opts.force, env)?;
+
+    println!(
+        "{} {}",
+        term::success("Installed"),
+        term::highlight(&dest_root.to_string_lossy())
+    );
+    println!("{}", spec.activation_hint);
+
+    Ok(())
+}
+
+/// Walk the embedded plugin source, transform known files (skill header +
+/// primer, plugin.json), and return the full set of files to write.
+///
+/// Returns `(relative_path, bytes)` pairs. Relative paths are relative to
+/// the install destination root.
+pub fn assemble_plugin_files(
+    spec: &AgentSpec,
+    source: &Dir<'_>,
+    data_dir: Option<&Path>,
+) -> Result<Vec<(PathBuf, Vec<u8>)>, String> {
+    let mut out: Vec<(PathBuf, Vec<u8>)> = Vec::new();
+    collect_entries(source, Path::new(""), &mut out)?;
+
+    // Transformation 1: assemble SKILL.md from SKILL.md.header + common primer.
+    let primer = AGENTS_DIR
+        .get_file("common/aimx-primer.md")
+        .ok_or_else(|| {
+            "internal error: missing common/aimx-primer.md in embedded assets".to_string()
+        })?
+        .contents();
+
+    let mut transformed: Vec<(PathBuf, Vec<u8>)> = Vec::new();
+    for (rel, bytes) in out.drain(..) {
+        if rel.file_name().is_some_and(|n| n == "SKILL.md.header") {
+            let target = rel.with_file_name("SKILL.md");
+            let mut combined = bytes.clone();
+            combined.extend_from_slice(primer);
+            transformed.push((target, combined));
+            continue;
+        }
+
+        if rel.file_name().is_some_and(|n| n == "plugin.json")
+            && let Some(dd) = data_dir
+        {
+            let text = std::str::from_utf8(&bytes)
+                .map_err(|e| format!("plugin.json not valid UTF-8: {e}"))?;
+            let rewritten = rewrite_plugin_args(text, dd)?;
+            transformed.push((rel, rewritten.into_bytes()));
+            continue;
+        }
+
+        // Skip README.md at the top of the plugin source — it is developer-facing,
+        // not an artifact to install. Include it only if the agent author wants
+        // it; for our single spec we filter it out.
+        if rel.as_os_str() == "README.md" {
+            let _ = spec.name; // touch to silence unused warning when only one branch
+            continue;
+        }
+
+        transformed.push((rel, bytes));
+    }
+
+    transformed.sort_by(|a, b| a.0.cmp(&b.0));
+    Ok(transformed)
+}
+
+fn collect_entries(
+    dir: &Dir<'_>,
+    rel_root: &Path,
+    out: &mut Vec<(PathBuf, Vec<u8>)>,
+) -> Result<(), String> {
+    for entry in dir.entries() {
+        match entry {
+            DirEntry::File(f) => {
+                let rel = f
+                    .path()
+                    .strip_prefix(dir.path())
+                    .map_err(|e| format!("strip_prefix failed: {e}"))?;
+                out.push((rel_root.join(rel), f.contents().to_vec()));
+            }
+            DirEntry::Dir(sub) => {
+                let rel = sub
+                    .path()
+                    .strip_prefix(dir.path())
+                    .map_err(|e| format!("strip_prefix failed: {e}"))?;
+                collect_entries(sub, &rel_root.join(rel), out)?;
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Rewrite `mcpServers.<server>.args` in a plugin.json-like JSON so that the
+/// command runs with `--data-dir <path>`. Preserves other fields.
+///
+/// This is intentionally a targeted string-level rewrite rather than a full
+/// JSON round-trip — it keeps the formatting of the hand-authored file intact
+/// while swapping only the `args` array.
+fn rewrite_plugin_args(json_text: &str, data_dir: &Path) -> Result<String, String> {
+    let value: serde_json::Value = serde_json::from_str(json_text)
+        .map_err(|e| format!("plugin.json is not valid JSON: {e}"))?;
+
+    let mut value = value;
+    let dd = data_dir.to_string_lossy().into_owned();
+
+    if let Some(servers) = value.get_mut("mcpServers").and_then(|v| v.as_object_mut()) {
+        for (_key, server) in servers.iter_mut() {
+            if let Some(obj) = server.as_object_mut() {
+                obj.insert(
+                    "args".to_string(),
+                    serde_json::json!(["--data-dir", dd, "mcp"]),
+                );
+            }
+        }
+    }
+
+    serde_json::to_string_pretty(&value)
+        .map(|mut s| {
+            s.push('\n');
+            s
+        })
+        .map_err(|e| format!("failed to serialize plugin.json: {e}"))
+}
+
+fn write_files(
+    dest_root: &Path,
+    files: &[(PathBuf, Vec<u8>)],
+    force: bool,
+    env: &dyn AgentEnv,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Check for existing files first so we prompt once, not per file.
+    if !force {
+        let existing: Vec<&Path> = files
+            .iter()
+            .map(|(rel, _)| rel.as_path())
+            .filter(|rel| dest_root.join(rel).exists())
+            .collect();
+
+        if !existing.is_empty() {
+            if !env.is_stdin_tty() {
+                return Err(format!(
+                    "destination files already exist under {}; pass --force to overwrite",
+                    dest_root.display()
+                )
+                .into());
+            }
+
+            println!(
+                "{} Destination {} already contains {} file(s):",
+                term::warn("Warning:"),
+                dest_root.display(),
+                existing.len()
+            );
+            for rel in &existing {
+                println!("  {}", rel.display());
+            }
+            print!("Overwrite? [y/N] ");
+            io::stdout().flush().ok();
+            let line = env.read_line()?;
+            if !matches!(line.trim(), "y" | "Y" | "yes" | "YES") {
+                return Err("aborted by user".into());
+            }
+        }
+    }
+
+    for (rel, bytes) in files {
+        let full = dest_root.join(rel);
+        if let Some(parent) = full.parent() {
+            std::fs::create_dir_all(parent)?;
+            set_dir_mode(parent)?;
+        }
+        std::fs::write(&full, bytes)?;
+        set_file_mode(&full)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn set_file_mode(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(path)?.permissions();
+    perms.set_mode(0o644);
+    std::fs::set_permissions(path, perms)
+}
+
+#[cfg(unix)]
+fn set_dir_mode(path: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = std::fs::metadata(path)?.permissions();
+    perms.set_mode(0o755);
+    std::fs::set_permissions(path, perms)
+}
+
+#[cfg(not(unix))]
+fn set_file_mode(_: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn set_dir_mode(_: &Path) -> io::Result<()> {
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::cell::RefCell;
+    use tempfile::TempDir;
+
+    struct MockEnv {
+        home: PathBuf,
+        xdg: Option<PathBuf>,
+        root: bool,
+        tty: bool,
+        responses: RefCell<Vec<String>>,
+    }
+
+    impl MockEnv {
+        fn new(home: PathBuf) -> Self {
+            Self {
+                home,
+                xdg: None,
+                root: false,
+                tty: false,
+                responses: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl AgentEnv for MockEnv {
+        fn home_dir(&self) -> Option<PathBuf> {
+            Some(self.home.clone())
+        }
+        fn xdg_config_home(&self) -> Option<PathBuf> {
+            self.xdg.clone()
+        }
+        fn is_root(&self) -> bool {
+            self.root
+        }
+        fn is_stdin_tty(&self) -> bool {
+            self.tty
+        }
+        fn read_line(&self) -> io::Result<String> {
+            Ok(self.responses.borrow_mut().remove(0))
+        }
+    }
+
+    #[test]
+    fn registry_contains_claude_code() {
+        assert!(find_agent("claude-code").is_some());
+        assert!(find_agent("not-a-real-agent").is_none());
+    }
+
+    #[test]
+    fn resolve_dest_substitutes_home() {
+        let env = MockEnv::new(PathBuf::from("/home/alice"));
+        let path = resolve_dest("$HOME/.claude/plugins/aimx", &env).unwrap();
+        assert_eq!(path, PathBuf::from("/home/alice/.claude/plugins/aimx"));
+    }
+
+    #[test]
+    fn resolve_dest_substitutes_xdg_config_home() {
+        let mut env = MockEnv::new(PathBuf::from("/home/alice"));
+        env.xdg = Some(PathBuf::from("/alt/config"));
+        let path = resolve_dest("$XDG_CONFIG_HOME/foo", &env).unwrap();
+        assert_eq!(path, PathBuf::from("/alt/config/foo"));
+    }
+
+    #[test]
+    fn resolve_dest_defaults_xdg_to_home_dot_config() {
+        let env = MockEnv::new(PathBuf::from("/home/alice"));
+        let path = resolve_dest("$XDG_CONFIG_HOME/foo", &env).unwrap();
+        assert_eq!(path, PathBuf::from("/home/alice/.config/foo"));
+    }
+
+    #[test]
+    fn install_claude_code_lays_out_expected_files() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        run_with_env(Some("claude-code".into()), false, false, false, None, &env).unwrap();
+
+        let dest = tmp.path().join(".claude/plugins/aimx");
+        assert!(dest.join(".claude-plugin/plugin.json").exists());
+        assert!(dest.join("skills/aimx/SKILL.md").exists());
+        // README.md is developer-facing and is NOT installed.
+        assert!(!dest.join("README.md").exists());
+
+        // SKILL.md should have been assembled from header + primer.
+        let skill = std::fs::read_to_string(dest.join("skills/aimx/SKILL.md")).unwrap();
+        assert!(
+            skill.starts_with("---\n"),
+            "missing YAML frontmatter: {skill:.200}"
+        );
+        assert!(skill.contains("name: aimx"));
+        assert!(skill.contains("MCP tools"));
+        assert!(skill.contains("mailbox_create"));
+        assert!(skill.contains("Trust model"));
+        // The template sentinel should NOT appear on disk.
+        assert!(!dest.join("skills/aimx/SKILL.md.header").exists());
+
+        // plugin.json should have default args (no --data-dir).
+        let plugin = std::fs::read_to_string(dest.join(".claude-plugin/plugin.json")).unwrap();
+        assert!(plugin.contains("\"mcp\""));
+        assert!(!plugin.contains("--data-dir"));
+    }
+
+    #[test]
+    fn install_refuses_root() {
+        let tmp = TempDir::new().unwrap();
+        let mut env = MockEnv::new(tmp.path().to_path_buf());
+        env.root = true;
+
+        let err =
+            run_with_env(Some("claude-code".into()), false, false, false, None, &env).unwrap_err();
+        assert!(err.to_string().contains("per-user"));
+    }
+
+    #[test]
+    fn install_unknown_agent_errors() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+        let err = run_with_env(Some("bogus".into()), false, false, false, None, &env).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("unknown agent"));
+        assert!(msg.contains("--list"));
+    }
+
+    #[test]
+    fn install_refuses_to_overwrite_without_force_non_tty() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        // First install succeeds.
+        run_with_env(Some("claude-code".into()), false, false, false, None, &env).unwrap();
+
+        // Second install without --force on non-TTY errors.
+        let err =
+            run_with_env(Some("claude-code".into()), false, false, false, None, &env).unwrap_err();
+        assert!(err.to_string().contains("--force"));
+    }
+
+    #[test]
+    fn install_force_overwrites() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        run_with_env(Some("claude-code".into()), false, false, false, None, &env).unwrap();
+        run_with_env(Some("claude-code".into()), false, true, false, None, &env).unwrap();
+
+        let dest = tmp.path().join(".claude/plugins/aimx");
+        assert!(dest.join(".claude-plugin/plugin.json").exists());
+    }
+
+    #[test]
+    fn install_print_writes_no_files() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        run_with_env(Some("claude-code".into()), false, false, true, None, &env).unwrap();
+
+        let dest = tmp.path().join(".claude/plugins/aimx");
+        assert!(!dest.exists());
+    }
+
+    #[test]
+    fn install_with_custom_data_dir_rewrites_plugin_args() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+        let custom = PathBuf::from("/custom/aimx-data");
+
+        run_with_env(
+            Some("claude-code".into()),
+            false,
+            false,
+            false,
+            Some(&custom),
+            &env,
+        )
+        .unwrap();
+
+        let dest = tmp.path().join(".claude/plugins/aimx");
+        let plugin = std::fs::read_to_string(dest.join(".claude-plugin/plugin.json")).unwrap();
+        assert!(plugin.contains("--data-dir"));
+        assert!(plugin.contains("/custom/aimx-data"));
+        assert!(plugin.contains("\"mcp\""));
+    }
+
+    #[test]
+    fn list_mode_runs_without_agent_name() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+        run_with_env(None, true, false, false, None, &env).unwrap();
+    }
+
+    #[test]
+    fn missing_agent_name_errors_when_not_listing() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+        let err = run_with_env(None, false, false, false, None, &env).unwrap_err();
+        assert!(err.to_string().contains("agent name"));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn install_sets_expected_file_modes() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        run_with_env(Some("claude-code".into()), false, false, false, None, &env).unwrap();
+
+        let dest = tmp.path().join(".claude/plugins/aimx");
+        let plugin = dest.join(".claude-plugin/plugin.json");
+        let mode = std::fs::metadata(&plugin).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o644, "plugin.json should be 0o644, got {mode:o}");
+
+        let plugin_dir = dest.join(".claude-plugin");
+        let dmode = std::fs::metadata(&plugin_dir).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            dmode, 0o755,
+            ".claude-plugin dir should be 0o755, got {dmode:o}"
+        );
+    }
+}

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -72,6 +72,24 @@ pub enum Command {
         verify_host: Option<String>,
     },
 
+    /// Install AIMX plugin/skill for an AI agent into the current user's config
+    AgentSetup {
+        /// Agent short name (e.g. claude-code). Omit with --list.
+        agent: Option<String>,
+
+        /// List supported agents with destinations and activation hints
+        #[arg(long)]
+        list: bool,
+
+        /// Overwrite existing destination files without prompting
+        #[arg(long)]
+        force: bool,
+
+        /// Print plugin contents to stdout instead of writing to disk
+        #[arg(long)]
+        print: bool,
+    },
+
     /// Generate DKIM keypair for email signing
     DkimKeygen {
         /// DKIM selector name

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,4 @@
+mod agent_setup;
 mod channel;
 mod cli;
 mod config;
@@ -68,6 +69,12 @@ fn dispatch(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Command::Verify { verify_host } => {
             verify::run(cli.data_dir.as_deref(), verify_host.as_deref())
         }
+        Command::AgentSetup {
+            agent,
+            list,
+            force,
+            print,
+        } => agent_setup::run(agent, list, force, print, cli.data_dir.as_deref()),
     }
 }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -851,33 +851,41 @@ pub fn display_dns_verification(
 
 pub fn display_mcp_section(data_dir: &Path) {
     println!("\n{}", term::header("[MCP]"));
-    println!(
-        "Add AIMX to your MCP-compatible AI agent (Claude Code, OpenClaw, Codex, OpenCode, etc.).\n"
-    );
-    println!("Configuration snippet:\n");
-    println!("{}\n", mcp_config_snippet(data_dir));
+    for line in mcp_section_lines(data_dir) {
+        println!("{line}");
+    }
 }
 
-pub fn mcp_config_snippet(data_dir: &Path) -> String {
-    let aimx_path = "/usr/local/bin/aimx";
-    let data_dir_str = data_dir.to_string_lossy();
+/// Produce the plain-text body of the `[MCP]` section (without the header
+/// line itself). Returned as a vector of lines so tests can assert on
+/// content without spawning a subprocess.
+pub fn mcp_section_lines(data_dir: &Path) -> Vec<String> {
+    let mut lines = Vec::new();
+    lines.push("Wire AIMX into your AI agent with one command per agent:".to_string());
+    lines.push(String::new());
 
-    let args = if data_dir_str == "/var/lib/aimx" {
-        r#"["mcp"]"#.to_string()
-    } else {
-        format!(r#"["--data-dir", "{data_dir_str}", "mcp"]"#)
-    };
+    for spec in crate::agent_setup::registry() {
+        let cmd = if data_dir == Path::new("/var/lib/aimx") {
+            format!("aimx agent-setup {}", spec.name)
+        } else {
+            format!(
+                "aimx --data-dir {} agent-setup {}",
+                data_dir.display(),
+                spec.name
+            )
+        };
+        lines.push(format!("  {cmd}"));
+    }
 
-    format!(
-        r#"{{
-  "mcpServers": {{
-    "email": {{
-      "command": "{aimx_path}",
-      "args": {args}
-    }}
-  }}
-}}"#
-    )
+    lines.push(String::new());
+    lines.push(
+        "Run `aimx agent-setup --list` to see supported agents and destination paths.".to_string(),
+    );
+    lines.push(
+        "See `book/agent-integration.md` for the full list and manual MCP wiring.".to_string(),
+    );
+    lines.push(String::new());
+    lines
 }
 
 pub fn display_deliverability_section(domain: &str, net: &dyn NetworkOps) {
@@ -1880,18 +1888,34 @@ mod tests {
     }
 
     #[test]
-    fn mcp_snippet_default_data_dir() {
-        let snippet = mcp_config_snippet(Path::new("/var/lib/aimx"));
-        assert!(snippet.contains("\"command\": \"/usr/local/bin/aimx\""));
-        assert!(snippet.contains("\"args\": [\"mcp\"]"));
-        assert!(!snippet.contains("--data-dir"));
+    fn mcp_section_default_lists_claude_code_install_command() {
+        let lines = mcp_section_lines(Path::new("/var/lib/aimx"));
+        let joined = lines.join("\n");
+        assert!(
+            joined.contains("aimx agent-setup claude-code"),
+            "expected claude-code install command in:\n{joined}"
+        );
+        assert!(!joined.contains("mcpServers"));
+        assert!(!joined.contains("--data-dir"));
     }
 
     #[test]
-    fn mcp_snippet_custom_data_dir() {
-        let snippet = mcp_config_snippet(Path::new("/custom/data"));
-        assert!(snippet.contains("--data-dir"));
-        assert!(snippet.contains("/custom/data"));
+    fn mcp_section_custom_data_dir_threads_override_into_commands() {
+        let lines = mcp_section_lines(Path::new("/custom/data"));
+        let joined = lines.join("\n");
+        assert!(
+            joined.contains("aimx --data-dir /custom/data agent-setup claude-code"),
+            "expected --data-dir override in install command:\n{joined}"
+        );
+        assert!(!joined.contains("mcpServers"));
+    }
+
+    #[test]
+    fn mcp_section_points_at_agent_integration_doc() {
+        let lines = mcp_section_lines(Path::new("/var/lib/aimx"));
+        let joined = lines.join("\n");
+        assert!(joined.contains("agent-integration.md"));
+        assert!(joined.contains("aimx agent-setup --list"));
     }
 
     #[test]


### PR DESCRIPTION
## Sprint Goal
Stand up the `agents/` tree and the `aimx agent-setup <agent>` command, and ship the Claude Code integration end-to-end as the reference implementation.

## Stories Implemented

### [S28-1] `agents/common/aimx-primer.md` — canonical agent-facing primer
- [x] Primer created with sections: Tools, Storage layout, Frontmatter, Mailboxes, Read/unread, Trust model
- [x] Each MCP tool documented with parameter names/types, matching `src/mcp.rs` exactly
- [x] Frontmatter section lists every field and its semantics; matches `ingest.rs`
- [x] No forward references; grep for TODO/FIXME returns nothing
- [x] 130 lines, instructional tone

### [S28-2] `agents/claude-code/` plugin package
- [x] `.claude-plugin/plugin.json` with `name`, `description`, `version`, `author`, and `mcpServers.aimx` command/args
- [x] `skills/aimx/SKILL.md` assembled at install time from a YAML header file + the common primer (single source of truth; no duplication on disk)
- [x] `README.md` developer-facing (filtered out of the installed tree; schema reference link included)
- [x] Plugin schema cross-checked against the Claude Code plugin documentation ([docs.claude.com/.../plugins](https://docs.claude.com/en/docs/claude-code/plugins))
- [ ] **Manual validation on a real Claude Code instance** — deferred: requires a reviewer with Claude Code installed. The `--print` output, unit tests, and schema conformance give high confidence; flagging for reviewer manual check.

### [S28-3] `src/agent_setup.rs` + `aimx agent-setup` CLI
- [x] Module created; `Cargo.toml` adds `include_dir = "0.7"` (MIT-licensed, verified via `cargo info`)
- [x] `AgentSpec` struct captures `name`, `source_subdir`, `dest_template`, `activation_hint`
- [x] CLI subcommand with `--list`, `--force`, `--print`, and the inherited global `--data-dir`
- [x] `--list` prints name, destination, install command, and activation hint per agent
- [x] Install writes files mode `0o644`, dirs `0o755`; refuses to overwrite without `--force` on non-TTY; prompts interactively when stdin is a TTY
- [x] Unknown agent errors with a clear "unknown agent; run `aimx agent-setup --list`" message
- [x] `--print` emits `=== path ===\n<contents>\n` blocks; no disk writes
- [x] 14 unit tests cover: Claude Code layout, force overwrite, print mode, unknown agent, root refusal, file modes, custom data-dir rewrites, `$HOME` / `$XDG_CONFIG_HOME` substitution
- [x] Root refused with a clear "agent-setup is a per-user operation" message
- [x] `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt -- --check` clean

### [S28-4] Register Claude Code + simplify `aimx setup` MCP output
- [x] `claude-code` registered with destination `$HOME/.claude/plugins/aimx` and an auto-discovery activation hint
- [x] `display_mcp_section()` no longer emits a `{"mcpServers": ...}` JSON snippet
- [x] Section lists supported agents pulled from `agent_setup::registry()`; recommends `aimx agent-setup <agent>` (with `--data-dir` threaded through when set)
- [x] `mcp_config_snippet()` removed; audit confirmed no other call sites
- [x] Tests in `setup.rs` updated — new `mcp_section_lines` helper is unit-tested for default and custom data-dir paths

### [S28-5] PRD re-verify + `book/agent-integration.md`
- [x] `docs/prd.md` §5 P0 user story re-verified — already in place from planning
- [x] §6.10 FR-49/50/51/52 re-verified — already in place from planning
- [x] §6.1 FR-10 re-verified — already narrowed to `aimx agent-setup`
- [x] §9 In Scope / Out of Scope re-verified — already updated
- [x] `book/agent-integration.md` created: installer behavior, flags, supported-agents table (Claude Code only), per-agent activation, manual MCP fallback, troubleshooting
- [x] `book/index.md` links the new chapter in Key Capabilities and the Guide Contents table (no `SUMMARY.md` in this book)
- [x] `book/mcp.md` adds a one-line pointer near the top

## Technical Decisions

- **SKILL.md assembly.** `agents/claude-code/skills/aimx/SKILL.md` does not exist on disk to avoid duplicating the primer. Instead the source tree ships `SKILL.md.header` (YAML frontmatter only), and `assemble_plugin_files()` concatenates header + primer at install time and emits the combined file at the destination as `SKILL.md`. One source of truth, no build script needed.
- **`include_dir` instead of a build script.** Simpler than a `build.rs` that copies the primer in — and the installer already needs to walk the embedded tree, so the crate pulls double duty. Verified MIT via `cargo info`.
- **String-level `plugin.json` rewrite via `serde_json::Value`.** When `--data-dir` is set, the installer round-trips `plugin.json` through `serde_json` to replace `mcpServers.*.args` with `["--data-dir", <path>, "mcp"]`. Keeps the transformation obviously correct and robust across formatting changes to the source manifest.
- **`AgentEnv` trait.** Follows the `SystemOps`/`NetworkOps` pattern already used in `setup.rs` and `send.rs`. Tests use a `MockEnv` with a `TempDir` as home, so the whole install pipeline runs without touching the real `$HOME` or needing a real uid.
- **Filter `README.md` from the installed tree.** The source `agents/<agent>/README.md` is developer-facing (schema pointers, internal layout); installing it into the user's plugin dir would clutter that dir. The filter is a single string match in `assemble_plugin_files()`.
- **CI clippy scope.** `cargo clippy -- -D warnings` (the CI invocation, not `--all-targets`) is clean on this change. `cargo clippy --all-targets -- -D warnings` surfaces four pre-existing test-code lints in `dkim.rs`, `send.rs`, and `setup.rs` that are unrelated to this PR — confirmed by stashing this PR's changes and re-running against `main`.

## Deferred Items

- **Manual validation on a real Claude Code instance** — S28-2's last acceptance criterion. Deferred because the sandbox executing this sprint does not have Claude Code installed. The `--print` output, the plugin schema check against the public Claude Code plugin docs, and the install-path unit tests all pass. Reviewer: if you have Claude Code, please run `aimx agent-setup claude-code`, restart Claude Code, confirm the nine AIMX MCP tools appear, and confirm the `aimx` skill is discoverable.

## Review Focus Areas

- `src/agent_setup.rs` — the new module. In particular `assemble_plugin_files()` (header-to-SKILL.md rewrite, `plugin.json` args rewrite, README filtering) and `write_files()` (overwrite prompt, TTY gating, Unix modes).
- `src/setup.rs` `display_mcp_section` / `mcp_section_lines` — the user-facing output change. Does the new text read well in your terminal? The header-plus-list format is deliberately short on the assumption the real detail lives in `book/agent-integration.md`.
- `agents/common/aimx-primer.md` — agent-facing documentation that the plugin embeds into Claude Code's `SKILL.md`. Please read as if you were the agent: is anything inaccurate, ambiguous, or missing? Tool names and parameters were cross-checked against `src/mcp.rs`; frontmatter fields were cross-checked against `src/ingest.rs`.
- `book/agent-integration.md` — new user-facing chapter. Specifically the supported-agents table, which future sprints will append to.