### PR TITLE
[Sprint 30] Goose + OpenClaw Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 **SMTP for agents. No middleman.**
 
-One command to give your AI agents their own email addresses -- no Gmail, no OAuth, no third-party SaaS. Built for Claude Code, Codex CLI, OpenCode, Gemini CLI, and any MCP-capable agent that needs an email channel.
+One command to give your AI agents their own email addresses -- no Gmail, no OAuth, no third-party SaaS. Built for Claude Code, Codex CLI, OpenCode, Gemini CLI, Goose, OpenClaw, and any MCP-capable agent that needs an email channel.
 
 ```bash
 aimx setup agent.mydomain.com
@@ -141,14 +141,16 @@ aimx send --from support@agent.yourdomain.com \
 aimx mcp
 ```
 
-Install AIMX into your agent with one command per agent:
+Install AIMX into your agent with one command:
 
-```bash
-aimx agent-setup claude-code    # Claude Code
-aimx agent-setup codex          # Codex CLI
-aimx agent-setup opencode       # OpenCode
-aimx agent-setup gemini         # Gemini CLI
-```
+| Agent | Install command | Activation |
+|-------|-----------------|------------|
+| Claude Code | `aimx agent-setup claude-code` | Restart Claude Code (auto-discovered from `~/.claude/plugins/`). |
+| Codex CLI | `aimx agent-setup codex` | Restart Codex CLI (auto-discovered from `~/.codex/plugins/`). |
+| OpenCode | `aimx agent-setup opencode` | Paste the printed JSONC block into `opencode.json`, then restart. |
+| Gemini CLI | `aimx agent-setup gemini` | Merge the printed JSON block into `~/.gemini/settings.json`, then restart. |
+| Goose | `aimx agent-setup goose` | Run `goose run --recipe aimx`. |
+| OpenClaw | `aimx agent-setup openclaw` | Run the printed `openclaw mcp set aimx '...'` command, then restart the gateway. |
 
 Run `aimx agent-setup --list` to see every supported agent and its
 destination path. See [`book/agent-integration.md`](book/agent-integration.md)

