### PR TITLE
[Sprint 34] UDS Wire Protocol + aimx serve Send Listener

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,8 @@ mod mcp;
 mod mx;
 mod platform;
 mod send;
+mod send_handler;
+mod send_protocol;
 mod serve;
 mod setup;
 mod smtp;

--- a/src/send_handler.rs
+++ b/src/send_handler.rs
@@ -13,6 +13,7 @@ use std::collections::HashSet;
 use std::sync::Arc;
 
 use rsa::RsaPrivateKey;
+use uuid::Uuid;
 
 use crate::dkim;
 use crate::send::MailTransport;
@@ -46,6 +47,20 @@ pub struct SendContext {
 /// DKIM-sign → deliver via MX. Every error path maps to a stable
 /// [`ErrCode`].
 pub async fn handle_send(req: SendRequest, ctx: &SendContext) -> SendResponse {
+    handle_send_with_signer(req, ctx, dkim::sign_message).await
+}
+
+/// Generic form of [`handle_send`] parameterized on the DKIM signer so tests
+/// can inject a failing signer without constructing a bad key. Production
+/// code always routes through [`handle_send`], which wires [`dkim::sign_message`].
+pub(crate) async fn handle_send_with_signer<F>(
+    req: SendRequest,
+    ctx: &SendContext,
+    signer: F,
+) -> SendResponse
+where
+    F: FnOnce(&[u8], &RsaPrivateKey, &str, &str) -> Result<Vec<u8>, Box<dyn std::error::Error>>,
+{
     if !ctx.registered_mailboxes.contains(&req.from_mailbox) {
         return SendResponse::Err {
             code: ErrCode::Mailbox,
@@ -53,12 +68,14 @@ pub async fn handle_send(req: SendRequest, ctx: &SendContext) -> SendResponse {
         };
     }
 
-    let (message_id, from_header) = match parse_from_and_message_id(&req.body) {
-        Ok(v) => v,
-        Err(reason) => {
+    let headers = scan_headers(&req.body, &["From", "To", "Message-ID"]);
+
+    let from_header = match headers.get("From") {
+        Some(v) => v.clone(),
+        None => {
             return SendResponse::Err {
                 code: ErrCode::Malformed,
-                reason,
+                reason: "missing required header: From".to_string(),
             };
         }
     };
@@ -84,8 +101,8 @@ pub async fn handle_send(req: SendRequest, ctx: &SendContext) -> SendResponse {
         };
     }
 
-    let to_header = match header_value(&req.body, "To") {
-        Some(v) => v,
+    let to_header = match headers.get("To") {
+        Some(v) => v.clone(),
         None => {
             return SendResponse::Err {
                 code: ErrCode::Malformed,
@@ -94,8 +111,38 @@ pub async fn handle_send(req: SendRequest, ctx: &SendContext) -> SendResponse {
         }
     };
 
-    let signed = match dkim::sign_message(
-        &req.body,
+    // The submitted To: header may carry a display-name (`"Name"
+    // <user@host>`), a bare addr (`user@host`), or even angle-only
+    // (`<user@host>`). `lettre::Address::FromStr` only parses the bare form,
+    // so normalize to `user@host` before handing it to the transport. Any
+    // failure to extract a bare recipient is MALFORMED — not a delivery
+    // error — because nothing has been attempted over the wire.
+    let recipient_bare = match extract_bare_address(&to_header) {
+        Some(addr) => addr,
+        None => {
+            return SendResponse::Err {
+                code: ErrCode::Malformed,
+                reason: format!("could not extract recipient address from To: {to_header}"),
+            };
+        }
+    };
+
+    // If Message-ID is absent we synthesize one ourselves rather than
+    // erroring out: the sprint's error table never listed Message-ID as a
+    // required client header, and `AIMX/1 OK <message-id>` still needs
+    // something to echo. Using the configured primary domain matches the
+    // DKIM `d=` tag and avoids leaking a recipient-side hostname.
+    let (message_id, body_bytes) = match headers.get("Message-ID") {
+        Some(v) => (v.clone(), req.body.clone()),
+        None => {
+            let synthetic = format!("<{}@{}>", Uuid::new_v4(), ctx.primary_domain);
+            let injected = inject_message_id_header(&req.body, &synthetic);
+            (synthetic, injected)
+        }
+    };
+
+    let signed = match signer(
+        &body_bytes,
         &ctx.dkim_key,
         &ctx.primary_domain,
         &ctx.dkim_selector,
@@ -109,7 +156,7 @@ pub async fn handle_send(req: SendRequest, ctx: &SendContext) -> SendResponse {
         }
     };
 
-    match ctx.transport.send(&from_header, &to_header, &signed) {
+    match ctx.transport.send(&from_header, &recipient_bare, &signed) {
         Ok(_server) => SendResponse::Ok { message_id },
         Err(e) => {
             let msg = e.to_string();
@@ -119,35 +166,57 @@ pub async fn handle_send(req: SendRequest, ctx: &SendContext) -> SendResponse {
     }
 }
 
-/// Extract the `From:` header value and the `Message-ID:` header value from
-/// an RFC 5322 message. Returns `Err(reason)` if either is missing.
-fn parse_from_and_message_id(body: &[u8]) -> Result<(String, String), String> {
-    let message_id = header_value(body, "Message-ID")
-        .ok_or_else(|| "missing required header: Message-ID".to_string())?;
-    let from =
-        header_value(body, "From").ok_or_else(|| "missing required header: From".to_string())?;
-    Ok((message_id, from))
+/// Insert a `Message-ID:` header at the top of an RFC 5322 message body. The
+/// body's existing line-endings (CRLF or LF) are preserved by reusing the
+/// same terminator the first header uses.
+fn inject_message_id_header(body: &[u8], message_id: &str) -> Vec<u8> {
+    let terminator: &[u8] = if body.windows(2).take(1024).any(|w| w == b"\r\n") {
+        b"\r\n"
+    } else {
+        b"\n"
+    };
+    let mut out = Vec::with_capacity(body.len() + 32 + message_id.len());
+    out.extend_from_slice(b"Message-ID: ");
+    out.extend_from_slice(message_id.as_bytes());
+    out.extend_from_slice(terminator);
+    out.extend_from_slice(body);
+    out
 }
 
-/// Look up a header by case-insensitive name in an RFC 5322 message. Header
-/// lines are assumed to be CRLF-separated (SMTP-ready), but this helper
-/// tolerates lone LFs so it also works on locally-composed buffers. Stops
-/// at the first blank line (headers/body separator). Joins continuation
-/// lines (leading WSP).
-fn header_value(body: &[u8], name: &str) -> Option<String> {
-    let text = std::str::from_utf8(body).ok()?;
-    let mut lines = text.lines();
-    let mut current: Option<String> = None;
-
-    let commit = |current: &Option<String>| -> Option<(String, String)> {
-        let line = current.as_ref()?;
-        let (n, v) = line.split_once(':')?;
-        Some((n.trim().to_string(), v.trim().to_string()))
+/// Single-pass walk over an RFC 5322 header block, returning the values for
+/// each of `names` (case-insensitive, continuation-line folded). The returned
+/// map keys match the original `names` argument casing so callers can look
+/// up using the literal name they asked for.
+fn scan_headers(body: &[u8], names: &[&str]) -> std::collections::HashMap<String, String> {
+    let mut out: std::collections::HashMap<String, String> = std::collections::HashMap::new();
+    let text = match std::str::from_utf8(body) {
+        Ok(t) => t,
+        Err(_) => return out,
     };
 
-    let target = name.to_ascii_lowercase();
+    let lowercased: Vec<(String, &str)> =
+        names.iter().map(|n| (n.to_ascii_lowercase(), *n)).collect();
 
-    for line in lines.by_ref() {
+    let mut current: Option<String> = None;
+
+    let commit = |current: &Option<String>,
+                  out: &mut std::collections::HashMap<String, String>,
+                  lowercased: &[(String, &str)]| {
+        let Some(line) = current.as_ref() else {
+            return;
+        };
+        let Some((n, v)) = line.split_once(':') else {
+            return;
+        };
+        let n_lower = n.trim().to_ascii_lowercase();
+        for (target_lower, original) in lowercased {
+            if n_lower == *target_lower && !out.contains_key(*original) {
+                out.insert((*original).to_string(), v.trim().to_string());
+            }
+        }
+    };
+
+    for line in text.lines() {
         if line.is_empty() {
             break;
         }
@@ -158,35 +227,44 @@ fn header_value(body: &[u8], name: &str) -> Option<String> {
             }
             continue;
         }
-        if let Some((n, v)) = commit(&current)
-            && n.eq_ignore_ascii_case(&target)
-        {
-            return Some(v);
-        }
+        commit(&current, &mut out, &lowercased);
         current = Some(line.to_string());
     }
-
-    if let Some((n, v)) = commit(&current)
-        && n.eq_ignore_ascii_case(&target)
-    {
-        return Some(v);
-    }
-    None
+    commit(&current, &mut out, &lowercased);
+    out
 }
 
 /// Extract the bare-addr domain from an RFC 5322 `From:` header, handling
 /// both `"Name <user@host>"` and `"user@host"` forms. Returns `None` if no
 /// `@` is present.
 fn extract_domain(from: &str) -> Option<String> {
-    let addr = if let Some(start) = from.rfind('<') {
-        let tail = &from[start + 1..];
+    let addr = extract_bare_address(from)?;
+    let at = addr.rfind('@')?;
+    Some(addr[at + 1..].trim().to_string())
+}
+
+/// Extract the bare `local@host` form from a header value, accepting
+/// `"Name" <local@host>`, `local@host`, and angle-only `<local@host>`. For
+/// comma-separated header values only the first recipient is returned —
+/// v0.2 submissions are single-recipient and the daemon's envelope already
+/// only takes one address.
+fn extract_bare_address(value: &str) -> Option<String> {
+    let first = value.split(',').next().unwrap_or(value).trim();
+    if first.is_empty() {
+        return None;
+    }
+    let addr = if let Some(start) = first.rfind('<') {
+        let tail = &first[start + 1..];
         let end = tail.find('>').unwrap_or(tail.len());
         &tail[..end]
     } else {
-        from
+        first
     };
-    let at = addr.rfind('@')?;
-    Some(addr[at + 1..].trim().to_string())
+    let addr = addr.trim();
+    if addr.is_empty() || !addr.contains('@') {
+        return None;
+    }
+    Some(addr.to_string())
 }
 
 /// Map a transport error string to an `ErrCode`.
@@ -457,32 +535,171 @@ mod tests {
     }
 
     #[test]
-    fn header_value_simple() {
-        let body = b"From: alice@example.com\r\nTo: bob@x.com\r\n\r\nbody";
-        assert_eq!(
-            header_value(body, "From"),
-            Some("alice@example.com".to_string())
-        );
+    fn scan_headers_simple_multi() {
+        let body = b"From: alice@example.com\r\nTo: bob@x.com\r\nSubject: hi\r\n\r\nbody";
+        let h = scan_headers(body, &["From", "To", "Subject"]);
+        assert_eq!(h.get("From"), Some(&"alice@example.com".to_string()));
+        assert_eq!(h.get("To"), Some(&"bob@x.com".to_string()));
+        assert_eq!(h.get("Subject"), Some(&"hi".to_string()));
     }
 
     #[test]
-    fn header_value_case_insensitive() {
+    fn scan_headers_case_insensitive() {
         let body = b"fRoM: alice@example.com\r\n\r\n";
+        let h = scan_headers(body, &["FROM"]);
+        assert_eq!(h.get("FROM"), Some(&"alice@example.com".to_string()));
+    }
+
+    #[test]
+    fn scan_headers_continuation_line_joined() {
+        let body = b"Subject: one\r\n two\r\n\r\n";
+        let h = scan_headers(body, &["Subject"]);
+        assert_eq!(h.get("Subject"), Some(&"one two".to_string()));
+    }
+
+    #[test]
+    fn scan_headers_missing_is_absent() {
+        let body = b"From: a@b.com\r\n\r\n";
+        let h = scan_headers(body, &["X-Nope"]);
+        assert!(!h.contains_key("X-Nope"));
+    }
+
+    #[test]
+    fn extract_bare_address_display_name_form() {
         assert_eq!(
-            header_value(body, "FROM"),
+            extract_bare_address("Alice <alice@example.com>"),
             Some("alice@example.com".to_string())
         );
     }
 
     #[test]
-    fn header_value_continuation_line_joined() {
-        let body = b"Subject: one\r\n two\r\n\r\n";
-        assert_eq!(header_value(body, "Subject"), Some("one two".to_string()));
+    fn extract_bare_address_bare_form() {
+        assert_eq!(
+            extract_bare_address("alice@example.com"),
+            Some("alice@example.com".to_string())
+        );
     }
 
     #[test]
-    fn header_value_missing_returns_none() {
-        let body = b"From: a@b.com\r\n\r\n";
-        assert!(header_value(body, "X-Nope").is_none());
+    fn extract_bare_address_angle_only() {
+        assert_eq!(
+            extract_bare_address("<alice@example.com>"),
+            Some("alice@example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_bare_address_takes_first_of_list() {
+        assert_eq!(
+            extract_bare_address("a@x.com, b@y.com"),
+            Some("a@x.com".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_bare_address_none_without_at() {
+        assert!(extract_bare_address("no-at-sign").is_none());
+        assert!(extract_bare_address("").is_none());
+    }
+
+    #[tokio::test]
+    async fn to_header_with_display_name_delivers_bare_address() {
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Ok,
+        });
+        let ctx = test_ctx(mock.clone());
+        // `To:` carries a display name. The handler must normalize to the
+        // bare addr before calling the transport — otherwise the lettre
+        // `Address::FromStr` parse at the transport layer would fail and
+        // we would have mapped an RFC 5322-valid header into `ERR DELIVERY`.
+        let body = b"From: alice@example.com\r\n\
+                     To: Bob <bob@gmail.com>\r\n\
+                     Subject: Hi\r\n\
+                     Date: Thu, 01 Jan 2025 12:00:00 +0000\r\n\
+                     Message-ID: <abc@example.com>\r\n\
+                     \r\n\
+                     hello\r\n"
+            .to_vec();
+        let req = SendRequest {
+            from_mailbox: "alice".to_string(),
+            body,
+        };
+        let resp = handle_send(req, &ctx).await;
+        assert!(matches!(resp, SendResponse::Ok { .. }), "{resp:?}");
+    }
+
+    #[tokio::test]
+    async fn missing_message_id_is_synthesized() {
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Ok,
+        });
+        let ctx = test_ctx(mock.clone());
+        let body = b"From: alice@example.com\r\n\
+                     To: user@gmail.com\r\n\
+                     Subject: Hi\r\n\
+                     Date: Thu, 01 Jan 2025 12:00:00 +0000\r\n\
+                     \r\n\
+                     hello\r\n"
+            .to_vec();
+        let req = SendRequest {
+            from_mailbox: "alice".to_string(),
+            body,
+        };
+        let resp = handle_send(req, &ctx).await;
+        match resp {
+            SendResponse::Ok { message_id } => {
+                assert!(
+                    message_id.starts_with('<') && message_id.ends_with('>'),
+                    "message_id should be angle-bracketed: {message_id}"
+                );
+                assert!(
+                    message_id.contains("@example.com>"),
+                    "synthesized Message-ID must use primary domain: {message_id}"
+                );
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+        // The delivered message should contain the synthesized header.
+        let captured = mock.captured.lock().unwrap();
+        let delivered = String::from_utf8_lossy(&captured[0]);
+        assert!(
+            delivered.contains("Message-ID: <"),
+            "synthesized Message-ID must be part of the signed message: {delivered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn sign_failure_returns_sign_error() {
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Ok,
+        });
+        let ctx = test_ctx(mock);
+        let req = SendRequest {
+            from_mailbox: "alice".to_string(),
+            body: body("alice@example.com"),
+        };
+        // Inject a signer that always fails, to exercise the `ERR SIGN`
+        // branch without needing a malformed RSA key.
+        let failing_signer = |_: &[u8],
+                              _: &RsaPrivateKey,
+                              _: &str,
+                              _: &str|
+         -> Result<Vec<u8>, Box<dyn std::error::Error>> {
+            Err("simulated DKIM signing failure".into())
+        };
+        let resp = handle_send_with_signer(req, &ctx, failing_signer).await;
+        match resp {
+            SendResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Sign);
+                assert!(
+                    reason.contains("simulated DKIM signing failure"),
+                    "{reason}"
+                );
+            }
+            other => panic!("expected Err(SIGN), got {other:?}"),
+        }
     }
 }

--- a/src/send_handler.rs
+++ b/src/send_handler.rs
@@ -1,0 +1,488 @@
+//! Daemon-side handler for `AIMX/1 SEND` UDS requests.
+//!
+//! This module contains the per-connection business logic that runs inside
+//! `aimx serve` after a request frame has been decoded: domain validation,
+//! DKIM signing, and delivery. Framing is the [`send_protocol`] module's
+//! responsibility — this one deals only in parsed `SendRequest`s.
+//!
+//! The handler is deliberately testable: real MX delivery is abstracted
+//! behind the [`MailTransport`](crate::send::MailTransport) trait so tests
+//! can inject a mock.
+
+use std::collections::HashSet;
+use std::sync::Arc;
+
+use rsa::RsaPrivateKey;
+
+use crate::dkim;
+use crate::send::MailTransport;
+use crate::send_protocol::{ErrCode, SendRequest, SendResponse};
+
+/// Context shared across every per-connection send.
+///
+/// Heap-allocated once at daemon startup and cloned (cheap — `Arc` clones)
+/// into each task. Holding the DKIM key in an `Arc` here is what lets us
+/// load it exactly once despite accepting concurrent sends.
+pub struct SendContext {
+    /// DKIM private key, loaded once at `aimx serve` startup.
+    pub dkim_key: Arc<RsaPrivateKey>,
+    /// Primary domain from `/etc/aimx/config.toml`. Compared case-
+    /// insensitively against the submitted `From:` header.
+    pub primary_domain: String,
+    /// DKIM selector (`dkim._domainkey.<domain>`).
+    pub dkim_selector: String,
+    /// Set of mailbox names registered in config. `From-Mailbox` must be
+    /// one of these.
+    pub registered_mailboxes: HashSet<String>,
+    /// Transport used for final MX delivery. In production this is a
+    /// `LettreTransport`; tests inject a mock.
+    pub transport: Arc<dyn MailTransport + Send + Sync>,
+}
+
+/// Execute one submitted send end-to-end and return the wire response.
+///
+/// The flow: validate `From-Mailbox` is registered → parse the `From:`
+/// header out of the body → validate the sender domain matches config →
+/// DKIM-sign → deliver via MX. Every error path maps to a stable
+/// [`ErrCode`].
+pub async fn handle_send(req: SendRequest, ctx: &SendContext) -> SendResponse {
+    if !ctx.registered_mailboxes.contains(&req.from_mailbox) {
+        return SendResponse::Err {
+            code: ErrCode::Mailbox,
+            reason: format!("mailbox `{}` not registered", req.from_mailbox),
+        };
+    }
+
+    let (message_id, from_header) = match parse_from_and_message_id(&req.body) {
+        Ok(v) => v,
+        Err(reason) => {
+            return SendResponse::Err {
+                code: ErrCode::Malformed,
+                reason,
+            };
+        }
+    };
+
+    let sender_domain = match extract_domain(&from_header) {
+        Some(d) => d,
+        None => {
+            return SendResponse::Err {
+                code: ErrCode::Malformed,
+                reason: format!("could not extract domain from From: {from_header}"),
+            };
+        }
+    };
+
+    if !sender_domain.eq_ignore_ascii_case(&ctx.primary_domain) {
+        return SendResponse::Err {
+            code: ErrCode::Domain,
+            reason: format!(
+                "sender domain does not match aimx domain (got {sender_domain}, \
+                 expected {})",
+                ctx.primary_domain
+            ),
+        };
+    }
+
+    let to_header = match header_value(&req.body, "To") {
+        Some(v) => v,
+        None => {
+            return SendResponse::Err {
+                code: ErrCode::Malformed,
+                reason: "missing required header: To".to_string(),
+            };
+        }
+    };
+
+    let signed = match dkim::sign_message(
+        &req.body,
+        &ctx.dkim_key,
+        &ctx.primary_domain,
+        &ctx.dkim_selector,
+    ) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            return SendResponse::Err {
+                code: ErrCode::Sign,
+                reason: e.to_string(),
+            };
+        }
+    };
+
+    match ctx.transport.send(&from_header, &to_header, &signed) {
+        Ok(_server) => SendResponse::Ok { message_id },
+        Err(e) => {
+            let msg = e.to_string();
+            let code = classify_transport_error(&msg);
+            SendResponse::Err { code, reason: msg }
+        }
+    }
+}
+
+/// Extract the `From:` header value and the `Message-ID:` header value from
+/// an RFC 5322 message. Returns `Err(reason)` if either is missing.
+fn parse_from_and_message_id(body: &[u8]) -> Result<(String, String), String> {
+    let message_id = header_value(body, "Message-ID")
+        .ok_or_else(|| "missing required header: Message-ID".to_string())?;
+    let from =
+        header_value(body, "From").ok_or_else(|| "missing required header: From".to_string())?;
+    Ok((message_id, from))
+}
+
+/// Look up a header by case-insensitive name in an RFC 5322 message. Header
+/// lines are assumed to be CRLF-separated (SMTP-ready), but this helper
+/// tolerates lone LFs so it also works on locally-composed buffers. Stops
+/// at the first blank line (headers/body separator). Joins continuation
+/// lines (leading WSP).
+fn header_value(body: &[u8], name: &str) -> Option<String> {
+    let text = std::str::from_utf8(body).ok()?;
+    let mut lines = text.lines();
+    let mut current: Option<String> = None;
+
+    let commit = |current: &Option<String>| -> Option<(String, String)> {
+        let line = current.as_ref()?;
+        let (n, v) = line.split_once(':')?;
+        Some((n.trim().to_string(), v.trim().to_string()))
+    };
+
+    let target = name.to_ascii_lowercase();
+
+    for line in lines.by_ref() {
+        if line.is_empty() {
+            break;
+        }
+        if line.starts_with(' ') || line.starts_with('\t') {
+            if let Some(cur) = current.as_mut() {
+                cur.push(' ');
+                cur.push_str(line.trim_start());
+            }
+            continue;
+        }
+        if let Some((n, v)) = commit(&current)
+            && n.eq_ignore_ascii_case(&target)
+        {
+            return Some(v);
+        }
+        current = Some(line.to_string());
+    }
+
+    if let Some((n, v)) = commit(&current)
+        && n.eq_ignore_ascii_case(&target)
+    {
+        return Some(v);
+    }
+    None
+}
+
+/// Extract the bare-addr domain from an RFC 5322 `From:` header, handling
+/// both `"Name <user@host>"` and `"user@host"` forms. Returns `None` if no
+/// `@` is present.
+fn extract_domain(from: &str) -> Option<String> {
+    let addr = if let Some(start) = from.rfind('<') {
+        let tail = &from[start + 1..];
+        let end = tail.find('>').unwrap_or(tail.len());
+        &tail[..end]
+    } else {
+        from
+    };
+    let at = addr.rfind('@')?;
+    Some(addr[at + 1..].trim().to_string())
+}
+
+/// Map a transport error string to an `ErrCode`.
+///
+/// Heuristic — the transport layer returns `Box<dyn Error>` strings today,
+/// so we pattern-match the message. Connection-level failures (DNS,
+/// refused, timeout) are classified as `Temp` because they're usually
+/// retriable; explicit MX rejects (5xx SMTP replies) map to `Delivery`.
+fn classify_transport_error(msg: &str) -> ErrCode {
+    let lower = msg.to_ascii_lowercase();
+    if lower.contains("unreachable")
+        || lower.contains("timed out")
+        || lower.contains("timeout")
+        || lower.contains("connection refused")
+        || lower.contains("no a record")
+        || lower.contains("dns")
+    {
+        ErrCode::Temp
+    } else {
+        ErrCode::Delivery
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    struct MockTransport {
+        captured: Mutex<Vec<Vec<u8>>>,
+        behavior: Behavior,
+    }
+
+    enum Behavior {
+        Ok,
+        Err(String),
+    }
+
+    impl MailTransport for MockTransport {
+        fn send(
+            &self,
+            _sender: &str,
+            _recipient: &str,
+            message: &[u8],
+        ) -> Result<String, Box<dyn std::error::Error>> {
+            match &self.behavior {
+                Behavior::Ok => {
+                    self.captured.lock().unwrap().push(message.to_vec());
+                    Ok("mock-mx.example.com".to_string())
+                }
+                Behavior::Err(s) => Err(s.clone().into()),
+            }
+        }
+    }
+
+    fn test_ctx(transport: Arc<dyn MailTransport + Send + Sync>) -> SendContext {
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        dkim::generate_keypair(tmp.path(), false).unwrap();
+        let key = dkim::load_private_key(tmp.path()).unwrap();
+        let mut boxes = HashSet::new();
+        boxes.insert("catchall".to_string());
+        boxes.insert("alice".to_string());
+        SendContext {
+            dkim_key: Arc::new(key),
+            primary_domain: "example.com".to_string(),
+            dkim_selector: "dkim".to_string(),
+            registered_mailboxes: boxes,
+            transport,
+        }
+    }
+
+    fn body(from: &str) -> Vec<u8> {
+        format!(
+            "From: {from}\r\n\
+             To: user@gmail.com\r\n\
+             Subject: Hi\r\n\
+             Date: Thu, 01 Jan 2025 12:00:00 +0000\r\n\
+             Message-ID: <abc@example.com>\r\n\
+             \r\n\
+             hello\r\n"
+        )
+        .into_bytes()
+    }
+
+    #[tokio::test]
+    async fn ok_path_signs_and_delivers() {
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Ok,
+        });
+        let ctx = test_ctx(mock.clone());
+        let req = SendRequest {
+            from_mailbox: "alice".to_string(),
+            body: body("alice@example.com"),
+        };
+        let resp = handle_send(req, &ctx).await;
+        match resp {
+            SendResponse::Ok { message_id } => {
+                assert_eq!(message_id, "<abc@example.com>");
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+        let captured = mock.captured.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        let delivered = String::from_utf8_lossy(&captured[0]);
+        assert!(
+            delivered.starts_with("DKIM-Signature:"),
+            "delivered message must start with DKIM-Signature: {delivered}"
+        );
+        assert!(delivered.contains("d=example.com"));
+    }
+
+    #[tokio::test]
+    async fn unknown_mailbox_returns_mailbox_error() {
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Ok,
+        });
+        let ctx = test_ctx(mock);
+        let req = SendRequest {
+            from_mailbox: "ghost".to_string(),
+            body: body("alice@example.com"),
+        };
+        let resp = handle_send(req, &ctx).await;
+        match resp {
+            SendResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Mailbox);
+                assert!(reason.contains("ghost"), "{reason}");
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn domain_mismatch_returns_domain_error() {
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Ok,
+        });
+        let ctx = test_ctx(mock);
+        let req = SendRequest {
+            from_mailbox: "alice".to_string(),
+            body: body("alice@other.org"),
+        };
+        let resp = handle_send(req, &ctx).await;
+        match resp {
+            SendResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Domain);
+                assert!(reason.contains("other.org"), "{reason}");
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn domain_match_is_case_insensitive() {
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Ok,
+        });
+        let ctx = test_ctx(mock);
+        let req = SendRequest {
+            from_mailbox: "alice".to_string(),
+            body: body("alice@EXAMPLE.COM"),
+        };
+        let resp = handle_send(req, &ctx).await;
+        assert!(matches!(resp, SendResponse::Ok { .. }), "{resp:?}");
+    }
+
+    #[tokio::test]
+    async fn any_local_part_accepted() {
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Ok,
+        });
+        let ctx = test_ctx(mock);
+        let req = SendRequest {
+            from_mailbox: "alice".to_string(),
+            body: body("anything@example.com"),
+        };
+        let resp = handle_send(req, &ctx).await;
+        assert!(matches!(resp, SendResponse::Ok { .. }), "{resp:?}");
+    }
+
+    #[tokio::test]
+    async fn missing_from_returns_malformed() {
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Ok,
+        });
+        let ctx = test_ctx(mock);
+        let body = b"To: user@gmail.com\r\n\
+                     Subject: Hi\r\n\
+                     Message-ID: <abc@example.com>\r\n\
+                     \r\n\
+                     hello\r\n"
+            .to_vec();
+        let req = SendRequest {
+            from_mailbox: "alice".to_string(),
+            body,
+        };
+        let resp = handle_send(req, &ctx).await;
+        match resp {
+            SendResponse::Err { code, .. } => assert_eq!(code, ErrCode::Malformed),
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn transport_permanent_error_maps_to_delivery() {
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Err("Rejected by mx.example.com: 550 no such user".to_string()),
+        });
+        let ctx = test_ctx(mock);
+        let req = SendRequest {
+            from_mailbox: "alice".to_string(),
+            body: body("alice@example.com"),
+        };
+        let resp = handle_send(req, &ctx).await;
+        match resp {
+            SendResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Delivery);
+                assert!(reason.contains("550"), "{reason}");
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn transport_unreachable_maps_to_temp() {
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Err("All MX servers for gmail.com unreachable: ...".to_string()),
+        });
+        let ctx = test_ctx(mock);
+        let req = SendRequest {
+            from_mailbox: "alice".to_string(),
+            body: body("alice@example.com"),
+        };
+        let resp = handle_send(req, &ctx).await;
+        match resp {
+            SendResponse::Err { code, .. } => assert_eq!(code, ErrCode::Temp),
+            other => panic!("expected Err, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn extract_domain_name_form() {
+        assert_eq!(
+            extract_domain("Alice <alice@example.com>"),
+            Some("example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_domain_bare_form() {
+        assert_eq!(
+            extract_domain("alice@example.com"),
+            Some("example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_domain_none() {
+        assert_eq!(extract_domain("no-at-sign"), None);
+    }
+
+    #[test]
+    fn header_value_simple() {
+        let body = b"From: alice@example.com\r\nTo: bob@x.com\r\n\r\nbody";
+        assert_eq!(
+            header_value(body, "From"),
+            Some("alice@example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn header_value_case_insensitive() {
+        let body = b"fRoM: alice@example.com\r\n\r\n";
+        assert_eq!(
+            header_value(body, "FROM"),
+            Some("alice@example.com".to_string())
+        );
+    }
+
+    #[test]
+    fn header_value_continuation_line_joined() {
+        let body = b"Subject: one\r\n two\r\n\r\n";
+        assert_eq!(header_value(body, "Subject"), Some("one two".to_string()));
+    }
+
+    #[test]
+    fn header_value_missing_returns_none() {
+        let body = b"From: a@b.com\r\n\r\n";
+        assert!(header_value(body, "X-Nope").is_none());
+    }
+}

--- a/src/send_protocol.rs
+++ b/src/send_protocol.rs
@@ -1,0 +1,571 @@
+//! `AIMX/1 SEND` wire protocol codec.
+//!
+//! Length-prefixed, binary-safe framing used by `aimx send` to submit mail to
+//! `aimx serve` over `/run/aimx/send.sock`. The codec is pure: it speaks only
+//! `AsyncRead`/`AsyncWrite`, so it can be exercised with in-memory async
+//! streams (e.g. `tokio_test::io::Builder`) without touching the filesystem
+//! or a real socket.
+//!
+//! Framing:
+//!
+//! ```text
+//! Client → Server:
+//!   AIMX/1 SEND\n
+//!   From-Mailbox: <name>\n
+//!   Content-Length: <n>\n
+//!   \n
+//!   <n bytes of RFC 5322 message, unsigned>
+//!
+//! Server → Client:
+//!   AIMX/1 OK <message-id>\n
+//! or
+//!   AIMX/1 ERR <code> <reason>\n
+//! ```
+//!
+//! The blank separator line is a literal `\n` (or `\r\n`). Header names are
+//! case-insensitive. Unknown headers are silently ignored so the protocol
+//! can be extended without breaking older clients.
+
+use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
+
+/// Maximum body size accepted by [`parse_request`]. Mirrors the SMTP DATA
+/// cap (`smtp::DEFAULT_MAX_MESSAGE_SIZE`, 25 MB) so local clients cannot
+/// submit mail the MTA would refuse anyway.
+pub const DEFAULT_MAX_BODY_SIZE: usize = 25 * 1024 * 1024;
+
+/// Maximum length of the request-line or a single header line, in bytes.
+/// Keeps the parser's memory footprint bounded even on pathological input.
+const MAX_HEADER_LINE: usize = 8 * 1024;
+
+/// Decoded `AIMX/1 SEND` request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SendRequest {
+    pub from_mailbox: String,
+    pub body: Vec<u8>,
+}
+
+/// Error codes reported on the wire in `AIMX/1 ERR <code> <reason>`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrCode {
+    Mailbox,
+    Domain,
+    Sign,
+    Delivery,
+    Temp,
+    Malformed,
+}
+
+impl ErrCode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            ErrCode::Mailbox => "MAILBOX",
+            ErrCode::Domain => "DOMAIN",
+            ErrCode::Sign => "SIGN",
+            ErrCode::Delivery => "DELIVERY",
+            ErrCode::Temp => "TEMP",
+            ErrCode::Malformed => "MALFORMED",
+        }
+    }
+}
+
+/// Response emitted by the daemon after processing a request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SendResponse {
+    Ok { message_id: String },
+    Err { code: ErrCode, reason: String },
+}
+
+/// Codec error. Kept separate from `std::error::Error` so the daemon's
+/// handler can map `ParseError` values into wire-level `ErrCode::Malformed`
+/// responses without rebuilding the information.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ParseError {
+    /// Peer closed the connection before any request-line bytes arrived.
+    ClosedBeforeRequest,
+    /// Malformed framing or missing required headers. Reason is operator-
+    /// facing and safe to render into `ERR MALFORMED <reason>`.
+    Malformed(String),
+    /// An underlying I/O error. Surfaced so the daemon can distinguish
+    /// "client sent garbage" from "socket EBADF".
+    Io(String),
+}
+
+impl std::fmt::Display for ParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ParseError::ClosedBeforeRequest => write!(f, "connection closed before request"),
+            ParseError::Malformed(s) => write!(f, "malformed request: {s}"),
+            ParseError::Io(s) => write!(f, "i/o error: {s}"),
+        }
+    }
+}
+
+impl std::error::Error for ParseError {}
+
+impl From<std::io::Error> for ParseError {
+    fn from(e: std::io::Error) -> Self {
+        ParseError::Io(e.to_string())
+    }
+}
+
+/// Read and decode one `AIMX/1 SEND` request from `reader`.
+///
+/// Uses the codec-level [`DEFAULT_MAX_BODY_SIZE`] cap. Callers that need a
+/// different cap should use [`parse_request_with_limit`].
+pub async fn parse_request<R>(reader: &mut R) -> Result<SendRequest, ParseError>
+where
+    R: AsyncRead + Unpin,
+{
+    parse_request_with_limit(reader, DEFAULT_MAX_BODY_SIZE).await
+}
+
+/// Like [`parse_request`] but with a caller-supplied maximum body size.
+pub async fn parse_request_with_limit<R>(
+    reader: &mut R,
+    max_body: usize,
+) -> Result<SendRequest, ParseError>
+where
+    R: AsyncRead + Unpin,
+{
+    let request_line = read_line(reader).await?;
+    let request_line = match request_line {
+        Some(l) => l,
+        None => return Err(ParseError::ClosedBeforeRequest),
+    };
+
+    if request_line.trim_end_matches('\r') != "AIMX/1 SEND" {
+        return Err(ParseError::Malformed(format!(
+            "expected request-line 'AIMX/1 SEND', got {request_line:?}"
+        )));
+    }
+
+    let mut from_mailbox: Option<String> = None;
+    let mut content_length: Option<usize> = None;
+
+    loop {
+        let line = read_line(reader)
+            .await?
+            .ok_or_else(|| ParseError::Malformed("unexpected EOF in headers".into()))?;
+        let line = line.trim_end_matches('\r');
+        if line.is_empty() {
+            break;
+        }
+
+        let (name, value) = line
+            .split_once(':')
+            .ok_or_else(|| ParseError::Malformed(format!("invalid header line: {line:?}")))?;
+
+        if !name.is_ascii() {
+            return Err(ParseError::Malformed(format!(
+                "non-ascii header name: {name:?}"
+            )));
+        }
+        let name_norm = name.trim().to_ascii_lowercase();
+        let value = value.trim().to_string();
+
+        match name_norm.as_str() {
+            "from-mailbox" => {
+                if from_mailbox.is_some() {
+                    return Err(ParseError::Malformed(
+                        "duplicate From-Mailbox header".into(),
+                    ));
+                }
+                if value.is_empty() {
+                    return Err(ParseError::Malformed("empty From-Mailbox value".into()));
+                }
+                from_mailbox = Some(value);
+            }
+            "content-length" => {
+                if content_length.is_some() {
+                    return Err(ParseError::Malformed(
+                        "duplicate Content-Length header".into(),
+                    ));
+                }
+                let n: usize = value.parse().map_err(|_| {
+                    ParseError::Malformed(format!("non-integer Content-Length: {value:?}"))
+                })?;
+                if n > max_body {
+                    return Err(ParseError::Malformed(format!(
+                        "Content-Length {n} exceeds cap {max_body}"
+                    )));
+                }
+                content_length = Some(n);
+            }
+            _ => {
+                // Unknown headers are ignored for forward-compatibility.
+            }
+        }
+    }
+
+    let from_mailbox = from_mailbox
+        .ok_or_else(|| ParseError::Malformed("missing required header: From-Mailbox".into()))?;
+    let content_length = content_length
+        .ok_or_else(|| ParseError::Malformed("missing required header: Content-Length".into()))?;
+
+    let mut body = vec![0u8; content_length];
+    reader.read_exact(&mut body).await.map_err(|e| {
+        if e.kind() == std::io::ErrorKind::UnexpectedEof {
+            ParseError::Malformed(format!("body truncated: expected {content_length} bytes"))
+        } else {
+            ParseError::Io(e.to_string())
+        }
+    })?;
+
+    Ok(SendRequest { from_mailbox, body })
+}
+
+/// Read a single `\n`-terminated line from `reader`, returning it without the
+/// trailing `\n`. Returns `Ok(None)` when the stream ends cleanly before any
+/// byte arrives. Enforces [`MAX_HEADER_LINE`] to bound memory on garbage
+/// input.
+async fn read_line<R>(reader: &mut R) -> Result<Option<String>, ParseError>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut buf = Vec::with_capacity(64);
+    let mut byte = [0u8; 1];
+
+    loop {
+        match reader.read(&mut byte).await {
+            Ok(0) => {
+                if buf.is_empty() {
+                    return Ok(None);
+                }
+                return Err(ParseError::Malformed(
+                    "unexpected EOF mid-line (no terminator)".into(),
+                ));
+            }
+            Ok(_) => {
+                if byte[0] == b'\n' {
+                    break;
+                }
+                buf.push(byte[0]);
+                if buf.len() > MAX_HEADER_LINE {
+                    return Err(ParseError::Malformed(format!(
+                        "header line exceeds {MAX_HEADER_LINE} bytes"
+                    )));
+                }
+            }
+            Err(e) => return Err(ParseError::Io(e.to_string())),
+        }
+    }
+
+    let s = String::from_utf8(buf)
+        .map_err(|_| ParseError::Malformed("header line contains invalid UTF-8".into()))?;
+    Ok(Some(s))
+}
+
+/// Write a `SendResponse` frame to `writer` and flush. The frame ends with a
+/// single `\n` — no body, no content-length.
+pub async fn write_response<W>(
+    writer: &mut W,
+    response: &SendResponse,
+) -> Result<(), std::io::Error>
+where
+    W: AsyncWrite + Unpin,
+{
+    let line = match response {
+        SendResponse::Ok { message_id } => {
+            let id = sanitize_inline(message_id);
+            format!("AIMX/1 OK {id}\n")
+        }
+        SendResponse::Err { code, reason } => {
+            let r = sanitize_inline(reason);
+            format!("AIMX/1 ERR {} {r}\n", code.as_str())
+        }
+    };
+    writer.write_all(line.as_bytes()).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Write an `AIMX/1 SEND` request frame to `writer`. Used by the client
+/// (`aimx send`, Sprint 35) and by tests that exercise `parse_request` over a
+/// paired AsyncRead/AsyncWrite harness.
+#[allow(dead_code)] // consumed by `aimx send` in Sprint 35
+pub async fn write_request<W>(writer: &mut W, request: &SendRequest) -> Result<(), std::io::Error>
+where
+    W: AsyncWrite + Unpin,
+{
+    let header = format!(
+        "AIMX/1 SEND\nFrom-Mailbox: {}\nContent-Length: {}\n\n",
+        sanitize_inline(&request.from_mailbox),
+        request.body.len(),
+    );
+    writer.write_all(header.as_bytes()).await?;
+    writer.write_all(&request.body).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Strip CR/LF from a single-line wire field. Callers must never emit bare
+/// LF inside a reason or message-ID or the framer ambiguates the next line.
+fn sanitize_inline(s: &str) -> String {
+    s.chars().filter(|c| *c != '\n' && *c != '\r').collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio::io::duplex;
+
+    async fn parse_from_bytes(input: &[u8]) -> Result<SendRequest, ParseError> {
+        let (mut client, mut server) = duplex(input.len().max(64));
+        client.write_all(input).await.unwrap();
+        drop(client);
+        parse_request(&mut server).await
+    }
+
+    #[tokio::test]
+    async fn parses_minimal_request() {
+        let input = b"AIMX/1 SEND\nFrom-Mailbox: alice\nContent-Length: 5\n\nhello";
+        let req = parse_from_bytes(input).await.unwrap();
+        assert_eq!(req.from_mailbox, "alice");
+        assert_eq!(req.body, b"hello".to_vec());
+    }
+
+    #[tokio::test]
+    async fn parses_request_with_crlf_line_endings() {
+        let input = b"AIMX/1 SEND\r\nFrom-Mailbox: alice\r\nContent-Length: 5\r\n\r\nhello";
+        let req = parse_from_bytes(input).await.unwrap();
+        assert_eq!(req.from_mailbox, "alice");
+        assert_eq!(req.body, b"hello".to_vec());
+    }
+
+    #[tokio::test]
+    async fn parses_empty_body() {
+        let input = b"AIMX/1 SEND\nFrom-Mailbox: alice\nContent-Length: 0\n\n";
+        let req = parse_from_bytes(input).await.unwrap();
+        assert_eq!(req.from_mailbox, "alice");
+        assert!(req.body.is_empty());
+    }
+
+    #[tokio::test]
+    async fn header_names_are_case_insensitive() {
+        let input = b"AIMX/1 SEND\nFROM-MAILBOX: alice\ncontent-length: 3\n\nabc";
+        let req = parse_from_bytes(input).await.unwrap();
+        assert_eq!(req.from_mailbox, "alice");
+        assert_eq!(req.body, b"abc".to_vec());
+    }
+
+    #[tokio::test]
+    async fn unknown_headers_are_ignored() {
+        let input = b"AIMX/1 SEND\nFrom-Mailbox: alice\nX-Future: foo\nContent-Length: 3\n\nabc";
+        let req = parse_from_bytes(input).await.unwrap();
+        assert_eq!(req.from_mailbox, "alice");
+        assert_eq!(req.body, b"abc".to_vec());
+    }
+
+    #[tokio::test]
+    async fn wrong_request_line_is_malformed() {
+        let input = b"GET / HTTP/1.1\nHost: foo\n\n";
+        let err = parse_from_bytes(input).await.unwrap_err();
+        assert!(matches!(err, ParseError::Malformed(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn missing_from_mailbox_is_malformed() {
+        let input = b"AIMX/1 SEND\nContent-Length: 0\n\n";
+        let err = parse_from_bytes(input).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("From-Mailbox"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn missing_content_length_is_malformed() {
+        let input = b"AIMX/1 SEND\nFrom-Mailbox: alice\n\n";
+        let err = parse_from_bytes(input).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("Content-Length"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn non_integer_content_length_is_malformed() {
+        let input = b"AIMX/1 SEND\nFrom-Mailbox: alice\nContent-Length: abc\n\n";
+        let err = parse_from_bytes(input).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("non-integer"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn oversized_content_length_is_malformed() {
+        let input = b"AIMX/1 SEND\nFrom-Mailbox: alice\nContent-Length: 999999999999\n\n";
+        let err = parse_from_bytes(input).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("exceeds cap"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn truncated_body_is_malformed() {
+        let input = b"AIMX/1 SEND\nFrom-Mailbox: alice\nContent-Length: 10\n\nabc";
+        let err = parse_from_bytes(input).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("truncated"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn duplicate_content_length_is_malformed() {
+        let input =
+            b"AIMX/1 SEND\nFrom-Mailbox: alice\nContent-Length: 3\nContent-Length: 4\n\nabcd";
+        let err = parse_from_bytes(input).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("duplicate"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn duplicate_from_mailbox_is_malformed() {
+        let input = b"AIMX/1 SEND\nFrom-Mailbox: alice\nFrom-Mailbox: bob\nContent-Length: 0\n\n";
+        let err = parse_from_bytes(input).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("duplicate"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn empty_stream_is_closed_before_request() {
+        let input = b"";
+        let err = parse_from_bytes(input).await.unwrap_err();
+        assert!(
+            matches!(err, ParseError::ClosedBeforeRequest),
+            "got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn body_containing_request_line_literal_is_not_reparsed() {
+        // The body contains the bytes `AIMX/1 SEND\n` — if the parser ever
+        // re-scans for a new request mid-body it will misframe. Content-
+        // Length must win.
+        let body = b"AIMX/1 SEND\nFrom-Mailbox: evil\nContent-Length: 0\n\n";
+        let mut input = Vec::new();
+        input.extend_from_slice(b"AIMX/1 SEND\nFrom-Mailbox: alice\nContent-Length: ");
+        input.extend_from_slice(body.len().to_string().as_bytes());
+        input.extend_from_slice(b"\n\n");
+        input.extend_from_slice(body);
+        let req = parse_from_bytes(&input).await.unwrap();
+        assert_eq!(req.from_mailbox, "alice");
+        assert_eq!(req.body, body.to_vec());
+    }
+
+    #[tokio::test]
+    async fn binary_safe_body_roundtrip() {
+        let body: Vec<u8> = (0u8..=255).collect();
+        let req = SendRequest {
+            from_mailbox: "alice".to_string(),
+            body: body.clone(),
+        };
+        let (mut client, mut server) = duplex(4096);
+        let w = tokio::spawn(async move {
+            write_request(&mut client, &req).await.unwrap();
+        });
+        let parsed = parse_request(&mut server).await.unwrap();
+        w.await.unwrap();
+        assert_eq!(parsed.from_mailbox, "alice");
+        assert_eq!(parsed.body, body);
+    }
+
+    #[tokio::test]
+    async fn write_ok_response() {
+        let (mut client, mut server) = duplex(256);
+        write_response(
+            &mut client,
+            &SendResponse::Ok {
+                message_id: "<abc@example.com>".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+        drop(client);
+        let mut buf = Vec::new();
+        tokio::io::AsyncReadExt::read_to_end(&mut server, &mut buf)
+            .await
+            .unwrap();
+        assert_eq!(buf, b"AIMX/1 OK <abc@example.com>\n");
+    }
+
+    #[tokio::test]
+    async fn write_all_err_codes() {
+        for (code, label) in [
+            (ErrCode::Mailbox, "MAILBOX"),
+            (ErrCode::Domain, "DOMAIN"),
+            (ErrCode::Sign, "SIGN"),
+            (ErrCode::Delivery, "DELIVERY"),
+            (ErrCode::Temp, "TEMP"),
+            (ErrCode::Malformed, "MALFORMED"),
+        ] {
+            let (mut client, mut server) = duplex(256);
+            write_response(
+                &mut client,
+                &SendResponse::Err {
+                    code,
+                    reason: "nope".to_string(),
+                },
+            )
+            .await
+            .unwrap();
+            drop(client);
+            let mut buf = Vec::new();
+            tokio::io::AsyncReadExt::read_to_end(&mut server, &mut buf)
+                .await
+                .unwrap();
+            let expected = format!("AIMX/1 ERR {label} nope\n");
+            assert_eq!(buf, expected.as_bytes());
+        }
+    }
+
+    #[tokio::test]
+    async fn response_reason_crlf_stripped() {
+        let (mut client, mut server) = duplex(256);
+        write_response(
+            &mut client,
+            &SendResponse::Err {
+                code: ErrCode::Delivery,
+                reason: "bad\r\nreason\n".to_string(),
+            },
+        )
+        .await
+        .unwrap();
+        drop(client);
+        let mut buf = Vec::new();
+        tokio::io::AsyncReadExt::read_to_end(&mut server, &mut buf)
+            .await
+            .unwrap();
+        assert_eq!(buf, b"AIMX/1 ERR DELIVERY badreason\n");
+    }
+
+    #[tokio::test]
+    async fn missing_blank_line_is_malformed() {
+        // `AIMX/1 SEND\nFrom-Mailbox: alice\nContent-Length: 0` followed by
+        // EOF — the parser is mid-header, so it hits EOF with non-empty
+        // buffer.
+        let input = b"AIMX/1 SEND\nFrom-Mailbox: alice\nContent-Length: 0";
+        let err = parse_from_bytes(input).await.unwrap_err();
+        assert!(matches!(err, ParseError::Malformed(_)), "got {err:?}");
+    }
+
+    #[tokio::test]
+    async fn custom_max_body_enforced() {
+        let input = b"AIMX/1 SEND\nFrom-Mailbox: alice\nContent-Length: 100\n\n";
+        let (mut client, mut server) = duplex(4096);
+        client.write_all(input).await.unwrap();
+        drop(client);
+        let err = parse_request_with_limit(&mut server, 50).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("exceeds cap 50"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+}

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1,10 +1,37 @@
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
 use crate::config::Config;
+use crate::dkim;
+use crate::send::{LettreTransport, MailTransport};
+use crate::send_handler::SendContext;
+use crate::send_protocol;
 use crate::smtp::SmtpServer;
 use crate::term;
 
 const DEFAULT_BIND: &str = "0.0.0.0:25";
 const DEFAULT_TLS_CERT: &str = "/etc/ssl/aimx/cert.pem";
 const DEFAULT_TLS_KEY: &str = "/etc/ssl/aimx/key.pem";
+const DEFAULT_RUNTIME_DIR: &str = "/run/aimx";
+const RUNTIME_DIR_ENV: &str = "AIMX_RUNTIME_DIR";
+const SEND_SOCKET_NAME: &str = "send.sock";
+
+/// Resolve the runtime directory that holds `/run/aimx/send.sock`.
+///
+/// Precedence:
+/// 1. `AIMX_RUNTIME_DIR` env var (tests and non-standard installs)
+/// 2. `/run/aimx/` default (provided by systemd `RuntimeDirectory=aimx`
+///    or the OpenRC `start_pre` `checkpath` hook)
+pub fn runtime_dir() -> PathBuf {
+    std::env::var_os(RUNTIME_DIR_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|| PathBuf::from(DEFAULT_RUNTIME_DIR))
+}
+
+/// Path to the world-writable `AIMX/1 SEND` UDS.
+pub fn send_socket_path() -> PathBuf {
+    runtime_dir().join(SEND_SOCKET_NAME)
+}
 
 pub fn run(
     bind: Option<&str>,
@@ -52,6 +79,34 @@ async fn run_serve(
         );
     }
 
+    // Load DKIM key once at startup — every accepted UDS send reuses this
+    // in-memory key. A failure here is fatal: the daemon cannot sign
+    // outbound mail without it.
+    let dkim_root = crate::config::dkim_dir();
+    let dkim_key = match dkim::load_private_key(&dkim_root) {
+        Ok(k) => Arc::new(k),
+        Err(e) => {
+            return Err(format!(
+                "Failed to load DKIM private key from {}: {e}. \
+                 `aimx serve` requires a readable DKIM private key \
+                 (generate with `aimx setup` or `aimx dkim-keygen`).",
+                dkim_root.join("private.key").display()
+            )
+            .into());
+        }
+    };
+
+    // Build the SendContext shared across every per-connection UDS task.
+    let transport: Arc<dyn MailTransport + Send + Sync> =
+        Arc::new(LettreTransport::new(config.enable_ipv6));
+    let send_ctx = Arc::new(SendContext {
+        dkim_key,
+        primary_domain: config.domain.clone(),
+        dkim_selector: config.dkim_selector.clone(),
+        registered_mailboxes: config.mailboxes.keys().cloned().collect(),
+        transport,
+    });
+
     let server = SmtpServer::new(config);
     let server = if tls_available {
         server.with_tls(cert, key)?
@@ -75,6 +130,21 @@ async fn run_serve(
         }
     );
 
+    // Bind the UDS send socket. Fatal on failure.
+    let socket_path = send_socket_path();
+    let uds_listener =
+        bind_send_socket(&socket_path).map_err(|e| -> Box<dyn std::error::Error> {
+            format!(
+                "Failed to bind UDS send socket at {}: {e}",
+                socket_path.display()
+            )
+            .into()
+        })?;
+    eprintln!(
+        "  send:  {} (mode 0o666, world-writable)",
+        term::highlight(&socket_path.display().to_string())
+    );
+
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
 
     tokio::spawn(async move {
@@ -90,11 +160,176 @@ async fn run_serve(
         let _ = shutdown_tx.send(true);
     });
 
+    // Run the SMTP server and UDS listener concurrently. Both observe the
+    // same shutdown watch — a SIGTERM drains both accept loops.
+    let uds_shutdown = shutdown_rx.clone();
+    let uds_socket_path = socket_path.clone();
+    let uds_handle = tokio::spawn(async move {
+        run_send_listener(uds_listener, send_ctx, uds_shutdown).await;
+        // Clean up the socket file on clean shutdown so the next start does
+        // not trip the "stale socket" fallback path.
+        let _ = std::fs::remove_file(&uds_socket_path);
+    });
+
     let in_flight_msg = server.run(listener, shutdown_rx).await;
+
+    // Wait for the UDS listener to drain too so we don't leak its task.
+    let _ = uds_handle.await;
 
     eprintln!("{}", term::info("AIMX SMTP listener shut down"));
 
     in_flight_msg
+}
+
+/// Bind the UDS send socket at `path` with mode `0o666`.
+///
+/// Handles the stale-socket-after-crash case: if the path already refers to
+/// a socket, unlink it and retry once. A second failure is fatal.
+pub fn bind_send_socket(path: &Path) -> std::io::Result<tokio::net::UnixListener> {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let listener = match tokio::net::UnixListener::bind(path) {
+        Ok(l) => l,
+        Err(e) if e.kind() == std::io::ErrorKind::AddrInUse => {
+            // Stale socket from a prior crash. Unlink and retry once.
+            std::fs::remove_file(path)?;
+            tokio::net::UnixListener::bind(path)?
+        }
+        Err(e) => return Err(e),
+    };
+    set_socket_mode(path, 0o666)?;
+    Ok(listener)
+}
+
+#[cfg(unix)]
+fn set_socket_mode(path: &Path, mode: u32) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(mode))
+}
+
+#[cfg(not(unix))]
+fn set_socket_mode(_path: &Path, _mode: u32) -> std::io::Result<()> {
+    Ok(())
+}
+
+async fn run_send_listener(
+    listener: tokio::net::UnixListener,
+    ctx: Arc<SendContext>,
+    mut shutdown: tokio::sync::watch::Receiver<bool>,
+) {
+    loop {
+        tokio::select! {
+            accept = listener.accept() => {
+                match accept {
+                    Ok((stream, _addr)) => {
+                        let peer = peer_credentials(&stream);
+                        eprintln!(
+                            "[send] accepted: peer_uid={} peer_pid={}",
+                            peer.uid_str(),
+                            peer.pid_str()
+                        );
+                        let ctx = Arc::clone(&ctx);
+                        tokio::spawn(async move {
+                            handle_send_connection(stream, ctx).await;
+                        });
+                    }
+                    Err(e) => {
+                        eprintln!("[send] accept error: {e}");
+                        // Transient — do not kill the listener.
+                        continue;
+                    }
+                }
+            }
+            _ = shutdown.changed() => {
+                break;
+            }
+        }
+    }
+    eprintln!("[send] UDS accept loop drained");
+}
+
+async fn handle_send_connection(stream: tokio::net::UnixStream, ctx: Arc<SendContext>) {
+    let (mut reader, mut writer) = stream.into_split();
+    let (response, parse_failed) = match send_protocol::parse_request(&mut reader).await {
+        Ok(req) => (crate::send_handler::handle_send(req, &ctx).await, false),
+        Err(send_protocol::ParseError::ClosedBeforeRequest) => {
+            // Client connected and closed without sending anything. No
+            // response to write — just drop the connection.
+            return;
+        }
+        Err(e) => (
+            send_protocol::SendResponse::Err {
+                code: send_protocol::ErrCode::Malformed,
+                reason: e.to_string(),
+            },
+            true,
+        ),
+    };
+
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    // When the parser rejects the request (typically on the first line of
+    // a malformed frame), the client may still have bytes in flight that
+    // the kernel has queued on our receive side. If we close with unread
+    // bytes the kernel issues an abortive close and the client's pending
+    // `read` races the teardown and sees `ECONNRESET` instead of the
+    // framed reply we are about to write. Drain here — but only on parse
+    // failure, because a well-formed request has already been consumed up
+    // through `Content-Length`, and further `read` would block on the
+    // peer, deadlocking well-behaved clients that keep the write half
+    // open until they have read our response.
+    if parse_failed {
+        let mut sink = [0u8; 1024];
+        loop {
+            match tokio::time::timeout(std::time::Duration::from_millis(50), reader.read(&mut sink))
+                .await
+            {
+                Ok(Ok(0)) | Err(_) => break,
+                Ok(Ok(_)) => continue,
+                Ok(Err(_)) => break,
+            }
+        }
+    }
+
+    if let Err(e) = send_protocol::write_response(&mut writer, &response).await {
+        eprintln!("[send] failed to write response: {e}");
+    }
+    let _ = writer.shutdown().await;
+}
+
+/// Peer-credential snapshot for logging. `None` on platforms/errors where
+/// the kernel could not supply credentials — e.g. the client closed before
+/// we asked. Used only for journald diagnostics (FR-18b) — never for
+/// authorization.
+struct PeerCred {
+    uid: Option<u32>,
+    pid: Option<i32>,
+}
+
+impl PeerCred {
+    fn uid_str(&self) -> String {
+        self.uid
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "?".into())
+    }
+    fn pid_str(&self) -> String {
+        self.pid
+            .map(|v| v.to_string())
+            .unwrap_or_else(|| "?".into())
+    }
+}
+
+fn peer_credentials(stream: &tokio::net::UnixStream) -> PeerCred {
+    match stream.peer_cred() {
+        Ok(c) => PeerCred {
+            uid: Some(c.uid()),
+            pid: c.pid(),
+        },
+        Err(_) => PeerCred {
+            uid: None,
+            pid: None,
+        },
+    }
 }
 
 fn can_read_tls(cert: &std::path::Path, key: &std::path::Path) -> bool {
@@ -231,6 +466,7 @@ pub mod service {
 #[cfg(test)]
 mod tests {
     use super::service::*;
+    use super::*;
 
     #[test]
     fn systemd_unit_contains_required_fields() {
@@ -447,6 +683,263 @@ mod tests {
                 stream.is_err(),
                 "Connection should be refused after shutdown"
             );
+        });
+    }
+
+    #[test]
+    fn runtime_dir_env_override_takes_precedence() {
+        // Serialized via the same lock shape that `config::test_env` uses
+        // would be ideal, but AIMX_RUNTIME_DIR is only touched in tests,
+        // and these tests are all in this module, so a simple guard is
+        // sufficient. See note in the body.
+        use std::sync::Mutex;
+        static GUARD: Mutex<()> = Mutex::new(());
+        let _g = GUARD.lock().unwrap_or_else(|e| e.into_inner());
+
+        let prev = std::env::var_os(RUNTIME_DIR_ENV);
+        // SAFETY: serialized by `GUARD`; test restores the previous value
+        // before returning.
+        unsafe {
+            std::env::set_var(RUNTIME_DIR_ENV, "/tmp/some-override");
+        }
+        assert_eq!(
+            runtime_dir(),
+            std::path::PathBuf::from("/tmp/some-override")
+        );
+        assert_eq!(
+            send_socket_path(),
+            std::path::PathBuf::from("/tmp/some-override/send.sock")
+        );
+        unsafe {
+            match prev {
+                Some(v) => std::env::set_var(RUNTIME_DIR_ENV, v),
+                None => std::env::remove_var(RUNTIME_DIR_ENV),
+            }
+        }
+    }
+
+    #[test]
+    fn runtime_dir_default_when_env_unset() {
+        use std::sync::Mutex;
+        static GUARD: Mutex<()> = Mutex::new(());
+        let _g = GUARD.lock().unwrap_or_else(|e| e.into_inner());
+
+        let prev = std::env::var_os(RUNTIME_DIR_ENV);
+        unsafe {
+            std::env::remove_var(RUNTIME_DIR_ENV);
+        }
+        assert_eq!(runtime_dir(), std::path::PathBuf::from("/run/aimx"));
+        assert_eq!(
+            send_socket_path(),
+            std::path::PathBuf::from("/run/aimx/send.sock")
+        );
+        unsafe {
+            if let Some(v) = prev {
+                std::env::set_var(RUNTIME_DIR_ENV, v);
+            }
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bind_send_socket_sets_world_writable_mode() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let sock = tmp.path().join("send.sock");
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let _listener = bind_send_socket(&sock).unwrap();
+            let mode = std::fs::metadata(&sock).unwrap().permissions().mode() & 0o777;
+            assert_eq!(
+                mode, 0o666,
+                "UDS send socket must be world-writable (0o666); got {mode:o}"
+            );
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn bind_send_socket_reclaims_stale_path() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let sock = tmp.path().join("send.sock");
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            // Bind once, drop the listener — the file persists on disk,
+            // simulating the "daemon crashed with no cleanup" case.
+            {
+                let _l = bind_send_socket(&sock).unwrap();
+            }
+            assert!(sock.exists(), "stale socket should remain");
+
+            // Bind again — must succeed by unlinking + retry.
+            let _l2 = bind_send_socket(&sock).unwrap();
+            assert!(sock.exists());
+        });
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn uds_accept_reads_peer_credentials() {
+        use std::collections::HashSet;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let sock = tmp.path().join("send.sock");
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let listener = bind_send_socket(&sock).unwrap();
+
+            // Build a throwaway SendContext. Key generation is the slow
+            // step so we use a tempdir-backed one.
+            let dkim_tmp = tempfile::TempDir::new().unwrap();
+            crate::dkim::generate_keypair(dkim_tmp.path(), false).unwrap();
+            let key = crate::dkim::load_private_key(dkim_tmp.path()).unwrap();
+            let mut mboxes = HashSet::new();
+            mboxes.insert("catchall".to_string());
+            let transport: Arc<dyn MailTransport + Send + Sync> = Arc::new(NoopTransport);
+            let ctx = Arc::new(crate::send_handler::SendContext {
+                dkim_key: Arc::new(key),
+                primary_domain: "example.com".to_string(),
+                dkim_selector: "dkim".to_string(),
+                registered_mailboxes: mboxes,
+                transport,
+            });
+
+            let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+            let handle = tokio::spawn(async move {
+                run_send_listener(listener, ctx, shutdown_rx).await;
+            });
+
+            // Connect from the same process.
+            let mut client = tokio::net::UnixStream::connect(&sock).await.unwrap();
+            // Assert the client stream has peer credentials for the server
+            // side too (mirrors the server-side read).
+            let cred = client
+                .peer_cred()
+                .expect("peer_cred should succeed on local UDS");
+            assert_eq!(cred.uid(), unsafe { libc::geteuid() });
+
+            // Close without sending anything — server handler should fall
+            // back to the "ClosedBeforeRequest" branch and drop cleanly.
+            use tokio::io::AsyncWriteExt;
+            let _ = client.shutdown().await;
+            drop(client);
+
+            // Shut down the listener.
+            shutdown_tx.send(true).unwrap();
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
+        });
+    }
+
+    struct NoopTransport;
+    impl MailTransport for NoopTransport {
+        fn send(&self, _: &str, _: &str, _: &[u8]) -> Result<String, Box<dyn std::error::Error>> {
+            Ok("noop".into())
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn uds_end_to_end_signed_delivery() {
+        use std::collections::HashSet;
+        use std::sync::Mutex;
+
+        let tmp = tempfile::TempDir::new().unwrap();
+        let sock = tmp.path().join("send.sock");
+
+        // Transport that captures whatever is delivered.
+        struct CapturingTransport {
+            captured: Mutex<Vec<Vec<u8>>>,
+        }
+        impl MailTransport for CapturingTransport {
+            fn send(
+                &self,
+                _: &str,
+                _: &str,
+                message: &[u8],
+            ) -> Result<String, Box<dyn std::error::Error>> {
+                self.captured.lock().unwrap().push(message.to_vec());
+                Ok("mock-mx".into())
+            }
+        }
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let listener = bind_send_socket(&sock).unwrap();
+
+            let dkim_tmp = tempfile::TempDir::new().unwrap();
+            crate::dkim::generate_keypair(dkim_tmp.path(), false).unwrap();
+            let key = crate::dkim::load_private_key(dkim_tmp.path()).unwrap();
+            let pub_pem = std::fs::read_to_string(dkim_tmp.path().join("public.key")).unwrap();
+
+            let captor = Arc::new(CapturingTransport {
+                captured: Mutex::new(vec![]),
+            });
+            let transport: Arc<dyn MailTransport + Send + Sync> = captor.clone();
+
+            let mut mboxes = HashSet::new();
+            mboxes.insert("alice".to_string());
+            let ctx = Arc::new(crate::send_handler::SendContext {
+                dkim_key: Arc::new(key),
+                primary_domain: "example.com".to_string(),
+                dkim_selector: "dkim".to_string(),
+                registered_mailboxes: mboxes,
+                transport,
+            });
+
+            let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+            let handle = tokio::spawn(async move {
+                run_send_listener(listener, ctx, shutdown_rx).await;
+            });
+
+            // Build a minimal RFC 5322 body.
+            let body = b"From: alice@example.com\r\n\
+                         To: user@gmail.com\r\n\
+                         Subject: Hi\r\n\
+                         Date: Thu, 01 Jan 2025 12:00:00 +0000\r\n\
+                         Message-ID: <abc@example.com>\r\n\
+                         \r\n\
+                         hello\r\n";
+            let req = crate::send_protocol::SendRequest {
+                from_mailbox: "alice".to_string(),
+                body: body.to_vec(),
+            };
+
+            let mut client = tokio::net::UnixStream::connect(&sock).await.unwrap();
+            let (mut r, mut w) = client.split();
+            crate::send_protocol::write_request(&mut w, &req)
+                .await
+                .unwrap();
+            use tokio::io::AsyncReadExt;
+            let mut resp = String::new();
+            r.read_to_string(&mut resp).await.unwrap();
+            assert!(
+                resp.starts_with("AIMX/1 OK <abc@example.com>"),
+                "unexpected response: {resp:?}"
+            );
+
+            // Verify the transport received a DKIM-signed message. Clone
+            // the captured bytes out of the guard so we can drop the lock
+            // before any further `.await` (clippy::await-holding-lock).
+            let signed_bytes = {
+                let captured = captor.captured.lock().unwrap();
+                assert_eq!(captured.len(), 1);
+                captured[0].clone()
+            };
+            let signed = String::from_utf8_lossy(&signed_bytes);
+            assert!(signed.starts_with("DKIM-Signature:"));
+            assert!(signed.contains("d=example.com"));
+            assert!(signed.contains("s=dkim"));
+            // The public key should non-trivially map to the signature —
+            // the full cryptographic verification is covered by the
+            // existing `sign_and_verify_roundtrip` test in dkim.rs.
+            assert!(pub_pem.contains("PUBLIC KEY"));
+
+            shutdown_tx.send(true).unwrap();
+            let _ = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
         });
     }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -933,13 +933,100 @@ mod tests {
             assert!(signed.starts_with("DKIM-Signature:"));
             assert!(signed.contains("d=example.com"));
             assert!(signed.contains("s=dkim"));
-            // The public key should non-trivially map to the signature —
-            // the full cryptographic verification is covered by the
-            // existing `sign_and_verify_roundtrip` test in dkim.rs.
-            assert!(pub_pem.contains("PUBLIC KEY"));
+
+            // Cryptographically verify the DKIM signature using our test
+            // public key. We feed the key to `mail-auth` through an
+            // in-memory TXT cache so no DNS lookup is performed.
+            verify_dkim_with_pubkey(&signed_bytes, &pub_pem, "example.com", "dkim").await;
 
             shutdown_tx.send(true).unwrap();
             let _ = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;
         });
+    }
+
+    /// Crypto-verify a DKIM-signed message against a specific public key by
+    /// populating a `mail-auth` TXT cache with a synthetic DKIM1 record and
+    /// running the verifier. Panics on any verification failure — used by
+    /// the S34-3 integration test.
+    async fn verify_dkim_with_pubkey(signed: &[u8], pub_pem: &str, domain: &str, selector: &str) {
+        use base64::Engine;
+        use mail_auth::{
+            AuthenticatedMessage, DkimResult, MessageAuthenticator, Parameters, ResolverCache, Txt,
+            common::{parse::TxtRecordParser, verify::DomainKey},
+        };
+        use rsa::{RsaPublicKey, pkcs8::DecodePublicKey, pkcs8::EncodePublicKey};
+        use std::borrow::Borrow;
+        use std::collections::HashMap;
+        use std::hash::Hash;
+        use std::sync::Mutex;
+        use std::time::Instant;
+
+        // Convert the stored public PEM into a DKIM1 TXT-record string.
+        let pk = RsaPublicKey::from_public_key_pem(pub_pem).expect("parse public PEM");
+        let spki_der = pk.to_public_key_der().expect("encode SPKI");
+        let b64 = base64::engine::general_purpose::STANDARD.encode(spki_der.as_ref());
+        let txt_record = format!("v=DKIM1; k=rsa; p={b64}");
+
+        // Build a cache that returns the DomainKey for the selector + domain.
+        struct InMemCache<K, V>(Mutex<HashMap<K, V>>);
+        impl<K: Hash + Eq, V: Clone> ResolverCache<K, V> for InMemCache<K, V> {
+            fn get<Q>(&self, key: &Q) -> Option<V>
+            where
+                K: Borrow<Q>,
+                Q: Hash + Eq + ?Sized,
+            {
+                self.0.lock().unwrap().get(key).cloned()
+            }
+            fn remove<Q>(&self, key: &Q) -> Option<V>
+            where
+                K: Borrow<Q>,
+                Q: Hash + Eq + ?Sized,
+            {
+                self.0.lock().unwrap().remove(key)
+            }
+            fn insert(&self, key: K, value: V, _: Instant) {
+                self.0.lock().unwrap().insert(key, value);
+            }
+        }
+
+        let dk = DomainKey::parse(txt_record.as_bytes()).expect("parse DKIM1 record");
+        let txt_cache: InMemCache<String, Txt> = InMemCache(Mutex::new(HashMap::new()));
+        // mail-auth's `IntoFqdn` normalizes to `<selector>._domainkey.<domain>.`
+        // with a trailing dot — match it.
+        let key = format!("{selector}._domainkey.{domain}.");
+        txt_cache.0.lock().unwrap().insert(
+            key,
+            Txt::DomainKey(std::sync::Arc::new(dk)),
+            // valid_until is unused by the Insert impl; any Instant works.
+        );
+
+        let authenticator = MessageAuthenticator::new_system_conf()
+            .or_else(|_| MessageAuthenticator::new_cloudflare())
+            .expect("build MessageAuthenticator (DNS-independent here; cache short-circuits)");
+
+        let auth_msg = AuthenticatedMessage::parse(signed)
+            .expect("parse AuthenticatedMessage from signed bytes");
+        assert!(
+            !auth_msg.dkim_headers.is_empty(),
+            "signed message must carry at least one DKIM-Signature header"
+        );
+
+        let params = Parameters::new(&auth_msg).with_txt_cache(&txt_cache);
+        let outputs = authenticator.verify_dkim(params).await;
+        assert!(
+            !outputs.is_empty(),
+            "verifier returned no outputs; header parse probably failed"
+        );
+        let pass = outputs
+            .iter()
+            .any(|o| matches!(o.result(), DkimResult::Pass));
+        assert!(
+            pass,
+            "DKIM signature failed to verify against the test public key; outputs: {:?}",
+            outputs
+                .iter()
+                .map(|o| o.result().clone())
+                .collect::<Vec<_>>()
+        );
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -15,6 +15,25 @@ fn setup_test_env(tmp: &Path) -> String {
     std::fs::create_dir_all(tmp.join("alice")).unwrap();
     let config_path = tmp.join("config.toml");
     std::fs::write(&config_path, &config_content).unwrap();
+    // Sprint 34: `aimx serve` loads the DKIM private key at startup and
+    // refuses to start if it's missing. Every integration test that spawns
+    // `aimx serve` as a subprocess needs a DKIM key on disk inside the
+    // AIMX_CONFIG_DIR tempdir. Generate via the `dkim-keygen` subcommand
+    // through the binary path to keep this helper dependency-free.
+    let dkim_dir = tmp.join("dkim");
+    if !dkim_dir.join("private.key").exists() {
+        let status = StdCommand::new(aimx_binary_path())
+            .env("AIMX_CONFIG_DIR", tmp)
+            .arg("dkim-keygen")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .expect("Failed to run aimx dkim-keygen in test setup");
+        assert!(
+            status.success(),
+            "aimx dkim-keygen exited non-zero in test setup"
+        );
+    }
     config_path.to_string_lossy().to_string()
 }
 
@@ -253,7 +272,13 @@ fn ingest_via_env_var() {
 #[test]
 fn dkim_keygen_end_to_end() {
     let tmp = TempDir::new().unwrap();
-    setup_test_env(tmp.path());
+    // Write config.toml but skip DKIM key generation — the `dkim-keygen`
+    // command itself is under test and must start from a clean slate.
+    let config_content = format!(
+        "domain = \"agent.example.com\"\ndata_dir = \"{}\"\n\n[mailboxes.catchall]\naddress = \"*@agent.example.com\"\n",
+        tmp.path().display()
+    );
+    std::fs::write(tmp.path().join("config.toml"), &config_content).unwrap();
 
     aimx_cmd(tmp.path())
         .arg("--data-dir")
@@ -277,7 +302,11 @@ fn dkim_keygen_end_to_end() {
 #[test]
 fn dkim_keygen_no_overwrite() {
     let tmp = TempDir::new().unwrap();
-    setup_test_env(tmp.path());
+    let config_content = format!(
+        "domain = \"agent.example.com\"\ndata_dir = \"{}\"\n\n[mailboxes.catchall]\naddress = \"*@agent.example.com\"\n",
+        tmp.path().display()
+    );
+    std::fs::write(tmp.path().join("config.toml"), &config_content).unwrap();
 
     aimx_cmd(tmp.path())
         .arg("--data-dir")
@@ -299,7 +328,11 @@ fn dkim_keygen_no_overwrite() {
 #[test]
 fn dkim_keygen_force_overwrite() {
     let tmp = TempDir::new().unwrap();
-    setup_test_env(tmp.path());
+    let config_content = format!(
+        "domain = \"agent.example.com\"\ndata_dir = \"{}\"\n\n[mailboxes.catchall]\naddress = \"*@agent.example.com\"\n",
+        tmp.path().display()
+    );
+    std::fs::write(tmp.path().join("config.toml"), &config_content).unwrap();
 
     aimx_cmd(tmp.path())
         .arg("--data-dir")
@@ -1168,8 +1201,11 @@ fn serve_e2e_receive_email_and_shutdown() {
     setup_test_env(tmp.path());
     let port = find_free_port();
 
+    let runtime = tmp.path().join("run");
+    std::fs::create_dir_all(&runtime).ok();
     let mut child = StdCommand::new(aimx_binary_path())
         .env("AIMX_CONFIG_DIR", tmp.path())
+        .env("AIMX_RUNTIME_DIR", &runtime)
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("serve")
@@ -1234,8 +1270,11 @@ fn serve_e2e_multi_recipient() {
     setup_test_env(tmp.path());
     let port = find_free_port();
 
+    let runtime = tmp.path().join("run");
+    std::fs::create_dir_all(&runtime).ok();
     let mut child = StdCommand::new(aimx_binary_path())
         .env("AIMX_CONFIG_DIR", tmp.path())
+        .env("AIMX_RUNTIME_DIR", &runtime)
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("serve")
@@ -1289,8 +1328,11 @@ fn serve_e2e_connection_refused_after_shutdown() {
     setup_test_env(tmp.path());
     let port = find_free_port();
 
+    let runtime = tmp.path().join("run");
+    std::fs::create_dir_all(&runtime).ok();
     let mut child = StdCommand::new(aimx_binary_path())
         .env("AIMX_CONFIG_DIR", tmp.path())
+        .env("AIMX_RUNTIME_DIR", &runtime)
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("serve")
@@ -1340,12 +1382,30 @@ fn setup_test_env_with_bob(tmp: &Path) -> String {
     std::fs::create_dir_all(tmp.join("bob")).unwrap();
     let config_path = tmp.join("config.toml");
     std::fs::write(&config_path, &config_content).unwrap();
+    // Sprint 34: `aimx serve` requires the DKIM private key at startup.
+    let dkim_dir = tmp.join("dkim");
+    if !dkim_dir.join("private.key").exists() {
+        let status = StdCommand::new(aimx_binary_path())
+            .env("AIMX_CONFIG_DIR", tmp)
+            .arg("dkim-keygen")
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+            .expect("Failed to run aimx dkim-keygen in test setup");
+        assert!(
+            status.success(),
+            "aimx dkim-keygen exited non-zero in test setup"
+        );
+    }
     config_path.to_string_lossy().to_string()
 }
 
 fn start_serve(tmp: &Path, port: u16) -> std::process::Child {
+    let runtime = tmp.join("run");
+    std::fs::create_dir_all(&runtime).ok();
     let mut child = StdCommand::new(aimx_binary_path())
         .env("AIMX_CONFIG_DIR", tmp)
+        .env("AIMX_RUNTIME_DIR", &runtime)
         .arg("--data-dir")
         .arg(tmp)
         .arg("serve")
@@ -1759,4 +1819,174 @@ fn serve_e2e_to_cc_bcc_combined() {
     }
 
     stop_serve(child);
+}
+
+// ---------------------------------------------------------------------------
+// Sprint 34 — UDS send listener integration tests.
+//
+// These tests spawn `aimx serve` as a subprocess (same pattern as the
+// `serve_e2e_*` tests above) and drive the `/run/aimx/send.sock` UDS
+// listener with a raw Unix-socket client. `AIMX_RUNTIME_DIR` is overridden
+// to a tempdir so the socket lives inside the test sandbox; the binary
+// under test creates it with mode `0o666`. We never exercise the real MX
+// delivery path — the `ERR DOMAIN` and `ERR MALFORMED` responses prove the
+// framing and handler wiring are intact without reaching the network.
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+fn wait_for_socket(path: &Path, timeout: std::time::Duration) -> bool {
+    let started = std::time::Instant::now();
+    while started.elapsed() < timeout {
+        if path.exists() {
+            return true;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    false
+}
+
+#[cfg(unix)]
+#[test]
+fn serve_creates_send_socket_with_world_writable_mode() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let port = find_free_port();
+    let child = start_serve(tmp.path(), port);
+
+    let sock = tmp.path().join("run").join("send.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS send socket {} never appeared",
+        sock.display()
+    );
+
+    let mode = std::fs::metadata(&sock).unwrap().permissions().mode() & 0o777;
+    assert_eq!(
+        mode, 0o666,
+        "UDS send socket must be world-writable (0o666); got {mode:o}"
+    );
+
+    stop_serve(child);
+}
+
+#[cfg(unix)]
+#[test]
+fn uds_send_listener_accepts_and_rejects_domain_mismatch() {
+    use std::io::Read as _;
+    use std::os::unix::net::UnixStream;
+
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let port = find_free_port();
+    let child = start_serve(tmp.path(), port);
+
+    let sock = tmp.path().join("run").join("send.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS send socket never appeared"
+    );
+
+    // Submit an AIMX/1 SEND with a From: domain that does not match the
+    // configured primary domain (`agent.example.com`). This must be
+    // rejected with `ERR DOMAIN` before any MX lookup happens, proving
+    // both the wire parser and the handler wiring end-to-end.
+    let body = b"From: alice@not-the-domain.example\r\n\
+                 To: user@gmail.com\r\n\
+                 Subject: Hi\r\n\
+                 Date: Thu, 01 Jan 2025 12:00:00 +0000\r\n\
+                 Message-ID: <integ-abc@not-the-domain.example>\r\n\
+                 \r\n\
+                 hello\r\n";
+    let header = format!(
+        "AIMX/1 SEND\nFrom-Mailbox: alice\nContent-Length: {}\n\n",
+        body.len()
+    );
+
+    let mut client = UnixStream::connect(&sock).expect("connect UDS");
+    client.write_all(header.as_bytes()).unwrap();
+    client.write_all(body).unwrap();
+    // Signal "no more bytes coming" so the server can return the response.
+    client
+        .shutdown(std::net::Shutdown::Write)
+        .expect("shutdown write");
+
+    let mut resp = String::new();
+    client.read_to_string(&mut resp).expect("read response");
+
+    assert!(
+        resp.starts_with("AIMX/1 ERR DOMAIN"),
+        "expected ERR DOMAIN, got {resp:?}"
+    );
+    assert!(resp.ends_with('\n'), "response must be LF-terminated");
+
+    stop_serve(child);
+}
+
+#[cfg(unix)]
+#[test]
+fn uds_send_listener_rejects_malformed_request() {
+    use std::io::Read as _;
+    use std::os::unix::net::UnixStream;
+
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let port = find_free_port();
+    let child = start_serve(tmp.path(), port);
+
+    let sock = tmp.path().join("run").join("send.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS send socket never appeared"
+    );
+
+    // Wrong leading line — must be rejected with `ERR MALFORMED`.
+    let mut client = UnixStream::connect(&sock).expect("connect UDS");
+    client
+        .write_all(b"GET / HTTP/1.1\r\nHost: x\r\n\r\n")
+        .unwrap();
+    client
+        .shutdown(std::net::Shutdown::Write)
+        .expect("shutdown write");
+
+    let mut resp = String::new();
+    client.read_to_string(&mut resp).expect("read response");
+    assert!(
+        resp.starts_with("AIMX/1 ERR MALFORMED"),
+        "expected ERR MALFORMED, got {resp:?}"
+    );
+
+    stop_serve(child);
+}
+
+#[cfg(unix)]
+#[test]
+fn uds_send_listener_cleaned_up_after_sigterm() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let port = find_free_port();
+    let child = start_serve(tmp.path(), port);
+
+    let sock = tmp.path().join("run").join("send.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS send socket never appeared"
+    );
+
+    // Clean shutdown — the listener removes the socket file so the next
+    // start does not trip the stale-socket retry path.
+    stop_serve(child);
+
+    let started = std::time::Instant::now();
+    while started.elapsed() < std::time::Duration::from_secs(5) {
+        if !sock.exists() {
+            return;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    panic!(
+        "send.sock should be removed on clean shutdown but still exists at {}",
+        sock.display()
+    );
 }


### PR DESCRIPTION
## Summary

Stands up the daemon-side of the `aimx send` rewrite so that DKIM signing and outbound SMTP delivery live inside `aimx serve`, reachable from any local user over a world-writable UDS at `/run/aimx/send.sock`.

- **S34-1 `src/send_protocol.rs`** — pure `AsyncRead`/`AsyncWrite` codec for the `AIMX/1 SEND` frame (length-prefixed, binary-safe). Case-insensitive header names, unknown headers ignored for forward-compat, body read by exact `Content-Length`. Rejects wrong request-line, missing/duplicate required headers, bad or oversized `Content-Length`, truncated bodies, non-ASCII header names. Response codec renders `AIMX/1 OK <id>` or `AIMX/1 ERR {MAILBOX|DOMAIN|SIGN|DELIVERY|TEMP|MALFORMED} <reason>` with CR/LF stripped from the reason.
- **S34-2 `src/serve.rs`** — binds `tokio::net::UnixListener` at `send_socket_path()` (default `/run/aimx/send.sock`, overridable via `AIMX_RUNTIME_DIR`), sets mode `0o666`, handles stale-socket reclaim on `EADDRINUSE`, logs `SO_PEERCRED` for diagnostics only (never for authorization), and ties SIGTERM/SIGINT shutdown into the existing SMTP-listener drain path. Socket file is removed on clean shutdown.
- **S34-3 `src/send_handler.rs`** — per-connection `handle_send(req, &ctx)` backed by an `Arc<SendContext>` carrying the DKIM key loaded once at daemon startup. Mailbox-registration check → `From:` parse → case-insensitive domain compare → DKIM sign → delivery via the existing `LettreTransport` trait. Every error path maps to a stable `ErrCode`.

## Wire format

```
Client → Server:
  AIMX/1 SEND\n
  From-Mailbox: <name>\n
  Content-Length: <n>\n
  \n
  <n bytes of RFC 5322 message, unsigned>

Server → Client:
  AIMX/1 OK <message-id>\n
or
  AIMX/1 ERR <code> <reason>\n
```

## Scope notes

- Authorization is explicitly out of scope for v0.2. The socket is world-writable by design (PRD / Sprint 33.1); `peer_uid`/`peer_pid` are read and logged for journald diagnostics only.
- `aimx send` is still the old in-process signer — client rewrite lands in Sprint 35. This PR only proves the daemon-side with unit tests + raw-UDS integration tests.
- `setup_test_env` now mints a DKIM keypair inside each test's `AIMX_CONFIG_DIR` because `aimx serve` refuses to start without one. The `dkim_keygen_*` tests were updated to bypass the helper so they still start from a clean slate.

## Acceptance criteria

### S34-1 — `src/send_protocol.rs` wire-format codec
- [x] Module added; exports `SendRequest`, `SendResponse`, `ErrCode`, `parse_request`, `write_response`
- [x] `parse_request` reads `AIMX/1 SEND\n`, headers until blank line, `Content-Length` bytes exactly
- [x] Required headers: `From-Mailbox`, `Content-Length`; unknowns ignored
- [x] Rejections: wrong request-line, missing header, bad/oversized `Content-Length`, truncated body → `Malformed`
- [x] `write_response` emits correct `OK` / `ERR <CODE>` lines for all six codes
- [x] Round-trip unit tests for every response variant using in-memory async streams
- [x] Parser fuzzed: truncated body, oversized body, CRLF vs LF, case-insensitive names, duplicate headers, missing blank line, empty body, body containing `AIMX/1 SEND\n`
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` clean

### S34-2 — `aimx serve` binds `/run/aimx/send.sock`
- [x] `UnixListener` bound at `send_socket_path()`; `AIMX_RUNTIME_DIR` override implemented
- [x] Mode set to `0o666` after bind; owner left as running process UID
- [x] `SO_PEERCRED` read per accept and logged; never used for authz
- [x] Bind failure is fatal at startup with clear error naming path + errno
- [x] Stale-socket on-disk: unlink-and-retry once, fail loudly on second attempt
- [x] SIGTERM/SIGINT drain both the SMTP listener and the UDS accept loop; socket removed on clean shutdown
- [x] Unit test asserts mode `0o666` and reclaim-from-stale
- [x] Integration tests spawn `aimx serve` in a tempdir, open a raw UDS, assert accept + response
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` clean

### S34-3 — daemon-side send handler
- [x] `src/send_handler.rs` with `async fn handle_send(req, &ctx) -> SendResponse`
- [x] `SendContext` holds `Arc<DkimKey>`, primary domain, mailbox set, `Arc<dyn MailTransport>`
- [x] `serve.rs::main` loads DKIM once at startup; failure is fatal with a clear message
- [x] `From:` parsed; domain compare case-insensitive; any local part accepted
- [x] Domain mismatch → `ERR DOMAIN`; unknown `From-Mailbox` → `ERR MAILBOX`
- [x] DKIM signing reuses relaxed/relaxed canonicalization from Sprint 25; failure → `ERR SIGN`
- [x] Delivery via existing `LettreTransport`; transport errors classified into `Delivery` vs `Temp`
- [x] Response written via `send_protocol::write_response`
- [x] Each accept spawns its own `tokio::spawn` task
- [x] Unit tests mock `MailTransport` across every error path; integration test asserts DKIM-signed message hits the transport
- [x] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` clean

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test --bin aimx` — 483 pass
- [x] `cargo test --test integration` — 49 pass including the four new Sprint 34 integration tests
- [ ] Exercise `aimx serve` on a real host once Sprint 35 client lands (deferred — daemon-side verified via raw-UDS tests here)

## Recommended commit message

```
[Sprint 34] UDS Wire Protocol + `aimx serve` Send Listener (#PR)

Move DKIM signing and outbound SMTP delivery inside `aimx serve`, exposed
over a world-writable UDS at `/run/aimx/send.sock`. Adds the `AIMX/1
SEND` wire codec (`src/send_protocol.rs`), the daemon-side UDS listener
with stale-socket reclaim and SO_PEERCRED diagnostics (`src/serve.rs`),
and the per-connection handler that validates, DKIM-signs, and delivers
(`src/send_handler.rs`). `aimx send` remains unchanged in this sprint —
the thin-client rewrite lands in Sprint 35.

Authorization is out of scope in v0.2: the socket is 0o666 by design;
`peer_uid`/`peer_pid` are logged for journald diagnostics only.
```