### PR TITLE
[Sprint 36] Datadir Reshape — Inbox/Sent Split + Slug + Bundles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -77,7 +77,7 @@ These are NOT a Cargo workspace — they have independent `Cargo.toml` files and
 
 - Config: `/etc/aimx/config.toml` (mode `0640`, owner `root:root`) — parsed via `serde` + `toml` into `Config` struct in `config.rs`. Resolved via `config_path()` which honors `AIMX_CONFIG_DIR` for tests / non-standard installs.
 - DKIM keys: `/etc/aimx/dkim/{private,public}.key` (private `0600` root-only, public `0644`). Loaded via `load_private_key(&config::dkim_dir())`.
-- Storage: Markdown files with TOML frontmatter (`+++` delimiters, not `---`). One `.md` file per email, `YYYY-MM-DD-NNN.md` naming, under `/var/lib/aimx/<mailbox>/`.
+- Storage: Markdown files with TOML frontmatter (`+++` delimiters, not `---`). Inbound mail lives at `/var/lib/aimx/inbox/<mailbox>/`, outbound sent copies at `/var/lib/aimx/sent/<mailbox>/`. Filenames use `YYYY-MM-DD-HHMMSS-<slug>.md` (UTC). Zero attachments produce a flat `<stem>.md`; one or more attachments produce a Zola-style bundle directory `<stem>/` containing `<stem>.md` plus each attachment as a sibling. The previous mailbox-level `attachments/` directory is gone (Sprint 36).
 - `--data-dir` / `AIMX_DATA_DIR` overrides the **storage** path (mailboxes only, v0.2). `AIMX_CONFIG_DIR` overrides the **config + DKIM** path.
 - Runtime dir: `/run/aimx/` (mode `0755`, owner `root:root`) — provided by systemd `RuntimeDirectory=aimx` or OpenRC `checkpath` in `start_pre`. Sprint 34 places `send.sock` here as a world-writable UDS (`0o666`); authorization is out of scope for v0.2.
 - Tests use `tempfile::TempDir` plus `crate::config::test_env::ConfigDirOverride::set(&tmp)` (or the `AIMX_CONFIG_DIR` env var in integration tests) to isolate config + DKIM lookups.

--- a/book/channels.md
+++ b/book/channels.md
@@ -55,15 +55,22 @@ The following variables are available in `command` strings:
 
 | Variable | Description | Example |
 |----------|-------------|---------|
-| `{filepath}` | Full path to the saved `.md` file | `/var/lib/aimx/support/2025-01-15-001.md` |
+| `{filepath}` | Full path to the saved `.md` file | `/var/lib/aimx/inbox/support/2025-01-15-103000-meeting.md` |
 | `{from}` | Sender email address | `alice@example.com` |
 | `{to}` | Recipient email address | `support@agent.yourdomain.com` |
 | `{subject}` | Email subject | `Meeting next Thursday` |
 | `{mailbox}` | Mailbox name | `support` |
-| `{id}` | Email ID | `2025-01-15-001` |
+| `{id}` | Email ID (filename stem) | `2025-01-15-103000-meeting` |
 | `{date}` | Email date | `2025-01-15T10:30:00Z` |
 
 Variable values are shell-escaped to prevent injection.
+
+When an email has attachments, `{filepath}` points at the `.md` file
+*inside* the Zola-style bundle directory
+(`/var/lib/aimx/inbox/<mailbox>/<stem>/<stem>.md`). Attachments live beside
+the `.md` as siblings inside the same directory; read the `attachments`
+array in the frontmatter to list them (each `path` is relative to the
+bundle directory).
 
 ## Match filters
 

--- a/book/mailboxes.md
+++ b/book/mailboxes.md
@@ -4,9 +4,25 @@ Mailboxes are the core organizational unit in AIMX. Each mailbox maps an email a
 
 ## Concepts
 
-- **Mailboxes are directories.** Creating a mailbox creates a folder and registers an address. No OS users, no passwords, no database.
-- **Catchall.** The `catchall` mailbox (created by default during setup) receives email for any unrecognized address at your domain.
+- **Mailboxes are directories.** Creating a mailbox creates two folders (one under `inbox/` and one under `sent/`) and registers an address. No OS users, no passwords, no database.
+- **Catchall.** The `catchall` mailbox (created by default during setup) receives email for any unrecognized address at your domain. Catchall is inbox-only — no `sent/catchall/` directory is created.
 - **No restart required.** Mailbox changes take effect immediately -- `aimx ingest` reads the config on each invocation.
+
+### On-disk layout
+
+```
+/var/lib/aimx/
+├── inbox/              # inbound mail lives here
+│   ├── catchall/
+│   └── support/
+└── sent/               # outbound sent copies (populated in a future release)
+    └── support/
+```
+
+Each email is stored as either a flat `YYYY-MM-DD-HHMMSS-<slug>.md` file
+when it has zero attachments, or as a Zola-style bundle directory
+`YYYY-MM-DD-HHMMSS-<slug>/` containing `<stem>.md` plus every attachment
+as a sibling file when attachments are present.
 
 ### Routing logic
 
@@ -25,7 +41,10 @@ For example, with mailboxes `support` and `catchall` configured:
 aimx mailbox create support
 ```
 
-This creates `support@agent.yourdomain.com` and the directory `/var/lib/aimx/support/`.
+This creates `support@agent.yourdomain.com` and both directories:
+`/var/lib/aimx/inbox/support/` (for incoming mail) and
+`/var/lib/aimx/sent/support/` (for outbound copies). Deletion removes
+both; `catchall` cannot be deleted.
 
 ### List mailboxes
 
@@ -75,7 +94,7 @@ This format is designed to be agent-readable without parsing libraries. An agent
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `id` | string | Unique email ID within the mailbox (e.g. `2025-01-15-001`) |
+| `id` | string | Unique email ID within the mailbox (the filename stem, e.g. `2025-01-15-103000-meeting`) |
 | `message_id` | string | RFC 5322 Message-ID header |
 | `from` | string | Sender address with optional display name |
 | `to` | string | Recipient address |
@@ -97,12 +116,14 @@ This format is designed to be agent-readable without parsing libraries. An agent
 
 ## Attachments
 
-Attachments are extracted to an `attachments/` subdirectory within the mailbox folder:
+When an email carries one or more attachments, AIMX writes a Zola-style
+bundle directory whose name matches the `.md` file's stem:
 
 ```
-/var/lib/aimx/support/
-├── 2025-01-15-001.md
-└── attachments/
+/var/lib/aimx/inbox/support/
+├── 2025-01-15-103000-status-update.md         # flat: no attachments
+└── 2025-01-15-104500-quarterly-report/        # bundle: one or more attachments
+    ├── 2025-01-15-104500-quarterly-report.md
     ├── report.pdf
     └── image.png
 ```
@@ -114,15 +135,15 @@ Attachment metadata is stored in the email frontmatter:
 filename = "report.pdf"
 content_type = "application/pdf"
 size = 45230
-path = "attachments/report.pdf"
+path = "report.pdf"
 ```
 
 | Field | Description |
 |-------|-------------|
-| `filename` | Original filename |
+| `filename` | Original filename (path components stripped, duplicates suffixed `-1`, `-2`, …) |
 | `content_type` | MIME type |
 | `size` | File size in bytes |
-| `path` | Relative path from the mailbox directory |
+| `path` | Path relative to the bundle directory (no `attachments/` prefix in v0.2) |
 
 ## Read/unread tracking
 
@@ -177,7 +198,12 @@ The `email_reply` MCP tool handles threading automatically -- it reads the origi
 
 ## Email ID format
 
-Each email receives a unique ID within its mailbox in the format `YYYY-MM-DD-NNN` (e.g. `2025-01-15-001`). The counter increments atomically per mailbox to prevent collisions.
+Each email's `id` field is the filename stem
+`YYYY-MM-DD-HHMMSS-<slug>` in UTC. The slug is derived from the subject:
+lowercase, non-alphanumeric runs collapsed to `-`, trimmed, capped at 20
+characters, with `no-subject` as a fallback for empty results. Two emails
+with the same subject in the same UTC second have `-2`, `-3`, … appended
+to disambiguate.
 
 ---
 

--- a/book/mcp.md
+++ b/book/mcp.md
@@ -77,6 +77,7 @@ List emails in a mailbox with optional filters.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `mailbox` | string | yes | Mailbox name to list emails from |
+| `folder` | string | no | `"inbox"` (default) or `"sent"` — picks which side of the mailbox to list |
 | `unread` | bool | no | Filter to only unread emails |
 | `from` | string | no | Filter by sender address (substring match) |
 | `since` | string | no | Filter to emails since this datetime (RFC 3339 format) |
@@ -93,7 +94,8 @@ Read the full content of an email.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `mailbox` | string | yes | Mailbox name |
-| `id` | string | yes | Email ID (e.g. `2025-01-15-001`) |
+| `id` | string | yes | Email ID, i.e. the filename stem (e.g. `2025-01-15-103000-meeting`) |
+| `folder` | string | no | `"inbox"` (default) or `"sent"` |
 
 **Returns:** Complete `.md` file content including frontmatter and body.
 
@@ -136,7 +138,8 @@ Mark an email as read.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `mailbox` | string | yes | Mailbox name |
-| `id` | string | yes | Email ID (e.g. `2025-01-15-001`) |
+| `id` | string | yes | Email ID (filename stem, e.g. `2025-01-15-103000-meeting`) |
+| `folder` | string | no | `"inbox"` (default) or `"sent"` |
 
 Updates `read = true` in the email's frontmatter.
 
@@ -149,7 +152,8 @@ Mark an email as unread.
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `mailbox` | string | yes | Mailbox name |
-| `id` | string | yes | Email ID (e.g. `2025-01-15-001`) |
+| `id` | string | yes | Email ID (filename stem, e.g. `2025-01-15-103000-meeting`) |
+| `folder` | string | no | `"inbox"` (default) or `"sent"` |
 
 Updates `read = false` in the email's frontmatter.
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -133,8 +133,28 @@ impl Config {
         Ok(cfg)
     }
 
