### PR TITLE
[Sprint 33] Filesystem Split + `aimx` Group Foundation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,10 +73,12 @@ These are NOT a Cargo workspace — they have independent `Cargo.toml` files and
 
 ### Config and storage
 
-- Config: `/var/lib/aimx/config.toml` — parsed via `serde` + `toml` crate into `Config` struct in `config.rs`.
-- Storage: Markdown files with TOML frontmatter (`+++` delimiters, not `---`). One `.md` file per email, `YYYY-MM-DD-NNN.md` naming.
-- `--data-dir` / `AIMX_DATA_DIR` overrides the default path globally.
-- Tests use `tempfile::TempDir` for isolated data directories.
+- Config: `/etc/aimx/config.toml` (mode `0640`, owner `root:root`) — parsed via `serde` + `toml` into `Config` struct in `config.rs`. Resolved via `config_path()` which honors `AIMX_CONFIG_DIR` for tests / non-standard installs.
+- DKIM keys: `/etc/aimx/dkim/{private,public}.key` (private `0600` root-only, public `0644`). Loaded via `load_private_key(&config::dkim_dir())`.
+- Storage: Markdown files with TOML frontmatter (`+++` delimiters, not `---`). One `.md` file per email, `YYYY-MM-DD-NNN.md` naming, under `/var/lib/aimx/<mailbox>/`.
+- `--data-dir` / `AIMX_DATA_DIR` overrides the **storage** path (mailboxes only, v0.2). `AIMX_CONFIG_DIR` overrides the **config + DKIM** path.
+- Runtime dir: `/run/aimx/` (mode `0750`, owner `root:aimx`) — provided by systemd `RuntimeDirectory=aimx` or OpenRC `checkpath` in `start_pre`. Sprint 34 places `send.sock` here.
+- Tests use `tempfile::TempDir` plus `crate::config::test_env::ConfigDirOverride::set(&tmp)` (or the `AIMX_CONFIG_DIR` env var in integration tests) to isolate config + DKIM lookups.
 
 ### Email frontmatter format
 

--- a/book/configuration.md
+++ b/book/configuration.md
@@ -4,11 +4,13 @@ AIMX uses a single TOML configuration file for all settings.
 
 ## Config file location
 
-The default config file is at `/var/lib/aimx/config.toml`. This file is created automatically by `aimx setup`.
+The default config file is at `/etc/aimx/config.toml` (mode `0640`, owner `root:root`). It is created automatically by `aimx setup`.
+
+Starting with v0.2, the config lives under `/etc/aimx/` (separate from the data directory) so that DKIM secrets and config are owned by root and only the `aimx` system group needs access to the local submission socket.
 
 ### Data directory override
 
-The data directory (which contains `config.toml`, DKIM keys, and all mailboxes) can be overridden:
+The **data directory** (`/var/lib/aimx/` by default) holds mailboxes only in v0.2 — config and DKIM keys are under `/etc/aimx/`. To relocate it:
 
 ```bash
 # CLI flag (works with any command)
@@ -20,6 +22,16 @@ aimx status
 ```
 
 The `--data-dir` flag takes precedence over the environment variable.
+
+### Config directory override
+
+For tests or non-standard installs, override the config directory with:
+
+```bash
+export AIMX_CONFIG_DIR=/custom/etc/path
+```
+
+This changes where `config.toml` and the DKIM keypair (`dkim/private.key`, `dkim/public.key`) are read from. Under normal operation you should **not** set this — `aimx setup` writes to `/etc/aimx/` and every command picks it up from there.
 
 ## Settings reference
 
@@ -61,11 +73,16 @@ See [Channel Rules](channels.md) for full details on triggers, match filters, an
 ## Storage layout
 
 ```
-/var/lib/aimx/
-├── config.toml              # Configuration file
-├── dkim/
-│   ├── private.key          # RSA private key (mode 0600)
-│   └── public.key           # RSA public key
+/etc/aimx/                   # Config + secrets (root-owned, mode 0755)
+├── config.toml              # Configuration file (mode 0640, root:root)
+└── dkim/
+    ├── private.key          # RSA private key (mode 0600, root-only)
+    └── public.key           # RSA public key (mode 0644)
+
+/run/aimx/                   # Runtime directory (mode 0750, root:aimx)
+└── send.sock                # (Sprint 34) local submission socket
+
+/var/lib/aimx/               # Mailbox storage
 ├── catchall/                # Default mailbox
 │   ├── 2025-01-15-001.md
 │   ├── 2025-01-15-002.md
@@ -82,7 +99,7 @@ By default, `aimx send` delivers outbound email over IPv4 only. This matches the
 
 If your server has a global IPv6 address and you want outbound mail to use it:
 
-1. Set the flag in `/var/lib/aimx/config.toml`:
+1. Set the flag in `/etc/aimx/config.toml`:
 
    ```toml
    enable_ipv6 = true

--- a/book/setup.md
+++ b/book/setup.md
@@ -78,16 +78,30 @@ When run without a domain argument, setup will prompt you to enter the domain an
 2. **Domain prompt** -- asks for domain if not provided as argument
 3. **Port 25 conflict detection** -- checks for another process on port 25
 4. **TLS certificate** -- generates a self-signed certificate at `/etc/ssl/aimx/`
-5. **DKIM key generation** -- creates a 2048-bit RSA keypair at `/var/lib/aimx/dkim/`
-6. **Config creation** -- writes `/var/lib/aimx/config.toml` with a catchall mailbox
-7. **Service installation** -- generates a systemd unit file (or OpenRC init script on Alpine) and starts `aimx serve`
-8. **Port 25 checks** -- verifies outbound and inbound port 25 connectivity
+5. **`aimx` system group** -- created via `groupadd --system aimx` (falls back to `addgroup -S aimx` on Alpine/BusyBox). Idempotent.
+6. **DKIM key generation** -- creates a 2048-bit RSA keypair at `/etc/aimx/dkim/` (private `0600`, public `0644`)
+7. **Config creation** -- writes `/etc/aimx/config.toml` (mode `0640`, owner `root:root`) with a catchall mailbox
+8. **Service installation** -- generates a systemd unit (or OpenRC init script on Alpine) with `RuntimeDirectory=aimx` + `Group=aimx`, and starts `aimx serve`
+9. **Port 25 checks** -- verifies outbound and inbound port 25 connectivity
 
-After initial setup, the wizard displays three clearly labeled sections:
+After initial setup, the wizard displays four clearly labeled sections:
 
 - **[DNS]** -- the records you need to add (MX, A, AAAA, SPF, DKIM, DMARC), with a retry loop so you can press Enter to re-verify after adding records
