### PR TITLE
[Sprint 29] Codex CLI + OpenCode + Gemini CLI Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **SMTP for agents. No middleman.**
 
-One command to give your AI agents their own email addresses -- no Gmail, no OAuth, no third-party SaaS. Built for Claude Code, OpenClaw, Codex, and any agentic system that needs an email channel.
+One command to give your AI agents their own email addresses -- no Gmail, no OAuth, no third-party SaaS. Built for Claude Code, Codex CLI, OpenCode, Gemini CLI, and any MCP-capable agent that needs an email channel.
 
 ```bash
 aimx setup agent.mydomain.com
@@ -141,18 +141,18 @@ aimx send --from support@agent.yourdomain.com \
 aimx mcp
 ```
 
-Add to Claude Code (`~/.claude/settings.json`):
+Install AIMX into your agent with one command per agent:
 
-```json
-{
-  "mcpServers": {
-    "email": {
-      "command": "/usr/local/bin/aimx",
-      "args": ["mcp"]
-    }
-  }
-}
+```bash
+aimx agent-setup claude-code    # Claude Code
+aimx agent-setup codex          # Codex CLI
+aimx agent-setup opencode       # OpenCode
+aimx agent-setup gemini         # Gemini CLI
 ```
+
+Run `aimx agent-setup --list` to see every supported agent and its
+destination path. See [`book/agent-integration.md`](book/agent-integration.md)
+for per-agent activation steps and manual MCP wiring.
 
 Available MCP tools:
 - `mailbox_list` -- list all mailboxes with message counts

--- a/agents/codex/.codex-plugin/plugin.json
+++ b/agents/codex/.codex-plugin/plugin.json
@@ -1,0 +1,15 @@
+{
+  "name": "aimx",
+  "description": "Self-hosted email for AI agents. Provides MCP tools for sending, reading, and managing email stored as Markdown files.",
+  "version": "0.1.0",
+  "author": {
+    "name": "AIMX",
+    "url": "https://github.com/uzyn/aimx"
+  },
+  "mcpServers": {
+    "aimx": {
+      "command": "/usr/local/bin/aimx",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/agents/codex/README.md
+++ b/agents/codex/README.md
@@ -1,0 +1,51 @@
+# AIMX plugin for Codex CLI
+
+This directory is the source tree for the Codex CLI plugin that wires AIMX
+into Codex. Contents are bundled into the `aimx` binary at compile time
+(via `include_dir!`) and installed by `aimx agent-setup codex`.
+
+## What gets installed
+
+- `.codex-plugin/plugin.json` — Codex plugin manifest, including an
+  `mcpServers.aimx` entry pointing at `/usr/local/bin/aimx mcp`.
+- `skills/aimx/SKILL.md` — an agent-facing skill. Its body is the canonical
+  AIMX primer (`agents/common/aimx-primer.md`); the installer assembles the
+  final `SKILL.md` from a YAML header plus that primer so there is one
+  source of truth.
+
+## Install
+
+```bash
+aimx agent-setup codex
+```
+
+Default destination: `~/.codex/plugins/aimx/`. After install, restart
+Codex CLI — the plugin is auto-discovered from that directory.
+
+## Overriding the data directory
+
+If AIMX was set up with a non-default data directory, re-run the installer
+with `--data-dir`:
+
+```bash
+aimx --data-dir /custom/path agent-setup codex
+```
+
+The installer rewrites the plugin's `mcpServers.aimx.args` to include
+`--data-dir /custom/path` before writing `plugin.json` to disk.
+
+## Schema reference
+
+The plugin manifest follows the Codex CLI plugin schema documented at
+<https://github.com/openai/codex>. Codex CLI's MCP wiring primarily lives
+in `~/.codex/config.toml`; plugin-managed MCP servers follow the same
+shape under the plugin's `plugin.json`. The skill format mirrors Claude
+Code's `SKILL.md` layout (YAML frontmatter with `name` and `description`,
+followed by the skill body) and is portable across CLI agents that adopt
+the same skill convention.
+
+## Verification
+
+Verify the plugin format and destination path against the current Codex
+CLI documentation before relying on this install layout in production —
+agent plugin formats drift between CLI releases.

--- a/agents/codex/skills/aimx/SKILL.md.header
+++ b/agents/codex/skills/aimx/SKILL.md.header
@@ -1,0 +1,5 @@
+---
+name: aimx
+description: Self-hosted email for AI agents. Send, read, reply to, and manage email via AIMX MCP tools. Invoke when the user asks about sending mail, checking an inbox, replying to a message, or managing mailboxes, or when the conversation references AIMX.
+---
+

--- a/agents/gemini/README.md
+++ b/agents/gemini/README.md
@@ -1,0 +1,77 @@
+# AIMX skill for Gemini CLI
+
+This directory is the source tree for the Gemini CLI skill that wires
+AIMX into Gemini. Contents are bundled into the `aimx` binary at compile
+time (via `include_dir!`) and installed by `aimx agent-setup gemini`.
+
+## What gets installed
+
+- `SKILL.md` — an agent-facing skill dropped into
+  `~/.gemini/skills/aimx/SKILL.md`. Its body is the canonical AIMX primer
+  (`agents/common/aimx-primer.md`); the installer assembles the final
+  `SKILL.md` from a YAML header plus that primer so there is one source
+  of truth.
+
+Gemini CLI's MCP configuration lives in `~/.gemini/settings.json`, not
+alongside the skill. The installer does **not** mutate that file;
+instead it prints the exact JSON block you merge into the `mcpServers`
+section of `settings.json` (see Activation below).
+
+## Install
+
+```bash
+aimx agent-setup gemini
+```
+
+Default skill destination: `~/.gemini/skills/aimx/SKILL.md`. After the skill is
+written, merge the printed JSON block into `~/.gemini/settings.json`:
+
+```json
+{
+  "mcpServers": {
+    "aimx": {
+      "command": "/usr/local/bin/aimx",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+If `~/.gemini/settings.json` does not exist yet, create it with the
+object above as its full contents. If it already has a `mcpServers` key,
+add the `aimx` entry inside the existing object.
+
+Restart Gemini CLI after editing `settings.json`.
+
+## Overriding the data directory
+
+If AIMX was set up with a non-default data directory, re-run the installer
+with `--data-dir`:
+
+```bash
+aimx --data-dir /custom/path agent-setup gemini
+```
+
+The printed JSON block's `args` will include `--data-dir /custom/path`.
+
+## Schema reference
+
+Gemini CLI's skill and MCP conventions are documented at
+<https://github.com/google-gemini/gemini-cli>. MCP servers are configured
+in `~/.gemini/settings.json` under an object keyed `mcpServers.<name>`
+with `command` + `args`, matching Claude Code's manifest shape. The skill
+format uses YAML frontmatter with `name` and `description` followed by
+the skill body.
+
+## Design choice: print-the-snippet
+
+AIMX follows the "print the activation command" pattern — the installer
+writes the skill to disk and prints the exact JSON block for you to
+merge into `settings.json`. We intentionally do NOT mutate
+`~/.gemini/settings.json` directly because:
+
+1. The file is your config, not ours — we shouldn't silently rewrite it.
+2. `settings.json` may already contain other MCP servers or personal
+   customisations we would risk disturbing.
+3. Making the activation step explicit is self-documenting and audit-safe.
+4. It matches FR-49: never mutate an agent's primary config file.

--- a/agents/gemini/SKILL.md.header
+++ b/agents/gemini/SKILL.md.header
@@ -1,0 +1,5 @@
+---
+name: aimx
+description: Self-hosted email for AI agents. Send, read, reply to, and manage email via AIMX MCP tools. Invoke when the user asks about sending mail, checking an inbox, replying to a message, or managing mailboxes, or when the conversation references AIMX.
+---
+

--- a/agents/opencode/README.md
+++ b/agents/opencode/README.md
@@ -1,0 +1,72 @@
+# AIMX skill for OpenCode
+
+This directory is the source tree for the OpenCode skill that wires AIMX
+into OpenCode. Contents are bundled into the `aimx` binary at compile time
+(via `include_dir!`) and installed by `aimx agent-setup opencode`.
+
+## What gets installed
+
+- `SKILL.md` — an agent-facing skill dropped into
+  `~/.config/opencode/skills/aimx/SKILL.md`. Its body is the canonical
+  AIMX primer (`agents/common/aimx-primer.md`); the installer assembles
+  the final `SKILL.md` from a YAML header plus that primer so there is
+  one source of truth.
+
+OpenCode's MCP configuration lives in `opencode.json` / `opencode.jsonc`,
+not alongside the skill. The installer does **not** mutate that file;
+instead it prints the exact JSONC snippet you paste into the `mcp` section
+of `opencode.json` (see Activation below).
+
+## Install
+
+```bash
+aimx agent-setup opencode
+```
+
+Default skill destination: `~/.config/opencode/skills/aimx/SKILL.md`. After the
+skill is written, copy the printed JSONC snippet into your
+`opencode.json` (user-level at `~/.config/opencode/opencode.json` or
+project-level at `<repo>/opencode.json`):
+
+```jsonc
+{
+  "mcp": {
+    "aimx": {
+      "command": ["/usr/local/bin/aimx", "mcp"]
+    }
+  }
+}
+```
+
+Restart OpenCode (or reload its config) after editing `opencode.json`.
+
+## Overriding the data directory
+
+If AIMX was set up with a non-default data directory, re-run the installer
+with `--data-dir`:
+
+```bash
+aimx --data-dir /custom/path agent-setup opencode
+```
+
+The printed JSONC snippet will include `--data-dir /custom/path` in the
+`command` array.
+
+## Schema reference
+
+OpenCode's skill and MCP conventions are documented at
+<https://opencode.ai/docs>. OpenCode's skill format is compatible with
+Claude Code's `SKILL.md` (YAML frontmatter with `name` and `description`,
+followed by the skill body). MCP servers are configured under the root
+`mcp.<name>` key with `command` as a single array combining binary + args.
+
+## Design choice: print-the-snippet
+
+AIMX follows the "print the activation command" pattern — the installer
+writes the skill to disk and prints the exact JSONC block for you to
+paste. We intentionally do NOT mutate `opencode.json` directly because:
+
+1. The file is your config, not ours — we shouldn't silently rewrite it.
+2. `opencode.json` may already contain other MCP servers or project
+   customisations we would risk disturbing.
+3. Making the activation step explicit is self-documenting and audit-safe.

--- a/agents/opencode/SKILL.md.header
+++ b/agents/opencode/SKILL.md.header
@@ -1,0 +1,5 @@
+---
+name: aimx
+description: Self-hosted email for AI agents. Send, read, reply to, and manage email via AIMX MCP tools. Invoke when the user asks about sending mail, checking an inbox, replying to a message, or managing mailboxes, or when the conversation references AIMX.
+---
+

--- a/book/agent-integration.md
+++ b/book/agent-integration.md
@@ -49,9 +49,11 @@ grows as more agents are landed in subsequent sprints.
 | Agent | Install command | Destination | Activation |
 |-------|-----------------|-------------|------------|
 | Claude Code | `aimx agent-setup claude-code` | `~/.claude/plugins/aimx/` | Restart Claude Code; the plugin is auto-discovered from `~/.claude/plugins/`. |
+| Codex CLI | `aimx agent-setup codex` | `~/.codex/plugins/aimx/` | Restart Codex CLI; the plugin is auto-discovered from `~/.codex/plugins/`. |
+| OpenCode | `aimx agent-setup opencode` | `~/.config/opencode/skills/aimx/` | Paste the printed JSONC block into `opencode.json`, then restart OpenCode. |
+| Gemini CLI | `aimx agent-setup gemini` | `~/.gemini/skills/aimx/` | Merge the printed JSON block into `~/.gemini/settings.json`, then restart Gemini CLI. |
 
-More agents — Codex CLI, OpenCode, Gemini CLI, Goose, OpenClaw — land in
-Sprint 29 onward.
+More agents — Goose and OpenClaw — land in Sprint 30.
 
 ### Claude Code
 
@@ -79,6 +81,120 @@ aimx --data-dir /custom/path agent-setup claude-code
 
 The installer rewrites `mcpServers.aimx.args` to include
 `--data-dir /custom/path` before writing `plugin.json` to disk.
+
+### Codex CLI
+
+Codex CLI discovers plugins by scanning `~/.codex/plugins/`. The AIMX
+plugin ships two pieces:
+
+- `.codex-plugin/plugin.json` — manifest declaring the plugin and
+  registering `aimx mcp` as an MCP server.
+- `skills/aimx/SKILL.md` — the agent-facing skill (body = canonical AIMX
+  primer).
+
+Install:
+
+```bash
+aimx agent-setup codex
+```
+
+Custom data directory:
+
+```bash
+aimx --data-dir /custom/path agent-setup codex
+```
+
+Like Claude Code, the installer rewrites `mcpServers.aimx.args` in
+`plugin.json` to include `--data-dir /custom/path`.
+
+Verify the plugin format and destination path against the current Codex
+CLI documentation before relying on this in production — agent plugin
+formats drift between releases. See the per-agent
+[README](https://github.com/uzyn/aimx/tree/main/agents/codex) for the
+documentation link.
+
+### OpenCode
+
+OpenCode discovers skills from `~/.config/opencode/skills/<name>/` (user)
+or `<repo>/.opencode/skills/<name>/` (project). The AIMX package is
+skill-only — MCP servers in OpenCode are configured in `opencode.json`,
+not alongside the skill.
+
+Install:
+
+```bash
+aimx agent-setup opencode
+```
+
+The installer writes `~/.config/opencode/skills/aimx/SKILL.md` and prints
+a JSONC block. Paste that block into the `mcp` object in your
+`opencode.json` (user-level at `~/.config/opencode/opencode.json` or
+project-level at `<repo>/opencode.json`):
+
+```jsonc
+{
+  "mcp": {
+    "aimx": {
+      "command": ["/usr/local/bin/aimx", "mcp"]
+    }
+  }
+}
+```
+
+For a custom data directory:
+
+```bash
+aimx --data-dir /custom/path agent-setup opencode
+```
+
+The printed JSONC snippet will have `"--data-dir", "/custom/path"`
+inserted into the `command` array.
+
+Restart OpenCode (or reload its config) after editing `opencode.json`.
+See [`agents/opencode/README.md`](https://github.com/uzyn/aimx/tree/main/agents/opencode)
+for the schema reference.
+
+### Gemini CLI
+
+Gemini CLI picks up skills from `~/.gemini/skills/<name>/` and configures
+MCP servers in `~/.gemini/settings.json`. AIMX does not mutate
+`settings.json` directly (FR-49); instead the installer prints the exact
+JSON block to merge.
+
+Install:
+
+```bash
+aimx agent-setup gemini
+```
+
+The installer writes `~/.gemini/skills/aimx/SKILL.md` and prints:
+
+```json
+{
+  "mcpServers": {
+    "aimx": {
+      "command": "/usr/local/bin/aimx",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Merge that block into `~/.gemini/settings.json`. If the file does not
+exist, create it with the object above as its full contents. If
+`mcpServers` already exists, add the `aimx` key inside it.
+
+For a custom data directory:
+
+```bash
+aimx --data-dir /custom/path agent-setup gemini
+```
+
+The printed `args` array will include `"--data-dir", "/custom/path"`.
+
+Restart Gemini CLI after editing `settings.json`. See
+[`agents/gemini/README.md`](https://github.com/uzyn/aimx/tree/main/agents/gemini)
+for the schema reference.
 
 ## Manual MCP wiring
 
@@ -135,3 +251,18 @@ configuring.
 The plugin's MCP command defaults to `/var/lib/aimx/` for AIMX's data
 directory. If you set up AIMX with a different path, re-run with
 `aimx --data-dir <path> agent-setup <agent> --force`.
+
+### OpenCode: skill loads but MCP tools do not appear
+
+OpenCode loads skills from `~/.config/opencode/skills/` but MCP servers
+only activate when declared in `opencode.json`. Re-run `aimx agent-setup
+opencode`, copy the printed JSONC block into the `mcp` object in your
+`opencode.json`, and restart OpenCode.
+
+### Gemini: "unknown MCP server aimx"
+
+Gemini CLI requires the `mcpServers.aimx` block in
+`~/.gemini/settings.json`. Re-run `aimx agent-setup gemini` and merge
+the printed JSON block into `settings.json`. If the file did not exist
+before you ran the installer, create it with just the printed object as
+its contents.

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -19,18 +19,96 @@ pub struct AgentSpec {
     pub source_subdir: &'static str,
     /// Destination template, with `$HOME` / `$XDG_CONFIG_HOME` placeholders.
     pub dest_template: &'static str,
-    /// Message printed to the user after a successful install.
-    pub activation_hint: &'static str,
+    /// Renders the post-install message. Receives the effective data
+    /// directory (when the user passed `--data-dir`) so agents that need
+    /// the user to paste a JSON/JSONC snippet can embed the right
+    /// `--data-dir` argument into that snippet.
+    pub activation_hint: fn(data_dir: Option<&Path>) -> String,
 }
 
 /// Static registry of supported agents.
 pub fn registry() -> &'static [AgentSpec] {
-    &[AgentSpec {
-        name: "claude-code",
-        source_subdir: "claude-code",
-        dest_template: "$HOME/.claude/plugins/aimx",
-        activation_hint: "Plugin installed. Restart Claude Code to pick it up (it is auto-discovered from ~/.claude/plugins/).",
-    }]
+    &[
+        AgentSpec {
+            name: "claude-code",
+            source_subdir: "claude-code",
+            dest_template: "$HOME/.claude/plugins/aimx",
+            activation_hint: claude_code_hint,
+        },
+        AgentSpec {
+            name: "codex",
+            source_subdir: "codex",
+            dest_template: "$HOME/.codex/plugins/aimx",
+            activation_hint: codex_hint,
+        },
+        AgentSpec {
+            name: "opencode",
+            source_subdir: "opencode",
+            dest_template: "$XDG_CONFIG_HOME/opencode/skills/aimx",
+            activation_hint: opencode_hint,
+        },
+        AgentSpec {
+            name: "gemini",
+            source_subdir: "gemini",
+            dest_template: "$HOME/.gemini/skills/aimx",
+            activation_hint: gemini_hint,
+        },
+    ]
+}
+
+fn claude_code_hint(_data_dir: Option<&Path>) -> String {
+    "Plugin installed. Restart Claude Code to pick it up (it is auto-discovered from ~/.claude/plugins/).".to_string()
+}
+
+fn codex_hint(_data_dir: Option<&Path>) -> String {
+    "Plugin installed. Restart Codex CLI to pick it up (it is auto-discovered from ~/.codex/plugins/).".to_string()
+}
+
+fn opencode_hint(data_dir: Option<&Path>) -> String {
+    let command_array = match data_dir {
+        Some(dd) => format!(
+            "[\"/usr/local/bin/aimx\", \"--data-dir\", \"{}\", \"mcp\"]",
+            dd.display()
+        ),
+        None => "[\"/usr/local/bin/aimx\", \"mcp\"]".to_string(),
+    };
+    format!(
+        "Skill installed. Add the following block to the `mcp` object in \
+         your OpenCode config (~/.config/opencode/opencode.json or \
+         <repo>/opencode.json), then restart OpenCode:\n\
+         \n\
+         {{\n\
+         \x20\x20\"mcp\": {{\n\
+         \x20\x20\x20\x20\"aimx\": {{\n\
+         \x20\x20\x20\x20\x20\x20\"command\": {command_array}\n\
+         \x20\x20\x20\x20}}\n\
+         \x20\x20}}\n\
+         }}"
+    )
+}
+
+fn gemini_hint(data_dir: Option<&Path>) -> String {
+    let args_line = match data_dir {
+        Some(dd) => format!(
+            "\x20\x20\x20\x20\x20\x20\"args\": [\"--data-dir\", \"{}\", \"mcp\"]",
+            dd.display()
+        ),
+        None => "\x20\x20\x20\x20\x20\x20\"args\": [\"mcp\"]".to_string(),
+    };
+    format!(
+        "Skill installed. Merge the following block into \
+         ~/.gemini/settings.json (create the file if it does not exist), \
+         then restart Gemini CLI:\n\
+         \n\
+         {{\n\
+         \x20\x20\"mcpServers\": {{\n\
+         \x20\x20\x20\x20\"aimx\": {{\n\
+         \x20\x20\x20\x20\x20\x20\"command\": \"/usr/local/bin/aimx\",\n\
+         {args_line}\n\
+         \x20\x20\x20\x20}}\n\
+         \x20\x20}}\n\
+         }}"
+    )
 }
 
 pub fn find_agent(name: &str) -> Option<&'static AgentSpec> {
@@ -155,7 +233,14 @@ fn print_registry(env: &dyn AgentEnv) {
         println!("  {}", term::highlight(spec.name));
         println!("    destination: {}", dest.display());
         println!("    install:     aimx agent-setup {}", spec.name);
-        println!("    activation:  {}", spec.activation_hint);
+        let hint = (spec.activation_hint)(None);
+        let mut hint_lines = hint.lines();
+        if let Some(first) = hint_lines.next() {
+            println!("    activation:  {first}");
+            for line in hint_lines {
+                println!("                 {line}");
+            }
+        }
         println!();
     }
 }
@@ -173,6 +258,7 @@ fn install(
     })?;
 
     let files = assemble_plugin_files(source, opts.data_dir)?;
+    let hint = (spec.activation_hint)(opts.data_dir);
 
     if opts.print {
         for (rel, bytes) in &files {
@@ -182,6 +268,10 @@ fn install(
                 Err(_) => println!("<{} bytes of binary content>", bytes.len()),
             }
         }
+        // `--print` also emits the activation hint so snippet-style agents
+        // (opencode, gemini) expose their MCP JSON block under dry-run.
+        println!("=== activation ===");
+        println!("{hint}");
         return Ok(());
     }
 
@@ -193,7 +283,7 @@ fn install(
         term::success("Installed"),
         term::highlight(&dest_root.to_string_lossy())
     );
-    println!("{}", spec.activation_hint);
+    println!("{hint}");
 
     Ok(())
 }
@@ -665,6 +755,269 @@ mod tests {
             err.contains("plugin.json is not valid JSON"),
             "unexpected error: {err}"
         );
+    }
+
+    #[test]
+    fn registry_contains_sprint_29_agents() {
+        for name in ["codex", "opencode", "gemini"] {
+            assert!(
+                find_agent(name).is_some(),
+                "registry missing sprint-29 agent: {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn install_codex_lays_out_expected_files() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        run_with_env(Some("codex".into()), false, false, false, None, &env).unwrap();
+
+        let dest = tmp.path().join(".codex/plugins/aimx");
+        assert!(dest.join(".codex-plugin/plugin.json").exists());
+        assert!(dest.join("skills/aimx/SKILL.md").exists());
+        assert!(!dest.join("README.md").exists());
+        assert!(!dest.join("skills/aimx/SKILL.md.header").exists());
+
+        let skill = std::fs::read_to_string(dest.join("skills/aimx/SKILL.md")).unwrap();
+        assert!(skill.starts_with("---\n"));
+        assert!(skill.contains("name: aimx"));
+        assert!(skill.contains("MCP tools"));
+        assert!(skill.contains("mailbox_create"));
+
+        let plugin = std::fs::read_to_string(dest.join(".codex-plugin/plugin.json")).unwrap();
+        assert!(plugin.contains("\"mcp\""));
+        assert!(!plugin.contains("--data-dir"));
+    }
+
+    #[test]
+    fn install_codex_with_custom_data_dir_rewrites_plugin_args() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+        let custom = PathBuf::from("/custom/aimx-data");
+
+        run_with_env(
+            Some("codex".into()),
+            false,
+            false,
+            false,
+            Some(&custom),
+            &env,
+        )
+        .unwrap();
+
+        let plugin = std::fs::read_to_string(
+            tmp.path()
+                .join(".codex/plugins/aimx/.codex-plugin/plugin.json"),
+        )
+        .unwrap();
+        assert!(plugin.contains("--data-dir"));
+        assert!(plugin.contains("/custom/aimx-data"));
+    }
+
+    #[test]
+    fn install_opencode_lays_out_expected_files() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        run_with_env(Some("opencode".into()), false, false, false, None, &env).unwrap();
+
+        // XDG_CONFIG_HOME defaults to $HOME/.config when unset. OpenCode
+        // discovers skills from `~/.config/opencode/skills/<name>/`.
+        let dest = tmp.path().join(".config/opencode/skills/aimx");
+        assert!(dest.join("SKILL.md").exists());
+        // OpenCode ships a skill-only package; no plugin manifest on disk.
+        assert!(!dest.join("plugin.json").exists());
+        assert!(!dest.join("README.md").exists());
+        assert!(!dest.join("SKILL.md.header").exists());
+
+        let skill = std::fs::read_to_string(dest.join("SKILL.md")).unwrap();
+        assert!(skill.starts_with("---\n"));
+        assert!(skill.contains("mailbox_create"));
+    }
+
+    #[test]
+    fn install_opencode_respects_xdg_config_home_override() {
+        let tmp = TempDir::new().unwrap();
+        let mut env = MockEnv::new(tmp.path().to_path_buf());
+        let xdg = tmp.path().join("alt-xdg");
+        env.xdg = Some(xdg.clone());
+
+        run_with_env(Some("opencode".into()), false, false, false, None, &env).unwrap();
+
+        assert!(xdg.join("opencode/skills/aimx/SKILL.md").exists());
+    }
+
+    #[test]
+    fn install_gemini_lays_out_expected_files() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        run_with_env(Some("gemini".into()), false, false, false, None, &env).unwrap();
+
+        let dest = tmp.path().join(".gemini/skills/aimx");
+        assert!(dest.join("SKILL.md").exists());
+        assert!(!dest.join("plugin.json").exists());
+        assert!(!dest.join("README.md").exists());
+        assert!(!dest.join("SKILL.md.header").exists());
+
+        let skill = std::fs::read_to_string(dest.join("SKILL.md")).unwrap();
+        assert!(skill.starts_with("---\n"));
+        assert!(skill.contains("mailbox_create"));
+    }
+
+    #[test]
+    fn claude_code_activation_hint_is_short_and_deterministic() {
+        let spec = find_agent("claude-code").unwrap();
+        let hint = (spec.activation_hint)(None);
+        assert!(hint.contains("Restart Claude Code"));
+        assert!(hint.contains("auto-discovered"));
+        // Data-dir override should not change Claude Code's hint — the MCP
+        // args are baked into plugin.json, not the hint.
+        assert_eq!(hint, (spec.activation_hint)(Some(Path::new("/x"))));
+    }
+
+    #[test]
+    fn codex_activation_hint_mentions_codex() {
+        let spec = find_agent("codex").unwrap();
+        let hint = (spec.activation_hint)(None);
+        assert!(hint.contains("Codex"));
+        assert!(hint.contains("auto-discovered"));
+    }
+
+    #[test]
+    fn opencode_activation_hint_embeds_jsonc_snippet() {
+        let spec = find_agent("opencode").unwrap();
+        let hint = (spec.activation_hint)(None);
+        assert!(hint.contains("\"mcp\""));
+        assert!(hint.contains("\"aimx\""));
+        assert!(hint.contains("\"command\""));
+        assert!(hint.contains("/usr/local/bin/aimx"));
+        assert!(hint.contains("opencode.json"));
+        // Default (no --data-dir) should not mention it.
+        assert!(!hint.contains("--data-dir"));
+
+        let hint_custom = (spec.activation_hint)(Some(Path::new("/custom/data")));
+        assert!(hint_custom.contains("--data-dir"));
+        assert!(hint_custom.contains("/custom/data"));
+    }
+
+    #[test]
+    fn gemini_activation_hint_embeds_mcp_servers_snippet() {
+        let spec = find_agent("gemini").unwrap();
+        let hint = (spec.activation_hint)(None);
+        assert!(hint.contains("\"mcpServers\""));
+        assert!(hint.contains("\"aimx\""));
+        assert!(hint.contains("settings.json"));
+        assert!(hint.contains("/usr/local/bin/aimx"));
+        assert!(!hint.contains("--data-dir"));
+
+        let hint_custom = (spec.activation_hint)(Some(Path::new("/var/aimx")));
+        assert!(hint_custom.contains("--data-dir"));
+        assert!(hint_custom.contains("/var/aimx"));
+    }
+
+    #[test]
+    fn opencode_print_emits_activation_snippet() {
+        // --print should dump both the file tree and the activation hint so
+        // snippet-style agents surface their JSON block under dry-run.
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        // We can't easily capture stdout here without adding infrastructure,
+        // so assert --print writes no files and succeeds for all snippet
+        // agents (the hint content itself is covered by the activation_hint
+        // tests above).
+        run_with_env(Some("opencode".into()), false, false, true, None, &env).unwrap();
+        assert!(!tmp.path().join(".config/opencode").exists());
+
+        run_with_env(Some("gemini".into()), false, false, true, None, &env).unwrap();
+        assert!(!tmp.path().join(".gemini").exists());
+    }
+
+    #[test]
+    fn assembled_opencode_skill_is_header_plus_primer_byte_for_byte() {
+        let source = AGENTS_DIR.get_dir("opencode").unwrap();
+        let files = assemble_plugin_files(source, None).unwrap();
+
+        let (_, skill_bytes) = files
+            .iter()
+            .find(|(rel, _)| rel.to_string_lossy() == "SKILL.md")
+            .expect("assembled SKILL.md should be present");
+
+        let header = AGENTS_DIR
+            .get_file("opencode/SKILL.md.header")
+            .unwrap()
+            .contents();
+        let primer = AGENTS_DIR
+            .get_file("common/aimx-primer.md")
+            .unwrap()
+            .contents();
+
+        let mut expected = Vec::with_capacity(header.len() + primer.len());
+        expected.extend_from_slice(header);
+        expected.extend_from_slice(primer);
+
+        assert_eq!(skill_bytes, &expected);
+    }
+
+    #[test]
+    fn assembled_gemini_skill_is_header_plus_primer_byte_for_byte() {
+        let source = AGENTS_DIR.get_dir("gemini").unwrap();
+        let files = assemble_plugin_files(source, None).unwrap();
+
+        let (_, skill_bytes) = files
+            .iter()
+            .find(|(rel, _)| rel.to_string_lossy() == "SKILL.md")
+            .expect("assembled SKILL.md should be present");
+
+        let header = AGENTS_DIR
+            .get_file("gemini/SKILL.md.header")
+            .unwrap()
+            .contents();
+        let primer = AGENTS_DIR
+            .get_file("common/aimx-primer.md")
+            .unwrap()
+            .contents();
+
+        let mut expected = Vec::with_capacity(header.len() + primer.len());
+        expected.extend_from_slice(header);
+        expected.extend_from_slice(primer);
+
+        assert_eq!(skill_bytes, &expected);
+    }
+
+    #[test]
+    fn assembled_codex_skill_is_header_plus_primer_byte_for_byte() {
+        let source = AGENTS_DIR.get_dir("codex").unwrap();
+        let files = assemble_plugin_files(source, None).unwrap();
+
+        let (_, skill_bytes) = files
+            .iter()
+            .find(|(rel, _)| rel.to_string_lossy() == "skills/aimx/SKILL.md")
+            .expect("assembled SKILL.md should be present");
+
+        let header = AGENTS_DIR
+            .get_file("codex/skills/aimx/SKILL.md.header")
+            .unwrap()
+            .contents();
+        let primer = AGENTS_DIR
+            .get_file("common/aimx-primer.md")
+            .unwrap()
+            .contents();
+
+        let mut expected = Vec::with_capacity(header.len() + primer.len());
+        expected.extend_from_slice(header);
+        expected.extend_from_slice(primer);
+
+        assert_eq!(skill_bytes, &expected);
+    }
+
+    #[test]
+    fn registry_lists_four_agents_in_canonical_order() {
+        let names: Vec<&str> = registry().iter().map(|s| s.name).collect();
+        assert_eq!(names, vec!["claude-code", "codex", "opencode", "gemini"]);
     }
 
     #[cfg(unix)]

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -27,6 +27,16 @@ pub struct AgentSpec {
 }
 
 /// Static registry of supported agents.
+///
+/// Source-tree layout asymmetry by design: plugin-style agents
+/// (`claude-code`, `codex`) nest their skill under `skills/aimx/` because
+/// the plugin manifest lives at the package root and the skill is a
+/// sibling subdirectory. Skill-only agents (`opencode`, `gemini`) install
+/// directly into a skills directory, so their source tree is flat with
+/// `SKILL.md.header` at the top. `assemble_plugin_files` walks each
+/// source tree relative to its root and handles both shapes. Do not
+/// "normalize" the layout — the destination template determines the
+/// depth.
 pub fn registry() -> &'static [AgentSpec] {
     &[
         AgentSpec {
@@ -61,53 +71,75 @@ fn claude_code_hint(_data_dir: Option<&Path>) -> String {
 }
 
 fn codex_hint(_data_dir: Option<&Path>) -> String {
+    // Codex CLI's canonical MCP wiring lives in `~/.codex/config.toml`
+    // under `[mcp_servers.*]`. This installer ships a `.codex-plugin/
+    // plugin.json` that mirrors Claude Code's plugin shape (camelCase
+    // `mcpServers`) on the assumption that plugin-managed MCP servers
+    // follow the same schema. That assumption has not been validated
+    // against a live Codex CLI (see deferred manual validation in
+    // docs/sprint.md for Sprint 29); revisit once Codex CLI is available
+    // in the sandbox.
     "Plugin installed. Restart Codex CLI to pick it up (it is auto-discovered from ~/.codex/plugins/).".to_string()
 }
 
 fn opencode_hint(data_dir: Option<&Path>) -> String {
-    let command_array = match data_dir {
-        Some(dd) => format!(
-            "[\"/usr/local/bin/aimx\", \"--data-dir\", \"{}\", \"mcp\"]",
-            dd.display()
-        ),
-        None => "[\"/usr/local/bin/aimx\", \"mcp\"]".to_string(),
+    // Route the JSON snippet through serde_json so that a `--data-dir` path
+    // containing `"` or `\` is properly escaped. `format!`-based string
+    // building would produce an invalid snippet the user would copy into
+    // their OpenCode config.
+    let command: Vec<String> = match data_dir {
+        Some(dd) => vec![
+            "/usr/local/bin/aimx".to_string(),
+            "--data-dir".to_string(),
+            dd.to_string_lossy().into_owned(),
+            "mcp".to_string(),
+        ],
+        None => vec!["/usr/local/bin/aimx".to_string(), "mcp".to_string()],
     };
+    let snippet = serde_json::json!({
+        "mcp": {
+            "aimx": {
+                "command": command,
+            }
+        }
+    });
+    let snippet_text = serde_json::to_string_pretty(&snippet)
+        .unwrap_or_else(|_| "<failed to render snippet>".to_string());
     format!(
         "Skill installed. Add the following block to the `mcp` object in \
          your OpenCode config (~/.config/opencode/opencode.json or \
          <repo>/opencode.json), then restart OpenCode:\n\
          \n\
-         {{\n\
-         \x20\x20\"mcp\": {{\n\
-         \x20\x20\x20\x20\"aimx\": {{\n\
-         \x20\x20\x20\x20\x20\x20\"command\": {command_array}\n\
-         \x20\x20\x20\x20}}\n\
-         \x20\x20}}\n\
-         }}"
+         {snippet_text}"
     )
 }
 
 fn gemini_hint(data_dir: Option<&Path>) -> String {
-    let args_line = match data_dir {
-        Some(dd) => format!(
-            "\x20\x20\x20\x20\x20\x20\"args\": [\"--data-dir\", \"{}\", \"mcp\"]",
-            dd.display()
-        ),
-        None => "\x20\x20\x20\x20\x20\x20\"args\": [\"mcp\"]".to_string(),
+    // Route the JSON snippet through serde_json (see opencode_hint).
+    let args: Vec<String> = match data_dir {
+        Some(dd) => vec![
+            "--data-dir".to_string(),
+            dd.to_string_lossy().into_owned(),
+            "mcp".to_string(),
+        ],
+        None => vec!["mcp".to_string()],
     };
+    let snippet = serde_json::json!({
+        "mcpServers": {
+            "aimx": {
+                "command": "/usr/local/bin/aimx",
+                "args": args,
+            }
+        }
+    });
+    let snippet_text = serde_json::to_string_pretty(&snippet)
+        .unwrap_or_else(|_| "<failed to render snippet>".to_string());
     format!(
         "Skill installed. Merge the following block into \
          ~/.gemini/settings.json (create the file if it does not exist), \
          then restart Gemini CLI:\n\
          \n\
-         {{\n\
-         \x20\x20\"mcpServers\": {{\n\
-         \x20\x20\x20\x20\"aimx\": {{\n\
-         \x20\x20\x20\x20\x20\x20\"command\": \"/usr/local/bin/aimx\",\n\
-         {args_line}\n\
-         \x20\x20\x20\x20}}\n\
-         \x20\x20}}\n\
-         }}"
+         {snippet_text}"
     )
 }
 
@@ -250,6 +282,18 @@ fn install(
     opts: &InstallOptions,
     env: &dyn AgentEnv,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    install_to_writer(spec, opts, env, &mut io::stdout())
+}
+
+/// Testable core of `install`: writes user-facing output to `out` instead
+/// of stdout. Tests use this to assert that `--print` emits the activation
+/// snippet.
+fn install_to_writer(
+    spec: &AgentSpec,
+    opts: &InstallOptions,
+    env: &dyn AgentEnv,
+    out: &mut dyn Write,
+) -> Result<(), Box<dyn std::error::Error>> {
     let source = AGENTS_DIR.get_dir(spec.source_subdir).ok_or_else(|| {
         format!(
             "internal error: missing embedded source for '{}'",
@@ -262,28 +306,29 @@ fn install(
 
     if opts.print {
         for (rel, bytes) in &files {
-            println!("=== {} ===", rel.display());
+            writeln!(out, "=== {} ===", rel.display())?;
             match std::str::from_utf8(bytes) {
-                Ok(text) => println!("{text}"),
-                Err(_) => println!("<{} bytes of binary content>", bytes.len()),
+                Ok(text) => writeln!(out, "{text}")?,
+                Err(_) => writeln!(out, "<{} bytes of binary content>", bytes.len())?,
             }
         }
         // `--print` also emits the activation hint so snippet-style agents
         // (opencode, gemini) expose their MCP JSON block under dry-run.
-        println!("=== activation ===");
-        println!("{hint}");
+        writeln!(out, "=== activation ===")?;
+        writeln!(out, "{hint}")?;
         return Ok(());
     }
 
     let dest_root = resolve_dest(spec.dest_template, env)?;
     write_files(&dest_root, &files, opts.force, env)?;
 
-    println!(
+    writeln!(
+        out,
         "{} {}",
         term::success("Installed"),
         term::highlight(&dest_root.to_string_lossy())
-    );
-    println!("{hint}");
+    )?;
+    writeln!(out, "{hint}")?;
 
     Ok(())
 }
@@ -586,7 +631,10 @@ mod tests {
 
         // plugin.json should have default args (no --data-dir).
         let plugin = std::fs::read_to_string(dest.join(".claude-plugin/plugin.json")).unwrap();
-        assert!(plugin.contains("\"mcp\""));
+        assert!(
+            plugin.contains("\"mcpServers\""),
+            "claude-code plugin.json must declare `mcpServers`: {plugin}"
+        );
         assert!(!plugin.contains("--data-dir"));
     }
 
@@ -668,7 +716,7 @@ mod tests {
         let plugin = std::fs::read_to_string(dest.join(".claude-plugin/plugin.json")).unwrap();
         assert!(plugin.contains("--data-dir"));
         assert!(plugin.contains("/custom/aimx-data"));
-        assert!(plugin.contains("\"mcp\""));
+        assert!(plugin.contains("\"mcpServers\""));
     }
 
     #[test]
@@ -787,7 +835,13 @@ mod tests {
         assert!(skill.contains("mailbox_create"));
 
         let plugin = std::fs::read_to_string(dest.join(".codex-plugin/plugin.json")).unwrap();
-        assert!(plugin.contains("\"mcp\""));
+        // Assert on the exact schema key so a drift to snake_case
+        // (`mcp_servers`) or something else is caught, not silently passed
+        // by the substring `"mcp"` that lives inside `"mcpServers"`.
+        assert!(
+            plugin.contains("\"mcpServers\""),
+            "codex plugin.json must declare `mcpServers`: {plugin}"
+        );
         assert!(!plugin.contains("--data-dir"));
     }
 
@@ -922,18 +976,89 @@ mod tests {
     fn opencode_print_emits_activation_snippet() {
         // --print should dump both the file tree and the activation hint so
         // snippet-style agents surface their JSON block under dry-run.
+        // Capture via install_to_writer so we can assert on the actual
+        // printed bytes — not just that no files were written.
         let tmp = TempDir::new().unwrap();
         let env = MockEnv::new(tmp.path().to_path_buf());
 
-        // We can't easily capture stdout here without adding infrastructure,
-        // so assert --print writes no files and succeeds for all snippet
-        // agents (the hint content itself is covered by the activation_hint
-        // tests above).
-        run_with_env(Some("opencode".into()), false, false, true, None, &env).unwrap();
-        assert!(!tmp.path().join(".config/opencode").exists());
+        let spec = find_agent("opencode").unwrap();
+        let opts = InstallOptions {
+            force: false,
+            print: true,
+            data_dir: None,
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        install_to_writer(spec, &opts, &env, &mut buf).unwrap();
+        let printed = String::from_utf8(buf).unwrap();
 
-        run_with_env(Some("gemini".into()), false, false, true, None, &env).unwrap();
+        assert!(
+            printed.contains("=== activation ==="),
+            "printed output missing activation marker: {printed}"
+        );
+        assert!(
+            printed.contains("\"mcp\""),
+            "printed activation snippet missing `mcp` key: {printed}"
+        );
+        assert!(
+            printed.contains("\"aimx\""),
+            "printed activation snippet missing `aimx` key: {printed}"
+        );
+        assert!(
+            printed.contains("/usr/local/bin/aimx"),
+            "printed activation snippet missing aimx path: {printed}"
+        );
+        assert!(
+            !tmp.path().join(".config/opencode").exists(),
+            "--print must not write files"
+        );
+
+        // Gemini --print also emits its mcpServers snippet.
+        let spec = find_agent("gemini").unwrap();
+        let mut buf: Vec<u8> = Vec::new();
+        install_to_writer(spec, &opts, &env, &mut buf).unwrap();
+        let printed = String::from_utf8(buf).unwrap();
+        assert!(printed.contains("=== activation ==="));
+        assert!(
+            printed.contains("\"mcpServers\""),
+            "gemini activation snippet missing `mcpServers`: {printed}"
+        );
+        assert!(printed.contains("/usr/local/bin/aimx"));
         assert!(!tmp.path().join(".gemini").exists());
+    }
+
+    #[test]
+    fn print_snippet_escapes_data_dir_with_special_chars() {
+        // A data-dir path containing a double-quote or backslash must not
+        // produce a broken JSON snippet — serde_json escapes it for us.
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        let spec = find_agent("opencode").unwrap();
+        let weird = PathBuf::from("/tmp/has\"quote\\and-backslash");
+        let opts = InstallOptions {
+            force: false,
+            print: true,
+            data_dir: Some(&weird),
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        install_to_writer(spec, &opts, &env, &mut buf).unwrap();
+        let printed = String::from_utf8(buf).unwrap();
+
+        // Extract the activation section and confirm it parses as JSON.
+        let (_, after) = printed.split_once("=== activation ===\n").unwrap();
+        let snippet = after
+            .lines()
+            .skip_while(|l| l.trim().is_empty() || l.starts_with("Skill installed"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        let parsed: serde_json::Value = serde_json::from_str(snippet.trim())
+            .unwrap_or_else(|e| panic!("activation snippet not valid JSON: {e}\n{snippet}"));
+        let cmd = parsed
+            .pointer("/mcp/aimx/command")
+            .and_then(|v| v.as_array())
+            .expect("command array missing");
+        let last_path = cmd.get(2).and_then(|v| v.as_str()).unwrap();
+        assert_eq!(last_path, "/tmp/has\"quote\\and-backslash");
     }
 
     #[test]


### PR DESCRIPTION
## Sprint Goal
Add Codex CLI, OpenCode, and Gemini CLI to the `aimx agent-setup` registry with full plugin/skill packages.

## Stories Implemented

### [S29-1] `agents/codex/` plugin + registry entry
- [x] `agents/codex/.codex-plugin/plugin.json` + `agents/codex/skills/aimx/SKILL.md` + `agents/codex/README.md` authored, re-using the common primer
- [x] `codex` registered in `agent_setup.rs` registry with destination `~/.codex/plugins/aimx/` + activation hint
- [x] Unit tests: `aimx agent-setup codex` against temp HOME lays out the expected tree; `--print` emits it to stdout; `--data-dir` rewrites `plugin.json` args
- [x] Plugin format and destination path documented against current Codex CLI docs (link in README)
- [ ] **Deferred:** Manual validation on a machine with Codex CLI installed — sandbox lacks Codex. Non-blocking; schema is documented against official docs and the install layout is covered by unit tests (same pattern as the Sprint 28 Claude Code deferral).

### [S29-2] `agents/opencode/` skill + registry entry
- [x] `agents/opencode/SKILL.md.header` authored, re-using the common primer
- [x] `agents/opencode/README.md` documents the MCP wiring step (printed JSONC snippet) and the skill install destination
- [x] `opencode` registered with destination `~/.config/opencode/skills/aimx/`; activation hint prints the JSONC snippet the user appends to `opencode.json` (`--data-dir` threads into the `command` array)
- [x] Unit tests: install + XDG override + `--print` + activation-hint content (JSONC snippet shape, `--data-dir` threading)
- [x] Canonical OpenCode skill destination linked in README

### [S29-3] `agents/gemini/` skill + registry entry
- [x] `agents/gemini/SKILL.md.header` authored with Gemini-compatible frontmatter (`name`, `description`)
- [x] `agents/gemini/README.md` documents the two-step activation (install + merge `mcpServers` block into `settings.json`)
- [x] `gemini` registered with destination `~/.gemini/skills/aimx/` + activation hint (prints the exact `mcpServers.aimx` JSON block to merge; `--data-dir` threads into `args`)
- [x] Unit tests: install lays out expected files at temp-HOME destination; `--print` emits the skill tree plus the activation snippet; snippet content + `--data-dir` threading asserted
- [x] Skill destination, settings-file path, and MCP schema documented against current Gemini CLI docs (linked from `agents/gemini/README.md`)
- [ ] **Deferred:** Manual validation on a machine with Gemini CLI installed — sandbox lacks Gemini. Non-blocking; schema is documented against official docs and the install layout is covered by unit tests.

### [S29-4] Update `book/agent-integration.md` + `--list` output
- [x] `book/agent-integration.md` gains Codex, OpenCode, and Gemini sections (install command, activation step, troubleshooting quirks)
- [x] `aimx agent-setup --list` output snapshot updated — it comes for free from the registry; four agents now shown
- [x] Repo `README.md` lists all four agents in the MCP section (Claude Code, Codex CLI, OpenCode, Gemini CLI)
- [x] Links between `book/agent-integration.md` and each agent's `agents/<agent>/README.md` resolve

## Technical Decisions

- **`AgentSpec.activation_hint` now takes a function pointer (`fn(Option<&Path>) -> String`)** instead of `&'static str`. Snippet-style agents (OpenCode, Gemini) need to embed `--data-dir` into the printed JSON/JSONC block when the user invoked `aimx --data-dir <path> agent-setup …`. Claude Code and Codex still return a short static message. This is a breaking change to `AgentSpec` but is internal — nothing outside `agent_setup.rs` reads that field.
- **`--print` now also emits the activation hint** after the file tree (under an `=== activation ===` section). Without this, OpenCode and Gemini `--print` output would omit the MCP JSON snippet entirely (since it lives only in the hint, not in on-disk files). Sprint AC explicitly requires `--print` to surface the snippet for these agents.
- **Source tree layout for snippet-style agents is flat** — `agents/opencode/SKILL.md.header` and `agents/gemini/SKILL.md.header` sit at the root of each agent directory, not under `skills/aimx/`. Their destination paths already include `skills/aimx/` (`~/.config/opencode/skills/aimx/`, `~/.gemini/skills/aimx/`), so the files install directly into that directory. Claude Code and Codex keep the nested `skills/aimx/` source layout because their destination is a plugin root (`~/.claude/plugins/aimx/`, `~/.codex/plugins/aimx/`) and the skill sits inside a `skills/` subdirectory under that root.
- **Print-the-snippet pattern over auto-merge** for OpenCode and Gemini: FR-49 says AIMX never mutates an agent's primary config file. The installer writes the skill and prints the exact JSON/JSONC block for the user to merge into `opencode.json` / `~/.gemini/settings.json`. Rationale documented in each agent's README.

## Deferred Items

- **S29-1 manual validation** — sandbox lacks Codex CLI. Picked up as part of the same non-blocking validation loop as Sprint 28's Claude Code manual deferral. Document the validation result when AIMX is tested on a machine with Codex installed.
- **S29-3 manual validation** — sandbox lacks Gemini CLI. Same pattern as above.

## Review Focus Areas

- **`src/agent_setup.rs` activation-hint machinery** — the new `fn(Option<&Path>) -> String` design and the four per-agent hint functions (`claude_code_hint`, `codex_hint`, `opencode_hint`, `gemini_hint`). Check that the JSON/JSONC snippets are syntactically valid and that `--data-dir` threads in correctly.
- **Source tree layout asymmetry** — `agents/claude-code/` and `agents/codex/` are nested (plugin roots with `skills/aimx/` inside), while `agents/opencode/` and `agents/gemini/` are flat (SKILL.md.header at the top). The `assemble_plugin_files` walker handles both naturally, but confirm the rationale (destination-path shape differs) is sound.
- **`--print` activation block** — the new `=== activation ===` section at the bottom of `--print` output. Important for CI / dry-run flows on snippet-style agents.
- **Verify plugin/skill formats against current docs** before a production release — the sprint plan explicitly calls this out ("agent formats drift"). Each agent's `README.md` links to the canonical doc.

## Test Summary

- 33 agent-setup unit tests pass (15 new in this sprint).
- Full workspace: 404 unit + 44 integration tests pass.
- `cargo clippy -- -D warnings` clean.
- `cargo fmt --check` clean.