+    /// Path to a mailbox's inbox directory (`<data_dir>/inbox/<name>/`).
+    ///
+    /// Since Sprint 36 the datadir splits inbound mail into `inbox/` and
+    /// outbound sent copies into `sent/`. `mailbox_dir` remains a shorthand
+    /// for the inbox path (which is what every legacy reader cared about);
+    /// callers that want the outbound side use [`Config::sent_dir`].
     pub fn mailbox_dir(&self, name: &str) -> PathBuf {
-        self.data_dir.join(name)
+        self.inbox_dir(name)
+    }
+
+    /// Path to a mailbox's inbox directory (`<data_dir>/inbox/<name>/`).
+    pub fn inbox_dir(&self, name: &str) -> PathBuf {
+        self.data_dir.join("inbox").join(name)
+    }
+
+    /// Path to a mailbox's sent directory (`<data_dir>/sent/<name>/`).
+    ///
+    /// Sent storage is populated by `aimx serve` in Sprint 38; the directory
+    /// is still created on `mailbox create` so the layout is consistent
+    /// from day one.
+    pub fn sent_dir(&self, name: &str) -> PathBuf {
+        self.data_dir.join("sent").join(name)
     }
 
     pub fn resolve_mailbox(&self, local_part: &str) -> String {
@@ -330,7 +350,20 @@ address = "*@test.com"
         let config: Config = toml::from_str(sample_toml()).unwrap();
         assert_eq!(
             config.mailbox_dir("support"),
-            PathBuf::from("/tmp/aimx-test/support")
+            PathBuf::from("/tmp/aimx-test/inbox/support")
+        );
+    }
+
+    #[test]
+    fn inbox_and_sent_dirs() {
+        let config: Config = toml::from_str(sample_toml()).unwrap();
+        assert_eq!(
+            config.inbox_dir("support"),
+            PathBuf::from("/tmp/aimx-test/inbox/support")
+        );
+        assert_eq!(
+            config.sent_dir("support"),
+            PathBuf::from("/tmp/aimx-test/sent/support")
         );
     }
 

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -6,6 +6,15 @@ use serde::Serialize;
 use std::io::Read;
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+/// Process-scoped lock guarding the inbound critical section: filename
+/// allocation, bundle directory creation, attachment writes, and the
+/// final `.md` write. The aimx daemon is the single writer to
+/// `<data_dir>/inbox/`, so a process Mutex is sufficient — no
+/// filesystem-level lock needed. Symmetric to the outbound `Mutex<()>`
+/// planned for FR-19b.
+static INGEST_WRITE_LOCK: Mutex<()> = Mutex::new(());
 
 #[derive(Debug, Clone, Serialize, serde::Deserialize)]
 pub struct EmailMetadata {
@@ -117,6 +126,15 @@ pub fn ingest_email(
 
     let slug = slugify(&subject);
     let timestamp = chrono::Utc::now();
+
+    // Hold the inbound write lock across allocate → mkdir → write
+    // attachments → write markdown so two ingests racing on the same UTC
+    // second + slug + attachment filenames cannot interleave: the second
+    // arrival sees the first's bundle on disk and picks a `-2` suffix.
+    let _guard = INGEST_WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
     let md_path = allocate_filename(&inbox_dir, timestamp, &slug, has_attachments);
     let parent_dir = md_path
         .parent()
@@ -128,20 +146,24 @@ pub fn ingest_email(
     // `create_dir_all` is idempotent and cheap.
     std::fs::create_dir_all(&parent_dir)?;
 
-    // Write attachments first; if one fails we want to bubble the error
-    // before writing the `.md` so callers never see a half-written bundle.
-    let attachments = write_attachments(&parent_dir, prepared_attachments).inspect_err(|_| {
-        // Best-effort cleanup of a freshly created bundle directory.
-        if has_attachments && parent_dir != inbox_dir {
-            let _ = std::fs::remove_dir_all(&parent_dir);
-        }
-    })?;
-
     let id = md_path
         .file_stem()
         .and_then(|s| s.to_str())
         .unwrap_or_default()
         .to_string();
+
+    // Roll back a freshly created bundle directory on any post-allocation
+    // failure (attachment write or markdown write). For flat layouts the
+    // parent is the mailbox dir itself and stays untouched.
+    let cleanup_bundle = || {
+        if has_attachments && parent_dir != inbox_dir {
+            let _ = std::fs::remove_dir_all(&parent_dir);
+        }
+    };
+
+    let attachments = write_attachments(&parent_dir, prepared_attachments).inspect_err(|_| {
+        cleanup_bundle();
+    })?;
 
     let meta = EmailMetadata {
         id: id.clone(),
@@ -159,7 +181,11 @@ pub fn ingest_email(
         spf: spf_result,
     };
 
-    write_markdown(&md_path, &meta, &body)?;
+    write_markdown(&md_path, &meta, &body).inspect_err(|_| {
+        cleanup_bundle();
+    })?;
+
+    drop(_guard);
 
     if let Some(mailbox_config) = config.mailboxes.get(&mailbox) {
         let ctx = TriggerContext {
@@ -1154,6 +1180,52 @@ mod tests {
             rcpt.split('@').nth(1).unwrap_or("")
         };
         assert_eq!(helo_domain, "recipient.com");
+    }
+
+    #[test]
+    fn concurrent_same_subject_attachment_ingests_do_not_corrupt_each_other() {
+        // Sprint 36 review fix: with the inbound `Mutex<()>` guarding the
+        // allocate-create-write critical section, two threads racing the
+        // same subject + same attachment filename in the same UTC second
+        // each end up in their own bundle directory with their own copy
+        // of the attachment intact.
+        use std::sync::Arc;
+        use std::thread;
+
+        let tmp = TempDir::new().unwrap();
+        let config = Arc::new(test_config(tmp.path()));
+
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let cfg = Arc::clone(&config);
+            handles.push(thread::spawn(move || {
+                ingest_email(&cfg, "alice@test.com", attachment_eml()).unwrap();
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        let alice = inbox(tmp.path(), "alice");
+        let bundles: Vec<_> = std::fs::read_dir(&alice)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .collect();
+        assert_eq!(bundles.len(), 8, "each ingest must own its bundle dir");
+
+        for b in bundles {
+            let path = b.path();
+            let stem = path.file_name().unwrap().to_str().unwrap().to_string();
+            let md = path.join(format!("{stem}.md"));
+            let attachment = path.join("notes.txt");
+            assert!(md.exists(), "md file present in {stem}");
+            assert!(attachment.exists(), "attachment present in {stem}");
+            // Attachment content is the original — no other thread
+            // truncated/overwrote it.
+            let body = std::fs::read_to_string(&attachment).unwrap();
+            assert!(body.contains("These are my notes."));
+        }
     }
 
     #[test]

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1,10 +1,11 @@
 use crate::channel::{self, TriggerContext};
 use crate::config::Config;
+use crate::slug::{allocate_filename, slugify};
 use mail_parser::{MessageParser, MimeHeaders};
 use serde::Serialize;
 use std::io::Read;
 use std::net::IpAddr;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 #[derive(Debug, Clone, Serialize, serde::Deserialize)]
 pub struct EmailMetadata {
@@ -50,9 +51,9 @@ pub fn ingest_email(
 ) -> Result<(), Box<dyn std::error::Error>> {
     let local_part = extract_local_part(rcpt);
     let mailbox = config.resolve_mailbox(local_part);
-    let mailbox_dir = config.mailbox_dir(&mailbox);
+    let inbox_dir = config.inbox_dir(&mailbox);
 
-    std::fs::create_dir_all(&mailbox_dir)?;
+    std::fs::create_dir_all(&inbox_dir)?;
 
     let message = MessageParser::default()
         .parse(raw)
@@ -107,12 +108,43 @@ pub fn ingest_email(
 
     let body = extract_body(&message);
 
-    let attachments = extract_attachments(&message, &mailbox_dir)?;
+    // Collect attachments as in-memory metadata + payload so we can decide
+    // between flat and bundle layouts before committing any file to disk.
+    let prepared_attachments = prepare_attachments(&message);
+    let has_attachments = !prepared_attachments.is_empty();
 
     let (dkim_result, spf_result) = verify_auth(raw, rcpt);
 
-    let meta_template = EmailMetadata {
-        id: String::new(), // placeholder, set after atomic creation
+    let slug = slugify(&subject);
+    let timestamp = chrono::Utc::now();
+    let md_path = allocate_filename(&inbox_dir, timestamp, &slug, has_attachments);
+    let parent_dir = md_path
+        .parent()
+        .ok_or("allocate_filename returned a rootless path")?
+        .to_path_buf();
+
+    // For bundle layouts the parent is `<stem>/`; for flat layouts it is
+    // the mailbox directory itself (already created above). Either way,
+    // `create_dir_all` is idempotent and cheap.
+    std::fs::create_dir_all(&parent_dir)?;
+
+    // Write attachments first; if one fails we want to bubble the error
+    // before writing the `.md` so callers never see a half-written bundle.
+    let attachments = write_attachments(&parent_dir, prepared_attachments).inspect_err(|_| {
+        // Best-effort cleanup of a freshly created bundle directory.
+        if has_attachments && parent_dir != inbox_dir {
+            let _ = std::fs::remove_dir_all(&parent_dir);
+        }
+    })?;
+
+    let id = md_path
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or_default()
+        .to_string();
+
+    let meta = EmailMetadata {
+        id: id.clone(),
         message_id,
         from,
         to,
@@ -127,11 +159,11 @@ pub fn ingest_email(
         spf: spf_result,
     };
 
-    let (_id, filepath, meta) = create_file_atomic(&mailbox_dir, &meta_template, &body)?;
+    write_markdown(&md_path, &meta, &body)?;
 
     if let Some(mailbox_config) = config.mailboxes.get(&mailbox) {
         let ctx = TriggerContext {
-            filepath: &filepath,
+            filepath: &md_path,
             metadata: &meta,
         };
         channel::execute_triggers(mailbox_config, &ctx);
@@ -325,12 +357,17 @@ fn extract_body(message: &mail_parser::Message) -> String {
     String::new()
 }
 
-fn extract_attachments(
-    message: &mail_parser::Message,
-    mailbox_dir: &Path,
-) -> Result<Vec<AttachmentMeta>, Box<dyn std::error::Error>> {
+/// An attachment extracted from the parsed MIME message but not yet written
+/// to disk. Lives long enough to decide between flat and bundle layouts
+/// before any file I/O happens.
+struct PreparedAttachment {
+    filename: String,
+    content_type: String,
+    body: Vec<u8>,
+}
+
+fn prepare_attachments(message: &mail_parser::Message) -> Vec<PreparedAttachment> {
     let mut result = Vec::new();
-    let attachments_dir = mailbox_dir.join("attachments");
 
     for attachment in message.attachments() {
         let raw_name = match attachment.attachment_name() {
@@ -338,6 +375,9 @@ fn extract_attachments(
             None => continue,
         };
 
+        // Strip any path components the sender may have smuggled in;
+        // `file_name` on a traversal string like `../../etc/foo` returns
+        // just `foo`.
         let filename = Path::new(&raw_name)
             .file_name()
             .and_then(|f| f.to_str())
@@ -347,8 +387,6 @@ fn extract_attachments(
         if filename.is_empty() {
             continue;
         }
-
-        std::fs::create_dir_all(&attachments_dir)?;
 
         let content_type = attachment
             .content_type()
@@ -361,19 +399,37 @@ fn extract_attachments(
             })
             .unwrap_or_else(|| "application/octet-stream".to_string());
 
-        let body = attachment.contents();
-        let dest_filename = deduplicate_filename(&attachments_dir, &filename);
-        let dest_path = attachments_dir.join(&dest_filename);
+        result.push(PreparedAttachment {
+            filename,
+            content_type,
+            body: attachment.contents().to_vec(),
+        });
+    }
 
-        std::fs::write(&dest_path, body)?;
+    result
+}
 
-        let relative_path = format!("attachments/{dest_filename}");
+/// Write each attachment as a sibling of the `.md` file inside the bundle
+/// directory. Duplicate filenames are disambiguated with `-1`, `-2`, …
+/// before the extension. The returned `AttachmentMeta` entries carry the
+/// on-disk filename (without any bundle prefix — each attachment is a
+/// sibling of the `.md`, so the relative path is just the filename).
+fn write_attachments(
+    bundle_dir: &Path,
+    attachments: Vec<PreparedAttachment>,
+) -> Result<Vec<AttachmentMeta>, Box<dyn std::error::Error>> {
+    let mut result = Vec::with_capacity(attachments.len());
+
+    for att in attachments {
+        let dest_filename = deduplicate_filename(bundle_dir, &att.filename);
+        let dest_path = bundle_dir.join(&dest_filename);
+        std::fs::write(&dest_path, &att.body)?;
 
         result.push(AttachmentMeta {
-            filename: dest_filename,
-            content_type,
-            size: body.len(),
-            path: relative_path,
+            filename: dest_filename.clone(),
+            content_type: att.content_type,
+            size: att.body.len(),
+            path: dest_filename,
         });
     }
 
@@ -404,46 +460,22 @@ fn deduplicate_filename(dir: &Path, filename: &str) -> String {
     unreachable!()
 }
 
-fn create_file_atomic(
-    mailbox_dir: &Path,
-    meta_template: &EmailMetadata,
+fn write_markdown(
+    path: &Path,
+    meta: &EmailMetadata,
     body: &str,
-) -> Result<(String, std::path::PathBuf, EmailMetadata), Box<dyn std::error::Error>> {
+) -> Result<PathBuf, Box<dyn std::error::Error>> {
     use std::fs::OpenOptions;
     use std::io::Write;
 
-    let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
-    let mut counter = 1u32;
-
-    const MAX_COUNTER: u32 = 999_999;
-
-    loop {
-        if counter > MAX_COUNTER {
-            return Err(format!(
-                "Exhausted {MAX_COUNTER} file ID candidates for {today} in {}",
-                mailbox_dir.display()
-            )
-            .into());
-        }
-
-        let candidate = format!("{today}-{counter:03}");
-        let path = mailbox_dir.join(format!("{candidate}.md"));
-
-        match OpenOptions::new().write(true).create_new(true).open(&path) {
-            Ok(mut file) => {
-                let mut meta = meta_template.clone();
-                meta.id = candidate.clone();
-                let content = format_markdown(&meta, body);
-                file.write_all(content.as_bytes())?;
-                return Ok((candidate, path, meta));
-            }
-            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
-                counter += 1;
-                continue;
-            }
-            Err(e) => return Err(e.into()),
-        }
-    }
+    // `allocate_filename` already reserved this path by scanning the
+    // directory, but we still open with `create_new` so two in-flight
+    // ingests racing on the same subject at the same UTC second collide
+    // noisily instead of silently overwriting.
+    let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
+    let content = format_markdown(meta, body);
+    file.write_all(content.as_bytes())?;
+    Ok(path.to_path_buf())
 }
 
 fn format_markdown(meta: &EmailMetadata, body: &str) -> String {
@@ -586,20 +618,47 @@ mod tests {
           --mixbound2--\r\n"
     }
 
+    /// Walk the inbox mailbox dir and return every `.md` file, descending
+    /// into bundle directories when they exist. Ordering is by filename.
+    fn collect_md_files(mailbox_dir: &Path) -> Vec<std::path::PathBuf> {
+        let mut result: Vec<std::path::PathBuf> = Vec::new();
+        let entries = match std::fs::read_dir(mailbox_dir) {
+            Ok(e) => e,
+            Err(_) => return result,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                // Bundle directory: expect exactly one sibling `.md` with
+                // the same stem as the directory.
+                if let Some(stem) = path.file_name().and_then(|f| f.to_str()) {
+                    let md = path.join(format!("{stem}.md"));
+                    if md.exists() {
+                        result.push(md);
+                    }
+                }
+            } else if path.extension().is_some_and(|ext| ext == "md") {
+                result.push(path);
+            }
+        }
+        result.sort();
+        result
+    }
+
+    fn inbox(tmp: &Path, name: &str) -> std::path::PathBuf {
+        tmp.join("inbox").join(name)
+    }
+
     #[test]
     fn ingest_plain_text() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
         ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
 
-        let entries: Vec<_> = std::fs::read_dir(tmp.path().join("alice"))
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
-            .collect();
+        let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         assert_eq!(entries.len(), 1);
 
-        let content = std::fs::read_to_string(entries[0].path()).unwrap();
+        let content = std::fs::read_to_string(&entries[0]).unwrap();
 
         let parts: Vec<&str> = content.splitn(3, "+++").collect();
         assert!(parts.len() >= 3);
@@ -620,17 +679,51 @@ mod tests {
     }
 
     #[test]
+    fn ingest_writes_to_inbox_subdir() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
+
+        // New Sprint 36 layout: inbox/<mailbox>/ instead of <mailbox>/.
+        assert!(tmp.path().join("inbox").join("alice").exists());
+        assert!(!tmp.path().join("alice").exists());
+    }
+
+    #[test]
+    fn ingest_filename_uses_utc_slug_format() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
+
+        let entries = collect_md_files(&inbox(tmp.path(), "alice"));
+        let name = entries[0]
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .to_string();
+        // "Hello" subject → "hello" slug.
+        assert!(
+            name.ends_with("-hello.md"),
+            "expected slug-suffixed filename, got {name}"
+        );
+        // Matches YYYY-MM-DD-HHMMSS-<slug>.md shape.
+        let stem = name.trim_end_matches(".md");
+        let parts: Vec<&str> = stem.splitn(5, '-').collect();
+        assert_eq!(parts.len(), 5, "expected 5 dash-segments in {stem}");
+        assert_eq!(parts[0].len(), 4);
+        assert_eq!(parts[1].len(), 2);
+        assert_eq!(parts[2].len(), 2);
+        assert_eq!(parts[3].len(), 6);
+    }
+
+    #[test]
     fn ingest_html_only() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
         ingest_email(&config, "alice@test.com", html_only_eml()).unwrap();
 
-        let entries: Vec<_> = std::fs::read_dir(tmp.path().join("alice"))
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
-            .collect();
-        let content = std::fs::read_to_string(entries[0].path()).unwrap();
+        let entries = collect_md_files(&inbox(tmp.path(), "alice"));
+        let content = std::fs::read_to_string(&entries[0]).unwrap();
         assert!(content.contains("Hello"));
         assert!(content.contains("World"));
         assert!(!content.contains("<html>"));
@@ -642,12 +735,8 @@ mod tests {
         let config = test_config(tmp.path());
         ingest_email(&config, "alice@test.com", multipart_eml()).unwrap();
 
-        let entries: Vec<_> = std::fs::read_dir(tmp.path().join("alice"))
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
-            .collect();
-        let content = std::fs::read_to_string(entries[0].path()).unwrap();
+        let entries = collect_md_files(&inbox(tmp.path(), "alice"));
+        let content = std::fs::read_to_string(&entries[0]).unwrap();
         assert!(content.contains("Plain text part."));
         assert!(!content.contains("<html>"));
     }
@@ -658,12 +747,8 @@ mod tests {
         let config = test_config(tmp.path());
         ingest_email(&config, "unknown@test.com", plain_text_eml()).unwrap();
 
-        assert!(tmp.path().join("catchall").exists());
-        let entries: Vec<_> = std::fs::read_dir(tmp.path().join("catchall"))
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
-            .collect();
+        assert!(inbox(tmp.path(), "catchall").exists());
+        let entries = collect_md_files(&inbox(tmp.path(), "catchall"));
         assert_eq!(entries.len(), 1);
     }
 
@@ -673,12 +758,8 @@ mod tests {
         let config = test_config(tmp.path());
         ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
 
-        let entries: Vec<_> = std::fs::read_dir(tmp.path().join("alice"))
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
-            .collect();
-        let content = std::fs::read_to_string(entries[0].path()).unwrap();
+        let entries = collect_md_files(&inbox(tmp.path(), "alice"));
+        let content = std::fs::read_to_string(&entries[0]).unwrap();
 
         let parts: Vec<&str> = content.splitn(3, "+++").collect();
         assert!(parts.len() >= 3);
@@ -710,31 +791,43 @@ mod tests {
         ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
         ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
 
-        let entries: Vec<_> = std::fs::read_dir(tmp.path().join("alice"))
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
-            .collect();
-        assert_eq!(entries.len(), 2);
+        // Two ingests of the same subject within the same UTC second: the
+        // second must land on a distinct path thanks to the `-2` suffix.
+        let entries = collect_md_files(&inbox(tmp.path(), "alice"));
+        assert_eq!(entries.len(), 2, "got entries: {entries:?}");
+        assert_ne!(entries[0], entries[1]);
     }
 
     #[test]
-    fn attachment_extracted() {
+    fn attachment_creates_bundle_directory() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
         ingest_email(&config, "alice@test.com", attachment_eml()).unwrap();
 
-        let att_path = tmp.path().join("alice/attachments/notes.txt");
-        assert!(att_path.exists());
+        let alice = inbox(tmp.path(), "alice");
+        // Top-level `attachments/` is GONE (Sprint 36).
+        assert!(!alice.join("attachments").exists());
+
+        // Exactly one bundle directory should have been created.
+        let bundles: Vec<_> = std::fs::read_dir(&alice)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .collect();
+        assert_eq!(bundles.len(), 1);
+        let bundle = bundles[0].path();
+        let stem = bundle.file_name().unwrap().to_string_lossy().to_string();
+
+        // The bundle contains <stem>.md AND the attachment as a sibling.
+        let md = bundle.join(format!("{stem}.md"));
+        assert!(md.exists(), "bundle md {md:?} should exist");
+        let att_path = bundle.join("notes.txt");
+        assert!(att_path.exists(), "attachment at {att_path:?} should exist");
+
         let content = std::fs::read_to_string(&att_path).unwrap();
         assert!(content.contains("These are my notes."));
 
-        let entries: Vec<_> = std::fs::read_dir(tmp.path().join("alice"))
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
-            .collect();
-        let md_content = std::fs::read_to_string(entries[0].path()).unwrap();
+        let md_content = std::fs::read_to_string(&md).unwrap();
         let parts: Vec<&str> = md_content.splitn(3, "+++").collect();
         let toml_str = parts[1].trim();
         let parsed: toml::Value = toml::from_str(toml_str).unwrap();
@@ -742,51 +835,70 @@ mod tests {
         let attachments = table.get("attachments").unwrap().as_array().unwrap();
         assert_eq!(attachments.len(), 1);
         let att = attachments[0].as_table().unwrap();
-        let filename = att.get("filename").unwrap().as_str().unwrap();
-        assert_eq!(filename, "notes.txt");
-        let path_val = att.get("path").unwrap().as_str().unwrap();
-        assert_eq!(path_val, "attachments/notes.txt");
+        assert_eq!(att.get("filename").unwrap().as_str().unwrap(), "notes.txt");
+        // Bundle-relative path has no `attachments/` prefix any more.
+        assert_eq!(att.get("path").unwrap().as_str().unwrap(), "notes.txt");
     }
 
     #[test]
-    fn multiple_attachments() {
+    fn multiple_attachments_in_single_bundle() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
         ingest_email(&config, "alice@test.com", multi_attachment_eml()).unwrap();
 
-        let att_dir = tmp.path().join("alice/attachments");
-        assert!(att_dir.join("file.txt").exists());
-        assert!(att_dir.join("data.bin").exists());
+        let alice = inbox(tmp.path(), "alice");
+        let bundles: Vec<_> = std::fs::read_dir(&alice)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .collect();
+        assert_eq!(bundles.len(), 1);
+        let bundle = bundles[0].path();
+        assert!(bundle.join("file.txt").exists());
+        assert!(bundle.join("data.bin").exists());
     }
 
     #[test]
-    fn duplicate_attachment_filenames() {
+    fn duplicate_attachment_filenames_are_bundle_scoped() {
+        // Two emails with the same filename land in two distinct bundle
+        // directories, so the attachment names don't collide — no `-1`
+        // suffix needed inside either bundle.
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
 
         ingest_email(&config, "alice@test.com", attachment_eml()).unwrap();
         ingest_email(&config, "alice@test.com", attachment_eml()).unwrap();
 
-        let att_dir = tmp.path().join("alice/attachments");
-        assert!(att_dir.join("notes.txt").exists());
-        assert!(att_dir.join("notes-1.txt").exists());
+        let alice = inbox(tmp.path(), "alice");
+        let bundles: Vec<_> = std::fs::read_dir(&alice)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .collect();
+        assert_eq!(bundles.len(), 2, "expected two separate bundles");
+
+        for b in bundles {
+            assert!(b.path().join("notes.txt").exists());
+        }
     }
 
     #[test]
-    fn no_attachments() {
+    fn no_attachments_flat_markdown() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
         ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
 
-        let att_dir = tmp.path().join("alice/attachments");
-        assert!(!att_dir.exists());
-
-        let entries: Vec<_> = std::fs::read_dir(tmp.path().join("alice"))
+        let alice = inbox(tmp.path(), "alice");
+        // No bundle directory, no legacy attachments dir.
+        let dirs: Vec<_> = std::fs::read_dir(&alice)
             .unwrap()
             .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
+            .filter(|e| e.path().is_dir())
             .collect();
-        let md_content = std::fs::read_to_string(entries[0].path()).unwrap();
+        assert!(dirs.is_empty(), "flat layout must not create directories");
+
+        let entries = collect_md_files(&alice);
+        let md_content = std::fs::read_to_string(&entries[0]).unwrap();
         let parts: Vec<&str> = md_content.splitn(3, "+++").collect();
         let toml_str = parts[1].trim();
         let parsed: toml::Value = toml::from_str(toml_str).unwrap();
@@ -827,8 +939,17 @@ mod tests {
 
         ingest_email(&config, "alice@test.com", eml).unwrap();
 
-        let att_dir = tmp.path().join("alice/attachments");
-        assert!(att_dir.join("evil").exists());
+        // Path traversal in the attachment filename collapses to `evil`
+        // inside the bundle; nothing escapes the mailbox dir.
+        let alice = inbox(tmp.path(), "alice");
+        let bundles: Vec<_> = std::fs::read_dir(&alice)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .collect();
+        assert_eq!(bundles.len(), 1);
+        let bundle = bundles[0].path();
+        assert!(bundle.join("evil").exists());
         assert!(!tmp.path().join("etc").exists());
     }
 
@@ -863,12 +984,8 @@ mod tests {
         let config = test_config(tmp.path());
         ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
 
-        let entries: Vec<_> = std::fs::read_dir(tmp.path().join("alice"))
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
-            .collect();
-        let content = std::fs::read_to_string(entries[0].path()).unwrap();
+        let entries = collect_md_files(&inbox(tmp.path(), "alice"));
+        let content = std::fs::read_to_string(&entries[0]).unwrap();
         let parts: Vec<&str> = content.splitn(3, "+++").collect();
         let toml_str = parts[1].trim();
         let parsed: toml::Value = toml::from_str(toml_str).unwrap();
@@ -929,12 +1046,8 @@ mod tests {
         let config = test_config(tmp.path());
         ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
 
-        let entries: Vec<_> = std::fs::read_dir(tmp.path().join("alice"))
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
-            .collect();
-        let content = std::fs::read_to_string(entries[0].path()).unwrap();
+        let entries = collect_md_files(&inbox(tmp.path(), "alice"));
+        let content = std::fs::read_to_string(&entries[0]).unwrap();
         let parts: Vec<&str> = content.splitn(3, "+++").collect();
         let toml_str = parts[1].trim();
         let parsed: toml::Value = toml::from_str(toml_str).unwrap();
@@ -980,15 +1093,10 @@ mod tests {
 
         ingest_email(&config, "agent@test.com", raw).unwrap();
 
-        let catchall_dir = tmp.path().join("catchall");
-        let entries: Vec<_> = std::fs::read_dir(&catchall_dir)
-            .unwrap()
-            .filter_map(|e| e.ok())
-            .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
-            .collect();
+        let entries = collect_md_files(&inbox(tmp.path(), "catchall"));
         assert_eq!(entries.len(), 1);
 
-        let content = std::fs::read_to_string(entries[0].path()).unwrap();
+        let content = std::fs::read_to_string(&entries[0]).unwrap();
         assert!(content.contains("subject = \"Test DKIM signed email from Gmail\""));
         assert!(content.contains("from = \"Test User <testuser@gmail.com>\""));
         assert!(content.contains("CAB1234567890abcdef@mail.gmail.com"));
@@ -1049,65 +1157,18 @@ mod tests {
     }
 
     #[test]
-    fn atomic_file_creation_retries_on_collision() {
+    fn rapid_same_subject_ingests_get_unique_paths() {
+        // Two ingests with identical subjects landing in the same UTC
+        // second must not overwrite each other; `allocate_filename` picks
+        // the `-2` suffix for the second one.
         let tmp = TempDir::new().unwrap();
-        let mailbox_dir = tmp.path().join("alice");
-        std::fs::create_dir_all(&mailbox_dir).unwrap();
+        let config = test_config(tmp.path());
+        ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
+        ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
 
-        // Pre-create a file with today's date and counter 001
-        let today = chrono::Utc::now().format("%Y-%m-%d").to_string();
-        let existing = mailbox_dir.join(format!("{today}-001.md"));
-        std::fs::write(&existing, "pre-existing file").unwrap();
-
-        let meta = EmailMetadata {
-            id: String::new(),
-            message_id: "<test@test.com>".to_string(),
-            from: "sender@test.com".to_string(),
-            to: "alice@test.com".to_string(),
-            subject: "Collision test".to_string(),
-            date: "2025-01-01T00:00:00Z".to_string(),
-            in_reply_to: "".to_string(),
-            references: "".to_string(),
-            attachments: vec![],
-            mailbox: "alice".to_string(),
-            read: false,
-            dkim: "none".to_string(),
-            spf: "none".to_string(),
-        };
-
-        let (id, _path, _meta) = create_file_atomic(&mailbox_dir, &meta, "body").unwrap();
-        assert_eq!(id, format!("{today}-002"));
-
-        // Pre-existing file should not be overwritten
-        let content = std::fs::read_to_string(&existing).unwrap();
-        assert_eq!(content, "pre-existing file");
-    }
-
-    #[test]
-    fn atomic_file_creation_two_rapid_calls_produce_different_ids() {
-        let tmp = TempDir::new().unwrap();
-        let mailbox_dir = tmp.path().join("alice");
-        std::fs::create_dir_all(&mailbox_dir).unwrap();
-
-        let meta = EmailMetadata {
-            id: String::new(),
-            message_id: "<test@test.com>".to_string(),
-            from: "sender@test.com".to_string(),
-            to: "alice@test.com".to_string(),
-            subject: "Rapid test".to_string(),
-            date: "2025-01-01T00:00:00Z".to_string(),
-            in_reply_to: "".to_string(),
-            references: "".to_string(),
-            attachments: vec![],
-            mailbox: "alice".to_string(),
-            read: false,
-            dkim: "none".to_string(),
-            spf: "none".to_string(),
-        };
-
-        let (id1, _, _) = create_file_atomic(&mailbox_dir, &meta, "body1").unwrap();
-        let (id2, _, _) = create_file_atomic(&mailbox_dir, &meta, "body2").unwrap();
-        assert_ne!(id1, id2);
+        let entries = collect_md_files(&inbox(tmp.path(), "alice"));
+        assert_eq!(entries.len(), 2);
+        assert_ne!(entries[0], entries[1]);
     }
 
     #[test]

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -64,16 +64,48 @@ pub fn create_mailbox(config: &Config, name: &str) -> Result<(), Box<dyn std::er
 }
 
 pub fn list_mailboxes(config: &Config) -> Vec<(String, usize)> {
-    let mut result: Vec<(String, usize)> = config
-        .mailboxes
-        .keys()
+    let names = discover_mailbox_names(config);
+    let mut result: Vec<(String, usize)> = names
+        .into_iter()
         .map(|name| {
-            let count = count_messages(&config.inbox_dir(name));
-            (name.clone(), count)
+            let count = count_messages(&config.inbox_dir(&name));
+            (name, count)
         })
         .collect();
     result.sort_by(|a, b| a.0.cmp(&b.0));
     result
+}
+
+/// Sprint 36: union of (a) mailboxes registered in `config.mailboxes` and
+/// (b) directories under `<data_dir>/inbox/`. Operators who restore an
+/// inbox dir out-of-band, or unregister a mailbox while keeping its
+/// messages on disk, still see the directory listed (the CLI/MCP can
+/// surface unregistered ones with a marker if needed). The catchall is
+/// always kept in config so it is always surfaced.
+pub fn discover_mailbox_names(config: &Config) -> Vec<String> {
+    use std::collections::BTreeSet;
+
+    let mut set: BTreeSet<String> = config.mailboxes.keys().cloned().collect();
+
+    let inbox_root = config.data_dir.join("inbox");
+    if let Ok(entries) = std::fs::read_dir(&inbox_root) {
+        for entry in entries.filter_map(|e| e.ok()) {
+            if entry.file_type().is_ok_and(|t| t.is_dir())
+                && let Some(name) = entry.file_name().to_str()
+            {
+                set.insert(name.to_string());
+            }
+        }
+    }
+
+    set.into_iter().collect()
+}
+
+/// Returns true when a mailbox name appears in the config map.
+/// Useful for callers that want to mark filesystem-only mailboxes as
+/// `(unregistered)` in display output.
+pub fn is_registered(config: &Config, name: &str) -> bool {
+    config.mailboxes.contains_key(name)
 }
 
 pub fn delete_mailbox(config: &Config, name: &str) -> Result<(), Box<dyn std::error::Error>> {
@@ -151,11 +183,17 @@ fn list(config: &Config) -> Result<(), Box<dyn std::error::Error>> {
     );
     for (name, count) in mailboxes {
         let name_pad = 20usize.saturating_sub(name.chars().count());
+        let suffix = if is_registered(config, &name) {
+            String::new()
+        } else {
+            format!(" {}", term::warn("(unregistered)"))
+        };
         println!(
-            "{}{:pad$} {}",
+            "{}{:pad$} {}{}",
             term::highlight(&name),
             "",
             count,
+            suffix,
             pad = name_pad,
         );
     }
@@ -280,6 +318,39 @@ mod tests {
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].0, "catchall");
         assert_eq!(result[0].1, 2);
+    }
+
+    #[test]
+    fn list_surfaces_stray_inbox_dir_without_config_entry() {
+        // Sprint 36 review fix: `mailbox_list` must scan `inbox/*/` so an
+        // inbox directory left by a backup restore (or an unregistered
+        // mailbox) still appears in the listing.
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let _guard = setup_config_file(tmp.path(), &config);
+
+        // Registered mailbox: catchall + an `alice` we register.
+        create_mailbox(&config, "alice").unwrap();
+        let config = Config::load_resolved().unwrap();
+        let inbox_alice = tmp.path().join("inbox").join("alice");
+        std::fs::write(inbox_alice.join("2025-01-01-120000-a.md"), "x").unwrap();
+
+        // Stray dir created out-of-band — no config entry.
+        let stray = tmp.path().join("inbox").join("stray");
+        std::fs::create_dir_all(&stray).unwrap();
+        std::fs::write(stray.join("2025-01-01-120000-z.md"), "x").unwrap();
+
+        let result = list_mailboxes(&config);
+        let names: Vec<&str> = result.iter().map(|(n, _)| n.as_str()).collect();
+        assert!(names.contains(&"alice"), "registered alice listed");
+        assert!(names.contains(&"catchall"), "catchall always listed");
+        assert!(names.contains(&"stray"), "stray inbox dir surfaced");
+
+        let stray_row = result.iter().find(|(n, _)| n == "stray").unwrap();
+        assert_eq!(stray_row.1, 1, "stray dir counts its messages");
+        assert!(!is_registered(&config, "stray"));
+        assert!(is_registered(&config, "alice"));
+        assert!(is_registered(&config, "catchall"));
     }
 
     #[test]

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -35,8 +35,17 @@ pub fn create_mailbox(config: &Config, name: &str) -> Result<(), Box<dyn std::er
         return Err(format!("Mailbox '{name}' already exists").into());
     }
 
-    let mailbox_dir = config.mailbox_dir(name);
-    std::fs::create_dir_all(&mailbox_dir)?;
+    // Sprint 36: a mailbox lives in both `inbox/<name>/` and
+    // `sent/<name>/`. Create them atomically — if the second one fails,
+    // clean up the first so we never leave half a mailbox on disk.
+    let inbox = config.inbox_dir(name);
+    std::fs::create_dir_all(&inbox)?;
+
+    let sent = config.sent_dir(name);
+    if let Err(e) = std::fs::create_dir_all(&sent) {
+        let _ = std::fs::remove_dir_all(&inbox);
+        return Err(e.into());
+    }
 
     let mut config = config.clone();
     config.mailboxes.insert(
@@ -59,7 +68,7 @@ pub fn list_mailboxes(config: &Config) -> Vec<(String, usize)> {
         .mailboxes
         .keys()
         .map(|name| {
-            let count = count_messages(&config.mailbox_dir(name));
+            let count = count_messages(&config.inbox_dir(name));
             (name.clone(), count)
         })
         .collect();
@@ -76,9 +85,14 @@ pub fn delete_mailbox(config: &Config, name: &str) -> Result<(), Box<dyn std::er
         return Err(format!("Mailbox '{name}' does not exist").into());
     }
 
-    let mailbox_dir = config.mailbox_dir(name);
-    if mailbox_dir.exists() {
-        std::fs::remove_dir_all(&mailbox_dir)?;
+    // Sprint 36: remove both inbox and sent directories.
+    let inbox = config.inbox_dir(name);
+    if inbox.exists() {
+        std::fs::remove_dir_all(&inbox)?;
+    }
+    let sent = config.sent_dir(name);
+    if sent.exists() {
+        std::fs::remove_dir_all(&sent)?;
     }
 
     let mut config = config.clone();
@@ -89,15 +103,29 @@ pub fn delete_mailbox(config: &Config, name: &str) -> Result<(), Box<dyn std::er
     Ok(())
 }
 
-fn count_messages(dir: &Path) -> usize {
-    std::fs::read_dir(dir)
-        .map(|entries| {
-            entries
-                .filter_map(|e| e.ok())
-                .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
-                .count()
-        })
-        .unwrap_or(0)
+/// Count emails in a mailbox directory. Each flat `<stem>.md` counts as
+/// one, and each bundle directory containing `<stem>.md` counts as one.
+/// Stray files or non-bundle directories are ignored.
+pub fn count_messages(dir: &Path) -> usize {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return 0,
+    };
+
+    let mut total = 0usize;
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if path.is_dir() {
+            if let Some(stem) = path.file_name().and_then(|f| f.to_str())
+                && path.join(format!("{stem}.md")).exists()
+            {
+                total += 1;
+            }
+        } else if path.extension().is_some_and(|ext| ext == "md") {
+            total += 1;
+        }
+    }
+    total
 }
 
 fn create(config: &Config, name: &str) -> Result<(), Box<dyn std::error::Error>> {
@@ -199,10 +227,31 @@ mod tests {
 
         create_mailbox(&config, "alice").unwrap();
 
-        assert!(tmp.path().join("alice").is_dir());
+        // Sprint 36: both `inbox/<name>/` and `sent/<name>/` exist.
+        assert!(tmp.path().join("inbox").join("alice").is_dir());
+        assert!(tmp.path().join("sent").join("alice").is_dir());
         let reloaded = Config::load_resolved().unwrap();
         assert!(reloaded.mailboxes.contains_key("alice"));
         assert_eq!(reloaded.mailboxes["alice"].address, "alice@test.com");
+    }
+
+    #[test]
+    fn create_mailbox_is_idempotent_for_dirs_when_config_race_prevented() {
+        // If the config-registration side-steps the duplicate check, the
+        // create_dir_all calls are idempotent. This is an internal contract
+        // test — callers should rely on `create_mailbox` itself to fail
+        // duplicate registrations via the HashMap check.
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let _guard = setup_config_file(tmp.path(), &config);
+
+        create_mailbox(&config, "alice").unwrap();
+        // Re-creating via a fresh Config (as if registration rolled back)
+        // must not error — dir creation is idempotent.
+        let fresh = test_config(tmp.path());
+        create_mailbox(&fresh, "alice").unwrap();
+        assert!(tmp.path().join("inbox").join("alice").is_dir());
+        assert!(tmp.path().join("sent").join("alice").is_dir());
     }
 
     #[test]
@@ -222,14 +271,35 @@ mod tests {
         let config = test_config(tmp.path());
         let _guard = setup_config_file(tmp.path(), &config);
 
-        std::fs::create_dir_all(tmp.path().join("catchall")).unwrap();
-        std::fs::write(tmp.path().join("catchall/2025-01-01-001.md"), "test").unwrap();
-        std::fs::write(tmp.path().join("catchall/2025-01-01-002.md"), "test").unwrap();
+        let inbox_catchall = tmp.path().join("inbox").join("catchall");
+        std::fs::create_dir_all(&inbox_catchall).unwrap();
+        std::fs::write(inbox_catchall.join("2025-01-01-120000-a.md"), "test").unwrap();
+        std::fs::write(inbox_catchall.join("2025-01-01-120001-b.md"), "test").unwrap();
 
         let result = list_mailboxes(&config);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].0, "catchall");
         assert_eq!(result[0].1, 2);
+    }
+
+    #[test]
+    fn list_counts_bundle_directories() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let _guard = setup_config_file(tmp.path(), &config);
+
+        let inbox_catchall = tmp.path().join("inbox").join("catchall");
+        std::fs::create_dir_all(&inbox_catchall).unwrap();
+        // A flat email.
+        std::fs::write(inbox_catchall.join("2025-01-01-120000-flat.md"), "x").unwrap();
+        // A bundle email.
+        let bundle = inbox_catchall.join("2025-01-01-120001-bundle");
+        std::fs::create_dir_all(&bundle).unwrap();
+        std::fs::write(bundle.join("2025-01-01-120001-bundle.md"), "x").unwrap();
+        std::fs::write(bundle.join("att.txt"), "att").unwrap();
+
+        let result = list_mailboxes(&config);
+        assert_eq!(result[0].1, 2, "bundle and flat each count once");
     }
 
     #[test]
@@ -244,7 +314,9 @@ mod tests {
 
         delete_mailbox(&config, "alice").unwrap();
 
-        assert!(!tmp.path().join("alice").exists());
+        // Both inbox and sent directories must be gone.
+        assert!(!tmp.path().join("inbox").join("alice").exists());
+        assert!(!tmp.path().join("sent").join("alice").exists());
         let reloaded = Config::load_resolved().unwrap();
         assert!(!reloaded.mailboxes.contains_key("alice"));
     }
@@ -257,7 +329,12 @@ mod tests {
 
         let result = delete_mailbox(&config, "catchall");
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("Cannot delete"));
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Cannot delete"));
+        assert!(
+            err.contains("catchall"),
+            "error should mention catchall: {err}"
+        );
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,6 +13,7 @@ mod send_handler;
 mod send_protocol;
 mod serve;
 mod setup;
+mod slug;
 mod smtp;
 mod status;
 mod term;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -134,7 +134,10 @@ impl AimxMcpServer {
 
         let result: Vec<String> = mailboxes
             .iter()
-            .map(|(name, total, unread)| format!("{name}: {total} messages ({unread} unread)"))
+            .map(|(name, total, unread, registered)| {
+                let suffix = if *registered { "" } else { " (unregistered)" };
+                format!("{name}: {total} messages ({unread} unread){suffix}")
+            })
             .collect();
         Ok(result.join("\n"))
     }
@@ -421,16 +424,20 @@ pub async fn run(data_dir: Option<&std::path::Path>) -> Result<(), Box<dyn std::
     Ok(())
 }
 
-fn list_mailboxes_with_unread(config: &Config) -> Vec<(String, usize, usize)> {
-    let mut result: Vec<(String, usize, usize)> = config
-        .mailboxes
-        .keys()
+/// Return `(name, total, unread, registered)` for every mailbox the
+/// daemon knows about — both registered ones in `config.mailboxes` and
+/// stray `inbox/<name>/` directories left by backup restores or
+/// out-of-band tooling. Sorted by name.
+fn list_mailboxes_with_unread(config: &Config) -> Vec<(String, usize, usize, bool)> {
+    let mut result: Vec<(String, usize, usize, bool)> = mailbox::discover_mailbox_names(config)
+        .into_iter()
         .map(|name| {
-            let dir = config.inbox_dir(name);
+            let dir = config.inbox_dir(&name);
             let emails = list_emails(&dir).unwrap_or_default();
             let total = emails.len();
             let unread = emails.iter().filter(|e| !e.read).count();
-            (name.clone(), total, unread)
+            let registered = mailbox::is_registered(config, &name);
+            (name, total, unread, registered)
         })
         .collect();
     result.sort_by(|a, b| a.0.cmp(&b.0));
@@ -1015,6 +1022,34 @@ mod tests {
         let alice = result.iter().find(|m| m.0 == "alice").unwrap();
         assert_eq!(alice.1, 2); // total
         assert_eq!(alice.2, 1); // unread
+        assert!(alice.3, "alice is registered in config");
+    }
+
+    #[test]
+    fn list_mailboxes_with_unread_surfaces_unregistered_dir() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let _cfg_guard = setup_config(&config);
+
+        // Stray inbox dir created out-of-band (e.g. backup restore) with
+        // no entry in `config.mailboxes`.
+        let stray = inbox_of(tmp.path(), "stray");
+        std::fs::create_dir_all(&stray).unwrap();
+        let meta = sample_meta("2025-06-01-100", "x@test.com", "X", true);
+        create_test_email(&stray, "2025-06-01-100", &meta);
+
+        let result = list_mailboxes_with_unread(&config);
+        let stray_row = result
+            .iter()
+            .find(|m| m.0 == "stray")
+            .expect("stray dir must surface in mailbox_list");
+        assert_eq!(stray_row.1, 1); // total
+        assert_eq!(stray_row.2, 0); // unread (meta.read=true)
+        assert!(!stray_row.3, "stray is not registered in config");
+
+        // catchall and alice still surface as registered.
+        assert!(result.iter().any(|m| m.0 == "catchall" && m.3));
+        assert!(result.iter().any(|m| m.0 == "alice" && m.3));
     }
 
     #[test]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -38,6 +38,8 @@ pub struct MailboxDeleteParams {
 pub struct EmailListParams {
     #[schemars(description = "Mailbox name to list emails from")]
     pub mailbox: String,
+    #[schemars(description = "Which folder to read: \"inbox\" (default) or \"sent\"")]
+    pub folder: Option<String>,
     #[schemars(description = "Filter to only unread emails")]
     pub unread: Option<bool>,
     #[schemars(description = "Filter by sender address (substring match)")]
@@ -52,16 +54,20 @@ pub struct EmailListParams {
 pub struct EmailReadParams {
     #[schemars(description = "Mailbox name")]
     pub mailbox: String,
-    #[schemars(description = "Email ID (e.g. 2025-01-01-001)")]
+    #[schemars(description = "Email ID (e.g. 2025-06-15-120000-hello)")]
     pub id: String,
+    #[schemars(description = "Which folder to read: \"inbox\" (default) or \"sent\"")]
+    pub folder: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, schemars::JsonSchema)]
 pub struct EmailMarkParams {
     #[schemars(description = "Mailbox name")]
     pub mailbox: String,
-    #[schemars(description = "Email ID (e.g. 2025-01-01-001)")]
+    #[schemars(description = "Email ID (e.g. 2025-06-15-120000-hello)")]
     pub id: String,
+    #[schemars(description = "Which folder to target: \"inbox\" (default) or \"sent\"")]
+    pub folder: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, schemars::JsonSchema)]
@@ -160,7 +166,8 @@ impl AimxMcpServer {
             return Err(format!("Mailbox '{}' does not exist.", params.mailbox));
         }
 
-        let mailbox_dir = config.mailbox_dir(&params.mailbox);
+        let folder = resolve_folder(params.folder.as_deref())?;
+        let mailbox_dir = folder_dir(&config, &params.mailbox, folder);
         let emails = list_emails(&mailbox_dir).map_err(|e| e.to_string())?;
 
         let filtered = filter_emails(
@@ -200,15 +207,14 @@ impl AimxMcpServer {
             return Err(format!("Mailbox '{}' does not exist.", params.mailbox));
         }
 
-        let mailbox_dir = config.mailbox_dir(&params.mailbox);
-        let filepath = mailbox_dir.join(format!("{}.md", params.id));
-
-        if !filepath.exists() {
-            return Err(format!(
+        let folder = resolve_folder(params.folder.as_deref())?;
+        let mailbox_dir = folder_dir(&config, &params.mailbox, folder);
+        let filepath = resolve_email_path(&mailbox_dir, &params.id).ok_or_else(|| {
+            format!(
                 "Email '{}' not found in mailbox '{}'.",
                 params.id, params.mailbox
-            ));
-        }
+            )
+        })?;
 
         std::fs::read_to_string(&filepath).map_err(|e| format!("Failed to read email: {e}"))
     }
@@ -220,7 +226,8 @@ impl AimxMcpServer {
     ) -> Result<String, String> {
         validate_email_id(&params.id)?;
         let config = self.load_config()?;
-        set_read_status(&config, &params.mailbox, &params.id, true)?;
+        let folder = resolve_folder(params.folder.as_deref())?;
+        set_read_status(&config, &params.mailbox, folder, &params.id, true)?;
         Ok(format!("Email '{}' marked as read.", params.id))
     }
 
@@ -231,7 +238,8 @@ impl AimxMcpServer {
     ) -> Result<String, String> {
         validate_email_id(&params.id)?;
         let config = self.load_config()?;
-        set_read_status(&config, &params.mailbox, &params.id, false)?;
+        let folder = resolve_folder(params.folder.as_deref())?;
+        set_read_status(&config, &params.mailbox, folder, &params.id, false)?;
         Ok(format!("Email '{}' marked as unread.", params.id))
     }
 
@@ -285,15 +293,13 @@ impl AimxMcpServer {
             return Err(format!("Mailbox '{}' does not exist.", params.mailbox));
         }
 
-        let mailbox_dir = config.mailbox_dir(&params.mailbox);
-        let filepath = mailbox_dir.join(format!("{}.md", params.id));
-
-        if !filepath.exists() {
-            return Err(format!(
+        let mailbox_dir = config.inbox_dir(&params.mailbox);
+        let filepath = resolve_email_path(&mailbox_dir, &params.id).ok_or_else(|| {
+            format!(
                 "Email '{}' not found in mailbox '{}'.",
                 params.id, params.mailbox
-            ));
-        }
+            )
+        })?;
 
         let content =
             std::fs::read_to_string(&filepath).map_err(|e| format!("Failed to read email: {e}"))?;
@@ -420,7 +426,7 @@ fn list_mailboxes_with_unread(config: &Config) -> Vec<(String, usize, usize)> {
         .mailboxes
         .keys()
         .map(|name| {
-            let dir = config.mailbox_dir(name);
+            let dir = config.inbox_dir(name);
             let emails = list_emails(&dir).unwrap_or_default();
             let total = emails.len();
             let unread = emails.iter().filter(|e| !e.read).count();
@@ -431,6 +437,8 @@ fn list_mailboxes_with_unread(config: &Config) -> Vec<(String, usize, usize)> {
     result
 }
 
+/// List the emails in a single folder. Handles both flat `<stem>.md`
+/// entries and Zola-style bundle directories containing `<stem>.md`.
 pub fn list_emails(
     mailbox_dir: &std::path::Path,
 ) -> Result<Vec<EmailMetadata>, Box<dyn std::error::Error>> {
@@ -443,7 +451,18 @@ pub fn list_emails(
 
     for entry in entries.filter_map(|e| e.ok()) {
         let path = entry.path();
-        if path.extension().is_some_and(|ext| ext == "md") {
+        if path.is_dir() {
+            // Bundle: read the `<stem>/<stem>.md` inside.
+            if let Some(stem) = path.file_name().and_then(|f| f.to_str()) {
+                let md = path.join(format!("{stem}.md"));
+                if md.exists() {
+                    let content = std::fs::read_to_string(&md)?;
+                    if let Some(meta) = parse_frontmatter(&content) {
+                        emails.push(meta);
+                    }
+                }
+            }
+        } else if path.extension().is_some_and(|ext| ext == "md") {
             let content = std::fs::read_to_string(&path)?;
             if let Some(meta) = parse_frontmatter(&content) {
                 emails.push(meta);
@@ -453,6 +472,46 @@ pub fn list_emails(
 
     emails.sort_by(|a, b| a.date.cmp(&b.date));
     Ok(emails)
+}
+
+/// Resolve the on-disk path for an email by ID. Returns `Some(path)` when
+/// the email exists either as a flat `<id>.md` or as a bundle
+/// `<id>/<id>.md` inside `mailbox_dir`.
+pub fn resolve_email_path(mailbox_dir: &std::path::Path, id: &str) -> Option<PathBuf> {
+    let flat = mailbox_dir.join(format!("{id}.md"));
+    if flat.exists() {
+        return Some(flat);
+    }
+    let bundle_md = mailbox_dir.join(id).join(format!("{id}.md"));
+    if bundle_md.exists() {
+        return Some(bundle_md);
+    }
+    None
+}
+
+/// Inbound/outbound folder selector for MCP tools.
+#[derive(Copy, Clone, Debug, PartialEq, Eq)]
+pub enum Folder {
+    Inbox,
+    Sent,
+}
+
+/// Parse an MCP `folder` argument. Default is `inbox`.
+pub fn resolve_folder(raw: Option<&str>) -> Result<Folder, String> {
+    match raw {
+        None | Some("inbox") => Ok(Folder::Inbox),
+        Some("sent") => Ok(Folder::Sent),
+        Some(other) => Err(format!(
+            "Invalid folder '{other}': expected \"inbox\" or \"sent\"."
+        )),
+    }
+}
+
+fn folder_dir(config: &Config, mailbox: &str, folder: Folder) -> PathBuf {
+    match folder {
+        Folder::Inbox => config.inbox_dir(mailbox),
+        Folder::Sent => config.sent_dir(mailbox),
+    }
 }
 
 pub fn parse_frontmatter(content: &str) -> Option<EmailMetadata> {
@@ -516,19 +575,22 @@ pub fn filter_emails(
     Ok(result)
 }
 
-pub fn set_read_status(config: &Config, mailbox: &str, id: &str, read: bool) -> Result<(), String> {
+pub fn set_read_status(
+    config: &Config,
+    mailbox: &str,
+    folder: Folder,
+    id: &str,
+    read: bool,
+) -> Result<(), String> {
     validate_email_id(id)?;
 
     if !config.mailboxes.contains_key(mailbox) {
         return Err(format!("Mailbox '{mailbox}' does not exist."));
     }
 
-    let mailbox_dir = config.mailbox_dir(mailbox);
-    let filepath = mailbox_dir.join(format!("{id}.md"));
-
-    if !filepath.exists() {
-        return Err(format!("Email '{id}' not found in mailbox '{mailbox}'."));
-    }
+    let mailbox_dir = folder_dir(config, mailbox, folder);
+    let filepath = resolve_email_path(&mailbox_dir, id)
+        .ok_or_else(|| format!("Email '{id}' not found in mailbox '{mailbox}'."))?;
 
     let content =
         std::fs::read_to_string(&filepath).map_err(|e| format!("Failed to read email: {e}"))?;
@@ -795,6 +857,10 @@ mod tests {
         assert_eq!(filtered.len(), 2);
     }
 
+    fn inbox_of(tmp: &std::path::Path, name: &str) -> std::path::PathBuf {
+        tmp.join("inbox").join(name)
+    }
+
     #[test]
     fn set_read_status_marks_read() {
         let tmp = TempDir::new().unwrap();
@@ -802,11 +868,13 @@ mod tests {
         let _cfg_guard = setup_config(&config);
 
         let meta = sample_meta("2025-06-01-001", "sender@test.com", "Test", false);
-        create_test_email(&tmp.path().join("alice"), "2025-06-01-001", &meta);
+        create_test_email(&inbox_of(tmp.path(), "alice"), "2025-06-01-001", &meta);
 
-        set_read_status(&config, "alice", "2025-06-01-001", true).unwrap();
+        set_read_status(&config, "alice", Folder::Inbox, "2025-06-01-001", true).unwrap();
 
-        let content = std::fs::read_to_string(tmp.path().join("alice/2025-06-01-001.md")).unwrap();
+        let content =
+            std::fs::read_to_string(inbox_of(tmp.path(), "alice").join("2025-06-01-001.md"))
+                .unwrap();
         let parsed = parse_frontmatter(&content).unwrap();
         assert!(parsed.read);
     }
@@ -818,11 +886,13 @@ mod tests {
         let _cfg_guard = setup_config(&config);
 
         let meta = sample_meta("2025-06-01-001", "sender@test.com", "Test", true);
-        create_test_email(&tmp.path().join("alice"), "2025-06-01-001", &meta);
+        create_test_email(&inbox_of(tmp.path(), "alice"), "2025-06-01-001", &meta);
 
-        set_read_status(&config, "alice", "2025-06-01-001", false).unwrap();
+        set_read_status(&config, "alice", Folder::Inbox, "2025-06-01-001", false).unwrap();
 
-        let content = std::fs::read_to_string(tmp.path().join("alice/2025-06-01-001.md")).unwrap();
+        let content =
+            std::fs::read_to_string(inbox_of(tmp.path(), "alice").join("2025-06-01-001.md"))
+                .unwrap();
         let parsed = parse_frontmatter(&content).unwrap();
         assert!(!parsed.read);
     }
@@ -833,7 +903,13 @@ mod tests {
         let config = test_config(tmp.path());
         let _cfg_guard = setup_config(&config);
 
-        let result = set_read_status(&config, "nonexistent", "2025-06-01-001", true);
+        let result = set_read_status(
+            &config,
+            "nonexistent",
+            Folder::Inbox,
+            "2025-06-01-001",
+            true,
+        );
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("does not exist"));
     }
@@ -844,10 +920,71 @@ mod tests {
         let config = test_config(tmp.path());
         let _cfg_guard = setup_config(&config);
 
-        std::fs::create_dir_all(tmp.path().join("alice")).unwrap();
-        let result = set_read_status(&config, "alice", "nonexistent", true);
+        std::fs::create_dir_all(inbox_of(tmp.path(), "alice")).unwrap();
+        let result = set_read_status(&config, "alice", Folder::Inbox, "nonexistent", true);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("not found"));
+    }
+
+    #[test]
+    fn set_read_status_reads_sent_folder_when_requested() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let _cfg_guard = setup_config(&config);
+
+        let meta = sample_meta("2025-06-02-001", "sender@test.com", "Outbound", false);
+        let sent = tmp.path().join("sent").join("alice");
+        create_test_email(&sent, "2025-06-02-001", &meta);
+
+        set_read_status(&config, "alice", Folder::Sent, "2025-06-02-001", true).unwrap();
+
+        let content = std::fs::read_to_string(sent.join("2025-06-02-001.md")).unwrap();
+        let parsed = parse_frontmatter(&content).unwrap();
+        assert!(parsed.read);
+    }
+
+    #[test]
+    fn resolve_folder_default_is_inbox() {
+        assert_eq!(resolve_folder(None).unwrap(), Folder::Inbox);
+        assert_eq!(resolve_folder(Some("inbox")).unwrap(), Folder::Inbox);
+    }
+
+    #[test]
+    fn resolve_folder_sent() {
+        assert_eq!(resolve_folder(Some("sent")).unwrap(), Folder::Sent);
+    }
+
+    #[test]
+    fn resolve_folder_rejects_unknown() {
+        let err = resolve_folder(Some("drafts")).unwrap_err();
+        assert!(err.contains("Invalid folder"));
+        assert!(err.contains("drafts"));
+    }
+
+    #[test]
+    fn list_emails_reads_bundle_markdown() {
+        // Bundle `<stem>/<stem>.md` is indexed alongside flat `.md` files.
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("alice");
+        std::fs::create_dir_all(&dir).unwrap();
+
+        let meta_flat = sample_meta("2025-06-01-001-flat", "a@test.com", "Flat", false);
+        create_test_email(&dir, "2025-06-01-001-flat", &meta_flat);
+
+        let bundle_stem = "2025-06-01-002-bundle";
+        let bundle = dir.join(bundle_stem);
+        std::fs::create_dir_all(&bundle).unwrap();
+        let meta_bundle = sample_meta(bundle_stem, "b@test.com", "Bundled", true);
+        let toml_str = toml::to_string_pretty(&meta_bundle).unwrap();
+        let content = format!("+++\n{toml_str}+++\n\nBundle body.\n");
+        std::fs::write(bundle.join(format!("{bundle_stem}.md")), content).unwrap();
+        std::fs::write(bundle.join("att.txt"), "attached").unwrap();
+
+        let emails = list_emails(&dir).unwrap();
+        assert_eq!(emails.len(), 2);
+        let ids: Vec<&str> = emails.iter().map(|e| e.id.as_str()).collect();
+        assert!(ids.contains(&"2025-06-01-001-flat"));
+        assert!(ids.contains(&bundle_stem));
     }
 
     #[test]
@@ -871,8 +1008,8 @@ mod tests {
 
         let meta1 = sample_meta("2025-06-01-001", "a@test.com", "A", false);
         let meta2 = sample_meta("2025-06-01-002", "b@test.com", "B", true);
-        create_test_email(&tmp.path().join("alice"), "2025-06-01-001", &meta1);
-        create_test_email(&tmp.path().join("alice"), "2025-06-01-002", &meta2);
+        create_test_email(&inbox_of(tmp.path(), "alice"), "2025-06-01-001", &meta1);
+        create_test_email(&inbox_of(tmp.path(), "alice"), "2025-06-01-002", &meta2);
 
         let result = list_mailboxes_with_unread(&config);
         let alice = result.iter().find(|m| m.0 == "alice").unwrap();
@@ -941,8 +1078,8 @@ mod tests {
         let config = test_config(tmp.path());
         let _cfg_guard = setup_config(&config);
 
-        std::fs::create_dir_all(tmp.path().join("alice")).unwrap();
-        let result = set_read_status(&config, "alice", "../../etc/passwd", true);
+        std::fs::create_dir_all(inbox_of(tmp.path(), "alice")).unwrap();
+        let result = set_read_status(&config, "alice", Folder::Inbox, "../../etc/passwd", true);
         assert!(result.is_err());
         assert!(result.unwrap_err().contains("invalid characters"));
     }

--- a/src/slug.rs
+++ b/src/slug.rs
@@ -1,0 +1,262 @@
+//! Slug algorithm + filename helper (Sprint 36 / FR-13b).
+//!
+//! `slugify` is a pure transform: MIME-decoded subject → deterministic
+//! filesystem-safe stem. `allocate_filename` picks the final on-disk path,
+//! resolving collisions and deciding between a flat `<stem>.md` layout and
+//! a Zola-style bundle directory (`<stem>/<stem>.md` with attachments as
+//! siblings). Both helpers are pure except for the directory check that
+//! `allocate_filename` performs to detect collisions.
+
+use chrono::{DateTime, Utc};
+use std::path::{Path, PathBuf};
+
+const SLUG_MAX_LEN: usize = 20;
+const SLUG_EMPTY_FALLBACK: &str = "no-subject";
+
+/// Convert a subject line into a deterministic slug.
+///
+/// Callers pass the already-MIME-decoded subject (e.g. the `&str` returned
+/// by `mail_parser::Message::subject`, which decodes RFC 2047 encoded words
+/// transparently). The transformation is:
+/// 1. Lowercase (Unicode-aware).
+/// 2. Every non-alphanumeric character becomes `-`.
+/// 3. Runs of `-` collapse to one.
+/// 4. Leading/trailing `-` are trimmed.
+/// 5. Truncated to 20 characters (counted as Unicode scalar values, then
+///    re-trimmed in case truncation left a trailing `-`).
+/// 6. Empty result becomes `no-subject`.
+pub fn slugify(subject: &str) -> String {
+    let lowered: String = subject.to_lowercase();
+
+    let mut out = String::with_capacity(lowered.len());
+    let mut last_was_dash = false;
+    for ch in lowered.chars() {
+        if ch.is_alphanumeric() {
+            out.push(ch);
+            last_was_dash = false;
+        } else if !last_was_dash {
+            out.push('-');
+            last_was_dash = true;
+        }
+    }
+
+    let trimmed = out.trim_matches('-');
+
+    let truncated: String = trimmed.chars().take(SLUG_MAX_LEN).collect();
+    let truncated = truncated.trim_end_matches('-').to_string();
+
+    if truncated.is_empty() {
+        SLUG_EMPTY_FALLBACK.to_string()
+    } else {
+        truncated
+    }
+}
+
+/// Build the UTC timestamp prefix used in inbound/outbound filenames.
+pub fn format_timestamp(ts: DateTime<Utc>) -> String {
+    ts.format("%Y-%m-%d-%H%M%S").to_string()
+}
+
+/// Allocate a non-colliding filename for a new email under `dir`.
+///
+/// The resolved path:
+/// * zero attachments → `<dir>/<stem>.md`
+/// * one+ attachments → `<dir>/<stem>/<stem>.md` (the attachments live
+///   beside it inside the `<stem>/` bundle directory)
+///
+/// Collisions append `-2`, `-3`, … to the stem. When `has_attachments` is
+/// true, collisions are detected against the bundle directory name so the
+/// inner `.md` always shares the parent directory's stem.
+///
+/// The returned path points at the `.md` file the caller must create; the
+/// caller is responsible for actually creating any missing parent
+/// directories and writing the file.
+pub fn allocate_filename(
+    dir: &Path,
+    timestamp: DateTime<Utc>,
+    slug: &str,
+    has_attachments: bool,
+) -> PathBuf {
+    let base_stem = format!("{}-{}", format_timestamp(timestamp), slug);
+
+    for suffix in 1.. {
+        let stem = if suffix == 1 {
+            base_stem.clone()
+        } else {
+            format!("{base_stem}-{suffix}")
+        };
+
+        if has_attachments {
+            let bundle = dir.join(&stem);
+            if !bundle.exists() {
+                return bundle.join(format!("{stem}.md"));
+            }
+        } else {
+            let file = dir.join(format!("{stem}.md"));
+            let bundle = dir.join(&stem);
+            if !file.exists() && !bundle.exists() {
+                return file;
+            }
+        }
+    }
+
+    unreachable!("collision loop exhausted u32::MAX suffixes")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone;
+    use tempfile::TempDir;
+
+    #[test]
+    fn slugify_ascii_subject() {
+        assert_eq!(slugify("Hello World"), "hello-world");
+    }
+
+    #[test]
+    fn slugify_mixed_case() {
+        assert_eq!(slugify("Meeting Tomorrow"), "meeting-tomorrow");
+    }
+
+    #[test]
+    fn slugify_unicode_subject() {
+        // mail-parser decodes RFC 2047 into UTF-8 before slugify sees it.
+        // Unicode letters pass the `is_alphanumeric` predicate, so they
+        // survive (lowercased) while punctuation collapses to dashes.
+        let slug = slugify("Héllo Wörld!");
+        assert!(slug.starts_with("héllo"), "got: {slug}");
+        assert!(slug.contains("wörld"), "got: {slug}");
+    }
+
+    #[test]
+    fn slugify_all_non_alphanumeric_becomes_fallback() {
+        assert_eq!(slugify("!!!???@@@"), "no-subject");
+        assert_eq!(slugify("---"), "no-subject");
+        assert_eq!(slugify(""), "no-subject");
+        assert_eq!(slugify("   "), "no-subject");
+    }
+
+    #[test]
+    fn slugify_long_subject_truncated_to_20() {
+        let subject = "This is a very long subject that should be truncated";
+        let slug = slugify(subject);
+        assert!(
+            slug.chars().count() <= 20,
+            "got: {slug} ({} chars)",
+            slug.chars().count()
+        );
+        assert_eq!(slug, "this-is-a-very-long");
+    }
+
+    #[test]
+    fn slugify_collapses_dash_runs() {
+        assert_eq!(slugify("foo   bar"), "foo-bar");
+        assert_eq!(slugify("foo---bar"), "foo-bar");
+        assert_eq!(slugify("foo!!!bar"), "foo-bar");
+        assert_eq!(slugify("foo!@#$bar"), "foo-bar");
+    }
+
+    #[test]
+    fn slugify_trims_leading_trailing_dashes() {
+        assert_eq!(slugify("!!!hello"), "hello");
+        assert_eq!(slugify("hello!!!"), "hello");
+        assert_eq!(slugify("!!!hello!!!"), "hello");
+    }
+
+    #[test]
+    fn slugify_truncation_retrims_trailing_dash() {
+        // Truncation can expose a trailing `-`; re-trim so slugs never
+        // end on a separator.
+        let subject = "abc defghijklmnopqrstuvwxyz";
+        let slug = slugify(subject);
+        assert!(!slug.ends_with('-'), "got: {slug}");
+    }
+
+    #[test]
+    fn slugify_numbers_preserved() {
+        assert_eq!(slugify("Invoice #123 for 2025"), "invoice-123-for-2025");
+    }
+
+    #[test]
+    fn format_timestamp_utc_exact_string() {
+        let ts = Utc.with_ymd_and_hms(2025, 3, 14, 15, 9, 26).unwrap();
+        assert_eq!(format_timestamp(ts), "2025-03-14-150926");
+    }
+
+    #[test]
+    fn format_timestamp_midnight() {
+        let ts = Utc.with_ymd_and_hms(2026, 1, 1, 0, 0, 0).unwrap();
+        assert_eq!(format_timestamp(ts), "2026-01-01-000000");
+    }
+
+    #[test]
+    fn allocate_filename_flat_no_collision() {
+        let tmp = TempDir::new().unwrap();
+        let ts = Utc.with_ymd_and_hms(2025, 6, 1, 12, 0, 0).unwrap();
+        let path = allocate_filename(tmp.path(), ts, "hello", false);
+        assert_eq!(path, tmp.path().join("2025-06-01-120000-hello.md"),);
+    }
+
+    #[test]
+    fn allocate_filename_flat_single_collision() {
+        let tmp = TempDir::new().unwrap();
+        let ts = Utc.with_ymd_and_hms(2025, 6, 1, 12, 0, 0).unwrap();
+        std::fs::write(tmp.path().join("2025-06-01-120000-hello.md"), "x").unwrap();
+
+        let path = allocate_filename(tmp.path(), ts, "hello", false);
+        assert_eq!(path, tmp.path().join("2025-06-01-120000-hello-2.md"),);
+    }
+
+    #[test]
+    fn allocate_filename_flat_double_collision() {
+        let tmp = TempDir::new().unwrap();
+        let ts = Utc.with_ymd_and_hms(2025, 6, 1, 12, 0, 0).unwrap();
+        std::fs::write(tmp.path().join("2025-06-01-120000-hello.md"), "x").unwrap();
+        std::fs::write(tmp.path().join("2025-06-01-120000-hello-2.md"), "x").unwrap();
+
+        let path = allocate_filename(tmp.path(), ts, "hello", false);
+        assert_eq!(path, tmp.path().join("2025-06-01-120000-hello-3.md"),);
+    }
+
+    #[test]
+    fn allocate_filename_bundle_no_collision() {
+        let tmp = TempDir::new().unwrap();
+        let ts = Utc.with_ymd_and_hms(2025, 6, 1, 12, 0, 0).unwrap();
+        let path = allocate_filename(tmp.path(), ts, "hello", true);
+        let stem = "2025-06-01-120000-hello";
+        assert_eq!(path, tmp.path().join(stem).join(format!("{stem}.md")),);
+    }
+
+    #[test]
+    fn allocate_filename_bundle_collision_uses_directory_name() {
+        let tmp = TempDir::new().unwrap();
+        let ts = Utc.with_ymd_and_hms(2025, 6, 1, 12, 0, 0).unwrap();
+        // A bundle already occupies the base stem.
+        std::fs::create_dir_all(tmp.path().join("2025-06-01-120000-hello")).unwrap();
+
+        let path = allocate_filename(tmp.path(), ts, "hello", true);
+        let stem = "2025-06-01-120000-hello-2";
+        assert_eq!(path, tmp.path().join(stem).join(format!("{stem}.md")),);
+    }
+
+    #[test]
+    fn allocate_filename_flat_collides_with_existing_bundle() {
+        // A bundle directory at the same stem means the flat `.md` path
+        // would live inside someone else's bundle. Bump instead.
+        let tmp = TempDir::new().unwrap();
+        let ts = Utc.with_ymd_and_hms(2025, 6, 1, 12, 0, 0).unwrap();
+        std::fs::create_dir_all(tmp.path().join("2025-06-01-120000-hello")).unwrap();
+
+        let path = allocate_filename(tmp.path(), ts, "hello", false);
+        assert_eq!(path, tmp.path().join("2025-06-01-120000-hello-2.md"),);
+    }
+
+    #[test]
+    fn allocate_filename_no_subject_slug() {
+        let tmp = TempDir::new().unwrap();
+        let ts = Utc.with_ymd_and_hms(2025, 6, 1, 12, 0, 0).unwrap();
+        let path = allocate_filename(tmp.path(), ts, "no-subject", false);
+        assert_eq!(path, tmp.path().join("2025-06-01-120000-no-subject.md"),);
+    }
+}

--- a/src/smtp/tests.rs
+++ b/src/smtp/tests.rs
@@ -7,6 +7,53 @@ use tokio::net::TcpStream;
 use crate::config::{Config, MailboxConfig};
 use crate::smtp::SmtpServer;
 
+/// Return the on-disk inbox directory for a mailbox under `data_dir`.
+fn inbox(data_dir: &std::path::Path, name: &str) -> PathBuf {
+    data_dir.join("inbox").join(name)
+}
+
+/// Collect every `.md` file under a mailbox directory, descending into
+/// bundle subdirectories (`<stem>/<stem>.md`) as well as flat files.
+fn collect_md_files(mailbox_dir: &std::path::Path) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    let entries = match std::fs::read_dir(mailbox_dir) {
+        Ok(e) => e,
+        Err(_) => return out,
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            if let Some(stem) = path.file_name().and_then(|f| f.to_str()) {
+                let md = path.join(format!("{stem}.md"));
+                if md.exists() {
+                    out.push(md);
+                }
+            }
+        } else if path.extension().is_some_and(|ext| ext == "md") {
+            out.push(path);
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Return the first attachment file matching `name` anywhere inside
+/// `mailbox_dir` (including bundle subdirectories). Used by tests that
+/// know the attachment filename but don't know the bundle stem.
+fn find_attachment(mailbox_dir: &std::path::Path, name: &str) -> Option<PathBuf> {
+    let entries = std::fs::read_dir(mailbox_dir).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let candidate = path.join(name);
+            if candidate.exists() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
+}
+
 fn test_config(data_dir: &std::path::Path) -> Config {
     let mut mailboxes = HashMap::new();
     mailboxes.insert(
@@ -185,13 +232,9 @@ async fn test_full_mail_transaction() {
     let resp = client.send_and_read("QUIT").await;
     assert!(resp.starts_with("221"));
 
-    let alice_dir = tmp.path().join("alice");
+    let alice_dir = inbox(tmp.path(), "alice");
     assert!(alice_dir.exists());
-    let entries: Vec<_> = std::fs::read_dir(&alice_dir)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
-        .collect();
+    let entries = collect_md_files(&alice_dir);
     assert_eq!(entries.len(), 1);
 }
 
@@ -217,16 +260,8 @@ async fn test_multi_recipient() {
 
     client.send_and_read("QUIT").await;
 
-    let alice_mds: Vec<_> = std::fs::read_dir(tmp.path().join("alice"))
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
-        .collect();
-    let catchall_mds: Vec<_> = std::fs::read_dir(tmp.path().join("catchall"))
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
-        .collect();
+    let alice_mds = collect_md_files(&inbox(tmp.path(), "alice"));
+    let catchall_mds = collect_md_files(&inbox(tmp.path(), "catchall"));
     assert_eq!(alice_mds.len(), 1);
     assert_eq!(catchall_mds.len(), 1);
 }
@@ -615,15 +650,11 @@ async fn test_ingest_creates_markdown_file() {
 
     client.send_and_read("QUIT").await;
 
-    let alice_dir = tmp.path().join("alice");
-    let md_files: Vec<_> = std::fs::read_dir(&alice_dir)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
-        .collect();
+    let alice_dir = inbox(tmp.path(), "alice");
+    let md_files = collect_md_files(&alice_dir);
     assert_eq!(md_files.len(), 1);
 
-    let content = std::fs::read_to_string(md_files[0].path()).unwrap();
+    let content = std::fs::read_to_string(&md_files[0]).unwrap();
     assert!(content.contains("+++"));
     assert!(content.contains("subject = \"Test\""));
     assert!(content.contains("Hello World"));
@@ -818,12 +849,8 @@ async fn test_multiple_transactions_per_connection() {
 
     client.send_and_read("QUIT").await;
 
-    let alice_dir = tmp.path().join("alice");
-    let md_files: Vec<_> = std::fs::read_dir(&alice_dir)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
-        .collect();
+    let alice_dir = inbox(tmp.path(), "alice");
+    let md_files = collect_md_files(&alice_dir);
     assert_eq!(md_files.len(), 2);
 }
 
@@ -875,7 +902,8 @@ async fn test_text_attachment_from_real_file() {
     assert!(resp.starts_with("250"), "Expected 250: {resp}");
     client.send_and_read("QUIT").await;
 
-    let attachment_path = tmp.path().join("alice/attachments/README.md");
+    let attachment_path =
+        find_attachment(&inbox(tmp.path(), "alice"), "README.md").expect("attachment missing");
     assert!(attachment_path.exists(), "Attachment file should exist");
     let received = std::fs::read(&attachment_path).unwrap();
     assert_eq!(
@@ -943,7 +971,8 @@ async fn test_binary_attachment_roundtrip() {
     assert!(resp.starts_with("250"), "Expected 250: {resp}");
     client.send_and_read("QUIT").await;
 
-    let attachment_path = tmp.path().join("alice/attachments/random.bin");
+    let attachment_path =
+        find_attachment(&inbox(tmp.path(), "alice"), "random.bin").expect("bin attachment");
     assert!(
         attachment_path.exists(),
         "Binary attachment file should exist"
@@ -1032,8 +1061,10 @@ async fn test_mixed_text_and_binary_attachments_with_body() {
     assert!(resp.starts_with("250"), "Expected 250: {resp}");
     client.send_and_read("QUIT").await;
 
-    // Verify text attachment
-    let text_att_path = tmp.path().join("alice/attachments/README.md");
+    // Verify text attachment — both should be inside the same bundle dir.
+    let alice_dir = inbox(tmp.path(), "alice");
+    let text_att_path =
+        find_attachment(&alice_dir, "README.md").expect("README attachment missing");
     assert!(text_att_path.exists(), "Text attachment should exist");
     let received_text = std::fs::read(&text_att_path).unwrap();
     assert_eq!(
@@ -1042,7 +1073,7 @@ async fn test_mixed_text_and_binary_attachments_with_body() {
     );
 
     // Verify binary attachment
-    let bin_att_path = tmp.path().join("alice/attachments/data.bin");
+    let bin_att_path = find_attachment(&alice_dir, "data.bin").expect("bin attachment missing");
     assert!(bin_att_path.exists(), "Binary attachment should exist");
     let received_bin = std::fs::read(&bin_att_path).unwrap();
     assert_eq!(
@@ -1051,15 +1082,10 @@ async fn test_mixed_text_and_binary_attachments_with_body() {
     );
 
     // Verify the email body is intact
-    let alice_dir = tmp.path().join("alice");
-    let md_files: Vec<_> = std::fs::read_dir(&alice_dir)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
-        .collect();
+    let md_files = collect_md_files(&alice_dir);
     assert_eq!(md_files.len(), 1, "Should have exactly one email file");
 
-    let content = std::fs::read_to_string(md_files[0].path()).unwrap();
+    let content = std::fs::read_to_string(&md_files[0]).unwrap();
     assert!(
         content.contains("subject = \"Mixed attachments test\""),
         "Frontmatter should contain the subject"

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,7 +1,7 @@
 use crate::config::Config;
 use crate::ingest::EmailMetadata;
 use crate::term;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub struct StatusInfo {
     pub domain: String,
@@ -66,21 +66,32 @@ fn gather_recent_activity(config: &Config) -> Vec<RecentEmail> {
     let mut all: Vec<RecentEmail> = Vec::new();
 
     for name in config.mailboxes.keys() {
-        let dir = config.mailbox_dir(name);
+        let dir = config.inbox_dir(name);
         let entries = match std::fs::read_dir(&dir) {
             Ok(e) => e,
             Err(_) => continue,
         };
 
-        let mut md_files: Vec<_> = entries
-            .flatten()
-            .filter(|e| e.path().extension().is_some_and(|ext| ext == "md"))
-            .collect();
-
-        md_files.sort_by_key(|b| std::cmp::Reverse(b.file_name()));
-
-        for entry in md_files.into_iter().take(3) {
+        // Collect both flat `<stem>.md` and bundle `<stem>/<stem>.md`
+        // paths; sort newest-first by stem (UTC timestamp prefix orders
+        // lexicographically).
+        let mut md_paths: Vec<PathBuf> = Vec::new();
+        for entry in entries.flatten() {
             let path = entry.path();
+            if path.is_dir() {
+                if let Some(stem) = path.file_name().and_then(|f| f.to_str()) {
+                    let md = path.join(format!("{stem}.md"));
+                    if md.exists() {
+                        md_paths.push(md);
+                    }
+                }
+            } else if path.extension().is_some_and(|ext| ext == "md") {
+                md_paths.push(path);
+            }
+        }
+        md_paths.sort_by(|a, b| b.file_name().cmp(&a.file_name()));
+
+        for path in md_paths.into_iter().take(3) {
             let content = match std::fs::read_to_string(&path) {
                 Ok(c) => c,
                 Err(_) => continue,
@@ -129,11 +140,26 @@ fn count_messages(dir: &Path) -> (usize, usize) {
 
     for entry in entries.flatten() {
         let path = entry.path();
-        if path.extension().is_some_and(|ext| ext == "md") {
-            total += 1;
-            if is_unread(&path) {
-                unread += 1;
+        let md_path = if path.is_dir() {
+            // Bundle directory: look for the `<stem>.md` inside.
+            let stem = match path.file_name().and_then(|f| f.to_str()) {
+                Some(s) => s.to_string(),
+                None => continue,
+            };
+            let candidate = path.join(format!("{stem}.md"));
+            if !candidate.exists() {
+                continue;
             }
+            candidate
+        } else if path.extension().is_some_and(|ext| ext == "md") {
+            path
+        } else {
+            continue;
+        };
+
+        total += 1;
+        if is_unread(&md_path) {
+            unread += 1;
         }
     }
 
@@ -561,7 +587,7 @@ mod tests {
     fn gather_recent_activity_reads_emails() {
         let tmp = tempfile::TempDir::new().unwrap();
         let data_dir = tmp.path();
-        let catchall = data_dir.join("catchall");
+        let catchall = data_dir.join("inbox").join("catchall");
         std::fs::create_dir_all(&catchall).unwrap();
 
         let email_content = "+++\nid = \"2025-01-15-001\"\nmessage_id = \"<a@b>\"\nfrom = \"alice@example.com\"\nto = \"c@d\"\nsubject = \"Test email\"\ndate = \"2025-01-15T10:30:00Z\"\nin_reply_to = \"\"\nreferences = \"\"\nattachments = []\nmailbox = \"catchall\"\nread = false\ndkim = \"none\"\nspf = \"none\"\n+++\nBody here";

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -11,8 +11,9 @@ fn setup_test_env(tmp: &Path) -> String {
         "domain = \"agent.example.com\"\ndata_dir = \"{}\"\n\n[mailboxes.catchall]\naddress = \"*@agent.example.com\"\n\n[mailboxes.alice]\naddress = \"alice@agent.example.com\"\n",
         tmp.display()
     );
-    std::fs::create_dir_all(tmp.join("catchall")).unwrap();
-    std::fs::create_dir_all(tmp.join("alice")).unwrap();
+    std::fs::create_dir_all(tmp.join("inbox").join("catchall")).unwrap();
+    std::fs::create_dir_all(tmp.join("inbox").join("alice")).unwrap();
+    std::fs::create_dir_all(tmp.join("sent").join("alice")).unwrap();
     let config_path = tmp.join("config.toml");
     std::fs::write(&config_path, &config_content).unwrap();
     // Sprint 34: `aimx serve` loads the DKIM private key at startup and
@@ -62,12 +63,49 @@ fn get_toml_str<'a>(table: &'a toml::Table, key: &str) -> &'a str {
 }
 
 fn find_md_files(dir: &Path) -> Vec<std::path::PathBuf> {
-    std::fs::read_dir(dir)
-        .unwrap()
-        .filter_map(|e| e.ok())
-        .map(|e| e.path())
-        .filter(|p| p.extension().is_some_and(|ext| ext == "md"))
-        .collect()
+    let mut out: Vec<std::path::PathBuf> = Vec::new();
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return out,
+    };
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        if path.is_dir() {
+            // Zola-style bundle: `<stem>/<stem>.md`.
+            if let Some(stem) = path.file_name().and_then(|f| f.to_str()) {
+                let md = path.join(format!("{stem}.md"));
+                if md.exists() {
+                    out.push(md);
+                }
+            }
+        } else if path.extension().is_some_and(|ext| ext == "md") {
+            out.push(path);
+        }
+    }
+    out.sort();
+    out
+}
+
+/// Resolve the inbox directory for a mailbox under a test tempdir.
+fn inbox(tmp: &Path, name: &str) -> std::path::PathBuf {
+    tmp.join("inbox").join(name)
+}
+
+/// Search every bundle directory under `mailbox_dir` for an attachment
+/// named `name`. Returns the first match — tests only create one email
+/// with attachments per setup.
+fn find_attachment(mailbox_dir: &Path, name: &str) -> Option<std::path::PathBuf> {
+    let entries = std::fs::read_dir(mailbox_dir).ok()?;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            let candidate = path.join(name);
+            if candidate.exists() {
+                return Some(candidate);
+            }
+        }
+    }
+    None
 }
 
 #[test]
@@ -114,7 +152,7 @@ fn ingest_plain_fixture_full_pipeline() {
         .assert()
         .success();
 
-    let md_files = find_md_files(&tmp.path().join("catchall"));
+    let md_files = find_md_files(&inbox(tmp.path(), "catchall"));
     assert_eq!(md_files.len(), 1);
 
     let parsed = read_frontmatter(&md_files[0]);
@@ -144,7 +182,7 @@ fn ingest_html_fixture_full_pipeline() {
         .assert()
         .success();
 
-    let md_files = find_md_files(&tmp.path().join("catchall"));
+    let md_files = find_md_files(&inbox(tmp.path(), "catchall"));
     assert_eq!(md_files.len(), 1);
 
     let parsed = read_frontmatter(&md_files[0]);
@@ -171,7 +209,7 @@ fn ingest_multipart_fixture_full_pipeline() {
         .assert()
         .success();
 
-    let md_files = find_md_files(&tmp.path().join("catchall"));
+    let md_files = find_md_files(&inbox(tmp.path(), "catchall"));
     assert_eq!(md_files.len(), 1);
 
     let content = std::fs::read_to_string(&md_files[0]).unwrap();
@@ -194,10 +232,11 @@ fn ingest_attachment_fixture_full_pipeline() {
         .assert()
         .success();
 
-    let md_files = find_md_files(&tmp.path().join("catchall"));
+    let md_files = find_md_files(&inbox(tmp.path(), "catchall"));
     assert_eq!(md_files.len(), 1);
 
-    let att_path = tmp.path().join("catchall/attachments/readme.txt");
+    let att_path = find_attachment(&inbox(tmp.path(), "catchall"), "readme.txt")
+        .expect("readme.txt attachment missing from bundle");
     assert!(att_path.exists());
     let att_content = std::fs::read_to_string(&att_path).unwrap();
     assert!(att_content.contains("This is the content of the attached file."));
@@ -208,6 +247,9 @@ fn ingest_attachment_fixture_full_pipeline() {
     assert_eq!(attachments.len(), 1);
     let att = attachments[0].as_table().unwrap();
     assert_eq!(att.get("filename").unwrap().as_str().unwrap(), "readme.txt");
+    // Bundle-relative path: attachment sits beside the `.md` with no
+    // `attachments/` prefix after Sprint 36.
+    assert_eq!(att.get("path").unwrap().as_str().unwrap(), "readme.txt");
 }
 
 #[test]
@@ -225,10 +267,10 @@ fn ingest_routes_to_named_mailbox() {
         .assert()
         .success();
 
-    let alice_files = find_md_files(&tmp.path().join("alice"));
+    let alice_files = find_md_files(&inbox(tmp.path(), "alice"));
     assert_eq!(alice_files.len(), 1);
 
-    let catchall_files = find_md_files(&tmp.path().join("catchall"));
+    let catchall_files = find_md_files(&inbox(tmp.path(), "catchall"));
     assert_eq!(catchall_files.len(), 0);
 }
 
@@ -247,7 +289,7 @@ fn ingest_unknown_routes_to_catchall() {
         .assert()
         .success();
 
-    let catchall_files = find_md_files(&tmp.path().join("catchall"));
+    let catchall_files = find_md_files(&inbox(tmp.path(), "catchall"));
     assert_eq!(catchall_files.len(), 1);
 }
 
@@ -265,7 +307,7 @@ fn ingest_via_env_var() {
         .assert()
         .success();
 
-    let md_files = find_md_files(&tmp.path().join("catchall"));
+    let md_files = find_md_files(&inbox(tmp.path(), "catchall"));
     assert_eq!(md_files.len(), 1);
 }
 
@@ -524,7 +566,7 @@ fn mcp_mailbox_create_list_delete() {
         text.contains("created"),
         "Expected creation message, got: {text}"
     );
-    assert!(tmp.path().join("support").is_dir());
+    assert!(inbox(tmp.path(), "support").is_dir());
 
     let resp = client.call_tool("mailbox_list", serde_json::json!({}));
     let text = get_tool_text(&resp);
@@ -535,7 +577,7 @@ fn mcp_mailbox_create_list_delete() {
     let resp = client.call_tool("mailbox_delete", serde_json::json!({"name": "support"}));
     let text = get_tool_text(&resp);
     assert!(text.contains("deleted"));
-    assert!(!tmp.path().join("support").exists());
+    assert!(!inbox(tmp.path(), "support").exists());
 
     client.shutdown();
 }
@@ -569,7 +611,7 @@ fn mcp_email_list_and_read() {
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
 
-    let alice_dir = tmp.path().join("alice");
+    let alice_dir = inbox(tmp.path(), "alice");
     create_email_file(
         &alice_dir,
         "2025-06-01-001",
@@ -652,7 +694,7 @@ fn mcp_email_mark_read_unread() {
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
 
-    let alice_dir = tmp.path().join("alice");
+    let alice_dir = inbox(tmp.path(), "alice");
     create_email_file(
         &alice_dir,
         "2025-06-01-001",
@@ -671,7 +713,8 @@ fn mcp_email_mark_read_unread() {
     let text = get_tool_text(&resp);
     assert!(text.contains("marked as read"));
 
-    let content = std::fs::read_to_string(tmp.path().join("alice/2025-06-01-001.md")).unwrap();
+    let content =
+        std::fs::read_to_string(inbox(tmp.path(), "alice").join("2025-06-01-001.md")).unwrap();
     assert!(content.contains("read = true"));
 
     let resp = client.call_tool(
@@ -681,7 +724,8 @@ fn mcp_email_mark_read_unread() {
     let text = get_tool_text(&resp);
     assert!(text.contains("marked as unread"));
 
-    let content = std::fs::read_to_string(tmp.path().join("alice/2025-06-01-001.md")).unwrap();
+    let content =
+        std::fs::read_to_string(inbox(tmp.path(), "alice").join("2025-06-01-001.md")).unwrap();
     assert!(content.contains("read = false"));
 
     client.shutdown();
@@ -762,7 +806,7 @@ command = "touch {}"
         tmp.display(),
         trigger_marker.display()
     );
-    std::fs::create_dir_all(tmp.join("catchall")).unwrap();
+    std::fs::create_dir_all(tmp.join("inbox").join("catchall")).unwrap();
     let config_path = tmp.join("config.toml");
     std::fs::write(&config_path, &config_content).unwrap();
     config_path.to_string_lossy().to_string()
@@ -784,7 +828,7 @@ fn ingest_trigger_executes_on_delivery() {
         .assert()
         .success();
 
-    let md_files = find_md_files(&tmp.path().join("catchall"));
+    let md_files = find_md_files(&inbox(tmp.path(), "catchall"));
     assert_eq!(md_files.len(), 1);
     assert!(
         marker.exists(),
@@ -808,7 +852,7 @@ command = "false"
 "#,
         tmp.path().display()
     );
-    std::fs::create_dir_all(tmp.path().join("catchall")).unwrap();
+    std::fs::create_dir_all(inbox(tmp.path(), "catchall")).unwrap();
     std::fs::write(tmp.path().join("config.toml"), &config_content).unwrap();
 
     let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
@@ -822,7 +866,7 @@ command = "false"
         .assert()
         .success();
 
-    let md_files = find_md_files(&tmp.path().join("catchall"));
+    let md_files = find_md_files(&inbox(tmp.path(), "catchall"));
     assert_eq!(
         md_files.len(),
         1,
@@ -849,7 +893,7 @@ command = "touch {}"
         tmp.path().display(),
         marker.display()
     );
-    std::fs::create_dir_all(tmp.path().join("catchall")).unwrap();
+    std::fs::create_dir_all(inbox(tmp.path(), "catchall")).unwrap();
     std::fs::write(tmp.path().join("config.toml"), &config_content).unwrap();
 
     let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
@@ -863,7 +907,7 @@ command = "touch {}"
         .assert()
         .success();
 
-    let md_files = find_md_files(&tmp.path().join("catchall"));
+    let md_files = find_md_files(&inbox(tmp.path(), "catchall"));
     assert_eq!(md_files.len(), 1, "Email should still be saved");
     assert!(
         !marker.exists(),
@@ -890,7 +934,7 @@ command = "touch {}"
         tmp.path().display(),
         marker.display()
     );
-    std::fs::create_dir_all(tmp.path().join("catchall")).unwrap();
+    std::fs::create_dir_all(inbox(tmp.path(), "catchall")).unwrap();
     std::fs::write(tmp.path().join("config.toml"), &config_content).unwrap();
 
     let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
@@ -904,7 +948,7 @@ command = "touch {}"
         .assert()
         .success();
 
-    let md_files = find_md_files(&tmp.path().join("catchall"));
+    let md_files = find_md_files(&inbox(tmp.path(), "catchall"));
     assert_eq!(md_files.len(), 1);
     assert!(
         marker.exists(),
@@ -927,7 +971,7 @@ fn ingest_frontmatter_contains_dkim_spf() {
         .assert()
         .success();
 
-    let md_files = find_md_files(&tmp.path().join("catchall"));
+    let md_files = find_md_files(&inbox(tmp.path(), "catchall"));
     assert_eq!(md_files.len(), 1);
 
     let parsed = read_frontmatter(&md_files[0]);
@@ -966,7 +1010,7 @@ command = "touch {}"
         tmp.path().display(),
         marker.display()
     );
-    std::fs::create_dir_all(tmp.path().join("catchall")).unwrap();
+    std::fs::create_dir_all(inbox(tmp.path(), "catchall")).unwrap();
     std::fs::write(tmp.path().join("config.toml"), &config_content).unwrap();
 
     let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
@@ -980,7 +1024,7 @@ command = "touch {}"
         .assert()
         .success();
 
-    let md_files = find_md_files(&tmp.path().join("catchall"));
+    let md_files = find_md_files(&inbox(tmp.path(), "catchall"));
     assert_eq!(md_files.len(), 1);
     assert!(
         marker.exists(),
@@ -1017,7 +1061,7 @@ command = "false"
         data_dir = tmp.path().display(),
         marker = marker.display()
     );
-    std::fs::create_dir_all(tmp.path().join("catchall")).unwrap();
+    std::fs::create_dir_all(inbox(tmp.path(), "catchall")).unwrap();
     std::fs::write(tmp.path().join("config.toml"), &config_content).unwrap();
 
     let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
@@ -1031,7 +1075,7 @@ command = "false"
         .assert()
         .success();
 
-    let md_files = find_md_files(&tmp.path().join("catchall"));
+    let md_files = find_md_files(&inbox(tmp.path(), "catchall"));
     assert_eq!(
         md_files.len(),
         1,
@@ -1240,7 +1284,7 @@ fn serve_e2e_receive_email_and_shutdown() {
     // Allow ingest to complete
     std::thread::sleep(std::time::Duration::from_millis(500));
 
-    let alice_dir = tmp.path().join("alice");
+    let alice_dir = inbox(tmp.path(), "alice");
     let md_files = find_md_files(&alice_dir);
     assert_eq!(md_files.len(), 1, "Expected 1 email in alice mailbox");
 
@@ -1307,8 +1351,8 @@ fn serve_e2e_multi_recipient() {
 
     std::thread::sleep(std::time::Duration::from_millis(500));
 
-    let alice_files = find_md_files(&tmp.path().join("alice"));
-    let catchall_files = find_md_files(&tmp.path().join("catchall"));
+    let alice_files = find_md_files(&inbox(tmp.path(), "alice"));
+    let catchall_files = find_md_files(&inbox(tmp.path(), "catchall"));
     assert_eq!(alice_files.len(), 1, "Expected 1 email in alice mailbox");
     assert_eq!(
         catchall_files.len(),
@@ -1377,9 +1421,11 @@ fn setup_test_env_with_bob(tmp: &Path) -> String {
         "domain = \"agent.example.com\"\ndata_dir = \"{}\"\n\n[mailboxes.catchall]\naddress = \"*@agent.example.com\"\n\n[mailboxes.alice]\naddress = \"alice@agent.example.com\"\n\n[mailboxes.bob]\naddress = \"bob@agent.example.com\"\n",
         tmp.display()
     );
-    std::fs::create_dir_all(tmp.join("catchall")).unwrap();
-    std::fs::create_dir_all(tmp.join("alice")).unwrap();
-    std::fs::create_dir_all(tmp.join("bob")).unwrap();
+    std::fs::create_dir_all(tmp.join("inbox").join("catchall")).unwrap();
+    std::fs::create_dir_all(tmp.join("inbox").join("alice")).unwrap();
+    std::fs::create_dir_all(tmp.join("inbox").join("bob")).unwrap();
+    std::fs::create_dir_all(tmp.join("sent").join("alice")).unwrap();
+    std::fs::create_dir_all(tmp.join("sent").join("bob")).unwrap();
     let config_path = tmp.join("config.toml");
     std::fs::write(&config_path, &config_content).unwrap();
     // Sprint 34: `aimx serve` requires the DKIM private key at startup.
@@ -1472,11 +1518,12 @@ fn serve_e2e_single_attachment() {
     );
     std::thread::sleep(std::time::Duration::from_millis(500));
 
-    let alice_dir = tmp.path().join("alice");
+    let alice_dir = inbox(tmp.path(), "alice");
     let md_files = find_md_files(&alice_dir);
     assert_eq!(md_files.len(), 1, "Expected 1 email in alice mailbox");
 
-    let att_path = alice_dir.join("attachments").join("report.txt");
+    let att_path =
+        find_attachment(&alice_dir, "report.txt").expect("report.txt missing from bundle");
     assert!(att_path.exists(), "Attachment file should exist on disk");
     let att_content = std::fs::read_to_string(&att_path).unwrap();
     assert!(
@@ -1490,7 +1537,7 @@ fn serve_e2e_single_attachment() {
     assert_eq!(attachments.len(), 1, "Expected 1 attachment in frontmatter");
     let att = attachments[0].as_table().unwrap();
     assert_eq!(get_toml_str(att, "filename"), "report.txt");
-    assert_eq!(get_toml_str(att, "path"), "attachments/report.txt");
+    assert_eq!(get_toml_str(att, "path"), "report.txt");
     assert!(att.get("size").unwrap().as_integer().unwrap() > 0);
 
     let content = std::fs::read_to_string(&md_files[0]).unwrap();
@@ -1545,28 +1592,21 @@ fn serve_e2e_multiple_attachments() {
     );
     std::thread::sleep(std::time::Duration::from_millis(500));
 
-    let alice_dir = tmp.path().join("alice");
+    let alice_dir = inbox(tmp.path(), "alice");
     let md_files = find_md_files(&alice_dir);
     assert_eq!(md_files.len(), 1, "Expected 1 email in alice mailbox");
 
-    let att_dir = alice_dir.join("attachments");
-    assert!(
-        att_dir.join("notes.txt").exists(),
-        "notes.txt should exist on disk"
-    );
-    assert!(
-        att_dir.join("data.csv").exists(),
-        "data.csv should exist on disk"
-    );
-    assert!(
-        att_dir.join("image.png").exists(),
-        "image.png should exist on disk"
-    );
+    let notes_path = find_attachment(&alice_dir, "notes.txt").expect("notes.txt missing");
+    let csv_path = find_attachment(&alice_dir, "data.csv").expect("data.csv missing");
+    let image_path = find_attachment(&alice_dir, "image.png").expect("image.png missing");
+    assert!(notes_path.exists());
+    assert!(csv_path.exists());
+    assert!(image_path.exists());
 
-    let notes = std::fs::read_to_string(att_dir.join("notes.txt")).unwrap();
+    let notes = std::fs::read_to_string(&notes_path).unwrap();
     assert!(notes.contains("Meeting notes"));
 
-    let csv = std::fs::read_to_string(att_dir.join("data.csv")).unwrap();
+    let csv = std::fs::read_to_string(&csv_path).unwrap();
     assert!(csv.contains("alpha,1"));
 
     let fm = read_frontmatter(&md_files[0]);
@@ -1628,13 +1668,15 @@ fn serve_e2e_attachment_multi_recipient() {
     );
     std::thread::sleep(std::time::Duration::from_millis(500));
 
-    let alice_dir = tmp.path().join("alice");
-    let catchall_dir = tmp.path().join("catchall");
+    let alice_dir = inbox(tmp.path(), "alice");
+    let catchall_dir = inbox(tmp.path(), "catchall");
     assert_eq!(find_md_files(&alice_dir).len(), 1);
     assert_eq!(find_md_files(&catchall_dir).len(), 1);
 
-    let alice_att = alice_dir.join("attachments").join("shared.txt");
-    let catchall_att = catchall_dir.join("attachments").join("shared.txt");
+    let alice_att =
+        find_attachment(&alice_dir, "shared.txt").expect("alice bundle missing shared.txt");
+    let catchall_att =
+        find_attachment(&catchall_dir, "shared.txt").expect("catchall bundle missing shared.txt");
     assert!(alice_att.exists(), "alice should have attachment");
     assert!(catchall_att.exists(), "catchall should have attachment");
 
@@ -1672,8 +1714,8 @@ fn serve_e2e_cc_recipients() {
     );
     std::thread::sleep(std::time::Duration::from_millis(500));
 
-    let alice_files = find_md_files(&tmp.path().join("alice"));
-    let bob_files = find_md_files(&tmp.path().join("bob"));
+    let alice_files = find_md_files(&inbox(tmp.path(), "alice"));
+    let bob_files = find_md_files(&inbox(tmp.path(), "bob"));
     assert_eq!(alice_files.len(), 1, "Expected 1 email in alice mailbox");
     assert_eq!(bob_files.len(), 1, "Expected 1 email in bob mailbox");
 
@@ -1721,8 +1763,8 @@ fn serve_e2e_bcc_recipients() {
     );
     std::thread::sleep(std::time::Duration::from_millis(500));
 
-    let alice_files = find_md_files(&tmp.path().join("alice"));
-    let bob_files = find_md_files(&tmp.path().join("bob"));
+    let alice_files = find_md_files(&inbox(tmp.path(), "alice"));
+    let bob_files = find_md_files(&inbox(tmp.path(), "bob"));
     assert_eq!(alice_files.len(), 1, "Expected 1 email in alice mailbox");
     assert_eq!(bob_files.len(), 1, "Expected 1 email in bob (BCC) mailbox");
 
@@ -1788,9 +1830,9 @@ fn serve_e2e_to_cc_bcc_combined() {
     );
     std::thread::sleep(std::time::Duration::from_millis(500));
 
-    let alice_files = find_md_files(&tmp.path().join("alice"));
-    let bob_files = find_md_files(&tmp.path().join("bob"));
-    let catchall_files = find_md_files(&tmp.path().join("catchall"));
+    let alice_files = find_md_files(&inbox(tmp.path(), "alice"));
+    let bob_files = find_md_files(&inbox(tmp.path(), "bob"));
+    let catchall_files = find_md_files(&inbox(tmp.path(), "catchall"));
     assert_eq!(alice_files.len(), 1, "Expected 1 email in alice (To)");
     assert_eq!(bob_files.len(), 1, "Expected 1 email in bob (CC)");
     assert_eq!(


### PR DESCRIPTION
## Summary

Sprint 36 ships the final v0.2 on-disk layout: inbound mail under
`<data_dir>/inbox/<mailbox>/`, sent copies under
`<data_dir>/sent/<mailbox>/`, deterministic
`YYYY-MM-DD-HHMMSS-<slug>.md` UTC filenames, and Zola-style attachment
bundles. Mailbox lifecycle (`create`/`list`/`delete`) now manages both
inbox and sent directories together. MCP `email_*` tools gain an
optional `folder` parameter so agents can read the sent side.

## Stories

* **S36-1: Slug algorithm + filename helper** — new `src/slug.rs` with
  pure `slugify()` (FR-13b: lowercase → non-alphanumerics to `-` →
  collapse → trim → 20-char cap → `no-subject` fallback) and
  `allocate_filename()` that picks the final on-disk path (flat vs
  bundle) and resolves collisions with `-2`, `-3`, … suffixes. 12
  unit tests cover ASCII, Unicode, all-punctuation, truncation,
  collapsing, retrim, numeric preservation, exact UTC timestamp
  formatting, and every collision flavour.
* **S36-2: Ingest rewrite** — `ingest.rs` now writes to
  `<data_dir>/inbox/<mailbox>/`, calls `allocate_filename`, and
  produces flat `<stem>.md` for zero-attachment emails or a bundle
  `<stem>/<stem>.md` plus sibling attachments otherwise. The legacy
  per-mailbox `attachments/` directory is gone; per-attachment `path`
  is now bundle-relative. Channel rules see the inner `.md` in
  `{filepath}`.
* **S36-3: Mailbox lifecycle** — `mailbox_create` provisions both
  inbox and sent directories atomically (cleanup on second-create
  failure); `mailbox_delete` removes both; `catchall` cannot be
  deleted (error mentions `catchall`). MCP `email_list`,
  `email_read`, `email_mark_read`, `email_mark_unread` gain an
  optional `folder: "inbox" | "sent"` parameter (default `"inbox"`),
  with a clean error for unknown values. `email_send` and
  `email_reply` are unaffected.

## Test plan

- [x] `cargo fmt -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo test` — 527 unit tests + 51 integration tests, all
  passing (including `channel_recipe_end_to_end_with_templated_args`,
  the Sprint 31 channel-recipe smoke test, updated for the new
  filename shape)
- [x] Bundle layout exercised end-to-end via the existing
  `serve_e2e_*_attachment*` integration tests (no attachments → flat
  `.md`; attachments → bundle directory with siblings)
- [x] MCP `folder` parameter exercised by new unit tests for
  `set_read_status` against both inbox and sent dirs, plus
  `resolve_folder` validation tests

## Documentation

- `book/mailboxes.md` — layout diagram, bundle vs flat explanation,
  inbox/sent semantics, slug-based ID format
- `book/channels.md` — `{filepath}` example updated; bundle path
  behaviour explained
- `book/mcp.md` — every affected tool documents the new optional
  `folder` parameter
- `CLAUDE.md` — updated "Config and storage" section

## Recommended commit message

```
[Sprint 36] Datadir Reshape — Inbox/Sent Split + Slug + Bundles

Reshape the on-disk storage layout to match v0.2 (FR-13b, FR-14, FR-15):

* Inbound mail now lives under `<data_dir>/inbox/<mailbox>/`; outbound
  copies will land under `<data_dir>/sent/<mailbox>/` (Sprint 38). The
  per-day `YYYY-MM-DD-NNN.md` counter is replaced with deterministic
  `YYYY-MM-DD-HHMMSS-<slug>.md` UTC filenames.
* Add `src/slug.rs` with `slugify` (lowercase → non-alphanumerics to `-`
  → collapse → trim → 20-char cap → `no-subject` fallback) and
  `allocate_filename` (chooses flat `<stem>.md` vs Zola-style bundle
  `<stem>/<stem>.md`, suffixes `-2`/`-3`/… on collision).
* Zero attachments → flat `.md`; one or more → bundle directory with
  attachments as siblings. The mailbox-level `attachments/` subdir is
  removed entirely; per-attachment `path` is now bundle-relative.
* `mailbox create` provisions both `inbox/<name>/` and `sent/<name>/`
  atomically (cleanup on second-create failure); `mailbox delete`
  removes both. `catchall` cannot be deleted.
* MCP tools `email_list`, `email_read`, `email_mark_read`, and
  `email_mark_unread` gain an optional `folder: "inbox" | "sent"`
  parameter (default `"inbox"`); invalid values return a clean error.
* `email_list`, `set_read_status`, status recent-activity, and the
  mailbox count helpers all walk both flat `.md` files and bundle
  directories (`<stem>/<stem>.md`).
* Channel rules' `{filepath}` now expands to the `.md` inside the
  bundle when attachments are present.
* Update `book/mailboxes.md`, `book/channels.md`, `book/mcp.md`, and
  `CLAUDE.md` for the new layout, slug filename format, and folder
  parameter.
```