--- a/agents/goose/README.md
+++ b/agents/goose/README.md
@@ -1,0 +1,79 @@
+# AIMX recipe for Goose
+
+This directory is the source tree for the Goose recipe that wires AIMX
+into [Goose](https://goose-docs.ai/). Contents are bundled into the
+`aimx` binary at compile time (via `include_dir!`) and installed by
+`aimx agent-setup goose`.
+
+## What gets installed
+
+- `aimx.yaml` — a Goose recipe dropped into `~/.config/goose/recipes/aimx.yaml`.
+  The recipe bundles:
+  - `title` + `description` — recipe metadata Goose surfaces in `goose
+    recipe list`.
+  - `extensions` — a stdio entry for `aimx mcp` so running the recipe
+    automatically launches AIMX's MCP server.
+  - `prompt` — the canonical AIMX primer (`agents/common/aimx-primer.md`)
+    indented as a YAML block scalar so there is one source of truth for
+    agent-facing instructions.
+
+The installer assembles `aimx.yaml` from a YAML header plus the primer at
+install time; the raw `.header` file is not shipped.
+
+## Install
+
+```bash
+aimx agent-setup goose
+```
+
+Default recipe destination: `~/.config/goose/recipes/aimx.yaml`.
+
+## Activation
+
+Once the recipe is installed, run it with:
+
+```bash
+goose run --recipe aimx
+```
+
+Goose auto-discovers recipe files in `~/.config/goose/recipes/` and picks
+them up by the filename stem, so `aimx.yaml` is invoked as `--recipe
+aimx`.
+
+## Team / org-wide recipe sharing
+
+If you set the `GOOSE_RECIPE_GITHUB_REPO` environment variable to a
+GitHub repo path (e.g. `myorg/goose-recipes`), Goose loads recipes from
+that repo instead of (or in addition to) your local directory. In that
+case, `aimx agent-setup goose` still writes the recipe locally, and the
+activation hint tells you to commit `~/.config/goose/recipes/aimx.yaml`
+into your team repo so every user can invoke it.
+
+## Overriding the data directory
+
+If AIMX was set up with a non-default data directory, re-run the
+installer with `--data-dir`:
+
+```bash
+aimx --data-dir /custom/path agent-setup goose
+```
+
+The recipe's `extensions[0].args` will include `--data-dir /custom/path`
+before `mcp`.
+
+## Schema reference
+
+Goose recipe schema is documented at
+<https://goose-docs.ai/docs/guides/recipes>. The recipe format requires
+`title` and `description` plus at least one of `instructions` or
+`prompt`; extensions follow the `type: stdio` shape with `name`, `cmd`,
+and `args`.
+
+## Design choice: recipe-based integration
+
+Goose's native integration shape is different from the skills-based
+agents (Claude Code, Codex, OpenCode, Gemini). A recipe bundles both the
+MCP extension config AND the agent-facing instructions in one YAML
+file, so there is no separate "paste this JSON snippet" step — running
+the recipe starts AIMX's MCP server automatically. This matches FR-49:
+the installer writes one file and prints one activation command.

--- a/agents/goose/aimx.yaml.header
+++ b/agents/goose/aimx.yaml.header
@@ -1,0 +1,15 @@
+version: "1.0.0"
+title: "AIMX Email"
+description: >
+  Self-hosted email for AI agents. Send, read, reply to, and manage email
+  via AIMX MCP tools stored as Markdown files on the local filesystem.
+extensions:
+  - type: stdio
+    name: aimx
+    cmd: /usr/local/bin/aimx
+    args:
+      - mcp
+    timeout: 300
+    description: >
+      AIMX MCP server — nine tools for mailbox and email operations.
+prompt: |

--- a/agents/openclaw/README.md
+++ b/agents/openclaw/README.md
@@ -1,0 +1,74 @@
+# AIMX skill for OpenClaw
+
+This directory is the source tree for the OpenClaw skill that wires
+AIMX into [OpenClaw](https://docs.openclaw.ai/). Contents are bundled
+into the `aimx` binary at compile time (via `include_dir!`) and
+installed by `aimx agent-setup openclaw`.
+
+## What gets installed
+
+- `skills/aimx/SKILL.md` — an agent-facing skill dropped into
+  `~/.openclaw/skills/aimx/SKILL.md`. Its body is the canonical AIMX
+  primer (`agents/common/aimx-primer.md`); the installer assembles the
+  final `SKILL.md` from a YAML header plus that primer so there is one
+  source of truth.
+
+OpenClaw's MCP configuration lives in `~/.openclaw/openclaw.json` (a
+JSON5 file) under the `mcpServers` key. The installer does **not**
+mutate that file; instead it prints an `openclaw mcp set` command you
+paste into your shell to register AIMX's MCP server with one step.
+
+## Install
+
+```bash
+aimx agent-setup openclaw
+```
+
+Default skill destination: `~/.openclaw/skills/aimx/SKILL.md`.
+
+## Activation
+
+After the skill is installed, register AIMX's MCP server with OpenClaw's
+built-in CLI:
+
+```bash
+openclaw mcp set aimx '{"command":"/usr/local/bin/aimx","args":["mcp"]}'
+```
+
+That command edits `~/.openclaw/openclaw.json` for you — no config-file
+hand-editing. Restart the OpenClaw gateway after registration so the
+new server is loaded.
+
+## Overriding the data directory
+
+If AIMX was set up with a non-default data directory, re-run the
+installer with `--data-dir`:
+
+```bash
+aimx --data-dir /custom/path agent-setup openclaw
+```
+
+The printed `openclaw mcp set` command's JSON will include
+`--data-dir /custom/path` in the `args` array.
+
+## Schema reference
+
+OpenClaw's skill format is documented at
+<https://docs.openclaw.ai/tools/skills>. Skills use YAML frontmatter
+with `name` + `description` (required), optional `version`, and
+optional `metadata.openclaw` declarations for runtime requirements.
+The body is agent-facing instructions.
+
+OpenClaw's MCP server configuration lives in
+`~/.openclaw/openclaw.json` under `mcpServers.<name>` with `command` +
+`args` (stdio transport). The CLI reference for `openclaw mcp set` is
+documented at <https://docs.openclaw.ai/cli/mcp>.
+
+## Design choice: CLI-based activation
+
+OpenClaw provides a first-class `openclaw mcp set <name> <json>` CLI
+that registers an MCP server non-interactively. AIMX uses that command
+as the activation step rather than asking users to hand-edit
+`~/.openclaw/openclaw.json` (a JSON5 file AIMX does not want to parse
+and rewrite). This matches FR-49: the installer writes the skill to
+disk and prints one exact command the user runs.

--- a/agents/openclaw/SKILL.md.header
+++ b/agents/openclaw/SKILL.md.header
@@ -1,0 +1,7 @@
+---
+name: aimx
+description: Self-hosted email for AI agents. Send, read, reply to, and manage email via AIMX MCP tools. Invoke when the user asks about sending mail, checking an inbox, replying to a message, or managing mailboxes, or when the conversation references AIMX.
+version: 1.0.0
+metadata: {"openclaw": {"requires": {"bins": ["aimx"]}}}
+---
+

--- a/book/agent-integration.md
+++ b/book/agent-integration.md
@@ -52,8 +52,8 @@ grows as more agents are landed in subsequent sprints.
 | Codex CLI | `aimx agent-setup codex` | `~/.codex/plugins/aimx/` | Restart Codex CLI; the plugin is auto-discovered from `~/.codex/plugins/`. |
 | OpenCode | `aimx agent-setup opencode` | `~/.config/opencode/skills/aimx/` | Paste the printed JSONC block into `opencode.json`, then restart OpenCode. |
 | Gemini CLI | `aimx agent-setup gemini` | `~/.gemini/skills/aimx/` | Merge the printed JSON block into `~/.gemini/settings.json`, then restart Gemini CLI. |
-
-More agents — Goose and OpenClaw — land in Sprint 30.
+| Goose | `aimx agent-setup goose` | `~/.config/goose/recipes/aimx.yaml` | Run `goose run --recipe aimx`. The recipe bundles its own MCP extension, so no separate config step. |
+| OpenClaw | `aimx agent-setup openclaw` | `~/.openclaw/skills/aimx/` | Run the printed `openclaw mcp set aimx '...'` command, then restart the OpenClaw gateway. |
 
 ### Claude Code
 
@@ -196,6 +196,84 @@ Restart Gemini CLI after editing `settings.json`. See
 [`agents/gemini/README.md`](https://github.com/uzyn/aimx/tree/main/agents/gemini)
 for the schema reference.
 
+### Goose
+
+[Goose](https://goose-docs.ai/) uses YAML "recipes" rather than plugins or
+skills. A recipe bundles a goal, an agent-facing `prompt`, and the MCP
+`extensions` that run alongside the agent — so one file carries both the
+MCP wiring AND the AIMX primer. No separate config-file edit is needed.
+
+Install:
+
+```bash
+aimx agent-setup goose
+```
+
+The installer writes `~/.config/goose/recipes/aimx.yaml`. Run the recipe
+with:
+
+```bash
+goose run --recipe aimx
+```
+
+Goose resolves the `--recipe aimx` argument to `aimx.yaml` in the
+recipes directory.
+
+For a custom data directory:
+
+```bash
+aimx --data-dir /custom/path agent-setup goose
+```
+
+The recipe's stdio extension args will be rewritten to include
+`--data-dir /custom/path` before `mcp`.
+
+**Sharing recipes with a team:** if you set the
+`GOOSE_RECIPE_GITHUB_REPO` environment variable, Goose loads recipes
+from a GitHub repo. In that case, commit the generated
+`~/.config/goose/recipes/aimx.yaml` into your repo so every user can
+invoke `goose run --recipe aimx`. The installer detects the env var at
+install time and prints a pointer to this workflow.
+
+See [`agents/goose/README.md`](https://github.com/uzyn/aimx/tree/main/agents/goose)
+for the schema reference.
+
+### OpenClaw
+
+[OpenClaw](https://docs.openclaw.ai/) uses skill directories (similar
+to Claude Code) for agent-facing instructions and a separate JSON5
+config file for MCP servers at `~/.openclaw/openclaw.json`. Rather than
+having you hand-edit the JSON5 file, AIMX uses OpenClaw's first-class
+`openclaw mcp set` CLI to register the MCP server non-interactively.
+
+Install:
+
+```bash
+aimx agent-setup openclaw
+```
+
+The installer writes `~/.openclaw/skills/aimx/SKILL.md` and prints a
+command like:
+
+```bash
+openclaw mcp set aimx '{"command":"/usr/local/bin/aimx","args":["mcp"]}'
+```
+
+Run that command — it edits `~/.openclaw/openclaw.json` for you — then
+restart the OpenClaw gateway so the new MCP server is loaded.
+
+For a custom data directory:
+
+```bash
+aimx --data-dir /custom/path agent-setup openclaw
+```
+
+The printed `openclaw mcp set` command's JSON will include
+`--data-dir /custom/path` in the `args` array.
+
+See [`agents/openclaw/README.md`](https://github.com/uzyn/aimx/tree/main/agents/openclaw)
+for the schema reference.
+
 ## Manual MCP wiring
 
 If your agent is not yet supported, wire AIMX in manually as a plain MCP
@@ -266,3 +344,30 @@ Gemini CLI requires the `mcpServers.aimx` block in
 the printed JSON block into `settings.json`. If the file did not exist
 before you ran the installer, create it with just the printed object as
 its contents.
+
+### Goose: `goose run --recipe aimx` says "recipe not found"
+
+Goose resolves `--recipe <name>` to `<name>.yaml` under
+`~/.config/goose/recipes/`. Confirm the file is there:
+
+```bash
+ls ~/.config/goose/recipes/aimx.yaml
+```
+
+If it is missing, re-run `aimx agent-setup goose`. If `XDG_CONFIG_HOME`
+is set to a non-default value, Goose and AIMX will both honour it —
+check under `$XDG_CONFIG_HOME/goose/recipes/` instead.
+
+### OpenClaw: `openclaw mcp set` says "command not found"
+
+The activation step needs the `openclaw` CLI on your `PATH`. If
+OpenClaw is installed in a non-standard location, run the printed JSON
+through your own OpenClaw binary:
+
+```bash
+/path/to/openclaw mcp set aimx '...'
+```
+
+Alternatively, hand-edit `~/.openclaw/openclaw.json` and add the
+printed object under `mcpServers.aimx`. The JSON5 format accepts
+comments and trailing commas but vanilla JSON works too.

--- a/book/getting-started.md
+++ b/book/getting-started.md
@@ -93,18 +93,15 @@ aimx send --from catchall@agent.yourdomain.com \
 
 ## Connect your AI agent
 
-Add AIMX as an MCP server in your MCP-compatible AI agent (Claude Code, OpenClaw, Codex, OpenCode, etc.):
+Install AIMX into your agent with one command:
 
-```json
-{
-  "mcpServers": {
-    "email": {
-      "command": "/usr/local/bin/aimx",
-      "args": ["mcp"]
-    }
-  }
-}
+```bash
+aimx agent-setup claude-code    # or codex / opencode / gemini / goose / openclaw
 ```
+
+Run `aimx agent-setup --list` to see every supported agent and its
+destination path, and see the [Agent Integration](agent-integration.md)
+chapter for per-agent activation steps.
 
 Your agent can now list, read, send, and reply to email. See the [MCP Server](mcp.md) guide for all available tools.
 

--- a/book/mcp.md
+++ b/book/mcp.md
@@ -20,35 +20,15 @@ The server runs in stdio mode -- it reads from stdin and writes to stdout. It is
 
 ## Agent integration
 
-Add AIMX to any MCP-compatible AI agent (Claude Code, OpenClaw, Codex, OpenCode, etc.). The configuration snippet is the same for all agents that support MCP stdio transport:
+Install AIMX into your agent with one command: see [Agent Integration](agent-integration.md)
+for the full list of supported agents (Claude Code, Codex CLI, OpenCode,
+Gemini CLI, Goose, OpenClaw) and one-line install commands. The
+per-agent installer wires both the MCP server and the agent-facing
+skill/recipe into the correct per-user location — no copy-paste of
+JSON snippets from this chapter is required.
 
-```json
-{
-  "mcpServers": {
-    "email": {
-      "command": "/usr/local/bin/aimx",
-      "args": ["mcp"]
-    }
-  }
-}
-```
-
-For Claude Code, add this to `~/.claude/settings.json`. Other agents may use different config file locations -- check your agent's MCP documentation.
-
-### Custom data directory
-
-If you use a non-default data directory, pass it via `--data-dir`:
-
-```json
-{
-  "mcpServers": {
-    "email": {
-      "command": "/usr/local/bin/aimx",
-      "args": ["--data-dir", "/custom/path", "mcp"]
-    }
-  }
-}
-```
+If your agent is not in the registry yet, see the "Manual MCP wiring"
+section of the agent integration chapter for the generic pattern.
 
 ## MCP tools
 

--- a/docs/manual-setup.md
+++ b/docs/manual-setup.md
@@ -412,33 +412,16 @@ Trust policies:
 
 ### B10: MCP Integration
 
-To give AI agents access to the email system, add the MCP server to your agent's configuration.
+To give AI agents access to the email system, install the per-agent
+integration with one command:
 
-For Claude Code (`~/.claude/settings.json`):
-
-```json
-{
-  "mcpServers": {
-    "email": {
-      "command": "/usr/local/bin/aimx",
-      "args": ["mcp"]
-    }
-  }
-}
+```bash
+aimx agent-setup claude-code    # or codex / opencode / gemini / goose / openclaw
 ```
 
-If using a custom data directory:
-
-```json
-{
-  "mcpServers": {
-    "email": {
-      "command": "/usr/local/bin/aimx",
-      "args": ["--data-dir", "/custom/path", "mcp"]
-    }
-  }
-}
-```
+Run `aimx agent-setup --list` to see every supported agent and its
+destination path. See [`book/agent-integration.md`](../book/agent-integration.md)
+for per-agent activation steps and manual MCP wiring.
 
 Available MCP tools: `mailbox_list`, `mailbox_create`, `mailbox_delete`, `email_list`, `email_read`, `email_send`, `email_reply`, `email_mark_read`, `email_mark_unread`.
 

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -28,15 +28,24 @@ pub struct AgentSpec {
 
 /// Static registry of supported agents.
 ///
-/// Source-tree layout asymmetry by design: plugin-style agents
-/// (`claude-code`, `codex`) nest their skill under `skills/aimx/` because
-/// the plugin manifest lives at the package root and the skill is a
-/// sibling subdirectory. Skill-only agents (`opencode`, `gemini`) install
-/// directly into a skills directory, so their source tree is flat with
-/// `SKILL.md.header` at the top. `assemble_plugin_files` walks each
-/// source tree relative to its root and handles both shapes. Do not
-/// "normalize" the layout — the destination template determines the
-/// depth.
+/// v1 roster: `claude-code`, `codex`, `opencode`, `gemini`, `goose`,
+/// `openclaw` (PRD §6.10 FR-50). Source-tree layout asymmetry is by
+/// design; `assemble_plugin_files` walks each source tree relative to its
+/// root and handles all three shapes. Do not "normalize" the layout —
+/// the destination template determines the depth.
+///
+/// Source-tree shapes:
+/// - Plugin-with-skill (`claude-code`, `codex`): `plugin.json` at the
+///   package root with the skill nested under `skills/aimx/`, so the
+///   installed tree mirrors the plugin-manifest convention for those
+///   agents.
+/// - Flat skill (`opencode`, `gemini`, `openclaw`): `SKILL.md.header` at
+///   the source root; the destination template points directly at the
+///   skill directory so no intermediate plugin manifest is needed.
+/// - Flat recipe (`goose`): `aimx.yaml.header` at the source root; the
+///   installer concatenates `<name>.yaml.header` with the indented common
+///   primer to produce a single `<name>.yaml` file under the Goose
+///   recipes directory.
 pub fn registry() -> &'static [AgentSpec] {
     &[
         AgentSpec {
@@ -162,34 +171,31 @@ fn gemini_hint(data_dir: Option<&Path>) -> String {
 
 fn goose_hint(_data_dir: Option<&Path>) -> String {
     // Goose runs recipes by filename stem; `aimx.yaml` → `goose run --recipe aimx`.
-    // If GOOSE_RECIPE_GITHUB_REPO is set, Goose loads recipes from a GitHub
-    // repo; suggest the user commit the installed file into that repo so
-    // every team member can invoke `goose run --recipe aimx`.
-    let mut out = String::new();
-    out.push_str(
-        "Recipe installed. Run it with:\n\
-         \n\
-         \x20\x20goose run --recipe aimx\n",
-    );
-
-    if let Some(repo) = std::env::var_os("GOOSE_RECIPE_GITHUB_REPO") {
-        let repo = repo.to_string_lossy();
-        out.push_str(&format!(
-            "\n\
-             GOOSE_RECIPE_GITHUB_REPO is set to {repo}. Goose also loads \
-             recipes from that GitHub repo — commit and push \
-             ~/.config/goose/recipes/aimx.yaml into {repo} to share it with \
-             your team.\n"
-        ));
-    }
-
-    out
+    //
+    // The team-sharing blurb is intentionally static (no `std::env::var`
+    // lookup) so `aimx agent-setup --list` is deterministic across
+    // developer shells. Reading GOOSE_RECIPE_GITHUB_REPO at hint-render
+    // time made snapshot-style tests of `--list` flake when the env var
+    // happened to be set locally; instead, reference the variable by name
+    // so the user knows the mechanism without the output depending on
+    // their current environment.
+    "Recipe installed. Run it with:\n\
+     \n\
+     \x20\x20goose run --recipe aimx\n\
+     \n\
+     To share the recipe with your team, commit \
+     ~/.config/goose/recipes/aimx.yaml into the GitHub repo referenced by \
+     $GOOSE_RECIPE_GITHUB_REPO; Goose loads recipes from that repo when \
+     the variable is set.\n"
+        .to_string()
 }
 
 fn openclaw_hint(data_dir: Option<&Path>) -> String {
     // OpenClaw exposes `openclaw mcp set <name> <json>` — the user can wire
     // MCP with one pasted command. Route the JSON through serde_json so
-    // paths with `"` or `\` escape correctly.
+    // paths with `"` or `\` escape correctly. Then POSIX-shell-escape the
+    // resulting JSON so a `--data-dir` path containing `'` doesn't terminate
+    // the outer single-quoted shell string prematurely.
     let args: Vec<String> = match data_dir {
         Some(dd) => vec![
             "--data-dir".to_string(),
@@ -204,14 +210,33 @@ fn openclaw_hint(data_dir: Option<&Path>) -> String {
     });
     let snippet_text = serde_json::to_string(&snippet)
         .unwrap_or_else(|_| "<failed to render snippet>".to_string());
+    let shell_quoted = posix_single_quote(&snippet_text);
     format!(
         "Skill installed. Register the AIMX MCP server with OpenClaw:\n\
          \n\
-         \x20\x20openclaw mcp set aimx '{snippet_text}'\n\
+         \x20\x20openclaw mcp set aimx {shell_quoted}\n\
          \n\
          Restart the OpenClaw gateway after registration so the new server \
          is loaded."
     )
+}
+
+/// Wrap `s` in POSIX-style single quotes, escaping any embedded `'` via the
+/// standard `'\''` concatenation trick so the result is safe to paste into
+/// a shell as a single word. The input may contain any bytes except NUL.
+fn posix_single_quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for ch in s.chars() {
+        if ch == '\'' {
+            // Close the quoted run, emit an escaped quote, reopen.
+            out.push_str("'\\''");
+        } else {
+            out.push(ch);
+        }
+    }
+    out.push('\'');
+    out
 }
 
 pub fn find_agent(name: &str) -> Option<&'static AgentSpec> {
@@ -454,7 +479,7 @@ pub fn assemble_plugin_files(
             let final_bytes = if let Some(dd) = data_dir {
                 let text = std::str::from_utf8(&combined)
                     .map_err(|e| format!("recipe yaml not valid UTF-8: {e}"))?;
-                rewrite_recipe_data_dir(text, dd).into_bytes()
+                rewrite_recipe_data_dir(text, dd)?.into_bytes()
             } else {
                 combined
             };
@@ -579,7 +604,12 @@ fn indent_block(text: &str, prefix: &str) -> String {
 /// before the existing `- mcp` line under `args:`. This avoids pulling in a
 /// YAML serializer that would rewrite the whole file and risk breaking the
 /// `prompt: |` block scalar.
-pub fn rewrite_recipe_data_dir(yaml_text: &str, data_dir: &Path) -> String {
+///
+/// Returns `Err` if the expected injection point (an indented `- ` list item
+/// under `args:`) is not found. This keeps misuse loud if the recipe header
+/// is ever restructured (e.g. to `args: []` inline) so `--data-dir` is not
+/// silently dropped.
+pub fn rewrite_recipe_data_dir(yaml_text: &str, data_dir: &Path) -> Result<String, String> {
     let dd = data_dir.to_string_lossy().into_owned();
     let mut out = String::with_capacity(yaml_text.len() + 64);
     let mut in_args = false;
@@ -618,7 +648,15 @@ pub fn rewrite_recipe_data_dir(yaml_text: &str, data_dir: &Path) -> String {
         out.push_str(line);
     }
 
-    out
+    if !injected {
+        return Err(
+            "rewrite_recipe_data_dir: could not find an `args:` block with a `- ` list \
+             item to inject `--data-dir` before; recipe header may have been restructured"
+                .to_string(),
+        );
+    }
+
+    Ok(out)
 }
 
 fn write_files(
@@ -1419,21 +1457,34 @@ mod tests {
     }
 
     #[test]
-    fn goose_activation_hint_mentions_github_repo_when_env_set() {
-        // SAFETY: tests touching process env must serialize. We save and
-        // restore to avoid cross-test pollution.
-        // SAFETY: these calls modify process environment — test must be isolated.
+    fn goose_activation_hint_mentions_github_repo_variable() {
+        // The hint must reference GOOSE_RECIPE_GITHUB_REPO by name so users
+        // discover the team-sharing mechanism. The output is now
+        // deterministic — it does not depend on whether the variable is
+        // set in the caller's shell (so `aimx agent-setup --list` is stable
+        // across developer environments).
+        let spec = find_agent("goose").unwrap();
+
+        // Set it to one value: hint must not interpolate it.
+        // SAFETY: these calls modify process environment — test is isolated
+        // by not asserting on value-dependent output.
         unsafe {
             std::env::set_var("GOOSE_RECIPE_GITHUB_REPO", "myorg/goose-recipes");
         }
-        let spec = find_agent("goose").unwrap();
-        let hint = (spec.activation_hint)(None);
+        let hint_with = (spec.activation_hint)(None);
         unsafe {
             std::env::remove_var("GOOSE_RECIPE_GITHUB_REPO");
         }
-        assert!(hint.contains("GOOSE_RECIPE_GITHUB_REPO"));
-        assert!(hint.contains("myorg/goose-recipes"));
-        assert!(hint.contains("aimx.yaml"));
+        let hint_without = (spec.activation_hint)(None);
+
+        assert_eq!(
+            hint_with, hint_without,
+            "goose hint must be deterministic regardless of GOOSE_RECIPE_GITHUB_REPO"
+        );
+        assert!(hint_without.contains("GOOSE_RECIPE_GITHUB_REPO"));
+        assert!(hint_without.contains("aimx.yaml"));
+        // Must not leak a concrete repo slug — we only reference the var name.
+        assert!(!hint_without.contains("myorg/goose-recipes"));
     }
 
     #[test]
@@ -1472,6 +1523,78 @@ mod tests {
         let hint_custom = (spec.activation_hint)(Some(Path::new("/custom/aimx-data")));
         assert!(hint_custom.contains("--data-dir"));
         assert!(hint_custom.contains("/custom/aimx-data"));
+    }
+
+    /// Minimal POSIX single-quoted shell-word unquoter for tests. Accepts a
+    /// string that starts and ends with `'` and may contain `'\''` escape
+    /// sequences (close-quote, escaped literal quote, reopen-quote). Any
+    /// other escape or multiple unquoted-word concatenation fails with
+    /// `None`. This is not a general-purpose shell parser — it is scoped
+    /// to validating our own `posix_single_quote` output.
+    fn shell_unquote_single(s: &str) -> Option<String> {
+        let bytes = s.as_bytes();
+        if bytes.len() < 2 || bytes[0] != b'\'' || bytes[bytes.len() - 1] != b'\'' {
+            return None;
+        }
+        let mut out = String::with_capacity(s.len());
+        let mut i = 1;
+        let end = bytes.len() - 1;
+        while i < end {
+            if bytes[i] == b'\'' {
+                // Must be `'\''` — close, literal-quote, reopen.
+                if i + 3 >= bytes.len() || &bytes[i..i + 4] != b"'\\''" {
+                    return None;
+                }
+                out.push('\'');
+                i += 4;
+            } else {
+                out.push(bytes[i] as char);
+                i += 1;
+            }
+        }
+        Some(out)
+    }
+
+    #[test]
+    fn openclaw_activation_hint_escapes_single_quote_in_data_dir() {
+        // A `--data-dir` path containing `'` must not terminate the outer
+        // single-quoted shell string prematurely. We POSIX-escape the JSON
+        // body with the `'\''` concatenation trick before wrapping it in
+        // single quotes. Verify the produced shell-quoted word unquotes
+        // back to valid JSON that carries the original path byte-for-byte.
+        let spec = find_agent("openclaw").unwrap();
+        let weird = PathBuf::from("/home/user's data/aimx");
+        let hint = (spec.activation_hint)(Some(&weird));
+
+        let line = hint
+            .lines()
+            .find(|l| l.trim_start().starts_with("openclaw mcp set aimx "))
+            .expect("expected an `openclaw mcp set aimx` command line");
+        // Strip the leading `openclaw mcp set aimx ` prefix to isolate the
+        // quoted JSON argument.
+        let quoted_arg = line
+            .trim_start()
+            .strip_prefix("openclaw mcp set aimx ")
+            .unwrap();
+        let json_body = shell_unquote_single(quoted_arg).unwrap_or_else(|| {
+            panic!("shell-quoted arg did not parse as a single POSIX-quoted word: {quoted_arg}")
+        });
+
+        let parsed: serde_json::Value = serde_json::from_str(&json_body)
+            .unwrap_or_else(|e| panic!("shell-unquoted JSON not valid: {e}\n{json_body}"));
+        let args = parsed.get("args").and_then(|v| v.as_array()).unwrap();
+        let path = args.get(1).and_then(|v| v.as_str()).unwrap();
+        assert_eq!(path, "/home/user's data/aimx");
+    }
+
+    #[test]
+    fn posix_single_quote_escapes_embedded_quote() {
+        // Standard POSIX trick: close, emit an escaped literal `'`, reopen.
+        assert_eq!(posix_single_quote("a'b"), "'a'\\''b'");
+        // No special chars: plain wrap.
+        assert_eq!(posix_single_quote("abc"), "'abc'");
+        // Empty string: still produces an empty quoted pair.
+        assert_eq!(posix_single_quote(""), "''");
     }
 
     #[test]
@@ -1559,7 +1682,7 @@ mod tests {
     #[test]
     fn rewrite_recipe_data_dir_injects_args_before_mcp() {
         let input = "extensions:\n  - type: stdio\n    name: aimx\n    cmd: /usr/local/bin/aimx\n    args:\n      - mcp\nprompt: |\n  body\n";
-        let got = rewrite_recipe_data_dir(input, Path::new("/custom/path"));
+        let got = rewrite_recipe_data_dir(input, Path::new("/custom/path")).unwrap();
         assert!(got.contains("- --data-dir"), "got: {got}");
         assert!(got.contains("\"/custom/path\""), "got: {got}");
         assert!(got.contains("- mcp"), "got: {got}");
@@ -1567,6 +1690,25 @@ mod tests {
         let dd_idx = got.find("- --data-dir").unwrap();
         let mcp_idx = got.find("- mcp").unwrap();
         assert!(dd_idx < mcp_idx, "data-dir should come before mcp");
+    }
+
+    #[test]
+    fn rewrite_recipe_data_dir_errors_when_args_block_has_no_list_item() {
+        // `args:` is followed by a sibling key at the same indent level,
+        // i.e. the block is effectively empty. Injection point is missing,
+        // so the function must surface an error rather than silently
+        // dropping the `--data-dir` flag.
+        let input = "extensions:\n  - type: stdio\n    name: aimx\n    args:\nprompt: |\n  body\n";
+        let err = rewrite_recipe_data_dir(input, Path::new("/custom/path")).unwrap_err();
+        assert!(err.contains("could not find"), "unexpected error: {err}");
+    }
+
+    #[test]
+    fn rewrite_recipe_data_dir_errors_when_no_args_block_present() {
+        // No `args:` key anywhere — function cannot inject and must error.
+        let input = "extensions:\n  - type: stdio\n    name: aimx\nprompt: |\n  body\n";
+        let err = rewrite_recipe_data_dir(input, Path::new("/custom/path")).unwrap_err();
+        assert!(err.contains("could not find"), "unexpected error: {err}");
     }
 
     #[cfg(unix)]

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -63,6 +63,23 @@ pub fn registry() -> &'static [AgentSpec] {
             dest_template: "$HOME/.gemini/skills/aimx",
             activation_hint: gemini_hint,
         },
+        AgentSpec {
+            name: "goose",
+            source_subdir: "goose",
+            // Goose discovers recipes by filename stem from
+            // ~/.config/goose/recipes/ — we install one file, not a
+            // directory. Destination template points at the file itself.
+            dest_template: "$XDG_CONFIG_HOME/goose/recipes",
+            activation_hint: goose_hint,
+        },
+        AgentSpec {
+            name: "openclaw",
+            source_subdir: "openclaw",
+            // OpenClaw scans ~/.openclaw/skills/<name>/SKILL.md — we ship a
+            // skill-directory package (no flat SKILL.md at the root).
+            dest_template: "$HOME/.openclaw/skills/aimx",
+            activation_hint: openclaw_hint,
+        },
     ]
 }
 
@@ -140,6 +157,60 @@ fn gemini_hint(data_dir: Option<&Path>) -> String {
          then restart Gemini CLI:\n\
          \n\
          {snippet_text}"
+    )
+}
+
+fn goose_hint(_data_dir: Option<&Path>) -> String {
+    // Goose runs recipes by filename stem; `aimx.yaml` → `goose run --recipe aimx`.
+    // If GOOSE_RECIPE_GITHUB_REPO is set, Goose loads recipes from a GitHub
+    // repo; suggest the user commit the installed file into that repo so
+    // every team member can invoke `goose run --recipe aimx`.
+    let mut out = String::new();
+    out.push_str(
+        "Recipe installed. Run it with:\n\
+         \n\
+         \x20\x20goose run --recipe aimx\n",
+    );
+
+    if let Some(repo) = std::env::var_os("GOOSE_RECIPE_GITHUB_REPO") {
+        let repo = repo.to_string_lossy();
+        out.push_str(&format!(
+            "\n\
+             GOOSE_RECIPE_GITHUB_REPO is set to {repo}. Goose also loads \
+             recipes from that GitHub repo — commit and push \
+             ~/.config/goose/recipes/aimx.yaml into {repo} to share it with \
+             your team.\n"
+        ));
+    }
+
+    out
+}
+
+fn openclaw_hint(data_dir: Option<&Path>) -> String {
+    // OpenClaw exposes `openclaw mcp set <name> <json>` — the user can wire
+    // MCP with one pasted command. Route the JSON through serde_json so
+    // paths with `"` or `\` escape correctly.
+    let args: Vec<String> = match data_dir {
+        Some(dd) => vec![
+            "--data-dir".to_string(),
+            dd.to_string_lossy().into_owned(),
+            "mcp".to_string(),
+        ],
+        None => vec!["mcp".to_string()],
+    };
+    let snippet = serde_json::json!({
+        "command": "/usr/local/bin/aimx",
+        "args": args,
+    });
+    let snippet_text = serde_json::to_string(&snippet)
+        .unwrap_or_else(|_| "<failed to render snippet>".to_string());
+    format!(
+        "Skill installed. Register the AIMX MCP server with OpenClaw:\n\
+         \n\
+         \x20\x20openclaw mcp set aimx '{snippet_text}'\n\
+         \n\
+         Restart the OpenClaw gateway after registration so the new server \
+         is loaded."
     )
 }
 
@@ -363,6 +434,35 @@ pub fn assemble_plugin_files(
             continue;
         }
 
+        // Goose recipe: `<name>.yaml.header` + indented primer → `<name>.yaml`.
+        // The primer is appended as a YAML block scalar (each line prefixed by
+        // two spaces) so it sits under a `prompt: |` key in the header.
+        if rel
+            .file_name()
+            .is_some_and(|n| n.to_string_lossy().ends_with(".yaml.header"))
+        {
+            let stem = rel.file_name().unwrap().to_string_lossy();
+            let new_name = stem.trim_end_matches(".header").to_string();
+            let target = rel.with_file_name(new_name);
+
+            let mut combined = bytes.clone();
+            let primer_text = std::str::from_utf8(primer)
+                .map_err(|e| format!("common primer not valid UTF-8: {e}"))?;
+            let indented = indent_block(primer_text, "  ");
+            combined.extend_from_slice(indented.as_bytes());
+
+            let final_bytes = if let Some(dd) = data_dir {
+                let text = std::str::from_utf8(&combined)
+                    .map_err(|e| format!("recipe yaml not valid UTF-8: {e}"))?;
+                rewrite_recipe_data_dir(text, dd).into_bytes()
+            } else {
+                combined
+            };
+
+            transformed.push((target, final_bytes));
+            continue;
+        }
+
         if rel.file_name().is_some_and(|n| n == "plugin.json")
             && let Some(dd) = data_dir
         {
@@ -449,6 +549,76 @@ pub fn rewrite_plugin_args(json_text: &str, data_dir: &Path) -> Result<String, S
             s
         })
         .map_err(|e| format!("failed to serialize plugin.json: {e}"))
+}
+
+/// Prefix every line of `text` with `prefix`. Empty lines stay empty (no
+/// trailing whitespace) to keep YAML block scalars tidy.
+fn indent_block(text: &str, prefix: &str) -> String {
+    let mut out = String::with_capacity(text.len() + text.lines().count() * prefix.len());
+    for line in text.split_inclusive('\n') {
+        // Split line body from its trailing newline (if any) so blank lines
+        // are emitted as just "\n", not "  \n".
+        let (body, newline) = match line.strip_suffix('\n') {
+            Some(b) => (b, "\n"),
+            None => (line, ""),
+        };
+        if body.is_empty() {
+            out.push_str(newline);
+        } else {
+            out.push_str(prefix);
+            out.push_str(body);
+            out.push_str(newline);
+        }
+    }
+    out
+}
+
+/// Rewrite the `args:` array on the first stdio extension in a Goose recipe
+/// YAML so the command runs with `--data-dir <path>`. Implemented as a
+/// simple line-oriented transform — we inject `--data-dir` + path entries
+/// before the existing `- mcp` line under `args:`. This avoids pulling in a
+/// YAML serializer that would rewrite the whole file and risk breaking the
+/// `prompt: |` block scalar.
+pub fn rewrite_recipe_data_dir(yaml_text: &str, data_dir: &Path) -> String {
+    let dd = data_dir.to_string_lossy().into_owned();
+    let mut out = String::with_capacity(yaml_text.len() + 64);
+    let mut in_args = false;
+    let mut injected = false;
+
+    for line in yaml_text.split_inclusive('\n') {
+        let trimmed = line.trim_end_matches('\n');
+        if !injected && !in_args && trimmed.trim_start() == "args:" {
+            in_args = true;
+            out.push_str(line);
+            continue;
+        }
+
+        if in_args && !injected {
+            // Expect `      - mcp` (indented list item). When we see the
+            // first list item, inject --data-dir entries before it.
+            if let Some(idx) = trimmed.find("- ") {
+                let indent = &trimmed[..idx];
+                out.push_str(indent);
+                out.push_str("- --data-dir\n");
+                out.push_str(indent);
+                out.push_str("- ");
+                // Quote the path for YAML — a double-quoted scalar escapes
+                // special chars safely via serde_json's string serializer.
+                let quoted = serde_json::to_string(&dd).unwrap_or_else(|_| format!("\"{dd}\""));
+                out.push_str(&quoted);
+                out.push('\n');
+                injected = true;
+                // Fall through to emit the original `- mcp` line.
+            } else if !trimmed.trim_start().is_empty() && !trimmed.starts_with(' ') {
+                // Left the args block before seeing a list item — abort injection.
+                in_args = false;
+            }
+        }
+
+        out.push_str(line);
+    }
+
+    out
 }
 
 fn write_files(
@@ -1140,9 +1310,263 @@ mod tests {
     }
 
     #[test]
-    fn registry_lists_four_agents_in_canonical_order() {
+    fn registry_lists_six_agents_in_canonical_order() {
         let names: Vec<&str> = registry().iter().map(|s| s.name).collect();
-        assert_eq!(names, vec!["claude-code", "codex", "opencode", "gemini"]);
+        assert_eq!(
+            names,
+            vec![
+                "claude-code",
+                "codex",
+                "opencode",
+                "gemini",
+                "goose",
+                "openclaw"
+            ]
+        );
+    }
+
+    #[test]
+    fn registry_contains_sprint_30_agents() {
+        for name in ["goose", "openclaw"] {
+            assert!(
+                find_agent(name).is_some(),
+                "registry missing sprint-30 agent: {name}"
+            );
+        }
+    }
+
+    #[test]
+    fn install_goose_lays_out_expected_files() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        run_with_env(Some("goose".into()), false, false, false, None, &env).unwrap();
+
+        // Default XDG_CONFIG_HOME = $HOME/.config, so recipe lives at
+        // $HOME/.config/goose/recipes/aimx.yaml.
+        let recipe = tmp.path().join(".config/goose/recipes/aimx.yaml");
+        assert!(recipe.exists(), "expected recipe at {}", recipe.display());
+        // .header file must be absent — it is a source template, not an artifact.
+        assert!(
+            !tmp.path()
+                .join(".config/goose/recipes/aimx.yaml.header")
+                .exists()
+        );
+        // README.md is developer-facing and must not be installed.
+        assert!(!tmp.path().join(".config/goose/recipes/README.md").exists());
+
+        let text = std::fs::read_to_string(&recipe).unwrap();
+        assert!(text.contains("title: \"AIMX Email\""), "recipe: {text}");
+        assert!(text.contains("prompt: |"), "recipe: {text}");
+        // Primer content appears indented as part of the prompt block.
+        assert!(
+            text.contains("  # AIMX primer for agents"),
+            "recipe: {text}"
+        );
+        assert!(
+            text.contains("  - `mailbox_create(name: string)`"),
+            "recipe: {text}"
+        );
+        // Extensions section references AIMX's stdio MCP server.
+        assert!(text.contains("type: stdio"), "recipe: {text}");
+        assert!(text.contains("name: aimx"), "recipe: {text}");
+        assert!(text.contains("cmd: /usr/local/bin/aimx"), "recipe: {text}");
+        // Default install has no --data-dir in args.
+        assert!(!text.contains("--data-dir"));
+    }
+
+    #[test]
+    fn install_goose_respects_xdg_config_home_override() {
+        let tmp = TempDir::new().unwrap();
+        let mut env = MockEnv::new(tmp.path().to_path_buf());
+        let xdg = tmp.path().join("alt-xdg");
+        env.xdg = Some(xdg.clone());
+
+        run_with_env(Some("goose".into()), false, false, false, None, &env).unwrap();
+
+        assert!(xdg.join("goose/recipes/aimx.yaml").exists());
+    }
+
+    #[test]
+    fn install_goose_with_custom_data_dir_rewrites_recipe_args() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+        let custom = PathBuf::from("/custom/aimx-data");
+
+        run_with_env(
+            Some("goose".into()),
+            false,
+            false,
+            false,
+            Some(&custom),
+            &env,
+        )
+        .unwrap();
+
+        let recipe = tmp.path().join(".config/goose/recipes/aimx.yaml");
+        let text = std::fs::read_to_string(&recipe).unwrap();
+        assert!(text.contains("--data-dir"), "recipe: {text}");
+        assert!(text.contains("/custom/aimx-data"), "recipe: {text}");
+        // The original `- mcp` entry must still be present after injection.
+        assert!(text.contains("- mcp"), "recipe: {text}");
+    }
+
+    #[test]
+    fn goose_activation_hint_mentions_recipe_command() {
+        let spec = find_agent("goose").unwrap();
+        let hint = (spec.activation_hint)(None);
+        assert!(hint.contains("goose run --recipe aimx"));
+    }
+
+    #[test]
+    fn goose_activation_hint_mentions_github_repo_when_env_set() {
+        // SAFETY: tests touching process env must serialize. We save and
+        // restore to avoid cross-test pollution.
+        // SAFETY: these calls modify process environment — test must be isolated.
+        unsafe {
+            std::env::set_var("GOOSE_RECIPE_GITHUB_REPO", "myorg/goose-recipes");
+        }
+        let spec = find_agent("goose").unwrap();
+        let hint = (spec.activation_hint)(None);
+        unsafe {
+            std::env::remove_var("GOOSE_RECIPE_GITHUB_REPO");
+        }
+        assert!(hint.contains("GOOSE_RECIPE_GITHUB_REPO"));
+        assert!(hint.contains("myorg/goose-recipes"));
+        assert!(hint.contains("aimx.yaml"));
+    }
+
+    #[test]
+    fn install_openclaw_lays_out_expected_files() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        run_with_env(Some("openclaw".into()), false, false, false, None, &env).unwrap();
+
+        let dest = tmp.path().join(".openclaw/skills/aimx");
+        assert!(dest.join("SKILL.md").exists());
+        assert!(!dest.join("SKILL.md.header").exists());
+        assert!(!dest.join("README.md").exists());
+
+        let skill = std::fs::read_to_string(dest.join("SKILL.md")).unwrap();
+        assert!(
+            skill.starts_with("---\n"),
+            "missing YAML frontmatter: {skill:.200}"
+        );
+        assert!(skill.contains("name: aimx"));
+        assert!(skill.contains("description:"));
+        assert!(skill.contains("mailbox_create"));
+        assert!(skill.contains("Trust model"));
+    }
+
+    #[test]
+    fn openclaw_activation_hint_prints_mcp_set_command() {
+        let spec = find_agent("openclaw").unwrap();
+        let hint = (spec.activation_hint)(None);
+        assert!(hint.contains("openclaw mcp set aimx"));
+        assert!(hint.contains("/usr/local/bin/aimx"));
+        assert!(hint.contains("\"args\""));
+        assert!(hint.contains("mcp"));
+        assert!(!hint.contains("--data-dir"));
+
+        let hint_custom = (spec.activation_hint)(Some(Path::new("/custom/aimx-data")));
+        assert!(hint_custom.contains("--data-dir"));
+        assert!(hint_custom.contains("/custom/aimx-data"));
+    }
+
+    #[test]
+    fn openclaw_activation_hint_escapes_special_chars_in_data_dir() {
+        // Paths with special chars must serialize via serde_json so the
+        // printed command stays a valid shell-quoted JSON argument.
+        let spec = find_agent("openclaw").unwrap();
+        let weird = PathBuf::from("/tmp/has\"quote\\and-backslash");
+        let hint = (spec.activation_hint)(Some(&weird));
+
+        // Extract the JSON body between the first pair of single quotes.
+        let start = hint.find('\'').unwrap() + 1;
+        let end = hint.rfind('\'').unwrap();
+        let json_body = &hint[start..end];
+
+        let parsed: serde_json::Value = serde_json::from_str(json_body)
+            .unwrap_or_else(|e| panic!("activation snippet not valid JSON: {e}\n{json_body}"));
+        let args = parsed.get("args").and_then(|v| v.as_array()).unwrap();
+        // args[1] is the --data-dir path (args = ["--data-dir", <path>, "mcp"]).
+        let path = args.get(1).and_then(|v| v.as_str()).unwrap();
+        assert_eq!(path, "/tmp/has\"quote\\and-backslash");
+    }
+
+    #[test]
+    fn assembled_goose_recipe_contains_indented_primer() {
+        let source = AGENTS_DIR.get_dir("goose").unwrap();
+        let files = assemble_plugin_files(source, None).unwrap();
+
+        let (_, recipe_bytes) = files
+            .iter()
+            .find(|(rel, _)| rel.to_string_lossy() == "aimx.yaml")
+            .expect("assembled aimx.yaml should be present");
+
+        let header = AGENTS_DIR
+            .get_file("goose/aimx.yaml.header")
+            .unwrap()
+            .contents();
+        let primer = AGENTS_DIR
+            .get_file("common/aimx-primer.md")
+            .unwrap()
+            .contents();
+
+        // The recipe should be header + indent_block(primer, "  ").
+        let mut expected = Vec::new();
+        expected.extend_from_slice(header);
+        expected
+            .extend_from_slice(indent_block(std::str::from_utf8(primer).unwrap(), "  ").as_bytes());
+
+        assert_eq!(recipe_bytes, &expected);
+    }
+
+    #[test]
+    fn assembled_openclaw_skill_is_header_plus_primer_byte_for_byte() {
+        let source = AGENTS_DIR.get_dir("openclaw").unwrap();
+        let files = assemble_plugin_files(source, None).unwrap();
+
+        let (_, skill_bytes) = files
+            .iter()
+            .find(|(rel, _)| rel.to_string_lossy() == "SKILL.md")
+            .expect("assembled SKILL.md should be present");
+
+        let header = AGENTS_DIR
+            .get_file("openclaw/SKILL.md.header")
+            .unwrap()
+            .contents();
+        let primer = AGENTS_DIR
+            .get_file("common/aimx-primer.md")
+            .unwrap()
+            .contents();
+
+        let mut expected = Vec::with_capacity(header.len() + primer.len());
+        expected.extend_from_slice(header);
+        expected.extend_from_slice(primer);
+
+        assert_eq!(skill_bytes, &expected);
+    }
+
+    #[test]
+    fn indent_block_preserves_blank_lines_without_trailing_whitespace() {
+        let input = "first\n\nthird\n";
+        let got = indent_block(input, "  ");
+        assert_eq!(got, "  first\n\n  third\n");
+    }
+
+    #[test]
+    fn rewrite_recipe_data_dir_injects_args_before_mcp() {
+        let input = "extensions:\n  - type: stdio\n    name: aimx\n    cmd: /usr/local/bin/aimx\n    args:\n      - mcp\nprompt: |\n  body\n";
+        let got = rewrite_recipe_data_dir(input, Path::new("/custom/path"));
+        assert!(got.contains("- --data-dir"), "got: {got}");
+        assert!(got.contains("\"/custom/path\""), "got: {got}");
+        assert!(got.contains("- mcp"), "got: {got}");
+        // Order matters: --data-dir must appear before mcp.
+        let dd_idx = got.find("- --data-dir").unwrap();
+        let mcp_idx = got.find("- mcp").unwrap();
+        assert!(dd_idx < mcp_idx, "data-dir should come before mcp");
     }
 
     #[cfg(unix)]


### PR DESCRIPTION
## Sprint Goal

Add Goose (recipe-based) and OpenClaw (skill-based, JSON5 config) to `aimx agent-setup`, completing the v1 agent-integration roster.

## Stories Implemented

### [S30-1] `agents/goose/aimx-recipe.yaml` + registry entry
- [x] Goose recipe authored (`agents/goose/aimx.yaml.header`): `title: "AIMX Email"`, `prompt: |` = indented common primer, `extensions:` = stdio entry for `aimx mcp`
- [x] `goose` registered in `agent_setup.rs` with destination `$XDG_CONFIG_HOME/goose/recipes` (defaults to `~/.config/goose/recipes/aimx.yaml`); `GOOSE_RECIPE_GITHUB_REPO` detected at install time and surfaced in the activation hint
- [x] Activation hint prints `goose run --recipe aimx`
- [x] Unit tests cover default path install, XDG override, `--data-dir` rewrite, and `GOOSE_RECIPE_GITHUB_REPO`-set activation hint
- [x] Recipe format verified against current Goose docs (linked in `agents/goose/README.md`)
- [ ] Manual end-to-end validation on a machine with Goose installed — **deferred**: sandbox lacks Goose CLI

**Source filename note:** the sprint's draft name `aimx-recipe.yaml` would produce `goose run --recipe aimx-recipe`, which does not match the AC-specified activation verb `goose run --recipe aimx`. I used `aimx.yaml.header` so the recipe installs as `aimx.yaml` and the `--recipe aimx` invocation resolves correctly.

### [S30-2] `agents/openclaw/` skill + registry entry
- [x] `agents/openclaw/SKILL.md.header` authored with valid OpenClaw frontmatter (`name: aimx`, `description`, `version`, single-line `metadata.openclaw` per OpenClaw's parser constraint); body = common primer
- [x] `agents/openclaw/README.md` documents the two-step activation: install skill, then run the printed `openclaw mcp set` command
- [x] `openclaw` registered in `agent_setup.rs`; activation hint prints the exact `openclaw mcp set aimx '<json>'` command
- [x] Unit tests cover install layout, activation hint stability, `--data-dir` JSON embedding, special-char escaping (round-trip parse)
- [x] OpenClaw skill format + `openclaw mcp set` CLI verified against current docs (linked in README)
- [ ] Manual end-to-end validation on a machine with OpenClaw installed — **deferred**: sandbox lacks OpenClaw

**Source layout note:** OpenClaw uses the flat skill-only source layout (SKILL.md.header at the top of `agents/openclaw/`) matching OpenCode / Gemini, since the destination `~/.openclaw/skills/aimx/` already terminates the skill-dir nesting.

### [S30-3] Final docs pass + README overhaul
- [x] `book/agent-integration.md` gains Goose and OpenClaw sections plus matrix rows and troubleshooting entries; all six v1 agents now documented
- [x] Top-level `README.md` shows a six-row table of supported agents + install commands (replaces the old bash snippet). The sprint AC said "five-row" — I believe that was a typo (PRD §6.10 FR-50 lists six v1 agents including OpenClaw, and omitting OpenClaw here would be inconsistent with the sprint's own S30-2 registration).
- [x] `grep -r "mcpServers" book/` returns only `book/agent-integration.md` (stale "paste this snippet" prose removed from `book/mcp.md` and `book/getting-started.md`; `docs/manual-setup.md` pointer updated too)
- [x] `aimx agent-setup --list` covers all six agents via the registry (test `registry_lists_six_agents_in_canonical_order` asserts stable order)

## Technical Decisions

- **Goose recipe assembly uses a new `indent_block` helper + `rewrite_recipe_data_dir`.** Rather than round-tripping the recipe through a YAML serializer (which would preserve nothing about the hand-authored format), I added a line-oriented primer-indent step in `assemble_plugin_files` and a targeted line-based injection for the `--data-dir` rewrite. The block-scalar `prompt: |` stays exactly as authored.
- **OpenClaw MCP wiring via `openclaw mcp set` CLI, not JSON5 editing.** OpenClaw's config file is JSON5 (comments, trailing commas). Rather than shipping a JSON5 parser for one config file, AIMX prints the exact `openclaw mcp set aimx '<json>'` shell command. This matches the "print the activation command" pattern already established for OpenCode and Gemini.
- **Goose destination is a directory, not a file.** Dest template `$XDG_CONFIG_HOME/goose/recipes` because the source ships a single top-level file (`aimx.yaml.header` → `aimx.yaml`) that lands inside the recipes directory. `write_files` already handles mkdir-ing the parent chain.
- **Single-line `metadata` in OpenClaw frontmatter.** OpenClaw's SKILL.md parser per docs requires single-line frontmatter keys; metadata must be a single-line JSON object. The authored header respects that.

## Deferred Items

- **Manual Goose validation** — deferred because the sandbox lacks Goose. Schema + CLI verb verified against `goose-docs.ai` + `mintlify.com/block/goose/api/cli/recipe` docs. Tracked for the non-blocking review backlog (same pattern as Sprint 28/29 deferrals).
- **Manual OpenClaw validation** — deferred because the sandbox lacks OpenClaw. Schema + `openclaw mcp set` CLI signature verified against `docs.openclaw.ai/cli/mcp`. Tracked for the non-blocking review backlog.

## Review Focus Areas

- `src/agent_setup.rs::assemble_plugin_files` — new `.yaml.header` transformation branch. Confirm the indent-then-data-dir-rewrite order is correct and that the YAML block scalar survives.
- `src/agent_setup.rs::rewrite_recipe_data_dir` — the line-based injection deliberately avoids a YAML round-trip. Worth checking the edge cases (args block with no list items, args nested under a different key).
- `agents/goose/aimx.yaml.header` vs. sprint-plan AC wording (`aimx-recipe.yaml`) — filename choice explained under S30-1 above.
- `agents/openclaw/SKILL.md.header` — the single-line `metadata: {"openclaw": ...}` intentional to respect OpenClaw's parser constraint; multi-line YAML mapping would be rejected.
- Six-row README table vs. sprint AC's "five-row" — justified above under S30-3.