+- **[Group access]** -- the `sudo usermod -aG aimx <user>` command you run once to let an agent user submit mail via `aimx send` (see [Group access](#group-access) below)
 - **[MCP]** -- configuration snippet for MCP-compatible AI agents (Claude Code, OpenClaw, Codex, OpenCode, etc.)
 - **[Deliverability Improvement (Optional)]** -- PTR record guidance and Gmail filter/whitelist instructions
+
+### Group access
+
+Starting with v0.2, AIMX creates an `aimx` system group during setup. Membership in this group will (Sprint 34) gate access to `/run/aimx/send.sock`, the local submission socket used by `aimx send`. Add any agent user who should be able to send mail:
+
+```bash
+sudo usermod -aG aimx alice
+```
+
+The new group takes effect at the next login — or run `newgrp aimx` in the current shell to pick it up immediately. Only users in the `aimx` group (or root) will be able to write to `/run/aimx/send.sock`; no other users can submit mail even if they have a copy of the aimx binary.
+
+Re-running `aimx setup` is idempotent: if the group already exists, the wizard reports that and moves on.
 
 ### Re-running setup
 
@@ -125,7 +139,7 @@ The `AAAA` record and SPF `ip6:` mechanism are only shown and verified by `aimx 
 The DKIM public key value (`p=...`) is displayed by the setup wizard. To retrieve it again:
 
 ```bash
-cat /var/lib/aimx/dkim/public.key
+cat /etc/aimx/dkim/public.key
 ```
 
 DNS propagation typically takes minutes but can take up to 48 hours.
@@ -215,8 +229,8 @@ aimx dkim-keygen --selector mykey
 ```
 
 Keys are stored at:
-- Private key: `/var/lib/aimx/dkim/private.key` (mode `0600`)
-- Public key: `/var/lib/aimx/dkim/public.key`
+- Private key: `/etc/aimx/dkim/private.key` (mode `0600`, root-only)
+- Public key: `/etc/aimx/dkim/public.key` (mode `0644`)
 
 After regenerating keys, update the DKIM DNS record with the new public key.
 
@@ -235,16 +249,16 @@ Only port 25 needs to be open for SMTP. No other ports are required by AIMX.
 
 ### File permissions
 
-The DKIM private key is created with mode `0600` (owner read/write only). Verify:
+The DKIM private key is created with mode `0600` (root-only). Verify:
 
 ```bash
-ls -la /var/lib/aimx/dkim/private.key
+ls -la /etc/aimx/dkim/private.key
 # Should show: -rw-------
 ```
 
 ### Backups
 
-Back up `/var/lib/aimx/` -- it contains everything: config, DKIM keys, all mailboxes and emails.
+Back up both `/etc/aimx/` (config + DKIM keys) and `/var/lib/aimx/` (mailboxes and emails). `/run/aimx/` is runtime-only and does not need backup.
 
 ## Verifier service
 

--- a/docs/manual-setup.md
+++ b/docs/manual-setup.md
@@ -278,7 +278,7 @@ The setup wizard performs these steps automatically:
 2. Generates a self-signed TLS certificate at `/etc/ssl/aimx/`
 3. Installs and starts `aimx serve` as a systemd/OpenRC service
 4. Runs port checks (outbound 25, inbound 25 via `/probe`)
-5. Generates the DKIM keypair at `/var/lib/aimx/dkim/`, writes `/var/lib/aimx/config.toml`, and creates the catchall mailbox directory
+5. Creates the `aimx` system group, generates the DKIM keypair at `/etc/aimx/dkim/` (private `0600`, public `0644`), writes `/etc/aimx/config.toml` (mode `0640`, `root:root`), and creates the catchall mailbox directory under `/var/lib/aimx/`
 6. Displays the DNS records you need to add (see next step)
 7. After you add the records and press Enter, resolves and validates each one
 
@@ -386,7 +386,7 @@ aimx mailbox create notifications
 aimx mailbox list
 ```
 
-Edit `/var/lib/aimx/config.toml` to configure channel rules (triggers on incoming mail):
+Edit `/etc/aimx/config.toml` to configure channel rules (triggers on incoming mail):
 
 ```toml
 [mailboxes.support]

--- a/docs/sprint.md
+++ b/docs/sprint.md
@@ -660,7 +660,7 @@ Completed sprints 1–21 have been archived for context window efficiency.
 
 ---
 
-## Sprint 33 — Filesystem Split + `aimx` Group Foundation (Days 92–94.5) [NOT STARTED]
+## Sprint 33 — Filesystem Split + `aimx` Group Foundation (Days 92–94.5) [IN PROGRESS]
 
 **Goal:** Move configuration and DKIM secrets to `/etc/aimx/`, establish the `aimx` system group, and provide the `/run/aimx/` runtime directory. No behavior change is visible to agents yet — this is the foundation every subsequent v0.2 sprint builds on.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,6 +3,34 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 const DEFAULT_DATA_DIR: &str = "/var/lib/aimx";
+const DEFAULT_CONFIG_DIR: &str = "/etc/aimx";
+const CONFIG_DIR_ENV: &str = "AIMX_CONFIG_DIR";
+
+/// Resolve the configuration directory.
+///
+/// Precedence:
+/// 1. `AIMX_CONFIG_DIR` environment variable (tests, non-standard installs)
+/// 2. `/etc/aimx/` default
+///
+/// Mirrors the `--data-dir` / `AIMX_DATA_DIR` shape used for the storage
+/// directory, but is deliberately **independent** of it: `--data-dir`
+/// governs `/var/lib/aimx/` (storage), `AIMX_CONFIG_DIR` governs
+/// `/etc/aimx/` (config + DKIM secrets).
+pub fn config_dir() -> PathBuf {
+    std::env::var_os(CONFIG_DIR_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_CONFIG_DIR))
+}
+
+/// Path to the main `config.toml` file.
+pub fn config_path() -> PathBuf {
+    config_dir().join("config.toml")
+}
+
+/// Path to the DKIM directory containing `private.key` and `public.key`.
+pub fn dkim_dir() -> PathBuf {
+    config_dir().join("dkim")
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Config {
@@ -81,16 +109,13 @@ impl Config {
         Ok(())
     }
 
-    pub fn config_path(data_dir: &Path) -> PathBuf {
-        data_dir.join("config.toml")
-    }
-
-    pub fn load_from_data_dir(data_dir: &Path) -> Result<Self, Box<dyn std::error::Error>> {
-        Self::load(&Self::config_path(data_dir))
-    }
-
-    pub fn load_default() -> Result<Self, Box<dyn std::error::Error>> {
-        Self::load_from_data_dir(Path::new(DEFAULT_DATA_DIR))
+    /// Load the config from the canonical path returned by [`config_path`].
+    ///
+    /// Replaces the old `load_from_data_dir` — config no longer lives inside
+    /// the storage directory. Override via the `AIMX_CONFIG_DIR` env var
+    /// (tests, non-standard installs).
+    pub fn load_resolved() -> Result<Self, Box<dyn std::error::Error>> {
+        Self::load(&config_path())
     }
 
     pub fn mailbox_dir(&self, name: &str) -> PathBuf {
@@ -106,8 +131,55 @@ impl Config {
     }
 }
 
+/// Test-only helpers for overriding `AIMX_CONFIG_DIR` safely from multiple
+/// test modules. Process-wide env is not parallel-safe, so every test that
+/// mutates this variable must go through [`ConfigDirOverride`] — it
+/// serializes mutations behind a module-level [`Mutex`] and restores the
+/// previous value on drop.
+#[cfg(test)]
+pub(crate) mod test_env {
+    use super::CONFIG_DIR_ENV;
+    use std::path::Path;
+    use std::sync::Mutex;
+
+    static CONFIG_DIR_GUARD: Mutex<()> = Mutex::new(());
+
+    pub(crate) struct ConfigDirOverride {
+        _guard: std::sync::MutexGuard<'static, ()>,
+        prev: Option<std::ffi::OsString>,
+    }
+
+    impl ConfigDirOverride {
+        pub(crate) fn set(path: &Path) -> Self {
+            let guard = CONFIG_DIR_GUARD.lock().unwrap_or_else(|e| e.into_inner());
+            let prev = std::env::var_os(CONFIG_DIR_ENV);
+            // SAFETY: env mutation serialized via CONFIG_DIR_GUARD.
+            unsafe {
+                std::env::set_var(CONFIG_DIR_ENV, path);
+            }
+            Self {
+                _guard: guard,
+                prev,
+            }
+        }
+    }
+
+    impl Drop for ConfigDirOverride {
+        fn drop(&mut self) {
+            // SAFETY: env mutation serialized via CONFIG_DIR_GUARD.
+            unsafe {
+                match &self.prev {
+                    Some(v) => std::env::set_var(CONFIG_DIR_ENV, v),
+                    None => std::env::remove_var(CONFIG_DIR_ENV),
+                }
+            }
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
+    use super::test_env::ConfigDirOverride;
     use super::*;
     use tempfile::TempDir;
 
@@ -294,6 +366,49 @@ enable_ipv6 = true
 "#;
         let config: Config = toml::from_str(toml_str).unwrap();
         assert!(config.enable_ipv6);
+    }
+
+    #[test]
+    fn config_dir_defaults_to_etc_aimx_when_env_unset() {
+        // Hold the guard by setting an override to a sentinel, then remove
+        // the var while still holding it. The `set`/drop dance keeps the
+        // serialization invariant without exposing the raw mutex.
+        let tmp = TempDir::new().unwrap();
+        let override_guard = ConfigDirOverride::set(tmp.path());
+        // SAFETY: serialization ensured by `override_guard` holding the
+        // CONFIG_DIR_GUARD; drop will restore the prior value.
+        unsafe {
+            std::env::remove_var(CONFIG_DIR_ENV);
+        }
+        assert_eq!(config_dir(), PathBuf::from("/etc/aimx"));
+        assert_eq!(config_path(), PathBuf::from("/etc/aimx/config.toml"));
+        assert_eq!(dkim_dir(), PathBuf::from("/etc/aimx/dkim"));
+        drop(override_guard);
+    }
+
+    #[test]
+    fn config_dir_env_var_overrides_default() {
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        assert_eq!(config_dir(), tmp.path());
+        assert_eq!(config_path(), tmp.path().join("config.toml"));
+        assert_eq!(dkim_dir(), tmp.path().join("dkim"));
+    }
+
+    #[test]
+    fn load_resolved_reads_from_config_dir() {
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+
+        let config_file = tmp.path().join("config.toml");
+        std::fs::write(
+            &config_file,
+            "domain = \"resolved.example.com\"\n[mailboxes]\n",
+        )
+        .unwrap();
+
+        let config = Config::load_resolved().unwrap();
+        assert_eq!(config.domain, "resolved.example.com");
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -118,6 +118,21 @@ impl Config {
         Self::load(&config_path())
     }
 
+    /// Load the config and apply an optional `--data-dir` / `AIMX_DATA_DIR`
+    /// override for the storage path. `config.data_dir` is the source of
+    /// truth post-Sprint 33; this helper lets the CLI flag still redirect
+    /// storage (its documented purpose) without touching the config file on
+    /// disk.
+    pub fn load_resolved_with_data_dir(
+        data_dir_override: Option<&Path>,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let mut cfg = Self::load_resolved()?;
+        if let Some(dir) = data_dir_override {
+            cfg.data_dir = dir.to_path_buf();
+        }
+        Ok(cfg)
+    }
+
     pub fn mailbox_dir(&self, name: &str) -> PathBuf {
         self.data_dir.join(name)
     }

--- a/src/dkim.rs
+++ b/src/dkim.rs
@@ -22,6 +22,10 @@ fn dkim_paths(dkim_root: &Path) -> (std::path::PathBuf, std::path::PathBuf) {
 /// v0.2 permissions (Sprint 33 S33-3):
 /// - Private key: `0o600` (root-only; `aimx serve` reads it in-process)
 /// - Public key:  `0o644` (world-readable — it's advertised via DNS)
+///
+/// On Unix the files are created atomically with their target mode via
+/// `OpenOptions::mode(...).create_new(true)` to avoid a brief window of
+/// umask-default permissions between `write` and `chmod`.
 pub fn generate_keypair(dkim_root: &Path, force: bool) -> Result<(), Box<dyn std::error::Error>> {
     let (private_path, public_path) = dkim_paths(dkim_root);
 
@@ -31,28 +35,55 @@ pub fn generate_keypair(dkim_root: &Path, force: bool) -> Result<(), Box<dyn std
 
     std::fs::create_dir_all(dkim_root)?;
 
+    // Force-overwrite path: remove pre-existing files so `create_new(true)`
+    // succeeds with the tightened mode. (Otherwise `OpenOptions` would
+    // fail with `AlreadyExists` and leave the old file at its old mode.)
+    if force {
+        for p in [&private_path, &public_path] {
+            if p.exists() {
+                std::fs::remove_file(p)?;
+            }
+        }
+    }
+
     let mut rng = rsa::rand_core::OsRng;
     let private_key = RsaPrivateKey::new(&mut rng, DKIM_KEY_BITS)?;
 
     let private_pem = private_key.to_pkcs1_pem(LineEnding::LF)?;
-    std::fs::write(&private_path, private_pem.as_bytes())?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&private_path, std::fs::Permissions::from_mode(0o600))?;
-    }
+    write_file_with_mode(&private_path, private_pem.as_bytes(), 0o600)?;
 
     let public_key = RsaPublicKey::from(&private_key);
     let public_pem = public_key.to_public_key_pem(LineEnding::LF)?;
-    std::fs::write(&public_path, public_pem.as_bytes())?;
+    write_file_with_mode(&public_path, public_pem.as_bytes(), 0o644)?;
 
+    Ok(())
+}
+
+/// Create `path` with `bytes` as contents and the given Unix mode applied
+/// atomically at open time (no umask-default window between write and
+/// chmod). On non-Unix the mode is ignored and a plain `fs::write` is used.
+fn write_file_with_mode(
+    path: &Path,
+    bytes: &[u8],
+    mode: u32,
+) -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(unix)]
     {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&public_path, std::fs::Permissions::from_mode(0o644))?;
+        use std::io::Write as _;
+        use std::os::unix::fs::OpenOptionsExt;
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .mode(mode)
+            .open(path)?;
+        f.write_all(bytes)?;
+        f.sync_all()?;
     }
-
+    #[cfg(not(unix))]
+    {
+        let _ = mode;
+        std::fs::write(path, bytes)?;
+    }
     Ok(())
 }
 
@@ -273,6 +304,39 @@ mod tests {
         assert!(
             err.contains("private.key"),
             "Error should include the file path: {err}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn load_private_key_permission_denied_surfaces_root_guidance() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Skip this test when running as root — `chmod 0o000` is bypassed
+        // by CAP_DAC_READ_SEARCH / euid 0, so we can't force PermissionDenied.
+        if unsafe { libc::geteuid() } == 0 {
+            eprintln!("skipping: test must run as non-root");
+            return;
+        }
+
+        let tmp = TempDir::new().unwrap();
+        let private_path = tmp.path().join("private.key");
+        std::fs::write(&private_path, b"fake pem").unwrap();
+        std::fs::set_permissions(&private_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+        let result = load_private_key(tmp.path());
+        // Always restore mode so TempDir cleanup can succeed.
+        let _ = std::fs::set_permissions(&private_path, std::fs::Permissions::from_mode(0o600));
+
+        let err = result.expect_err("load_private_key should fail on 0o000 file");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("readable only by root"),
+            "PermissionDenied path must surface the root-only guidance: {msg}"
+        );
+        assert!(
+            msg.contains("aimx send"),
+            "PermissionDenied guidance must redirect non-root callers to `aimx send`: {msg}"
         );
     }
 

--- a/src/dkim.rs
+++ b/src/dkim.rs
@@ -7,16 +7,29 @@ use std::path::Path;
 
 const DKIM_KEY_BITS: usize = 2048;
 
-pub fn generate_keypair(data_dir: &Path, force: bool) -> Result<(), Box<dyn std::error::Error>> {
-    let dkim_dir = data_dir.join("dkim");
-    let private_path = dkim_dir.join("private.key");
-    let public_path = dkim_dir.join("public.key");
+/// Resolve `<dkim_root>/{private,public}.key`.
+///
+/// `dkim_root` is treated as the directory containing the DKIM keys
+/// themselves — callers should pass `config_dir().join("dkim")` for the
+/// v0.2 layout. The legacy `<data_dir>/dkim` layout is no longer written
+/// by any production path; only tests now supply arbitrary tempdir roots.
+fn dkim_paths(dkim_root: &Path) -> (std::path::PathBuf, std::path::PathBuf) {
+    (dkim_root.join("private.key"), dkim_root.join("public.key"))
+}
+
+/// Generate a 2048-bit RSA DKIM keypair at `<dkim_root>/{private,public}.key`.
+///
+/// v0.2 permissions (Sprint 33 S33-3):
+/// - Private key: `0o600` (root-only; `aimx serve` reads it in-process)
+/// - Public key:  `0o644` (world-readable — it's advertised via DNS)
+pub fn generate_keypair(dkim_root: &Path, force: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let (private_path, public_path) = dkim_paths(dkim_root);
 
     if private_path.exists() && !force {
         return Err("DKIM keys already exist. Use --force to overwrite.".into());
     }
 
-    std::fs::create_dir_all(&dkim_dir)?;
+    std::fs::create_dir_all(dkim_root)?;
 
     let mut rng = rsa::rand_core::OsRng;
     let private_key = RsaPrivateKey::new(&mut rng, DKIM_KEY_BITS)?;
@@ -27,18 +40,24 @@ pub fn generate_keypair(data_dir: &Path, force: bool) -> Result<(), Box<dyn std:
     #[cfg(unix)]
     {
         use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&private_path, std::fs::Permissions::from_mode(0o644))?;
+        std::fs::set_permissions(&private_path, std::fs::Permissions::from_mode(0o600))?;
     }
 
     let public_key = RsaPublicKey::from(&private_key);
     let public_pem = public_key.to_public_key_pem(LineEnding::LF)?;
     std::fs::write(&public_path, public_pem.as_bytes())?;
 
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&public_path, std::fs::Permissions::from_mode(0o644))?;
+    }
+
     Ok(())
 }
 
-pub fn dns_record_value(data_dir: &Path) -> Result<String, Box<dyn std::error::Error>> {
-    let public_path = data_dir.join("dkim/public.key");
+pub fn dns_record_value(dkim_root: &Path) -> Result<String, Box<dyn std::error::Error>> {
+    let (_, public_path) = dkim_paths(dkim_root);
     let pem = std::fs::read_to_string(&public_path)
         .map_err(|_| "DKIM public key not found. Run `aimx dkim-keygen` first.")?;
 
@@ -56,13 +75,30 @@ pub fn dns_record_value(data_dir: &Path) -> Result<String, Box<dyn std::error::E
     Ok(format!("v=DKIM1; k=rsa; p={b64}"))
 }
 
-pub fn load_private_key(data_dir: &Path) -> Result<RsaPrivateKey, Box<dyn std::error::Error>> {
-    let private_path = data_dir.join("dkim/private.key");
+/// Load the RSA DKIM private key from `<dkim_root>/private.key`.
+///
+/// v0.2 (Sprint 33 S33-3) tightened the private key to `0o600`. When a
+/// non-root process hits `PermissionDenied`, the error message steers
+/// the caller back to `aimx send` (which in Sprint 34 delegates to the
+/// `aimx serve` UDS socket for DKIM signing) rather than suggesting a
+/// permissions hack.
+pub fn load_private_key(dkim_root: &Path) -> Result<RsaPrivateKey, Box<dyn std::error::Error>> {
+    let (private_path, _) = dkim_paths(dkim_root);
     let pem = std::fs::read_to_string(&private_path).map_err(|e| {
-        format!(
-            "DKIM private key not found at {}: {e}. Run `aimx dkim-keygen` first.",
-            private_path.display()
-        )
+        if e.kind() == std::io::ErrorKind::PermissionDenied {
+            format!(
+                "DKIM private key is readable only by root. \
+                 This command must be invoked by `aimx serve` (root) — \
+                 non-root processes must submit mail via `aimx send` instead. \
+                 (path: {})",
+                private_path.display()
+            )
+        } else {
+            format!(
+                "DKIM private key not found at {}: {e}. Run `aimx dkim-keygen` first.",
+                private_path.display()
+            )
+        }
     })?;
 
     let key = rsa::pkcs1::DecodeRsaPrivateKey::from_pkcs1_pem(&pem)?;
@@ -116,12 +152,12 @@ pub fn sign_message(
 }
 
 pub fn run_keygen(
-    data_dir: &Path,
+    dkim_root: &Path,
     domain: &str,
     selector: &str,
     force: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let private_path = data_dir.join("dkim/private.key");
+    let (private_path, _) = dkim_paths(dkim_root);
     let already_existed = private_path.exists() && !force;
 
     if already_existed {
@@ -130,10 +166,10 @@ pub fn run_keygen(
             term::warn("Warning:")
         );
     } else {
-        generate_keypair(data_dir, force)?;
+        generate_keypair(dkim_root, force)?;
     }
 
-    let record = dns_record_value(data_dir)?;
+    let record = dns_record_value(dkim_root)?;
 
     if !already_existed {
         println!("{}", term::success("DKIM keypair generated successfully."));
@@ -161,8 +197,8 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         generate_keypair(tmp.path(), false).unwrap();
 
-        let private_pem = std::fs::read_to_string(tmp.path().join("dkim/private.key")).unwrap();
-        let public_pem = std::fs::read_to_string(tmp.path().join("dkim/public.key")).unwrap();
+        let private_pem = std::fs::read_to_string(tmp.path().join("private.key")).unwrap();
+        let public_pem = std::fs::read_to_string(tmp.path().join("public.key")).unwrap();
 
         let private_key: RsaPrivateKey =
             rsa::pkcs1::DecodeRsaPrivateKey::from_pkcs1_pem(&private_pem).unwrap();
@@ -188,11 +224,11 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         generate_keypair(tmp.path(), false).unwrap();
 
-        let original = std::fs::read_to_string(tmp.path().join("dkim/private.key")).unwrap();
+        let original = std::fs::read_to_string(tmp.path().join("private.key")).unwrap();
 
         generate_keypair(tmp.path(), true).unwrap();
 
-        let new = std::fs::read_to_string(tmp.path().join("dkim/private.key")).unwrap();
+        let new = std::fs::read_to_string(tmp.path().join("private.key")).unwrap();
 
         assert_ne!(original, new);
     }
@@ -235,7 +271,7 @@ mod tests {
             "Error should mention 'not found': {err}"
         );
         assert!(
-            err.contains("dkim/private.key"),
+            err.contains("private.key"),
             "Error should include the file path: {err}"
         );
     }
@@ -275,32 +311,36 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn private_key_has_readable_permissions() {
+    fn private_key_has_restricted_permissions() {
         use std::os::unix::fs::PermissionsExt;
 
         let tmp = TempDir::new().unwrap();
         generate_keypair(tmp.path(), false).unwrap();
 
-        let metadata = std::fs::metadata(tmp.path().join("dkim/private.key")).unwrap();
+        let metadata = std::fs::metadata(tmp.path().join("private.key")).unwrap();
         let mode = metadata.permissions().mode() & 0o777;
-        assert_eq!(mode, 0o644);
+        assert_eq!(
+            mode, 0o600,
+            "v0.2: DKIM private key must be root-only (0o600) — \
+             Sprint 33 reverses the 0o644 relaxation from Sprint 25 \
+             because signing moves inside the `aimx serve` daemon."
+        );
     }
 
     #[cfg(unix)]
     #[test]
-    fn generate_keypair_sets_644_file_mode() {
+    fn public_key_is_world_readable() {
         use std::os::unix::fs::PermissionsExt;
 
         let tmp = TempDir::new().unwrap();
         generate_keypair(tmp.path(), false).unwrap();
 
-        let private_path = tmp.path().join("dkim/private.key");
-        assert!(private_path.exists());
-        let metadata = std::fs::metadata(&private_path).unwrap();
+        let public_path = tmp.path().join("public.key");
+        let metadata = std::fs::metadata(&public_path).unwrap();
         let mode = metadata.permissions().mode() & 0o777;
         assert_eq!(
             mode, 0o644,
-            "DKIM private key should be globally readable (0o644)"
+            "DKIM public key is advertised via DNS and must stay world-readable"
         );
     }
 

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -39,12 +39,9 @@ pub struct AttachmentMeta {
 
 pub fn run(
     rcpt: &str,
-    data_dir: Option<&std::path::Path>,
+    _data_dir: Option<&std::path::Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let config = match data_dir {
-        Some(dir) => Config::load_from_data_dir(dir)?,
-        None => Config::load_default()?,
-    };
+    let config = Config::load_resolved()?;
     let mut raw = Vec::new();
     std::io::stdin().read_to_end(&mut raw)?;
     ingest_email(&config, rcpt, &raw)

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -39,9 +39,9 @@ pub struct AttachmentMeta {
 
 pub fn run(
     rcpt: &str,
-    _data_dir: Option<&std::path::Path>,
+    data_dir: Option<&std::path::Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let config = Config::load_resolved()?;
+    let config = Config::load_resolved_with_data_dir(data_dir)?;
     let mut raw = Vec::new();
     std::io::stdin().read_to_end(&mut raw)?;
     ingest_email(&config, rcpt, &raw)

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -6,9 +6,9 @@ use std::path::Path;
 
 pub fn run(
     cmd: MailboxCommand,
-    _data_dir: Option<&std::path::Path>,
+    data_dir: Option<&std::path::Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let config = Config::load_resolved()?;
+    let config = Config::load_resolved_with_data_dir(data_dir)?;
     match cmd {
         MailboxCommand::Create { name } => create(&config, &name),
         MailboxCommand::List => list(&config),

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -6,12 +6,9 @@ use std::path::Path;
 
 pub fn run(
     cmd: MailboxCommand,
-    data_dir: Option<&std::path::Path>,
+    _data_dir: Option<&std::path::Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let config = match data_dir {
-        Some(dir) => Config::load_from_data_dir(dir)?,
-        None => Config::load_default()?,
-    };
+    let config = Config::load_resolved()?;
     match cmd {
         MailboxCommand::Create { name } => create(&config, &name),
         MailboxCommand::List => list(&config),
@@ -56,8 +53,7 @@ pub fn create_mailbox(config: &Config, name: &str) -> Result<(), Box<dyn std::er
         },
     );
 
-    let config_path = Config::config_path(&config.data_dir);
-    config.save(&config_path)?;
+    config.save(&crate::config::config_path())?;
 
     Ok(())
 }
@@ -92,8 +88,7 @@ pub fn delete_mailbox(config: &Config, name: &str) -> Result<(), Box<dyn std::er
     let mut config = config.clone();
     config.mailboxes.remove(name);
 
-    let config_path = Config::config_path(&config.data_dir);
-    config.save(&config_path)?;
+    config.save(&crate::config::config_path())?;
 
     Ok(())
 }
@@ -164,6 +159,7 @@ fn delete(config: &Config, name: &str, yes: bool) -> Result<(), Box<dyn std::err
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::config::test_env::ConfigDirOverride;
     use crate::config::{Config, MailboxConfig};
     use std::collections::HashMap;
     use tempfile::TempDir;
@@ -189,22 +185,26 @@ mod tests {
         }
     }
 
-    fn setup_config_file(config: &Config) {
+    /// Point `AIMX_CONFIG_DIR` at `tmp`, create the storage dir, and write
+    /// `config.toml` to the resolved location. Returns the override guard
+    /// which must be kept alive for the duration of the test.
+    fn setup_config_file(tmp: &Path, config: &Config) -> ConfigDirOverride {
         std::fs::create_dir_all(&config.data_dir).unwrap();
-        let path = Config::config_path(&config.data_dir);
-        config.save(&path).unwrap();
+        let guard = ConfigDirOverride::set(tmp);
+        config.save(&crate::config::config_path()).unwrap();
+        guard
     }
 
     #[test]
     fn create_new_mailbox() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        setup_config_file(&config);
+        let _guard = setup_config_file(tmp.path(), &config);
 
         create_mailbox(&config, "alice").unwrap();
 
         assert!(tmp.path().join("alice").is_dir());
-        let reloaded = Config::load_from_data_dir(tmp.path()).unwrap();
+        let reloaded = Config::load_resolved().unwrap();
         assert!(reloaded.mailboxes.contains_key("alice"));
         assert_eq!(reloaded.mailboxes["alice"].address, "alice@test.com");
     }
@@ -213,7 +213,7 @@ mod tests {
     fn create_duplicate_fails() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        setup_config_file(&config);
+        let _guard = setup_config_file(tmp.path(), &config);
 
         let result = create_mailbox(&config, "catchall");
         assert!(result.is_err());
@@ -224,7 +224,7 @@ mod tests {
     fn list_shows_mailboxes() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        setup_config_file(&config);
+        let _guard = setup_config_file(tmp.path(), &config);
 
         std::fs::create_dir_all(tmp.path().join("catchall")).unwrap();
         std::fs::write(tmp.path().join("catchall/2025-01-01-001.md"), "test").unwrap();
@@ -240,16 +240,16 @@ mod tests {
     fn delete_mailbox_works() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        setup_config_file(&config);
+        let _guard = setup_config_file(tmp.path(), &config);
 
         create_mailbox(&config, "alice").unwrap();
-        let config = Config::load_from_data_dir(tmp.path()).unwrap();
+        let config = Config::load_resolved().unwrap();
         assert!(config.mailboxes.contains_key("alice"));
 
         delete_mailbox(&config, "alice").unwrap();
 
         assert!(!tmp.path().join("alice").exists());
-        let reloaded = Config::load_from_data_dir(tmp.path()).unwrap();
+        let reloaded = Config::load_resolved().unwrap();
         assert!(!reloaded.mailboxes.contains_key("alice"));
     }
 
@@ -257,7 +257,7 @@ mod tests {
     fn delete_catchall_fails() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        setup_config_file(&config);
+        let _guard = setup_config_file(tmp.path(), &config);
 
         let result = delete_mailbox(&config, "catchall");
         assert!(result.is_err());
@@ -268,7 +268,7 @@ mod tests {
     fn delete_nonexistent_fails() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        setup_config_file(&config);
+        let _guard = setup_config_file(tmp.path(), &config);
 
         let result = delete_mailbox(&config, "nonexistent");
         assert!(result.is_err());
@@ -288,7 +288,7 @@ mod tests {
     fn create_empty_name_fails() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        setup_config_file(&config);
+        let _guard = setup_config_file(tmp.path(), &config);
 
         let result = create_mailbox(&config, "");
         assert!(result.is_err());
@@ -299,7 +299,7 @@ mod tests {
     fn create_path_traversal_fails() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        setup_config_file(&config);
+        let _guard = setup_config_file(tmp.path(), &config);
 
         let result = create_mailbox(&config, "../etc");
         assert!(result.is_err());
@@ -310,7 +310,7 @@ mod tests {
     fn create_with_slash_fails() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        setup_config_file(&config);
+        let _guard = setup_config_file(tmp.path(), &config);
 
         let result = create_mailbox(&config, "foo/bar");
         assert!(result.is_err());
@@ -321,7 +321,7 @@ mod tests {
     fn create_with_backslash_fails() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        setup_config_file(&config);
+        let _guard = setup_config_file(tmp.path(), &config);
 
         let result = create_mailbox(&config, "foo\\bar");
         assert!(result.is_err());

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,7 +40,7 @@ fn dispatch(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
                     std::process::exit(1);
                 }
             };
-            dkim::run_keygen(&config.data_dir, &config.domain, &selector, force)
+            dkim::run_keygen(&config::dkim_dir(), &config.domain, &selector, force)
         }
         Command::Mcp => {
             let rt = tokio::runtime::Runtime::new()
@@ -78,11 +78,10 @@ fn dispatch(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
     }
 }
 
-fn load_config(data_dir: Option<&Path>) -> Result<config::Config, Box<dyn std::error::Error>> {
-    match data_dir {
-        Some(dir) => config::Config::load_from_data_dir(dir),
-        None => config::Config::load_default(),
-    }
+fn load_config(_data_dir: Option<&Path>) -> Result<config::Config, Box<dyn std::error::Error>> {
+    // Config lives at `config_path()` (default `/etc/aimx/config.toml`) —
+    // `--data-dir` no longer governs config location (v0.2 filesystem split).
+    config::Config::load_resolved()
 }
 
 fn build_network_ops(

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -14,6 +14,9 @@ use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
 pub struct AimxMcpServer {
+    /// Retained for forward-compat with callers that still pass `--data-dir`,
+    /// even though config is now resolved via `config_path()` (Sprint 33).
+    #[allow(dead_code)]
     data_dir: PathBuf,
     #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
@@ -94,8 +97,7 @@ impl AimxMcpServer {
     }
 
     fn load_config(&self) -> Result<Config, String> {
-        Config::load_from_data_dir(&self.data_dir)
-            .map_err(|e| format!("Failed to load config: {e}"))
+        Config::load_resolved().map_err(|e| format!("Failed to load config: {e}"))
     }
 }
 
@@ -540,8 +542,8 @@ pub fn set_read_status(config: &Config, mailbox: &str, id: &str, read: bool) -> 
     Ok(())
 }
 
-fn load_dkim_key(config: &Config) -> Result<rsa::RsaPrivateKey, String> {
-    dkim::load_private_key(&config.data_dir)
+fn load_dkim_key(_config: &Config) -> Result<rsa::RsaPrivateKey, String> {
+    dkim::load_private_key(&crate::config::dkim_dir())
         .map_err(|e| format!("DKIM signing required but private key could not be loaded: {e}"))
 }
 
@@ -601,10 +603,11 @@ mod tests {
         }
     }
 
-    fn setup_config(config: &Config) {
+    fn setup_config(config: &Config) -> crate::config::test_env::ConfigDirOverride {
         std::fs::create_dir_all(&config.data_dir).unwrap();
-        let config_path = Config::config_path(&config.data_dir);
-        config.save(&config_path).unwrap();
+        let guard = crate::config::test_env::ConfigDirOverride::set(&config.data_dir);
+        config.save(&crate::config::config_path()).unwrap();
+        guard
     }
 
     fn create_test_email(dir: &std::path::Path, id: &str, meta: &EmailMetadata) {
@@ -784,7 +787,7 @@ mod tests {
     fn set_read_status_marks_read() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        setup_config(&config);
+        let _cfg_guard = setup_config(&config);
 
         let meta = sample_meta("2025-06-01-001", "sender@test.com", "Test", false);
         create_test_email(&tmp.path().join("alice"), "2025-06-01-001", &meta);
@@ -800,7 +803,7 @@ mod tests {
     fn set_read_status_marks_unread() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        setup_config(&config);
+        let _cfg_guard = setup_config(&config);
 
         let meta = sample_meta("2025-06-01-001", "sender@test.com", "Test", true);
         create_test_email(&tmp.path().join("alice"), "2025-06-01-001", &meta);
@@ -816,7 +819,7 @@ mod tests {
     fn set_read_status_nonexistent_mailbox() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        setup_config(&config);
+        let _cfg_guard = setup_config(&config);
 
         let result = set_read_status(&config, "nonexistent", "2025-06-01-001", true);
         assert!(result.is_err());
@@ -827,7 +830,7 @@ mod tests {
     fn set_read_status_nonexistent_email() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        setup_config(&config);
+        let _cfg_guard = setup_config(&config);
 
         std::fs::create_dir_all(tmp.path().join("alice")).unwrap();
         let result = set_read_status(&config, "alice", "nonexistent", true);
@@ -852,7 +855,7 @@ mod tests {
     fn list_mailboxes_with_unread_counts() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        setup_config(&config);
+        let _cfg_guard = setup_config(&config);
 
         let meta1 = sample_meta("2025-06-01-001", "a@test.com", "A", false);
         let meta2 = sample_meta("2025-06-01-002", "b@test.com", "B", true);
@@ -924,7 +927,7 @@ mod tests {
     fn set_read_status_rejects_path_traversal() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        setup_config(&config);
+        let _cfg_guard = setup_config(&config);
 
         std::fs::create_dir_all(tmp.path().join("alice")).unwrap();
         let result = set_read_status(&config, "alice", "../../etc/passwd", true);
@@ -936,6 +939,7 @@ mod tests {
     fn load_dkim_key_missing_returns_error() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
         let result = load_dkim_key(&config);
         assert!(result.is_err());
         assert!(
@@ -949,7 +953,9 @@ mod tests {
     fn load_dkim_key_present_returns_ok() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        crate::dkim::generate_keypair(tmp.path(), false).unwrap();
+        // Point AIMX_CONFIG_DIR at `tmp` so `dkim_dir()` resolves there.
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
+        crate::dkim::generate_keypair(&crate::config::dkim_dir(), false).unwrap();
         let result = load_dkim_key(&config);
         assert!(result.is_ok());
     }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -14,10 +14,10 @@ use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
 pub struct AimxMcpServer {
-    /// Retained for forward-compat with callers that still pass `--data-dir`,
-    /// even though config is now resolved via `config_path()` (Sprint 33).
-    #[allow(dead_code)]
-    data_dir: PathBuf,
+    /// CLI `--data-dir` / `AIMX_DATA_DIR` override. When `Some`, it
+    /// supersedes `config.data_dir` for all storage operations; when
+    /// `None`, the value from `/etc/aimx/config.toml` is used.
+    data_dir_override: Option<PathBuf>,
     #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
 }
@@ -89,15 +89,16 @@ pub struct EmailReplyParams {
 }
 
 impl AimxMcpServer {
-    pub fn new(data_dir: PathBuf) -> Self {
+    pub fn new(data_dir_override: Option<PathBuf>) -> Self {
         Self {
-            data_dir,
+            data_dir_override,
             tool_router: Self::tool_router(),
         }
     }
 
     fn load_config(&self) -> Result<Config, String> {
-        Config::load_resolved().map_err(|e| format!("Failed to load config: {e}"))
+        Config::load_resolved_with_data_dir(self.data_dir_override.as_deref())
+            .map_err(|e| format!("Failed to load config: {e}"))
     }
 }
 
@@ -382,11 +383,7 @@ impl ServerHandler for AimxMcpServer {
 }
 
 pub async fn run(data_dir: Option<&std::path::Path>) -> Result<(), Box<dyn std::error::Error>> {
-    let data_dir = data_dir
-        .map(|p| p.to_path_buf())
-        .unwrap_or_else(|| PathBuf::from("/var/lib/aimx"));
-
-    let server = AimxMcpServer::new(data_dir);
+    let server = AimxMcpServer::new(data_dir.map(|p| p.to_path_buf()));
     let transport = rmcp::transport::io::stdio();
 
     let service = server
@@ -877,7 +874,7 @@ mod tests {
     #[test]
     fn mcp_server_has_correct_tool_count() {
         let tmp = TempDir::new().unwrap();
-        let server = AimxMcpServer::new(tmp.path().to_path_buf());
+        let server = AimxMcpServer::new(Some(tmp.path().to_path_buf()));
         let tools = server.tool_router.list_all();
         assert_eq!(tools.len(), 9);
     }
@@ -885,7 +882,7 @@ mod tests {
     #[test]
     fn mcp_server_tool_names() {
         let tmp = TempDir::new().unwrap();
-        let server = AimxMcpServer::new(tmp.path().to_path_buf());
+        let server = AimxMcpServer::new(Some(tmp.path().to_path_buf()));
         let tools = server.tool_router.list_all();
         let names: Vec<&str> = tools.iter().map(|t| t.name.as_ref()).collect();
 

--- a/src/send.rs
+++ b/src/send.rs
@@ -423,8 +423,7 @@ pub fn run(
     args: SendArgs,
     data_dir: Option<&std::path::Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let _ = data_dir;
-    let config = Config::load_resolved()
+    let config = Config::load_resolved_with_data_dir(data_dir)
         .map_err(|e| format!("Failed to load config for DKIM signing: {e}"))?;
     let transport = LettreTransport::new(config.enable_ipv6);
     let private_key = dkim::load_private_key(&crate::config::dkim_dir())

--- a/src/send.rs
+++ b/src/send.rs
@@ -423,14 +423,11 @@ pub fn run(
     args: SendArgs,
     data_dir: Option<&std::path::Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let config = match data_dir {
-        Some(dir) => Config::load_from_data_dir(dir)
-            .map_err(|e| format!("Failed to load config for DKIM signing: {e}"))?,
-        None => Config::load_default()
-            .map_err(|e| format!("Failed to load config for DKIM signing: {e}"))?,
-    };
+    let _ = data_dir;
+    let config = Config::load_resolved()
+        .map_err(|e| format!("Failed to load config for DKIM signing: {e}"))?;
     let transport = LettreTransport::new(config.enable_ipv6);
-    let private_key = dkim::load_private_key(&config.data_dir)
+    let private_key = dkim::load_private_key(&crate::config::dkim_dir())
         .map_err(|e| format!("DKIM signing required but private key could not be loaded: {e}"))?;
 
     let dkim_info = Some((
@@ -1026,6 +1023,7 @@ mod tests {
     #[test]
     fn run_with_missing_dkim_key_returns_error() {
         let tmp = tempfile::TempDir::new().unwrap();
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
         let mut mailboxes = std::collections::HashMap::new();
         mailboxes.insert(
             "catchall".to_string(),
@@ -1044,9 +1042,7 @@ mod tests {
             verify_host: None,
             enable_ipv6: false,
         };
-        config
-            .save(&crate::config::Config::config_path(tmp.path()))
-            .unwrap();
+        config.save(&crate::config::config_path()).unwrap();
 
         let args = test_args();
         let result = run(args, Some(tmp.path()));

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -14,10 +14,12 @@ pub fn run(
     tls_key: Option<&str>,
     data_dir: Option<&Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let config = match data_dir {
-        Some(dir) => Config::load_from_data_dir(dir)?,
-        None => Config::load_default()?,
-    };
+    // Config lives at `config_path()` (default `/etc/aimx/config.toml`).
+    // `--data-dir` is kept for forward-compat (callers may still pass it for
+    // storage overrides applied downstream of this call), but it no longer
+    // governs the config location (v0.2 filesystem split — Sprint 33).
+    let _ = data_dir;
+    let config = Config::load_resolved()?;
 
     let bind_addr = bind.unwrap_or(DEFAULT_BIND);
     let tls_explicit = tls_cert.is_some() || tls_key.is_some();
@@ -113,7 +115,15 @@ fn can_read_tls(cert: &std::path::Path, key: &std::path::Path) -> bool {
 }
 
 pub mod service {
+    /// Name of the POSIX group that owns `/run/aimx/` and (in Sprint 34)
+    /// `/run/aimx/send.sock`. Agent users are added with `usermod -aG aimx`.
+    pub const AIMX_GROUP: &str = "aimx";
+
     pub fn generate_systemd_unit(aimx_path: &str, data_dir: &str) -> String {
+        // `RuntimeDirectory=aimx` makes systemd create `/run/aimx/` at
+        // service start and tear it down on stop. Mode `0750` + `Group=aimx`
+        // gate socket access to members of the `aimx` system group (the
+        // socket itself lands inside `/run/aimx/` in Sprint 34).
         format!(
             "[Unit]\n\
              Description=AIMX SMTP server\n\
@@ -124,12 +134,16 @@ pub mod service {
              \n\
              [Service]\n\
              Type=simple\n\
+             User=root\n\
+             Group=aimx\n\
              ExecStart={aimx_path} serve --data-dir {data_dir}\n\
              Restart=on-failure\n\
              RestartSec=5s\n\
              LimitNOFILE=65536\n\
              TasksMax=4096\n\
              ReadWritePaths={data_dir}\n\
+             RuntimeDirectory=aimx\n\
+             RuntimeDirectoryMode=0750\n\
              StandardOutput=journal\n\
              StandardError=journal\n\
              \n\
@@ -139,16 +153,24 @@ pub mod service {
     }
 
     pub fn generate_openrc_script(aimx_path: &str, data_dir: &str) -> String {
+        // OpenRC has no direct `RuntimeDirectory=` analogue — use
+        // `checkpath` in `start_pre` to mint `/run/aimx/` owned by
+        // `root:aimx` with mode `0750` every service start.
         format!(
             "#!/sbin/openrc-run\n\
              \n\
              description=\"AIMX SMTP server\"\n\
              command={aimx_path}\n\
              command_args=\"serve --data-dir {data_dir}\"\n\
+             command_user=\"root:aimx\"\n\
              supervisor=supervise-daemon\n\
              \n\
              depend() {{\n\
              \tafter net\n\
+             }}\n\
+             \n\
+             start_pre() {{\n\
+             \tcheckpath -d -m 0750 -o root:aimx /run/aimx || return 1\n\
              }}\n"
         )
     }
@@ -261,6 +283,42 @@ mod tests {
     fn systemd_unit_custom_paths() {
         let unit = generate_systemd_unit("/opt/bin/aimx", "/data/aimx");
         assert!(unit.contains("ExecStart=/opt/bin/aimx serve --data-dir /data/aimx"));
+    }
+
+    #[test]
+    fn systemd_unit_exposes_runtime_dir_and_aimx_group() {
+        let unit = generate_systemd_unit("/usr/local/bin/aimx", "/var/lib/aimx");
+        assert!(
+            unit.contains("RuntimeDirectory=aimx"),
+            "systemd unit must declare RuntimeDirectory=aimx so `/run/aimx/` \
+             is created by systemd (Sprint 33 S33-4)"
+        );
+        assert!(
+            unit.contains("RuntimeDirectoryMode=0750"),
+            "runtime dir mode must be 0750 so only root + aimx group can traverse it"
+        );
+        assert!(
+            unit.contains("Group=aimx"),
+            "service must run with the aimx supplementary group so the UDS \
+             socket (Sprint 34) inherits group ownership"
+        );
+        assert!(
+            unit.contains("User=root"),
+            "User=root remains — the daemon still binds port 25"
+        );
+    }
+
+    #[test]
+    fn openrc_script_creates_runtime_dir_with_aimx_group() {
+        let script = generate_openrc_script("/usr/local/bin/aimx", "/var/lib/aimx");
+        assert!(
+            script.contains("checkpath -d -m 0750 -o root:aimx /run/aimx"),
+            "OpenRC script must mint /run/aimx with the aimx group (S33-4): {script}"
+        );
+        assert!(
+            script.contains("start_pre()"),
+            "start_pre hook is how OpenRC emulates systemd's RuntimeDirectory"
+        );
     }
 
     #[test]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -14,12 +14,11 @@ pub fn run(
     tls_key: Option<&str>,
     data_dir: Option<&Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Config lives at `config_path()` (default `/etc/aimx/config.toml`).
-    // `--data-dir` is kept for forward-compat (callers may still pass it for
-    // storage overrides applied downstream of this call), but it no longer
-    // governs the config location (v0.2 filesystem split — Sprint 33).
-    let _ = data_dir;
-    let config = Config::load_resolved()?;
+    // Config lives at `config_path()` (default `/etc/aimx/config.toml`);
+    // `--data-dir` no longer governs that path (v0.2 filesystem split —
+    // Sprint 33). It still overrides `config.data_dir` for the storage
+    // directory used by the ingest pipeline.
+    let config = Config::load_resolved_with_data_dir(data_dir)?;
 
     let bind_addr = bind.unwrap_or(DEFAULT_BIND);
     let tls_explicit = tls_cert.is_some() || tls_key.is_some();

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1085,10 +1085,12 @@ fn install_config_dir() -> Result<(), Box<dyn std::error::Error>> {
     let dir = crate::config::config_dir();
     std::fs::create_dir_all(&dir)?;
 
-    // Only enforce directory mode when running as root on the real install
-    // path. Test runs under `AIMX_CONFIG_DIR` leave the tempdir's default
-    // mode untouched — `tempfile::TempDir` can't host root-owned files.
-    if std::env::var_os("AIMX_CONFIG_DIR").is_none() && is_root() {
+    // Gate mode enforcement on `is_root()` alone: an operator who happens
+    // to have `AIMX_CONFIG_DIR` exported on a real install still gets
+    // tightened perms. Tests run as a non-root user so the branch is
+    // skipped for their tempdir — `apply_config_file_mode_sets_640`
+    // covers the real-install invariant directly.
+    if is_root() {
         #[cfg(unix)]
         {
             use std::os::unix::fs::PermissionsExt;
@@ -1098,14 +1100,36 @@ fn install_config_dir() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 
-/// Write `config.toml` via `Config::save` and (on real installs) tighten its
-/// mode to `0o640`, owner `root:root`. In tests (`AIMX_CONFIG_DIR` set) or
-/// when running non-root, the mode is left at the OS default — the dedicated
-/// [`tests::config_file_has_mode_640_on_real_install`] test covers the
-/// real-install invariant directly via [`apply_config_file_mode`].
+/// Write `config.toml` and (on real installs) tighten its mode to `0o640`,
+/// owner `root:root`. Non-root invocations leave the mode at the OS default
+/// — the dedicated [`tests::apply_config_file_mode_sets_640`] test covers
+/// the real-install invariant directly via [`apply_config_file_mode`].
+///
+/// When the file does not yet exist and we are running as root, it is
+/// created atomically with mode `0o640` via `OpenOptions::mode(...)
+/// .create_new(true)` so there is no brief window of umask-default
+/// permissions between write and chmod. The rewrite path (re-entrant
+/// setup) falls back to `Config::save` + `apply_config_file_mode`.
 fn install_config_file(cfg: &Config, path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let is_root = is_root();
+    if is_root && !path.exists() {
+        #[cfg(unix)]
+        {
+            use std::io::Write as _;
+            use std::os::unix::fs::OpenOptionsExt;
+            let content = toml::to_string_pretty(cfg)?;
+            let mut f = std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .mode(0o640)
+                .open(path)?;
+            f.write_all(content.as_bytes())?;
+            f.sync_all()?;
+            return Ok(());
+        }
+    }
     cfg.save(path)?;
-    if std::env::var_os("AIMX_CONFIG_DIR").is_none() && is_root() {
+    if is_root {
         apply_config_file_mode(path)?;
     }
     Ok(())
@@ -2177,6 +2201,57 @@ mod tests {
         assert!(
             sys.created_groups.borrow().contains(&"aimx".to_string()),
             "run_setup must create the aimx group during the install phase"
+        );
+
+        // Ordering invariant: the group is created before the service file
+        // is installed, because the systemd/OpenRC units the service file
+        // embeds reference `Group=aimx` (and OpenRC's `start_pre` chowns
+        // `/run/aimx/` to `root:aimx`). If the service file were written
+        // before the group exists, re-running `aimx setup` after an abort
+        // would install a unit that refers to a non-existent group.
+        if *sys.service_file_installed.borrow() {
+            assert!(
+                sys.created_groups.borrow().iter().any(|g| g == "aimx"),
+                "group must be created whenever a service file is installed"
+            );
+        }
+    }
+
+    #[test]
+    fn run_setup_skips_group_creation_on_reentrant_path() {
+        // When `is_already_configured` returns true, the entire install
+        // block is skipped — so `create_system_group` must NOT be called.
+        // Guards against a future refactor that drops the re-entrant shortcut.
+        let tmp = TempDir::new().unwrap();
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
+
+        let mut existing = HashMap::new();
+        existing.insert(PathBuf::from("/etc/ssl/aimx/cert.pem"), "cert".to_string());
+        existing.insert(
+            crate::config::dkim_dir().join("private.key"),
+            "key".to_string(),
+        );
+
+        let sys = MockSystemOps {
+            existing_files: existing,
+            service_running: true,
+            ..Default::default()
+        };
+        let net = MockNetworkOps {
+            outbound_port25: false,
+            ..Default::default()
+        };
+
+        let _ = run_setup(Some("example.com"), Some(tmp.path()), &sys, &net);
+
+        assert!(
+            sys.created_groups.borrow().is_empty(),
+            "re-entrant setup must skip `create_system_group` — found: {:?}",
+            sys.created_groups.borrow()
+        );
+        assert!(
+            !*sys.service_file_installed.borrow(),
+            "re-entrant setup must skip `install_service_file`"
         );
     }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -27,6 +27,12 @@ pub trait SystemOps {
     fn check_root(&self) -> bool;
     fn check_port25_occupancy(&self) -> Result<Port25Status, Box<dyn std::error::Error>>;
     fn install_service_file(&self, data_dir: &Path) -> Result<(), Box<dyn std::error::Error>>;
+    /// Create an OS-level system group idempotently.
+    ///
+    /// Returns `Ok(true)` when the group was newly created, `Ok(false)` when
+    /// it already existed. Implementations detect `groupadd` (systemd/Linux)
+    /// vs `addgroup` (Alpine/BusyBox) and pick the right tool.
+    fn create_system_group(&self, name: &str) -> Result<bool, Box<dyn std::error::Error>>;
 }
 
 pub trait NetworkOps {
@@ -140,6 +146,45 @@ impl SystemOps for RealSystemOps {
             .output()?;
         let stdout = String::from_utf8_lossy(&output.stdout);
         parse_port25_status(&stdout)
+    }
+
+    fn create_system_group(&self, name: &str) -> Result<bool, Box<dyn std::error::Error>> {
+        // Idempotent: `getent group <name>` returns exit code 2 when absent.
+        let exists = std::process::Command::new("getent")
+            .args(["group", name])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .map(|s| s.success())
+            .unwrap_or(false);
+        if exists {
+            return Ok(false);
+        }
+
+        // Prefer groupadd (util-linux) but fall back to addgroup (BusyBox/Alpine).
+        let groupadd = std::process::Command::new("groupadd")
+            .args(["--system", name])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+        if let Ok(status) = groupadd
+            && status.success()
+        {
+            return Ok(true);
+        }
+
+        let addgroup = std::process::Command::new("addgroup")
+            .args(["-S", name])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()?;
+        if !addgroup.success() {
+            return Err(format!(
+                "Failed to create system group '{name}'. Tried groupadd and addgroup."
+            )
+            .into());
+        }
+        Ok(true)
     }
 
     fn install_service_file(&self, data_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
@@ -958,8 +1003,9 @@ pub fn finalize_setup(
     dkim_selector: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
     std::fs::create_dir_all(data_dir)?;
+    install_config_dir()?;
 
-    let config_path = Config::config_path(data_dir);
+    let config_path = crate::config::config_path();
     let _config = if config_path.exists() {
         let mut cfg = Config::load(&config_path)?;
         if cfg.domain != domain {
@@ -974,7 +1020,7 @@ pub fn finalize_setup(
                     mailbox.address = format!("{local_part}@{domain}");
                 }
             }
-            cfg.save(&config_path)?;
+            install_config_file(&cfg, &config_path)?;
         }
         if !cfg.mailboxes.contains_key("catchall") {
             cfg.mailboxes.insert(
@@ -986,7 +1032,7 @@ pub fn finalize_setup(
                     trusted_senders: vec![],
                 },
             );
-            cfg.save(&config_path)?;
+            install_config_file(&cfg, &config_path)?;
         }
         cfg
     } else {
@@ -1008,17 +1054,18 @@ pub fn finalize_setup(
             verify_host: None,
             enable_ipv6: false,
         };
-        cfg.save(&config_path)?;
+        install_config_file(&cfg, &config_path)?;
         cfg
     };
 
     let catchall_dir = data_dir.join("catchall");
     std::fs::create_dir_all(&catchall_dir)?;
 
-    let dkim_private = data_dir.join("dkim/private.key");
+    let dkim_root = crate::config::dkim_dir();
+    let dkim_private = dkim_root.join("private.key");
     if !dkim_private.exists() {
         println!("Generating DKIM keypair...");
-        dkim::generate_keypair(data_dir, false)?;
+        dkim::generate_keypair(&dkim_root, false)?;
         println!("DKIM keypair generated.");
     } else {
         println!("DKIM keypair already exists.");
@@ -1030,6 +1077,65 @@ pub fn finalize_setup(
     );
 
     Ok(())
+}
+
+/// Create the config dir (default `/etc/aimx`, or `AIMX_CONFIG_DIR` override)
+/// with mode `0o755`. Idempotent — a pre-existing directory is left as-is.
+fn install_config_dir() -> Result<(), Box<dyn std::error::Error>> {
+    let dir = crate::config::config_dir();
+    std::fs::create_dir_all(&dir)?;
+
+    // Only enforce directory mode when running as root on the real install
+    // path. Test runs under `AIMX_CONFIG_DIR` leave the tempdir's default
+    // mode untouched — `tempfile::TempDir` can't host root-owned files.
+    if std::env::var_os("AIMX_CONFIG_DIR").is_none() && is_root() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o755))?;
+        }
+    }
+    Ok(())
+}
+
+/// Write `config.toml` via `Config::save` and (on real installs) tighten its
+/// mode to `0o640`, owner `root:root`. In tests (`AIMX_CONFIG_DIR` set) or
+/// when running non-root, the mode is left at the OS default — the dedicated
+/// [`tests::config_file_has_mode_640_on_real_install`] test covers the
+/// real-install invariant directly via [`apply_config_file_mode`].
+fn install_config_file(cfg: &Config, path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    cfg.save(path)?;
+    if std::env::var_os("AIMX_CONFIG_DIR").is_none() && is_root() {
+        apply_config_file_mode(path)?;
+    }
+    Ok(())
+}
+
+/// Set `config.toml` to mode `0o640`. Factored out of [`install_config_file`]
+/// so the mode-enforcement path is unit-testable without actually running
+/// as root on a real install.
+pub(crate) fn apply_config_file_mode(path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o640))?;
+    }
+    #[cfg(not(unix))]
+    {
+        let _ = path;
+    }
+    Ok(())
+}
+
+fn is_root() -> bool {
+    #[cfg(unix)]
+    {
+        unsafe { libc::geteuid() == 0 }
+    }
+    #[cfg(not(unix))]
+    {
+        false
+    }
 }
 
 fn validate_domain(domain: &str) -> Result<(), Box<dyn std::error::Error>> {
@@ -1083,9 +1189,9 @@ pub fn prompt_domain(reader: &mut dyn BufRead) -> Result<String, Box<dyn std::er
     Ok(domain)
 }
 
-pub fn is_already_configured(sys: &dyn SystemOps, data_dir: &Path) -> bool {
+pub fn is_already_configured(sys: &dyn SystemOps, _data_dir: &Path) -> bool {
     let tls_cert = Path::new("/etc/ssl/aimx/cert.pem");
-    let dkim_key = data_dir.join("dkim/private.key");
+    let dkim_key = crate::config::dkim_dir().join("private.key");
 
     let service_running = sys.is_service_running("aimx");
     let cert_exists = sys.file_exists(tls_cert);
@@ -1136,8 +1242,9 @@ pub fn run_setup(
 
     let data_dir = data_dir.unwrap_or(Path::new("/var/lib/aimx"));
     std::fs::create_dir_all(data_dir)?;
+    install_config_dir()?;
 
-    let config_path = Config::config_path(data_dir);
+    let config_path = crate::config::config_path();
     let (dkim_selector, enable_ipv6) = if config_path.exists() {
         match Config::load(&config_path) {
             Ok(c) => (c.dkim_selector, c.enable_ipv6),
@@ -1181,6 +1288,23 @@ pub fn run_setup(
             println!("TLS certificate generated in /etc/ssl/aimx/");
         } else {
             println!("TLS certificate already exists.");
+        }
+
+        // Step 3b (S33-4): create the `aimx` system group before installing
+        // the service so the unit's `Group=aimx` directive resolves.
+        match sys.create_system_group(crate::serve::service::AIMX_GROUP) {
+            Ok(true) => println!(
+                "{}",
+                term::success("Created `aimx` system group (grants access to /run/aimx/).")
+            ),
+            Ok(false) => println!("`aimx` system group already exists."),
+            Err(e) => {
+                return Err(format!(
+                    "Failed to create `aimx` system group: {e}. \
+                     Create it manually with `sudo groupadd --system aimx` and re-run setup."
+                )
+                .into());
+            }
         }
 
         println!("Installing AIMX service...");
@@ -1239,7 +1363,7 @@ pub fn run_setup(
     let server_ipv6 = detect_server_ipv6(enable_ipv6, ipv6_detected);
     let server_ip: IpAddr = IpAddr::V4(server_ipv4);
     let server_ipv6_ip: Option<IpAddr> = server_ipv6.map(IpAddr::V6);
-    let dkim_value = dkim::dns_record_value(data_dir)?;
+    let dkim_value = dkim::dns_record_value(&crate::config::dkim_dir())?;
 
     let local_dkim_pubkey = dkim_value
         .strip_prefix("v=DKIM1; k=rsa; p=")
@@ -1302,6 +1426,9 @@ pub fn run_setup(
         }
     }
 
+    // Section [Group access]
+    display_group_section();
+
     // Section [MCP]
     display_mcp_section(data_dir);
 
@@ -1309,6 +1436,40 @@ pub fn run_setup(
     display_deliverability_section(&domain, net);
 
     Ok(())
+}
+
+/// Render the `[Group access]` setup section. Extracted into its own
+/// function so `display_group_section_lines` can be unit-tested without
+/// touching stdout.
+pub fn display_group_section() {
+    for line in display_group_section_lines() {
+        println!("{line}");
+    }
+}
+
+pub fn display_group_section_lines() -> Vec<String> {
+    vec![
+        String::new(),
+        term::header("[Group access]").to_string(),
+        format!(
+            "  To let an agent user submit mail via `aimx send`, add them to the `{}` group:",
+            crate::serve::service::AIMX_GROUP
+        ),
+        String::new(),
+        format!(
+            "    {}",
+            term::highlight(&format!(
+                "sudo usermod -aG {} <user>",
+                crate::serve::service::AIMX_GROUP
+            ))
+        ),
+        String::new(),
+        "  The user must then log out and back in (or run `newgrp aimx`) for the new group to take effect.".to_string(),
+        format!(
+            "  Group membership gates access to `/run/{}/send.sock`, the local submission socket.",
+            crate::serve::service::AIMX_GROUP
+        ),
+    ]
 }
 
 #[cfg(test)]
@@ -1388,6 +1549,8 @@ mod tests {
         is_root: bool,
         port25_status: Port25Status,
         service_running: bool,
+        existing_groups: RefCell<std::collections::HashSet<String>>,
+        created_groups: RefCell<Vec<String>>,
     }
 
     impl Default for MockSystemOps {
@@ -1400,6 +1563,8 @@ mod tests {
                 is_root: true,
                 port25_status: Port25Status::Free,
                 service_running: false,
+                existing_groups: RefCell::new(std::collections::HashSet::new()),
+                created_groups: RefCell::new(vec![]),
             }
         }
     }
@@ -1446,6 +1611,14 @@ mod tests {
         fn install_service_file(&self, _data_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
             *self.service_file_installed.borrow_mut() = true;
             Ok(())
+        }
+        fn create_system_group(&self, name: &str) -> Result<bool, Box<dyn std::error::Error>> {
+            if self.existing_groups.borrow().contains(name) {
+                return Ok(false);
+            }
+            self.existing_groups.borrow_mut().insert(name.to_string());
+            self.created_groups.borrow_mut().push(name.to_string());
+            Ok(true)
         }
     }
 
@@ -1947,16 +2120,110 @@ mod tests {
     }
 
     #[test]
+    fn group_section_mentions_aimx_group_and_usermod() {
+        let lines = display_group_section_lines();
+        let joined = lines.join("\n");
+        assert!(
+            joined.contains("sudo usermod -aG aimx"),
+            "group section must print the exact usermod command: {joined}"
+        );
+        assert!(
+            joined.contains("newgrp aimx") || joined.contains("log out"),
+            "group section must mention either `newgrp aimx` or the \
+             logout/login step so the group membership takes effect: {joined}"
+        );
+        assert!(
+            joined.contains("send.sock"),
+            "group section must name the UDS socket so users connect the \
+             group to the access it gates: {joined}"
+        );
+    }
+
+    #[test]
+    fn mock_create_system_group_is_idempotent() {
+        let sys = MockSystemOps::default();
+        assert!(
+            sys.create_system_group("aimx").unwrap(),
+            "first call creates"
+        );
+        assert!(
+            !sys.create_system_group("aimx").unwrap(),
+            "second call must be a no-op (Ok(false))"
+        );
+        assert_eq!(
+            sys.created_groups.borrow().as_slice(),
+            &["aimx".to_string()],
+            "mock must only record one creation even after two calls"
+        );
+    }
+
+    #[test]
+    fn run_setup_creates_aimx_group_when_not_configured() {
+        let tmp = TempDir::new().unwrap();
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
+        let sys = MockSystemOps {
+            // inbound port will pass so run_setup proceeds past port checks
+            // into finalize_setup + DNS loop; the DNS loop blocks on stdin,
+            // so stop short by failing outbound.
+            ..Default::default()
+        };
+        let net = MockNetworkOps {
+            outbound_port25: false,
+            ..Default::default()
+        };
+        // run_setup will fail at the port-25 outbound check, which is AFTER
+        // the `create_system_group` call — so the group should be recorded.
+        let _ = run_setup(Some("example.com"), Some(tmp.path()), &sys, &net);
+        assert!(
+            sys.created_groups.borrow().contains(&"aimx".to_string()),
+            "run_setup must create the aimx group during the install phase"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn apply_config_file_mode_sets_640() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(&path, "domain = \"test.example.com\"\n").unwrap();
+        // Give it an obviously-wrong mode first so we can see the change.
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o777)).unwrap();
+
+        apply_config_file_mode(&path).unwrap();
+
+        let mode = std::fs::metadata(&path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(
+            mode, 0o640,
+            "install_config_file must tighten config.toml to 0o640"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn config_dir_exists_after_finalize() {
+        let tmp = TempDir::new().unwrap();
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
+        finalize_setup(tmp.path(), "mode.example.com", "dkim").unwrap();
+
+        // Config file resolved via AIMX_CONFIG_DIR lives inside tmp.
+        let cfg_path = crate::config::config_path();
+        assert!(cfg_path.exists(), "config.toml must be created by finalize");
+    }
+
+    #[test]
     fn finalize_creates_data_dir_and_config() {
         let tmp = TempDir::new().unwrap();
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
         finalize_setup(tmp.path(), "test.example.com", "dkim").unwrap();
 
-        assert!(Config::config_path(tmp.path()).exists());
+        assert!(crate::config::config_path().exists());
         assert!(tmp.path().join("catchall").exists());
         assert!(tmp.path().join("dkim/private.key").exists());
         assert!(tmp.path().join("dkim/public.key").exists());
 
-        let config = Config::load_from_data_dir(tmp.path()).unwrap();
+        let config = Config::load_resolved().unwrap();
         assert_eq!(config.domain, "test.example.com");
         assert!(config.mailboxes.contains_key("catchall"));
         assert_eq!(config.mailboxes["catchall"].address, "*@test.example.com");
@@ -1965,6 +2232,7 @@ mod tests {
     #[test]
     fn finalize_is_idempotent() {
         let tmp = TempDir::new().unwrap();
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
         finalize_setup(tmp.path(), "test.example.com", "dkim").unwrap();
 
         let key1 = std::fs::read_to_string(tmp.path().join("dkim/private.key")).unwrap();
@@ -1974,7 +2242,7 @@ mod tests {
         let key2 = std::fs::read_to_string(tmp.path().join("dkim/private.key")).unwrap();
         assert_eq!(key1, key2);
 
-        let config = Config::load_from_data_dir(tmp.path()).unwrap();
+        let config = Config::load_resolved().unwrap();
         assert_eq!(config.domain, "test.example.com");
         assert!(config.mailboxes.contains_key("catchall"));
     }
@@ -1982,14 +2250,15 @@ mod tests {
     #[test]
     fn finalize_preserves_existing_mailboxes() {
         let tmp = TempDir::new().unwrap();
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
         finalize_setup(tmp.path(), "test.example.com", "dkim").unwrap();
 
-        let config = Config::load_from_data_dir(tmp.path()).unwrap();
+        let config = Config::load_resolved().unwrap();
         mailbox::create_mailbox(&config, "alice").unwrap();
 
         finalize_setup(tmp.path(), "test.example.com", "dkim").unwrap();
 
-        let config = Config::load_from_data_dir(tmp.path()).unwrap();
+        let config = Config::load_resolved().unwrap();
         assert!(config.mailboxes.contains_key("alice"));
         assert!(config.mailboxes.contains_key("catchall"));
     }
@@ -1997,11 +2266,12 @@ mod tests {
     #[test]
     fn finalize_updates_domain_if_changed() {
         let tmp = TempDir::new().unwrap();
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
         finalize_setup(tmp.path(), "old.example.com", "dkim").unwrap();
 
         finalize_setup(tmp.path(), "new.example.com", "dkim").unwrap();
 
-        let config = Config::load_from_data_dir(tmp.path()).unwrap();
+        let config = Config::load_resolved().unwrap();
         assert_eq!(config.domain, "new.example.com");
         let catchall = config.mailboxes.get("catchall").unwrap();
         assert_eq!(catchall.address, "*@new.example.com");
@@ -2064,6 +2334,7 @@ mod tests {
     #[test]
     fn other_process_detected_exits_with_error() {
         let tmp = TempDir::new().unwrap();
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
         let sys = MockSystemOps {
             port25_status: Port25Status::OtherProcess("postfix".to_string()),
             ..Default::default()
@@ -2345,6 +2616,7 @@ mod tests {
     #[test]
     fn setup_with_domain_arg_skips_prompt() {
         let tmp = TempDir::new().unwrap();
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
         let sys = MockSystemOps::default();
         let net = MockNetworkOps {
             inbound_port25: false,
@@ -2375,10 +2647,14 @@ mod tests {
     #[test]
     fn is_already_configured_all_present() {
         let tmp = TempDir::new().unwrap();
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
 
         let mut existing = HashMap::new();
         existing.insert(PathBuf::from("/etc/ssl/aimx/cert.pem"), "cert".to_string());
-        existing.insert(tmp.path().join("dkim/private.key"), "key".to_string());
+        existing.insert(
+            crate::config::dkim_dir().join("private.key"),
+            "key".to_string(),
+        );
 
         let sys = MockSystemOps {
             existing_files: existing,
@@ -2391,9 +2667,13 @@ mod tests {
     #[test]
     fn is_already_configured_service_not_running() {
         let tmp = TempDir::new().unwrap();
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
         let mut existing = HashMap::new();
         existing.insert(PathBuf::from("/etc/ssl/aimx/cert.pem"), "cert".to_string());
-        existing.insert(tmp.path().join("dkim/private.key"), "key".to_string());
+        existing.insert(
+            crate::config::dkim_dir().join("private.key"),
+            "key".to_string(),
+        );
 
         let sys = MockSystemOps {
             existing_files: existing,
@@ -2406,6 +2686,7 @@ mod tests {
     #[test]
     fn is_already_configured_missing_dkim() {
         let tmp = TempDir::new().unwrap();
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
         let mut existing = HashMap::new();
         existing.insert(PathBuf::from("/etc/ssl/aimx/cert.pem"), "cert".to_string());
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -237,10 +237,11 @@ pub fn format_status(info: &StatusInfo) -> String {
     out
 }
 
-pub fn run(_data_dir: Option<&Path>) -> Result<(), Box<dyn std::error::Error>> {
+pub fn run(data_dir: Option<&Path>) -> Result<(), Box<dyn std::error::Error>> {
     // Config path is resolved via `config_path()` (default `/etc/aimx/`) —
-    // `--data-dir` no longer drives it post-filesystem-split (Sprint 33).
-    let config = Config::load_resolved()?;
+    // `--data-dir` no longer drives *config* location post-filesystem-split
+    // (Sprint 33), but still overrides `config.data_dir` for storage.
+    let config = Config::load_resolved_with_data_dir(data_dir)?;
 
     let info = gather_status(&config);
     print!("{}", format_status(&info));

--- a/src/status.rs
+++ b/src/status.rs
@@ -29,7 +29,7 @@ pub struct RecentEmail {
 }
 
 pub fn gather_status(config: &Config) -> StatusInfo {
-    let dkim_key_present = config.data_dir.join("dkim/private.key").exists();
+    let dkim_key_present = crate::config::dkim_dir().join("private.key").exists();
     let smtp_running = check_smtp_running();
 
     let mut mailboxes: Vec<MailboxStatus> = config
@@ -237,11 +237,10 @@ pub fn format_status(info: &StatusInfo) -> String {
     out
 }
 
-pub fn run(data_dir: Option<&Path>) -> Result<(), Box<dyn std::error::Error>> {
-    let config = match data_dir {
-        Some(dir) => Config::load_from_data_dir(dir)?,
-        None => Config::load_default()?,
-    };
+pub fn run(_data_dir: Option<&Path>) -> Result<(), Box<dyn std::error::Error>> {
+    // Config path is resolved via `config_path()` (default `/etc/aimx/`) —
+    // `--data-dir` no longer drives it post-filesystem-split (Sprint 33).
+    let config = Config::load_resolved()?;
 
     let info = gather_status(&config);
     print!("{}", format_status(&info));
@@ -473,6 +472,9 @@ mod tests {
     fn gather_status_with_temp_dir() {
         let tmp = tempfile::TempDir::new().unwrap();
         let data_dir = tmp.path();
+
+        // Point AIMX_CONFIG_DIR at `tmp` so `dkim_dir()` resolves inside it.
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(data_dir);
 
         std::fs::create_dir_all(data_dir.join("dkim")).unwrap();
         std::fs::write(data_dir.join("dkim/private.key"), "test").unwrap();

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -19,10 +19,8 @@ pub(crate) fn run_verify(
         return Err("`aimx verify` requires root. Run with: sudo aimx verify".into());
     }
 
-    let config = match data_dir {
-        Some(dir) => Config::load_from_data_dir(dir).ok(),
-        None => Config::load_default().ok(),
-    };
+    let _ = data_dir;
+    let config = Config::load_resolved().ok();
 
     let host = resolve_verify_host(verify_host, config.as_ref(), DEFAULT_VERIFY_HOST);
     let net = setup::RealNetworkOps::from_verify_host(host)?;
@@ -299,6 +297,9 @@ mod tests {
         }
         fn install_service_file(&self, _data_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
             Ok(())
+        }
+        fn create_system_group(&self, _name: &str) -> Result<bool, Box<dyn std::error::Error>> {
+            Ok(false)
         }
     }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -18,6 +18,16 @@ fn setup_test_env(tmp: &Path) -> String {
     config_path.to_string_lossy().to_string()
 }
 
+/// Build an `aimx` Command pre-wired with `AIMX_CONFIG_DIR` pointed at the
+/// test's tempdir. v0.2 (Sprint 33) moved config out of the storage
+/// directory, so integration tests must override both the storage path
+/// (`--data-dir` / `AIMX_DATA_DIR`) and the config lookup via this env var.
+fn aimx_cmd(tmp: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("aimx").unwrap();
+    cmd.env("AIMX_CONFIG_DIR", tmp);
+    cmd
+}
+
 fn read_frontmatter(md_path: &Path) -> toml::Value {
     let content = std::fs::read_to_string(md_path).unwrap();
     let parts: Vec<&str> = content.splitn(3, "+++").collect();
@@ -76,8 +86,7 @@ fn ingest_plain_fixture_full_pipeline() {
     setup_test_env(tmp.path());
     let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
 
-    Command::cargo_bin("aimx")
-        .unwrap()
+    aimx_cmd(tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("ingest")
@@ -107,8 +116,7 @@ fn ingest_html_fixture_full_pipeline() {
     setup_test_env(tmp.path());
     let eml = std::fs::read("tests/fixtures/html_only.eml").unwrap();
 
-    Command::cargo_bin("aimx")
-        .unwrap()
+    aimx_cmd(tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("ingest")
@@ -135,8 +143,7 @@ fn ingest_multipart_fixture_full_pipeline() {
     setup_test_env(tmp.path());
     let eml = std::fs::read("tests/fixtures/multipart.eml").unwrap();
 
-    Command::cargo_bin("aimx")
-        .unwrap()
+    aimx_cmd(tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("ingest")
@@ -159,8 +166,7 @@ fn ingest_attachment_fixture_full_pipeline() {
     setup_test_env(tmp.path());
     let eml = std::fs::read("tests/fixtures/with_attachment.eml").unwrap();
 
-    Command::cargo_bin("aimx")
-        .unwrap()
+    aimx_cmd(tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("ingest")
@@ -191,8 +197,7 @@ fn ingest_routes_to_named_mailbox() {
     setup_test_env(tmp.path());
     let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
 
-    Command::cargo_bin("aimx")
-        .unwrap()
+    aimx_cmd(tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("ingest")
@@ -214,8 +219,7 @@ fn ingest_unknown_routes_to_catchall() {
     setup_test_env(tmp.path());
     let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
 
-    Command::cargo_bin("aimx")
-        .unwrap()
+    aimx_cmd(tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("ingest")
@@ -234,8 +238,7 @@ fn ingest_via_env_var() {
     setup_test_env(tmp.path());
     let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
 
-    Command::cargo_bin("aimx")
-        .unwrap()
+    aimx_cmd(tmp.path())
         .env("AIMX_DATA_DIR", tmp.path())
         .arg("ingest")
         .arg("catchall@agent.example.com")
@@ -252,8 +255,7 @@ fn dkim_keygen_end_to_end() {
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
 
-    Command::cargo_bin("aimx")
-        .unwrap()
+    aimx_cmd(tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("dkim-keygen")
@@ -277,16 +279,14 @@ fn dkim_keygen_no_overwrite() {
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
 
-    Command::cargo_bin("aimx")
-        .unwrap()
+    aimx_cmd(tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("dkim-keygen")
         .assert()
         .success();
 
-    Command::cargo_bin("aimx")
-        .unwrap()
+    aimx_cmd(tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("dkim-keygen")
@@ -301,8 +301,7 @@ fn dkim_keygen_force_overwrite() {
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
 
-    Command::cargo_bin("aimx")
-        .unwrap()
+    aimx_cmd(tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("dkim-keygen")
@@ -311,8 +310,7 @@ fn dkim_keygen_force_overwrite() {
 
     let original = std::fs::read_to_string(tmp.path().join("dkim/private.key")).unwrap();
 
-    Command::cargo_bin("aimx")
-        .unwrap()
+    aimx_cmd(tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("dkim-keygen")
@@ -338,6 +336,7 @@ struct McpClient {
 impl McpClient {
     fn spawn(data_dir: &Path) -> Self {
         let mut child = StdCommand::new(aimx_binary_path())
+            .env("AIMX_CONFIG_DIR", data_dir)
             .arg("--data-dir")
             .arg(data_dir)
             .arg("mcp")
@@ -743,8 +742,7 @@ fn ingest_trigger_executes_on_delivery() {
     setup_test_env_with_triggers(tmp.path(), &marker);
     let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
 
-    Command::cargo_bin("aimx")
-        .unwrap()
+    aimx_cmd(tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("ingest")
@@ -782,8 +780,7 @@ command = "false"
 
     let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
 
-    Command::cargo_bin("aimx")
-        .unwrap()
+    aimx_cmd(tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("ingest")
@@ -824,8 +821,7 @@ command = "touch {}"
 
     let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
 
-    Command::cargo_bin("aimx")
-        .unwrap()
+    aimx_cmd(tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("ingest")
@@ -866,8 +862,7 @@ command = "touch {}"
 
     let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
 
-    Command::cargo_bin("aimx")
-        .unwrap()
+    aimx_cmd(tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("ingest")
@@ -890,8 +885,7 @@ fn ingest_frontmatter_contains_dkim_spf() {
     setup_test_env(tmp.path());
     let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
 
-    Command::cargo_bin("aimx")
-        .unwrap()
+    aimx_cmd(tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("ingest")
@@ -944,8 +938,7 @@ command = "touch {}"
 
     let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
 
-    Command::cargo_bin("aimx")
-        .unwrap()
+    aimx_cmd(tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("ingest")
@@ -996,8 +989,7 @@ command = "false"
 
     let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
 
-    Command::cargo_bin("aimx")
-        .unwrap()
+    aimx_cmd(tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("ingest")
@@ -1062,8 +1054,7 @@ fn status_shows_domain_and_mailboxes() {
     setup_test_env(tmp.path());
 
     let eml = b"From: sender@example.com\r\nTo: catchall@agent.example.com\r\nSubject: Test\r\nMessage-ID: <status-test@example.com>\r\n\r\nBody\r\n";
-    Command::cargo_bin("aimx")
-        .unwrap()
+    aimx_cmd(tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("ingest")
@@ -1072,8 +1063,7 @@ fn status_shows_domain_and_mailboxes() {
         .assert()
         .success();
 
-    Command::cargo_bin("aimx")
-        .unwrap()
+    aimx_cmd(tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("status")
@@ -1179,6 +1169,7 @@ fn serve_e2e_receive_email_and_shutdown() {
     let port = find_free_port();
 
     let mut child = StdCommand::new(aimx_binary_path())
+        .env("AIMX_CONFIG_DIR", tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("serve")
@@ -1244,6 +1235,7 @@ fn serve_e2e_multi_recipient() {
     let port = find_free_port();
 
     let mut child = StdCommand::new(aimx_binary_path())
+        .env("AIMX_CONFIG_DIR", tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("serve")
@@ -1298,6 +1290,7 @@ fn serve_e2e_connection_refused_after_shutdown() {
     let port = find_free_port();
 
     let mut child = StdCommand::new(aimx_binary_path())
+        .env("AIMX_CONFIG_DIR", tmp.path())
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("serve")
@@ -1352,6 +1345,7 @@ fn setup_test_env_with_bob(tmp: &Path) -> String {
 
 fn start_serve(tmp: &Path, port: u16) -> std::process::Child {
     let mut child = StdCommand::new(aimx_binary_path())
+        .env("AIMX_CONFIG_DIR", tmp)
         .arg("--data-dir")
         .arg(tmp)
         .arg("serve")


### PR DESCRIPTION
## Summary

Sprint 33 lands the v0.2 filesystem layout: config and DKIM secrets move out of `/var/lib/aimx/` into `/etc/aimx/`, the `aimx` system group is created idempotently, and `/run/aimx/` is provisioned (`0750`, `root:aimx`) ready for the Sprint 34 UDS send socket. No behaviour change is visible to agents yet — this is the foundation every subsequent v0.2 sprint builds on.

### Stories

- **S33-1** — `config::{config_dir, config_path, dkim_dir}` helpers + `AIMX_CONFIG_DIR` env var. Every `Config::load_from_data_dir` / `load_default` caller rewired to `Config::load_resolved`. Shared `ConfigDirOverride` serial-guard keeps env mutations parallel-safe across test modules.
- **S33-2** — `aimx setup` writes `/etc/aimx/` (mode `0755`) + `config.toml` (mode `0640`, owner `root:root`) via a new `install_config_file` helper. Real-install-only mode enforcement covered by a dedicated `apply_config_file_mode_sets_640` test.
- **S33-3** — DKIM keys move to `/etc/aimx/dkim/` with private `0600` (root-only) and public `0644`. `load_private_key` now surfaces a root-only guidance message on `PermissionDenied`. Sprint 25's `0o644` private-key test flipped back to `0o600`; new `public_key_is_world_readable` test added.
- **S33-4** — `SystemOps::create_system_group` (prefers `groupadd`, falls back to `addgroup` on Alpine/BusyBox), idempotent. Systemd unit gains `RuntimeDirectory=aimx`, `RuntimeDirectoryMode=0750`, `Group=aimx`. OpenRC script adds a `start_pre` `checkpath` for `/run/aimx/`. New `[Group access]` setup section prints the `sudo usermod -aG aimx <user>` instruction plus `newgrp aimx` hint.

### Docs

`book/configuration.md`, `book/setup.md`, `docs/manual-setup.md`, and `CLAUDE.md` updated to reflect the `/etc/aimx/` vs `/var/lib/aimx/` split and the new `aimx` group + runtime dir.

## Test plan

- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean (main crate)
- [x] `cargo test` — 444 unit + 45 integration tests all pass
- [x] Verifier crate: `cd services/verifier && cargo test && cargo clippy -- -D warnings && cargo fmt -- --check` clean
- [x] No production code references `/var/lib/aimx/config.toml` literally (grep confirmed)
- [x] Integration tests wire `AIMX_CONFIG_DIR` via a new `aimx_cmd` helper so `--data-dir` + config-dir overrides coexist