### PR TITLE
[Sprint 37] Expanded Frontmatter Schema + DMARC Verification

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -60,6 +60,7 @@ dependencies = [
  "mail-parser",
  "mime_guess",
  "predicates",
+ "psl",
  "rcgen",
  "rmcp",
  "rsa",
@@ -1739,6 +1740,21 @@ checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
+
+[[package]]
+name = "psl"
+version = "2.1.203"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c0777260d32b76a8c3c197646707085d37e79d63b5872a29192c8d4f60f50b"
+dependencies = [
+ "psl-types",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "quick-xml"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,8 @@ rustls-pki-types = { version = "1", features = ["alloc"] }
 lettre = { version = "0.11", default-features = false, features = ["smtp-transport", "tokio1", "tokio1-rustls-tls"] }
 hickory-resolver = "0.25"
 include_dir = "0.7"
+sha2 = "0.10"
+psl = "2"
 
 [dev-dependencies]
 tempfile = "3"

--- a/book/configuration.md
+++ b/book/configuration.md
@@ -58,6 +58,28 @@ Mailboxes are defined under `[mailboxes.<name>]`:
 
 See [Mailboxes](mailboxes.md) for mailbox management and [Channel Rules](channels.md) for trigger configuration.
 
+### Inbound email verification
+
+AIMX verifies three authentication mechanisms on every inbound email and records the results in the email's TOML frontmatter:
+
+| Field | Values | Description |
+|-------|--------|-------------|
+| `dkim` | `pass`, `fail`, `none` | DKIM signature verification result. `none` when no DKIM signature is present. |
+| `spf` | `pass`, `fail`, `none` | SPF record check against the sending server's IP. `none` when no SPF record exists or no IP could be extracted. |
+| `dmarc` | `pass`, `fail`, `none` | DMARC alignment check combining DKIM and SPF results against the sender's published DMARC policy. `none` when no DMARC record is published or the check could not be performed. |
+
+All three fields are always written (never omitted), so agents can reliably check authentication status without guessing whether a missing field means "not checked" or "failed."
+
+The `trusted` frontmatter field summarizes the per-mailbox trust evaluation:
+
+| Value | Meaning |
+|-------|---------|
+| `"none"` | Mailbox `trust` is `none` (default) -- no trust evaluation performed. |
+| `"true"` | Mailbox `trust` is `verified`, sender matches `trusted_senders`, AND DKIM passed. |
+| `"false"` | Mailbox `trust` is `verified`, any other outcome. |
+
+Trust only gates channel trigger execution -- all email is stored regardless of the `trusted` result.
+
 ### Channel rule settings
 
 Channel rules are defined as `[[mailboxes.<name>.on_receive]]` arrays:
@@ -80,17 +102,21 @@ See [Channel Rules](channels.md) for full details on triggers, match filters, an
     └── public.key           # RSA public key (mode 0644)
 
 /run/aimx/                   # Runtime directory (mode 0755, root:root)
-└── send.sock                # (Sprint 34) world-writable UDS for aimx send
+└── send.sock                # World-writable UDS for aimx send
 
 /var/lib/aimx/               # Mailbox storage
-├── catchall/                # Default mailbox
-│   ├── 2025-01-15-001.md
-│   ├── 2025-01-15-002.md
-│   └── attachments/
-│       └── document.pdf
-└── support/                 # Named mailbox
-    ├── 2025-01-15-001.md
-    └── attachments/
+├── inbox/
+│   ├── catchall/            # Default mailbox
+│   │   ├── 2025-04-15-143022-hello.md
+│   │   └── 2025-04-15-153300-invoice-march/   # Attachment bundle
+│   │       ├── 2025-04-15-153300-invoice-march.md
+│   │       ├── invoice.pdf
+│   │       └── receipt.png
+│   └── support/             # Named mailbox
+│       └── ...
+└── sent/
+    └── support/             # Outbound sent copies
+        └── ...
 ```
 
 ## IPv6 delivery (advanced)

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,5 +1,5 @@
 use crate::config::{MailboxConfig, MatchFilter, OnReceiveRule};
-use crate::ingest::EmailMetadata;
+use crate::frontmatter::InboundFrontmatter;
 use shell_escape::escape;
 use std::borrow::Cow;
 use std::path::Path;
@@ -7,7 +7,7 @@ use std::process::Command;
 
 pub struct TriggerContext<'a> {
     pub filepath: &'a Path,
-    pub metadata: &'a EmailMetadata,
+    pub metadata: &'a InboundFrontmatter,
 }
 
 fn shell_escape_value(val: &str) -> String {
@@ -28,7 +28,7 @@ pub fn substitute_template(command: &str, ctx: &TriggerContext) -> String {
         .replace("{date}", &shell_escape_value(&ctx.metadata.date))
 }
 
-pub fn matches_filter(filter: &MatchFilter, metadata: &EmailMetadata) -> bool {
+pub fn matches_filter(filter: &MatchFilter, metadata: &InboundFrontmatter) -> bool {
     if let Some(ref from_pattern) = filter.from {
         let from_addr = extract_email_for_match(&metadata.from);
         if !glob_match::glob_match(from_pattern, &from_addr) {
@@ -64,7 +64,7 @@ fn extract_email_for_match(from: &str) -> String {
     from.to_lowercase()
 }
 
-pub fn should_fire(rule: &OnReceiveRule, metadata: &EmailMetadata) -> bool {
+pub fn should_fire(rule: &OnReceiveRule, metadata: &InboundFrontmatter) -> bool {
     if rule.rule_type != "cmd" {
         return false;
     }
@@ -84,7 +84,10 @@ pub fn is_sender_trusted(mailbox_config: &MailboxConfig, from: &str) -> bool {
     false
 }
 
-pub fn should_execute_triggers(mailbox_config: &MailboxConfig, metadata: &EmailMetadata) -> bool {
+pub fn should_execute_triggers(
+    mailbox_config: &MailboxConfig,
+    metadata: &InboundFrontmatter,
+) -> bool {
     if mailbox_config.trust == "none" {
         return true;
     }
@@ -137,28 +140,40 @@ pub fn execute_triggers(mailbox_config: &MailboxConfig, ctx: &TriggerContext) {
 mod tests {
     use super::*;
     use crate::config::{MatchFilter, OnReceiveRule};
-    use crate::ingest::{AttachmentMeta, EmailMetadata};
+    use crate::frontmatter::{AttachmentMeta, InboundFrontmatter};
     use std::path::PathBuf;
 
-    fn sample_metadata() -> EmailMetadata {
-        EmailMetadata {
+    fn sample_metadata() -> InboundFrontmatter {
+        InboundFrontmatter {
             id: "2025-06-01-001".to_string(),
             message_id: "<test@example.com>".to_string(),
+            thread_id: "0123456789abcdef".to_string(),
             from: "alice@gmail.com".to_string(),
             to: "agent@test.com".to_string(),
+            cc: None,
+            reply_to: None,
+            delivered_to: "agent@test.com".to_string(),
             subject: "Hello World".to_string(),
             date: "2025-06-01T12:00:00Z".to_string(),
-            in_reply_to: "".to_string(),
-            references: "".to_string(),
+            received_at: "2025-06-01T12:00:01Z".to_string(),
+            received_from_ip: None,
+            size_bytes: 100,
+            in_reply_to: None,
+            references: None,
             attachments: vec![],
-            mailbox: "catchall".to_string(),
-            read: false,
+            list_id: None,
+            auto_submitted: None,
             dkim: "none".to_string(),
             spf: "none".to_string(),
+            dmarc: "none".to_string(),
+            trusted: "none".to_string(),
+            mailbox: "catchall".to_string(),
+            read: false,
+            labels: vec![],
         }
     }
 
-    fn sample_ctx<'a>(filepath: &'a Path, metadata: &'a EmailMetadata) -> TriggerContext<'a> {
+    fn sample_ctx<'a>(filepath: &'a Path, metadata: &'a InboundFrontmatter) -> TriggerContext<'a> {
         TriggerContext { filepath, metadata }
     }
 

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -1,0 +1,569 @@
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InboundFrontmatter {
+    // -- Identity --
+    pub id: String,
+    pub message_id: String,
+    #[serde(default)]
+    pub thread_id: String,
+
+    // -- Parties --
+    pub from: String,
+    pub to: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cc: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reply_to: Option<String>,
+    #[serde(default)]
+    pub delivered_to: String,
+
+    // -- Content --
+    pub subject: String,
+    pub date: String,
+    #[serde(default)]
+    pub received_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub received_from_ip: Option<String>,
+    #[serde(default)]
+    pub size_bytes: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachments: Vec<AttachmentMeta>,
+
+    // -- Threading --
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub in_reply_to: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub references: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub list_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_submitted: Option<String>,
+
+    // -- Auth --
+    #[serde(default = "default_auth_result")]
+    pub dkim: String,
+    #[serde(default = "default_auth_result")]
+    pub spf: String,
+    #[serde(default = "default_auth_result")]
+    pub dmarc: String,
+    #[serde(default = "default_auth_result")]
+    pub trusted: String,
+
+    // -- Storage --
+    pub mailbox: String,
+    pub read: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttachmentMeta {
+    pub filename: String,
+    pub content_type: String,
+    pub size: usize,
+    pub path: String,
+}
+
+fn default_auth_result() -> String {
+    "none".to_string()
+}
+
+pub struct AuthResults {
+    pub dkim: String,
+    pub spf: String,
+    pub dmarc: String,
+}
+
+impl Default for AuthResults {
+    fn default() -> Self {
+        Self {
+            dkim: "none".to_string(),
+            spf: "none".to_string(),
+            dmarc: "none".to_string(),
+        }
+    }
+}
+
+/// Compute a deterministic thread ID from email threading headers.
+///
+/// Resolution order:
+/// 1. Walk `In-Reply-To` — use the first Message-ID found.
+/// 2. Walk `References` — use the earliest (leftmost) Message-ID.
+/// 3. Fall back to the message's own `Message-ID`.
+///
+/// The resolved root Message-ID is SHA-256 hashed and truncated to 16 hex chars.
+pub fn compute_thread_id(
+    message_id: &str,
+    in_reply_to: Option<&str>,
+    references: Option<&str>,
+) -> String {
+    let root = resolve_thread_root(message_id, in_reply_to, references);
+    let mut hasher = Sha256::new();
+    hasher.update(root.as_bytes());
+    let hash = hasher.finalize();
+    hex::encode(&hash[..8])
+}
+
+fn resolve_thread_root(
+    message_id: &str,
+    in_reply_to: Option<&str>,
+    references: Option<&str>,
+) -> String {
+    if let Some(irt) = in_reply_to {
+        let extracted = extract_first_message_id(irt);
+        if !extracted.is_empty() {
+            return extracted;
+        }
+    }
+
+    if let Some(refs) = references {
+        let extracted = extract_first_message_id(refs);
+        if !extracted.is_empty() {
+            return extracted;
+        }
+    }
+
+    let own = extract_first_message_id(message_id);
+    if own.is_empty() {
+        message_id.to_string()
+    } else {
+        own
+    }
+}
+
+fn extract_first_message_id(header_value: &str) -> String {
+    let trimmed = header_value.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+
+    // Message-IDs are angle-bracket-delimited: <id@domain>
+    if let Some(start) = trimmed.find('<')
+        && let Some(end) = trimmed[start..].find('>')
+    {
+        let id = &trimmed[start..start + end + 1];
+        if !id.is_empty() {
+            return id.to_string();
+        }
+    }
+
+    // Bare Message-ID without angle brackets
+    trimmed.to_string()
+}
+
+fn hex_encode(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02x}")).collect()
+}
+
+mod hex {
+    pub fn encode(bytes: &[u8]) -> String {
+        super::hex_encode(bytes)
+    }
+}
+
+pub fn format_frontmatter(meta: &InboundFrontmatter, body: &str) -> String {
+    let toml_str = toml::to_string(meta).expect("InboundFrontmatter must serialize to TOML");
+    let mut result = String::new();
+    result.push_str("+++\n");
+    result.push_str(&toml_str);
+    result.push_str("+++\n\n");
+    result.push_str(body);
+
+    if !body.ends_with('\n') {
+        result.push('\n');
+    }
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn sample_frontmatter() -> InboundFrontmatter {
+        InboundFrontmatter {
+            id: "2025-01-01-120000-hello".to_string(),
+            message_id: "<abc123@example.com>".to_string(),
+            thread_id: "a1b2c3d4e5f6a7b8".to_string(),
+            from: "sender@example.com".to_string(),
+            to: "alice@test.com".to_string(),
+            cc: None,
+            reply_to: None,
+            delivered_to: "alice@test.com".to_string(),
+            subject: "Hello".to_string(),
+            date: "2025-01-01T12:00:00Z".to_string(),
+            received_at: "2025-01-01T12:00:01Z".to_string(),
+            received_from_ip: Some("203.0.113.1".to_string()),
+            size_bytes: 256,
+            attachments: vec![],
+            in_reply_to: None,
+            references: None,
+            list_id: None,
+            auto_submitted: None,
+            dkim: "none".to_string(),
+            spf: "none".to_string(),
+            dmarc: "none".to_string(),
+            trusted: "none".to_string(),
+            mailbox: "alice".to_string(),
+            read: false,
+            labels: vec![],
+        }
+    }
+
+    #[test]
+    fn field_order_matches_spec() {
+        let fm = sample_frontmatter();
+        let toml_str = toml::to_string(&fm).unwrap();
+        let lines: Vec<&str> = toml_str.lines().collect();
+
+        // Verify field ordering: Identity -> Parties -> Content -> Threading -> Auth -> Storage
+        let field_positions: Vec<(&str, usize)> = lines
+            .iter()
+            .enumerate()
+            .filter_map(|(i, line)| {
+                let key = line.split('=').next()?.trim();
+                if key.starts_with('[') || key.is_empty() {
+                    None
+                } else {
+                    Some((key, i))
+                }
+            })
+            .collect();
+
+        let field_names: Vec<&str> = field_positions.iter().map(|(name, _)| *name).collect();
+
+        // Identity section
+        assert!(
+            field_names.iter().position(|&f| f == "id").unwrap()
+                < field_names.iter().position(|&f| f == "message_id").unwrap()
+        );
+        assert!(
+            field_names.iter().position(|&f| f == "message_id").unwrap()
+                < field_names.iter().position(|&f| f == "thread_id").unwrap()
+        );
+
+        // Parties section comes after Identity
+        assert!(
+            field_names.iter().position(|&f| f == "thread_id").unwrap()
+                < field_names.iter().position(|&f| f == "from").unwrap()
+        );
+        assert!(
+            field_names.iter().position(|&f| f == "from").unwrap()
+                < field_names.iter().position(|&f| f == "to").unwrap()
+        );
+        assert!(
+            field_names.iter().position(|&f| f == "to").unwrap()
+                < field_names
+                    .iter()
+                    .position(|&f| f == "delivered_to")
+                    .unwrap()
+        );
+
+        // Content section comes after Parties
+        assert!(
+            field_names
+                .iter()
+                .position(|&f| f == "delivered_to")
+                .unwrap()
+                < field_names.iter().position(|&f| f == "subject").unwrap()
+        );
+        assert!(
+            field_names.iter().position(|&f| f == "subject").unwrap()
+                < field_names.iter().position(|&f| f == "date").unwrap()
+        );
+
+        // Auth section
+        assert!(
+            field_names.iter().position(|&f| f == "dkim").unwrap()
+                < field_names.iter().position(|&f| f == "spf").unwrap()
+        );
+        assert!(
+            field_names.iter().position(|&f| f == "spf").unwrap()
+                < field_names.iter().position(|&f| f == "dmarc").unwrap()
+        );
+        assert!(
+            field_names.iter().position(|&f| f == "dmarc").unwrap()
+                < field_names.iter().position(|&f| f == "trusted").unwrap()
+        );
+
+        // Storage section comes after Auth
+        assert!(
+            field_names.iter().position(|&f| f == "trusted").unwrap()
+                < field_names.iter().position(|&f| f == "mailbox").unwrap()
+        );
+        assert!(
+            field_names.iter().position(|&f| f == "mailbox").unwrap()
+                < field_names.iter().position(|&f| f == "read").unwrap()
+        );
+    }
+
+    #[test]
+    fn optional_fields_omitted_when_none() {
+        let fm = sample_frontmatter();
+        let toml_str = toml::to_string(&fm).unwrap();
+        assert!(!toml_str.contains("cc ="));
+        assert!(!toml_str.contains("reply_to ="));
+        assert!(!toml_str.contains("in_reply_to ="));
+        assert!(!toml_str.contains("references ="));
+        assert!(!toml_str.contains("list_id ="));
+        assert!(!toml_str.contains("auto_submitted ="));
+    }
+
+    #[test]
+    fn empty_vecs_omitted() {
+        let fm = sample_frontmatter();
+        let toml_str = toml::to_string(&fm).unwrap();
+        assert!(!toml_str.contains("attachments"));
+        assert!(!toml_str.contains("labels"));
+    }
+
+    #[test]
+    fn optional_fields_present_when_set() {
+        let mut fm = sample_frontmatter();
+        fm.cc = Some("bob@example.com".to_string());
+        fm.reply_to = Some("reply@example.com".to_string());
+        fm.in_reply_to = Some("<parent@example.com>".to_string());
+        fm.references = Some("<root@example.com> <parent@example.com>".to_string());
+        fm.list_id = Some("<mylist.example.com>".to_string());
+        fm.auto_submitted = Some("auto-generated".to_string());
+
+        let toml_str = toml::to_string(&fm).unwrap();
+        assert!(toml_str.contains("cc ="));
+        assert!(toml_str.contains("reply_to ="));
+        assert!(toml_str.contains("in_reply_to ="));
+        assert!(toml_str.contains("references ="));
+        assert!(toml_str.contains("list_id ="));
+        assert!(toml_str.contains("auto_submitted ="));
+    }
+
+    #[test]
+    fn always_written_fields_present_at_defaults() {
+        let fm = sample_frontmatter();
+        let toml_str = toml::to_string(&fm).unwrap();
+        assert!(toml_str.contains("dkim = \"none\""));
+        assert!(toml_str.contains("spf = \"none\""));
+        assert!(toml_str.contains("dmarc = \"none\""));
+        assert!(toml_str.contains("trusted = \"none\""));
+        assert!(toml_str.contains("read = false"));
+    }
+
+    #[test]
+    fn trusted_placeholder_always_none() {
+        let fm = sample_frontmatter();
+        assert_eq!(fm.trusted, "none");
+        let toml_str = toml::to_string(&fm).unwrap();
+        assert!(toml_str.contains("trusted = \"none\""));
+    }
+
+    #[test]
+    fn format_frontmatter_wraps_with_delimiters() {
+        let fm = sample_frontmatter();
+        let output = format_frontmatter(&fm, "Hello world");
+        assert!(output.starts_with("+++\n"));
+        assert!(output.contains("+++\n\nHello world\n"));
+        let parts: Vec<&str> = output.splitn(3, "+++").collect();
+        assert_eq!(parts.len(), 3);
+    }
+
+    #[test]
+    fn serialized_frontmatter_is_valid_toml() {
+        let fm = sample_frontmatter();
+        let toml_str = toml::to_string(&fm).unwrap();
+        let parsed: toml::Value = toml::from_str(&toml_str).unwrap();
+        let table = parsed.as_table().unwrap();
+        assert!(table.contains_key("id"));
+        assert!(table.contains_key("message_id"));
+        assert!(table.contains_key("thread_id"));
+        assert!(table.contains_key("from"));
+        assert!(table.contains_key("to"));
+        assert!(table.contains_key("delivered_to"));
+        assert!(table.contains_key("subject"));
+        assert!(table.contains_key("date"));
+        assert!(table.contains_key("received_at"));
+        assert!(table.contains_key("size_bytes"));
+        assert!(table.contains_key("dkim"));
+        assert!(table.contains_key("spf"));
+        assert!(table.contains_key("dmarc"));
+        assert!(table.contains_key("trusted"));
+        assert!(table.contains_key("mailbox"));
+        assert!(table.contains_key("read"));
+    }
+
+    #[test]
+    fn attachments_vec_serialized_when_non_empty() {
+        let mut fm = sample_frontmatter();
+        fm.attachments = vec![AttachmentMeta {
+            filename: "file.txt".to_string(),
+            content_type: "text/plain".to_string(),
+            size: 42,
+            path: "file.txt".to_string(),
+        }];
+        let toml_str = toml::to_string(&fm).unwrap();
+        assert!(toml_str.contains("[[attachments]]"));
+        assert!(toml_str.contains("filename = \"file.txt\""));
+    }
+
+    #[test]
+    fn compute_thread_id_orphan_message() {
+        let tid = compute_thread_id("<abc@example.com>", None, None);
+        assert_eq!(tid.len(), 16);
+        // Deterministic: same input always yields same output
+        let tid2 = compute_thread_id("<abc@example.com>", None, None);
+        assert_eq!(tid, tid2);
+    }
+
+    #[test]
+    fn compute_thread_id_direct_reply() {
+        let tid = compute_thread_id("<reply@example.com>", Some("<parent@example.com>"), None);
+        // Should hash the In-Reply-To parent, not the current message
+        let parent_tid = compute_thread_id("<parent@example.com>", None, None);
+        assert_eq!(tid, parent_tid);
+    }
+
+    #[test]
+    fn compute_thread_id_uses_references_earliest() {
+        let tid = compute_thread_id(
+            "<msg3@example.com>",
+            None,
+            Some("<root@example.com> <msg2@example.com>"),
+        );
+        // Should hash the earliest reference (root)
+        let root_tid = compute_thread_id("<root@example.com>", None, None);
+        assert_eq!(tid, root_tid);
+    }
+
+    #[test]
+    fn compute_thread_id_in_reply_to_takes_precedence() {
+        let tid = compute_thread_id(
+            "<msg3@example.com>",
+            Some("<irt@example.com>"),
+            Some("<ref-root@example.com> <ref2@example.com>"),
+        );
+        // In-Reply-To takes precedence over References
+        let irt_tid = compute_thread_id("<irt@example.com>", None, None);
+        assert_eq!(tid, irt_tid);
+    }
+
+    #[test]
+    fn compute_thread_id_missing_headers() {
+        let tid = compute_thread_id("bare-id", None, None);
+        assert_eq!(tid.len(), 16);
+    }
+
+    #[test]
+    fn compute_thread_id_empty_in_reply_to_falls_through() {
+        let tid = compute_thread_id("<own@example.com>", Some(""), Some("<ref@example.com>"));
+        let ref_tid = compute_thread_id("<ref@example.com>", None, None);
+        assert_eq!(tid, ref_tid);
+    }
+
+    #[test]
+    fn compute_thread_id_multiple_message_ids_in_references() {
+        let tid1 = compute_thread_id(
+            "<msg@example.com>",
+            None,
+            Some("<first@example.com> <second@example.com> <third@example.com>"),
+        );
+        let tid2 = compute_thread_id("<first@example.com>", None, None);
+        assert_eq!(tid1, tid2);
+    }
+
+    #[test]
+    fn extract_first_message_id_angle_brackets() {
+        assert_eq!(
+            extract_first_message_id("<abc@example.com>"),
+            "<abc@example.com>"
+        );
+    }
+
+    #[test]
+    fn extract_first_message_id_multiple() {
+        assert_eq!(
+            extract_first_message_id("<first@ex.com> <second@ex.com>"),
+            "<first@ex.com>"
+        );
+    }
+
+    #[test]
+    fn extract_first_message_id_empty() {
+        assert_eq!(extract_first_message_id(""), "");
+    }
+
+    #[test]
+    fn extract_first_message_id_bare() {
+        assert_eq!(
+            extract_first_message_id("bare-id@example.com"),
+            "bare-id@example.com"
+        );
+    }
+
+    #[test]
+    fn golden_frontmatter_output() {
+        let fm = sample_frontmatter();
+        let output = format_frontmatter(&fm, "Test body content.");
+        // Verify exact structure
+        assert!(output.starts_with("+++\n"));
+        assert!(output.contains("\n+++\n\n"));
+        assert!(output.ends_with("Test body content.\n"));
+
+        // Parse back to validate roundtrip
+        let parts: Vec<&str> = output.splitn(3, "+++").collect();
+        let toml_str = parts[1].trim();
+        let parsed: InboundFrontmatter = toml::from_str(toml_str).unwrap();
+        assert_eq!(parsed.id, fm.id);
+        assert_eq!(parsed.thread_id, fm.thread_id);
+        assert_eq!(parsed.dmarc, "none");
+        assert_eq!(parsed.trusted, "none");
+    }
+
+    #[test]
+    fn field_order_regression_golden() {
+        let fm = sample_frontmatter();
+        let toml_str = toml::to_string(&fm).unwrap();
+
+        // Capture the expected field order by parsing keys in order
+        let expected_keys = vec![
+            "id",
+            "message_id",
+            "thread_id",
+            "from",
+            "to",
+            "delivered_to",
+            "subject",
+            "date",
+            "received_at",
+            "received_from_ip",
+            "size_bytes",
+            "dkim",
+            "spf",
+            "dmarc",
+            "trusted",
+            "mailbox",
+            "read",
+        ];
+
+        let actual_keys: Vec<&str> = toml_str
+            .lines()
+            .filter_map(|line| {
+                let key = line.split('=').next()?.trim();
+                if key.starts_with('[') || key.is_empty() {
+                    None
+                } else {
+                    Some(key)
+                }
+            })
+            .collect();
+
+        assert_eq!(actual_keys, expected_keys);
+    }
+
+    #[test]
+    fn received_from_ip_omitted_when_none() {
+        let mut fm = sample_frontmatter();
+        fm.received_from_ip = None;
+        let toml_str = toml::to_string(&fm).unwrap();
+        assert!(!toml_str.contains("received_from_ip"));
+    }
+}

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -100,10 +100,17 @@ pub fn compute_thread_id(
     references: Option<&str>,
 ) -> String {
     let root = resolve_thread_root(message_id, in_reply_to, references);
+    let normalized = strip_angle_brackets(&root);
     let mut hasher = Sha256::new();
-    hasher.update(root.as_bytes());
+    hasher.update(normalized.as_bytes());
     let hash = hasher.finalize();
-    hex::encode(&hash[..8])
+    hex_encode(&hash[..8])
+}
+
+fn strip_angle_brackets(s: &str) -> &str {
+    s.strip_prefix('<')
+        .and_then(|s| s.strip_suffix('>'))
+        .unwrap_or(s)
 }
 
 fn resolve_thread_root(
@@ -155,12 +162,6 @@ fn extract_first_message_id(header_value: &str) -> String {
 
 fn hex_encode(bytes: &[u8]) -> String {
     bytes.iter().map(|b| format!("{b:02x}")).collect()
-}
-
-mod hex {
-    pub fn encode(bytes: &[u8]) -> String {
-        super::hex_encode(bytes)
-    }
 }
 
 pub fn format_frontmatter(meta: &InboundFrontmatter, body: &str) -> String {

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -146,7 +146,7 @@ pub fn ingest_email(
     let prepared_attachments = prepare_attachments(&message);
     let has_attachments = !prepared_attachments.is_empty();
 
-    let auth_results = verify_auth(raw, rcpt);
+    let auth_results = verify_auth(raw);
 
     let received_at = chrono::Utc::now().to_rfc3339();
     let size_bytes = raw.len();
@@ -253,7 +253,7 @@ fn create_resolver() -> Option<mail_auth::MessageAuthenticator> {
         .ok()
 }
 
-fn verify_auth(raw: &[u8], rcpt: &str) -> AuthResults {
+fn verify_auth(raw: &[u8]) -> AuthResults {
     let rt = match tokio::runtime::Runtime::new() {
         Ok(rt) => rt,
         Err(_) => return AuthResults::default(),
@@ -267,15 +267,15 @@ fn verify_auth(raw: &[u8], rcpt: &str) -> AuthResults {
     rt.block_on(async {
         let auth_msg = mail_auth::AuthenticatedMessage::parse(raw);
 
-        let dkim_result = verify_dkim_async(raw, &resolver).await;
-        let spf_result = verify_spf_async(raw, rcpt, &resolver).await;
-
         let dkim_output = match &auth_msg {
             Some(msg) => resolver.verify_dkim(msg).await,
             None => vec![],
         };
 
-        let spf_output = build_spf_output(raw, rcpt, &resolver).await;
+        let dkim_result = dkim_output_to_string(&dkim_output, auth_msg.is_some());
+
+        let spf_result = verify_spf_async(raw, &resolver).await;
+        let spf_output = build_spf_output(raw, &resolver).await;
 
         let dmarc_result = match &auth_msg {
             Some(msg) => verify_dmarc_async(msg, &dkim_output, &spf_output, raw, &resolver).await,
@@ -290,9 +290,26 @@ fn verify_auth(raw: &[u8], rcpt: &str) -> AuthResults {
     })
 }
 
+fn dkim_output_to_string(results: &[mail_auth::DkimOutput<'_>], parsed: bool) -> String {
+    if !parsed {
+        return "none".to_string();
+    }
+
+    if results.is_empty() {
+        return "none".to_string();
+    }
+
+    for output in results {
+        if matches!(output.result(), mail_auth::DkimResult::Pass) {
+            return "pass".to_string();
+        }
+    }
+
+    "fail".to_string()
+}
+
 async fn build_spf_output(
     raw: &[u8],
-    _rcpt: &str,
     resolver: &mail_auth::MessageAuthenticator,
 ) -> mail_auth::SpfOutput {
     let ip = match extract_received_ip(raw) {
@@ -350,31 +367,6 @@ async fn verify_dmarc_async(
     }
 }
 
-async fn verify_dkim_async(raw: &[u8], resolver: &mail_auth::MessageAuthenticator) -> String {
-    let auth_msg = match mail_auth::AuthenticatedMessage::parse(raw) {
-        Some(msg) => msg,
-        None => return "none".to_string(),
-    };
-
-    if auth_msg.dkim_headers.is_empty() {
-        return "none".to_string();
-    }
-
-    let results = resolver.verify_dkim(&auth_msg).await;
-
-    if results.is_empty() {
-        return "none".to_string();
-    }
-
-    for output in &results {
-        if matches!(output.result(), mail_auth::DkimResult::Pass) {
-            return "pass".to_string();
-        }
-    }
-
-    "fail".to_string()
-}
-
 pub fn spf_domain(mail_from: &str) -> Option<&str> {
     let domain = mail_from.split('@').nth(1).unwrap_or("");
     if domain.is_empty() {
@@ -384,11 +376,7 @@ pub fn spf_domain(mail_from: &str) -> Option<&str> {
     }
 }
 
-async fn verify_spf_async(
-    raw: &[u8],
-    _rcpt: &str,
-    resolver: &mail_auth::MessageAuthenticator,
-) -> String {
+async fn verify_spf_async(raw: &[u8], resolver: &mail_auth::MessageAuthenticator) -> String {
     let ip = match extract_received_ip(raw) {
         Some(ip) => ip,
         None => return "none".to_string(),

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -1,8 +1,10 @@
 use crate::channel::{self, TriggerContext};
 use crate::config::Config;
+use crate::frontmatter::{
+    AttachmentMeta, AuthResults, InboundFrontmatter, compute_thread_id, format_frontmatter,
+};
 use crate::slug::{allocate_filename, slugify};
 use mail_parser::{MessageParser, MimeHeaders};
-use serde::Serialize;
 use std::io::Read;
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
@@ -16,47 +18,20 @@ use std::sync::Mutex;
 /// planned for FR-19b.
 static INGEST_WRITE_LOCK: Mutex<()> = Mutex::new(());
 
-#[derive(Debug, Clone, Serialize, serde::Deserialize)]
-pub struct EmailMetadata {
-    pub id: String,
-    pub message_id: String,
-    pub from: String,
-    pub to: String,
-    pub subject: String,
-    pub date: String,
-    pub in_reply_to: String,
-    pub references: String,
-    pub attachments: Vec<AttachmentMeta>,
-    pub mailbox: String,
-    pub read: bool,
-    #[serde(default = "default_auth_result")]
-    pub dkim: String,
-    #[serde(default = "default_auth_result")]
-    pub spf: String,
-}
-
-fn default_auth_result() -> String {
-    "none".to_string()
-}
-
-#[derive(Debug, Clone, Serialize, serde::Deserialize)]
-pub struct AttachmentMeta {
-    pub filename: String,
-    pub content_type: String,
-    pub size: usize,
-    pub path: String,
-}
-
 pub fn run(rcpt: &str, config: Config) -> Result<(), Box<dyn std::error::Error>> {
     let mut raw = Vec::new();
     std::io::stdin().read_to_end(&mut raw)?;
-    ingest_email(&config, rcpt, &raw)
+    // Manual stdin path: no SMTP session, so received_from_ip is the
+    // unspecified sentinel (0.0.0.0).
+    let sentinel_ip: IpAddr = "0.0.0.0".parse().unwrap();
+    ingest_email(&config, rcpt, &raw, sentinel_ip)
 }
 
 pub fn ingest_email(
     config: &Config,
     rcpt: &str,
     raw: &[u8],
+    received_from_ip: IpAddr,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let local_part = extract_local_part(rcpt);
     let mailbox = config.resolve_mailbox(local_part);
@@ -94,6 +69,40 @@ pub fn ingest_email(
         })
         .unwrap_or_default();
 
+    let cc = message.cc().and_then(|addrs| {
+        let parts: Vec<String> = addrs
+            .iter()
+            .filter_map(|a| {
+                a.address().map(|addr| match a.name() {
+                    Some(name) => format!("{name} <{addr}>"),
+                    None => addr.to_string(),
+                })
+            })
+            .collect();
+        if parts.is_empty() {
+            None
+        } else {
+            Some(parts.join(", "))
+        }
+    });
+
+    let reply_to = message.reply_to().and_then(|addrs| {
+        let parts: Vec<String> = addrs
+            .iter()
+            .filter_map(|a| {
+                a.address().map(|addr| match a.name() {
+                    Some(name) => format!("{name} <{addr}>"),
+                    None => addr.to_string(),
+                })
+            })
+            .collect();
+        if parts.is_empty() {
+            None
+        } else {
+            Some(parts.join(", "))
+        }
+    });
+
     let subject = message.subject().unwrap_or("(no subject)").to_string();
 
     let date = message
@@ -103,34 +112,54 @@ pub fn ingest_email(
 
     let message_id = message.message_id().unwrap_or("").to_string();
 
-    let in_reply_to = message
+    let in_reply_to_raw = message
         .in_reply_to()
         .as_text()
         .unwrap_or_default()
         .to_string();
 
-    let references = message
+    let references_raw = message
         .references()
         .as_text()
         .unwrap_or_default()
         .to_string();
 
+    let thread_id = compute_thread_id(
+        &message_id,
+        if in_reply_to_raw.is_empty() {
+            None
+        } else {
+            Some(in_reply_to_raw.as_str())
+        },
+        if references_raw.is_empty() {
+            None
+        } else {
+            Some(references_raw.as_str())
+        },
+    );
+
+    let list_id = extract_header_value(&message, "List-ID");
+    let auto_submitted = extract_header_value(&message, "Auto-Submitted");
+
     let body = extract_body(&message);
 
-    // Collect attachments as in-memory metadata + payload so we can decide
-    // between flat and bundle layouts before committing any file to disk.
     let prepared_attachments = prepare_attachments(&message);
     let has_attachments = !prepared_attachments.is_empty();
 
-    let (dkim_result, spf_result) = verify_auth(raw, rcpt);
+    let auth_results = verify_auth(raw, rcpt);
+
+    let received_at = chrono::Utc::now().to_rfc3339();
+    let size_bytes = raw.len();
+
+    let ip_str = if received_from_ip.is_unspecified() {
+        None
+    } else {
+        Some(received_from_ip.to_string())
+    };
 
     let slug = slugify(&subject);
     let timestamp = chrono::Utc::now();
 
-    // Hold the inbound write lock across allocate → mkdir → write
-    // attachments → write markdown so two ingests racing on the same UTC
-    // second + slug + attachment filenames cannot interleave: the second
-    // arrival sees the first's bundle on disk and picks a `-2` suffix.
     let _guard = INGEST_WRITE_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -141,9 +170,6 @@ pub fn ingest_email(
         .ok_or("allocate_filename returned a rootless path")?
         .to_path_buf();
 
-    // For bundle layouts the parent is `<stem>/`; for flat layouts it is
-    // the mailbox directory itself (already created above). Either way,
-    // `create_dir_all` is idempotent and cheap.
     std::fs::create_dir_all(&parent_dir)?;
 
     let id = md_path
@@ -152,9 +178,6 @@ pub fn ingest_email(
         .unwrap_or_default()
         .to_string();
 
-    // Roll back a freshly created bundle directory on any post-allocation
-    // failure (attachment write or markdown write). For flat layouts the
-    // parent is the mailbox dir itself and stays untouched.
     let cleanup_bundle = || {
         if has_attachments && parent_dir != inbox_dir {
             let _ = std::fs::remove_dir_all(&parent_dir);
@@ -165,20 +188,40 @@ pub fn ingest_email(
         cleanup_bundle();
     })?;
 
-    let meta = EmailMetadata {
+    let meta = InboundFrontmatter {
         id: id.clone(),
         message_id,
+        thread_id,
         from,
         to,
+        cc,
+        reply_to,
+        delivered_to: rcpt.to_string(),
         subject,
         date,
-        in_reply_to,
-        references,
+        received_at,
+        received_from_ip: ip_str,
+        size_bytes,
         attachments,
+        in_reply_to: if in_reply_to_raw.is_empty() {
+            None
+        } else {
+            Some(in_reply_to_raw)
+        },
+        references: if references_raw.is_empty() {
+            None
+        } else {
+            Some(references_raw)
+        },
+        list_id,
+        auto_submitted,
+        dkim: auth_results.dkim,
+        spf: auth_results.spf,
+        dmarc: auth_results.dmarc,
+        trusted: "none".to_string(),
         mailbox: mailbox.clone(),
         read: false,
-        dkim: dkim_result,
-        spf: spf_result,
+        labels: vec![],
     };
 
     write_markdown(&md_path, &meta, &body).inspect_err(|_| {
@@ -198,28 +241,113 @@ pub fn ingest_email(
     Ok(())
 }
 
+fn extract_header_value(message: &mail_parser::Message, name: &str) -> Option<String> {
+    let val = message.header_raw(name)?;
+    let s = val.trim().to_string();
+    if s.is_empty() { None } else { Some(s) }
+}
+
 fn create_resolver() -> Option<mail_auth::MessageAuthenticator> {
     mail_auth::MessageAuthenticator::new_system_conf()
         .or_else(|_| mail_auth::MessageAuthenticator::new_cloudflare())
         .ok()
 }
 
-fn verify_auth(raw: &[u8], rcpt: &str) -> (String, String) {
+fn verify_auth(raw: &[u8], rcpt: &str) -> AuthResults {
     let rt = match tokio::runtime::Runtime::new() {
         Ok(rt) => rt,
-        Err(_) => return ("none".to_string(), "none".to_string()),
+        Err(_) => return AuthResults::default(),
     };
 
     let resolver = match create_resolver() {
         Some(r) => r,
-        None => return ("none".to_string(), "none".to_string()),
+        None => return AuthResults::default(),
     };
 
     rt.block_on(async {
+        let auth_msg = mail_auth::AuthenticatedMessage::parse(raw);
+
         let dkim_result = verify_dkim_async(raw, &resolver).await;
         let spf_result = verify_spf_async(raw, rcpt, &resolver).await;
-        (dkim_result, spf_result)
+
+        let dkim_output = match &auth_msg {
+            Some(msg) => resolver.verify_dkim(msg).await,
+            None => vec![],
+        };
+
+        let spf_output = build_spf_output(raw, rcpt, &resolver).await;
+
+        let dmarc_result = match &auth_msg {
+            Some(msg) => verify_dmarc_async(msg, &dkim_output, &spf_output, raw, &resolver).await,
+            None => "none".to_string(),
+        };
+
+        AuthResults {
+            dkim: dkim_result,
+            spf: spf_result,
+            dmarc: dmarc_result,
+        }
     })
+}
+
+async fn build_spf_output(
+    raw: &[u8],
+    _rcpt: &str,
+    resolver: &mail_auth::MessageAuthenticator,
+) -> mail_auth::SpfOutput {
+    let ip = match extract_received_ip(raw) {
+        Some(ip) => ip,
+        None => return mail_auth::SpfOutput::new(String::new()),
+    };
+
+    let mail_from = extract_mail_from(raw).unwrap_or_default();
+
+    let helo_domain = match spf_domain(&mail_from) {
+        Some(d) => d.to_string(),
+        None => return mail_auth::SpfOutput::new(String::new()),
+    };
+
+    resolver
+        .verify_spf(mail_auth::spf::verify::SpfParameters::verify_mail_from(
+            ip,
+            &helo_domain,
+            &helo_domain,
+            &mail_from,
+        ))
+        .await
+}
+
+async fn verify_dmarc_async(
+    auth_msg: &mail_auth::AuthenticatedMessage<'_>,
+    dkim_output: &[mail_auth::DkimOutput<'_>],
+    spf_output: &mail_auth::SpfOutput,
+    raw: &[u8],
+    resolver: &mail_auth::MessageAuthenticator,
+) -> String {
+    let mail_from = extract_mail_from(raw).unwrap_or_default();
+    let mail_from_domain = spf_domain(&mail_from).unwrap_or("");
+
+    let params = mail_auth::dmarc::verify::DmarcParameters {
+        message: auth_msg,
+        dkim_output,
+        rfc5321_mail_from_domain: mail_from_domain,
+        spf_output,
+        domain_suffix_fn: |d| psl::domain_str(d).unwrap_or(d),
+    };
+
+    let output = resolver.verify_dmarc(params).await;
+
+    if output.dkim_result() == &mail_auth::DmarcResult::Pass {
+        return "pass".to_string();
+    }
+    if output.spf_result() == &mail_auth::DmarcResult::Pass {
+        return "pass".to_string();
+    }
+
+    match (output.dkim_result(), output.spf_result()) {
+        (mail_auth::DmarcResult::None, mail_auth::DmarcResult::None) => "none".to_string(),
+        _ => "fail".to_string(),
+    }
 }
 
 async fn verify_dkim_async(raw: &[u8], resolver: &mail_auth::MessageAuthenticator) -> String {
@@ -383,9 +511,6 @@ fn extract_body(message: &mail_parser::Message) -> String {
     String::new()
 }
 
-/// An attachment extracted from the parsed MIME message but not yet written
-/// to disk. Lives long enough to decide between flat and bundle layouts
-/// before any file I/O happens.
 struct PreparedAttachment {
     filename: String,
     content_type: String,
@@ -401,9 +526,6 @@ fn prepare_attachments(message: &mail_parser::Message) -> Vec<PreparedAttachment
             None => continue,
         };
 
-        // Strip any path components the sender may have smuggled in;
-        // `file_name` on a traversal string like `../../etc/foo` returns
-        // just `foo`.
         let filename = Path::new(&raw_name)
             .file_name()
             .and_then(|f| f.to_str())
@@ -435,11 +557,6 @@ fn prepare_attachments(message: &mail_parser::Message) -> Vec<PreparedAttachment
     result
 }
 
-/// Write each attachment as a sibling of the `.md` file inside the bundle
-/// directory. Duplicate filenames are disambiguated with `-1`, `-2`, …
-/// before the extension. The returned `AttachmentMeta` entries carry the
-/// on-disk filename (without any bundle prefix — each attachment is a
-/// sibling of the `.md`, so the relative path is just the filename).
 fn write_attachments(
     bundle_dir: &Path,
     attachments: Vec<PreparedAttachment>,
@@ -488,35 +605,16 @@ fn deduplicate_filename(dir: &Path, filename: &str) -> String {
 
 fn write_markdown(
     path: &Path,
-    meta: &EmailMetadata,
+    meta: &InboundFrontmatter,
     body: &str,
 ) -> Result<PathBuf, Box<dyn std::error::Error>> {
     use std::fs::OpenOptions;
     use std::io::Write;
 
-    // `allocate_filename` already reserved this path by scanning the
-    // directory, but we still open with `create_new` so two in-flight
-    // ingests racing on the same subject at the same UTC second collide
-    // noisily instead of silently overwriting.
     let mut file = OpenOptions::new().write(true).create_new(true).open(path)?;
-    let content = format_markdown(meta, body);
+    let content = format_frontmatter(meta, body);
     file.write_all(content.as_bytes())?;
     Ok(path.to_path_buf())
-}
-
-fn format_markdown(meta: &EmailMetadata, body: &str) -> String {
-    let toml_str = toml::to_string_pretty(meta).expect("EmailMetadata must serialize to TOML");
-    let mut result = String::new();
-    result.push_str("+++\n");
-    result.push_str(&toml_str);
-    result.push_str("+++\n\n");
-    result.push_str(body);
-
-    if !body.ends_with('\n') {
-        result.push('\n');
-    }
-
-    result
 }
 
 #[cfg(test)]
@@ -554,6 +652,10 @@ mod tests {
             verify_host: None,
             enable_ipv6: false,
         }
+    }
+
+    fn sentinel_ip() -> IpAddr {
+        "0.0.0.0".parse().unwrap()
     }
 
     fn plain_text_eml() -> &'static [u8] {
@@ -644,8 +746,6 @@ mod tests {
           --mixbound2--\r\n"
     }
 
-    /// Walk the inbox mailbox dir and return every `.md` file, descending
-    /// into bundle directories when they exist. Ordering is by filename.
     fn collect_md_files(mailbox_dir: &Path) -> Vec<std::path::PathBuf> {
         let mut result: Vec<std::path::PathBuf> = Vec::new();
         let entries = match std::fs::read_dir(mailbox_dir) {
@@ -655,8 +755,6 @@ mod tests {
         for entry in entries.flatten() {
             let path = entry.path();
             if path.is_dir() {
-                // Bundle directory: expect exactly one sibling `.md` with
-                // the same stem as the directory.
                 if let Some(stem) = path.file_name().and_then(|f| f.to_str()) {
                     let md = path.join(format!("{stem}.md"));
                     if md.exists() {
@@ -675,31 +773,32 @@ mod tests {
         tmp.join("inbox").join(name)
     }
 
+    fn parse_toml_frontmatter(content: &str) -> toml::value::Table {
+        let parts: Vec<&str> = content.splitn(3, "+++").collect();
+        assert!(parts.len() >= 3);
+        let toml_str = parts[1].trim();
+        let parsed: toml::Value = toml::from_str(toml_str).unwrap();
+        parsed.as_table().unwrap().clone()
+    }
+
     #[test]
     fn ingest_plain_text() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
+        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         assert_eq!(entries.len(), 1);
 
         let content = std::fs::read_to_string(&entries[0]).unwrap();
+        let table = parse_toml_frontmatter(&content);
 
-        let parts: Vec<&str> = content.splitn(3, "+++").collect();
-        assert!(parts.len() >= 3);
-        let toml_str = parts[1].trim();
-        let parsed: toml::Value = toml::from_str(toml_str).unwrap();
-        let table = parsed.as_table().unwrap();
-
-        let from_val = table.get("from").unwrap().as_str().unwrap();
-        assert_eq!(from_val, "sender@example.com");
-
-        let subject_val = table.get("subject").unwrap().as_str().unwrap();
-        assert_eq!(subject_val, "Hello");
-
-        let read_val = table.get("read").unwrap();
-        assert_eq!(read_val, &toml::Value::Boolean(false));
+        assert_eq!(
+            table.get("from").unwrap().as_str().unwrap(),
+            "sender@example.com"
+        );
+        assert_eq!(table.get("subject").unwrap().as_str().unwrap(), "Hello");
+        assert_eq!(table.get("read").unwrap(), &toml::Value::Boolean(false));
 
         assert!(content.contains("This is a plain text email."));
     }
@@ -708,9 +807,8 @@ mod tests {
     fn ingest_writes_to_inbox_subdir() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
+        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
 
-        // New Sprint 36 layout: inbox/<mailbox>/ instead of <mailbox>/.
         assert!(tmp.path().join("inbox").join("alice").exists());
         assert!(!tmp.path().join("alice").exists());
     }
@@ -719,7 +817,7 @@ mod tests {
     fn ingest_filename_uses_utc_slug_format() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
+        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         let name = entries[0]
@@ -727,12 +825,10 @@ mod tests {
             .unwrap()
             .to_string_lossy()
             .to_string();
-        // "Hello" subject → "hello" slug.
         assert!(
             name.ends_with("-hello.md"),
             "expected slug-suffixed filename, got {name}"
         );
-        // Matches YYYY-MM-DD-HHMMSS-<slug>.md shape.
         let stem = name.trim_end_matches(".md");
         let parts: Vec<&str> = stem.splitn(5, '-').collect();
         assert_eq!(parts.len(), 5, "expected 5 dash-segments in {stem}");
@@ -746,7 +842,7 @@ mod tests {
     fn ingest_html_only() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", html_only_eml()).unwrap();
+        ingest_email(&config, "alice@test.com", html_only_eml(), sentinel_ip()).unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         let content = std::fs::read_to_string(&entries[0]).unwrap();
@@ -759,7 +855,7 @@ mod tests {
     fn ingest_multipart_prefers_text() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", multipart_eml()).unwrap();
+        ingest_email(&config, "alice@test.com", multipart_eml(), sentinel_ip()).unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         let content = std::fs::read_to_string(&entries[0]).unwrap();
@@ -771,7 +867,7 @@ mod tests {
     fn ingest_routes_unknown_to_catchall() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "unknown@test.com", plain_text_eml()).unwrap();
+        ingest_email(&config, "unknown@test.com", plain_text_eml(), sentinel_ip()).unwrap();
 
         assert!(inbox(tmp.path(), "catchall").exists());
         let entries = collect_md_files(&inbox(tmp.path(), "catchall"));
@@ -782,31 +878,30 @@ mod tests {
     fn frontmatter_valid_toml() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
+        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         let content = std::fs::read_to_string(&entries[0]).unwrap();
-
-        let parts: Vec<&str> = content.splitn(3, "+++").collect();
-        assert!(parts.len() >= 3);
-        let toml_str = parts[1].trim();
-        let parsed: toml::Value = toml::from_str(toml_str).unwrap();
-        let table = parsed.as_table().unwrap();
+        let table = parse_toml_frontmatter(&content);
 
         assert!(table.contains_key("id"));
         assert!(table.contains_key("message_id"));
+        assert!(table.contains_key("thread_id"));
         assert!(table.contains_key("from"));
         assert!(table.contains_key("to"));
+        assert!(table.contains_key("delivered_to"));
         assert!(table.contains_key("subject"));
         assert!(table.contains_key("date"));
-        assert!(table.contains_key("in_reply_to"));
-        assert!(table.contains_key("references"));
-        assert!(table.contains_key("attachments"));
+        assert!(table.contains_key("received_at"));
+        assert!(table.contains_key("size_bytes"));
+        assert!(table.contains_key("dkim"));
+        assert!(table.contains_key("spf"));
+        assert!(table.contains_key("dmarc"));
+        assert!(table.contains_key("trusted"));
         assert!(table.contains_key("mailbox"));
         assert!(table.contains_key("read"));
 
-        let read_val = table.get("read").unwrap();
-        assert_eq!(read_val, &toml::Value::Boolean(false));
+        assert_eq!(table.get("read").unwrap(), &toml::Value::Boolean(false));
     }
 
     #[test]
@@ -814,11 +909,9 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
 
-        ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
-        ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
+        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
+        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
 
-        // Two ingests of the same subject within the same UTC second: the
-        // second must land on a distinct path thanks to the `-2` suffix.
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         assert_eq!(entries.len(), 2, "got entries: {entries:?}");
         assert_ne!(entries[0], entries[1]);
@@ -828,13 +921,11 @@ mod tests {
     fn attachment_creates_bundle_directory() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", attachment_eml()).unwrap();
+        ingest_email(&config, "alice@test.com", attachment_eml(), sentinel_ip()).unwrap();
 
         let alice = inbox(tmp.path(), "alice");
-        // Top-level `attachments/` is GONE (Sprint 36).
         assert!(!alice.join("attachments").exists());
 
-        // Exactly one bundle directory should have been created.
         let bundles: Vec<_> = std::fs::read_dir(&alice)
             .unwrap()
             .filter_map(|e| e.ok())
@@ -844,7 +935,6 @@ mod tests {
         let bundle = bundles[0].path();
         let stem = bundle.file_name().unwrap().to_string_lossy().to_string();
 
-        // The bundle contains <stem>.md AND the attachment as a sibling.
         let md = bundle.join(format!("{stem}.md"));
         assert!(md.exists(), "bundle md {md:?} should exist");
         let att_path = bundle.join("notes.txt");
@@ -854,15 +944,11 @@ mod tests {
         assert!(content.contains("These are my notes."));
 
         let md_content = std::fs::read_to_string(&md).unwrap();
-        let parts: Vec<&str> = md_content.splitn(3, "+++").collect();
-        let toml_str = parts[1].trim();
-        let parsed: toml::Value = toml::from_str(toml_str).unwrap();
-        let table = parsed.as_table().unwrap();
+        let table = parse_toml_frontmatter(&md_content);
         let attachments = table.get("attachments").unwrap().as_array().unwrap();
         assert_eq!(attachments.len(), 1);
         let att = attachments[0].as_table().unwrap();
         assert_eq!(att.get("filename").unwrap().as_str().unwrap(), "notes.txt");
-        // Bundle-relative path has no `attachments/` prefix any more.
         assert_eq!(att.get("path").unwrap().as_str().unwrap(), "notes.txt");
     }
 
@@ -870,7 +956,13 @@ mod tests {
     fn multiple_attachments_in_single_bundle() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", multi_attachment_eml()).unwrap();
+        ingest_email(
+            &config,
+            "alice@test.com",
+            multi_attachment_eml(),
+            sentinel_ip(),
+        )
+        .unwrap();
 
         let alice = inbox(tmp.path(), "alice");
         let bundles: Vec<_> = std::fs::read_dir(&alice)
@@ -886,14 +978,11 @@ mod tests {
 
     #[test]
     fn duplicate_attachment_filenames_are_bundle_scoped() {
-        // Two emails with the same filename land in two distinct bundle
-        // directories, so the attachment names don't collide — no `-1`
-        // suffix needed inside either bundle.
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
 
-        ingest_email(&config, "alice@test.com", attachment_eml()).unwrap();
-        ingest_email(&config, "alice@test.com", attachment_eml()).unwrap();
+        ingest_email(&config, "alice@test.com", attachment_eml(), sentinel_ip()).unwrap();
+        ingest_email(&config, "alice@test.com", attachment_eml(), sentinel_ip()).unwrap();
 
         let alice = inbox(tmp.path(), "alice");
         let bundles: Vec<_> = std::fs::read_dir(&alice)
@@ -912,10 +1001,9 @@ mod tests {
     fn no_attachments_flat_markdown() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
+        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
 
         let alice = inbox(tmp.path(), "alice");
-        // No bundle directory, no legacy attachments dir.
         let dirs: Vec<_> = std::fs::read_dir(&alice)
             .unwrap()
             .filter_map(|e| e.ok())
@@ -925,12 +1013,9 @@ mod tests {
 
         let entries = collect_md_files(&alice);
         let md_content = std::fs::read_to_string(&entries[0]).unwrap();
-        let parts: Vec<&str> = md_content.splitn(3, "+++").collect();
-        let toml_str = parts[1].trim();
-        let parsed: toml::Value = toml::from_str(toml_str).unwrap();
-        let table = parsed.as_table().unwrap();
-        let attachments = table.get("attachments").unwrap().as_array().unwrap();
-        assert!(attachments.is_empty());
+        let table = parse_toml_frontmatter(&md_content);
+        // Empty attachments vec is omitted from TOML output
+        assert!(!table.contains_key("attachments"));
     }
 
     #[test]
@@ -963,10 +1048,8 @@ mod tests {
             malicious content\r\n\
             --evilbound--\r\n";
 
-        ingest_email(&config, "alice@test.com", eml).unwrap();
+        ingest_email(&config, "alice@test.com", eml, sentinel_ip()).unwrap();
 
-        // Path traversal in the attachment filename collapses to `evil`
-        // inside the bundle; nothing escapes the mailbox dir.
         let alice = inbox(tmp.path(), "alice");
         let bundles: Vec<_> = std::fs::read_dir(&alice)
             .unwrap()
@@ -981,23 +1064,35 @@ mod tests {
 
     #[test]
     fn toml_handles_special_characters() {
-        let meta = EmailMetadata {
+        let meta = InboundFrontmatter {
             id: "2025-01-01-001".to_string(),
             message_id: "<test@example.com>".to_string(),
+            thread_id: "0123456789abcdef".to_string(),
             from: "test\n+++\ninjected: true".to_string(),
             to: "to@test.com".to_string(),
+            cc: None,
+            reply_to: None,
+            delivered_to: "to@test.com".to_string(),
             subject: "colons: and #hashes".to_string(),
             date: "2025-01-01T00:00:00Z".to_string(),
-            in_reply_to: "".to_string(),
-            references: "".to_string(),
+            received_at: "2025-01-01T00:00:01Z".to_string(),
+            received_from_ip: None,
+            size_bytes: 100,
+            in_reply_to: None,
+            references: None,
             attachments: vec![],
-            mailbox: "catchall".to_string(),
-            read: false,
+            list_id: None,
+            auto_submitted: None,
             dkim: "none".to_string(),
             spf: "none".to_string(),
+            dmarc: "none".to_string(),
+            trusted: "none".to_string(),
+            mailbox: "catchall".to_string(),
+            read: false,
+            labels: vec![],
         };
 
-        let toml_str = toml::to_string_pretty(&meta).unwrap();
+        let toml_str = toml::to_string(&meta).unwrap();
         let parsed: toml::Value = toml::from_str(&toml_str).unwrap();
         let table = parsed.as_table().unwrap();
         let from = table.get("from").unwrap();
@@ -1005,23 +1100,18 @@ mod tests {
     }
 
     #[test]
-    fn unsigned_email_has_dkim_none_spf_none() {
+    fn unsigned_email_has_dkim_none_spf_none_dmarc_none() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
+        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         let content = std::fs::read_to_string(&entries[0]).unwrap();
-        let parts: Vec<&str> = content.splitn(3, "+++").collect();
-        let toml_str = parts[1].trim();
-        let parsed: toml::Value = toml::from_str(toml_str).unwrap();
-        let table = parsed.as_table().unwrap();
+        let table = parse_toml_frontmatter(&content);
 
-        let dkim = table.get("dkim").unwrap().as_str().unwrap();
-        assert_eq!(dkim, "none");
-
-        let spf = table.get("spf").unwrap().as_str().unwrap();
-        assert_eq!(spf, "none");
+        assert_eq!(table.get("dkim").unwrap().as_str().unwrap(), "none");
+        assert_eq!(table.get("spf").unwrap().as_str().unwrap(), "none");
+        assert_eq!(table.get("dmarc").unwrap().as_str().unwrap(), "none");
     }
 
     #[test]
@@ -1067,20 +1157,18 @@ mod tests {
     }
 
     #[test]
-    fn frontmatter_includes_dkim_spf_fields() {
+    fn frontmatter_includes_dkim_spf_dmarc_fields() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
+        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         let content = std::fs::read_to_string(&entries[0]).unwrap();
-        let parts: Vec<&str> = content.splitn(3, "+++").collect();
-        let toml_str = parts[1].trim();
-        let parsed: toml::Value = toml::from_str(toml_str).unwrap();
-        let table = parsed.as_table().unwrap();
+        let table = parse_toml_frontmatter(&content);
 
         assert!(table.contains_key("dkim"));
         assert!(table.contains_key("spf"));
+        assert!(table.contains_key("dmarc"));
     }
 
     #[test]
@@ -1117,7 +1205,7 @@ mod tests {
         let config = test_config(tmp.path());
         let raw = include_bytes!("../tests/fixtures/gmail_dkim_signed.eml");
 
-        ingest_email(&config, "agent@test.com", raw).unwrap();
+        ingest_email(&config, "agent@test.com", raw, sentinel_ip()).unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "catchall"));
         assert_eq!(entries.len(), 1);
@@ -1184,11 +1272,6 @@ mod tests {
 
     #[test]
     fn concurrent_same_subject_attachment_ingests_do_not_corrupt_each_other() {
-        // Sprint 36 review fix: with the inbound `Mutex<()>` guarding the
-        // allocate-create-write critical section, two threads racing the
-        // same subject + same attachment filename in the same UTC second
-        // each end up in their own bundle directory with their own copy
-        // of the attachment intact.
         use std::sync::Arc;
         use std::thread;
 
@@ -1199,7 +1282,7 @@ mod tests {
         for _ in 0..8 {
             let cfg = Arc::clone(&config);
             handles.push(thread::spawn(move || {
-                ingest_email(&cfg, "alice@test.com", attachment_eml()).unwrap();
+                ingest_email(&cfg, "alice@test.com", attachment_eml(), sentinel_ip()).unwrap();
             }));
         }
         for h in handles {
@@ -1221,8 +1304,6 @@ mod tests {
             let attachment = path.join("notes.txt");
             assert!(md.exists(), "md file present in {stem}");
             assert!(attachment.exists(), "attachment present in {stem}");
-            // Attachment content is the original — no other thread
-            // truncated/overwrote it.
             let body = std::fs::read_to_string(&attachment).unwrap();
             assert!(body.contains("These are my notes."));
         }
@@ -1230,13 +1311,10 @@ mod tests {
 
     #[test]
     fn rapid_same_subject_ingests_get_unique_paths() {
-        // Two ingests with identical subjects landing in the same UTC
-        // second must not overwrite each other; `allocate_filename` picks
-        // the `-2` suffix for the second one.
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
-        ingest_email(&config, "alice@test.com", plain_text_eml()).unwrap();
+        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
+        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         assert_eq!(entries.len(), 2);
@@ -1261,5 +1339,142 @@ mod tests {
     #[test]
     fn spf_domain_empty_domain_part_returns_none() {
         assert_eq!(spf_domain("user@"), None);
+    }
+
+    #[test]
+    fn frontmatter_new_fields_populated() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let ip: IpAddr = "203.0.113.50".parse().unwrap();
+        ingest_email(&config, "alice@test.com", plain_text_eml(), ip).unwrap();
+
+        let entries = collect_md_files(&inbox(tmp.path(), "alice"));
+        let content = std::fs::read_to_string(&entries[0]).unwrap();
+        let table = parse_toml_frontmatter(&content);
+
+        assert!(table.contains_key("thread_id"));
+        let thread_id = table.get("thread_id").unwrap().as_str().unwrap();
+        assert_eq!(thread_id.len(), 16);
+
+        assert!(table.contains_key("received_at"));
+
+        assert_eq!(
+            table.get("received_from_ip").unwrap().as_str().unwrap(),
+            "203.0.113.50"
+        );
+
+        assert_eq!(
+            table.get("delivered_to").unwrap().as_str().unwrap(),
+            "alice@test.com"
+        );
+
+        assert!(table.get("size_bytes").unwrap().as_integer().unwrap() > 0);
+
+        assert_eq!(table.get("trusted").unwrap().as_str().unwrap(), "none");
+        assert_eq!(table.get("dmarc").unwrap().as_str().unwrap(), "none");
+    }
+
+    #[test]
+    fn frontmatter_received_from_ip_omitted_for_sentinel() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
+
+        let entries = collect_md_files(&inbox(tmp.path(), "alice"));
+        let content = std::fs::read_to_string(&entries[0]).unwrap();
+        let table = parse_toml_frontmatter(&content);
+
+        // 0.0.0.0 sentinel is omitted
+        assert!(!table.contains_key("received_from_ip"));
+    }
+
+    #[test]
+    fn frontmatter_list_id_populated() {
+        let eml = b"From: sender@example.com\r\n\
+            To: alice@test.com\r\n\
+            Subject: List email\r\n\
+            Date: Thu, 01 Jan 2025 12:00:00 +0000\r\n\
+            Message-ID: <list1@example.com>\r\n\
+            List-ID: <mylist.example.com>\r\n\
+            \r\n\
+            List message body.\r\n";
+
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        ingest_email(&config, "alice@test.com", eml, sentinel_ip()).unwrap();
+
+        let entries = collect_md_files(&inbox(tmp.path(), "alice"));
+        let content = std::fs::read_to_string(&entries[0]).unwrap();
+        let table = parse_toml_frontmatter(&content);
+        assert_eq!(
+            table.get("list_id").unwrap().as_str().unwrap(),
+            "<mylist.example.com>"
+        );
+    }
+
+    #[test]
+    fn frontmatter_auto_submitted_populated() {
+        let eml = b"From: sender@example.com\r\n\
+            To: alice@test.com\r\n\
+            Subject: Auto reply\r\n\
+            Date: Thu, 01 Jan 2025 12:00:00 +0000\r\n\
+            Message-ID: <auto1@example.com>\r\n\
+            Auto-Submitted: auto-replied\r\n\
+            \r\n\
+            Automatic reply.\r\n";
+
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        ingest_email(&config, "alice@test.com", eml, sentinel_ip()).unwrap();
+
+        let entries = collect_md_files(&inbox(tmp.path(), "alice"));
+        let content = std::fs::read_to_string(&entries[0]).unwrap();
+        let table = parse_toml_frontmatter(&content);
+        assert_eq!(
+            table.get("auto_submitted").unwrap().as_str().unwrap(),
+            "auto-replied"
+        );
+    }
+
+    #[test]
+    fn frontmatter_optional_headers_omitted_when_absent() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
+
+        let entries = collect_md_files(&inbox(tmp.path(), "alice"));
+        let content = std::fs::read_to_string(&entries[0]).unwrap();
+        let table = parse_toml_frontmatter(&content);
+
+        assert!(!table.contains_key("cc"));
+        assert!(!table.contains_key("reply_to"));
+        assert!(!table.contains_key("list_id"));
+        assert!(!table.contains_key("auto_submitted"));
+        assert!(!table.contains_key("in_reply_to"));
+        assert!(!table.contains_key("references"));
+        assert!(!table.contains_key("labels"));
+    }
+
+    #[test]
+    fn thread_id_deterministic_for_same_message() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+
+        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
+        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
+
+        let entries = collect_md_files(&inbox(tmp.path(), "alice"));
+        assert_eq!(entries.len(), 2);
+
+        let content1 = std::fs::read_to_string(&entries[0]).unwrap();
+        let content2 = std::fs::read_to_string(&entries[1]).unwrap();
+
+        let table1 = parse_toml_frontmatter(&content1);
+        let table2 = parse_toml_frontmatter(&content2);
+
+        assert_eq!(
+            table1.get("thread_id").unwrap().as_str().unwrap(),
+            table2.get("thread_id").unwrap().as_str().unwrap(),
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod channel;
 mod cli;
 mod config;
 mod dkim;
+mod frontmatter;
 mod ingest;
 mod mailbox;
 mod mcp;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,6 +1,6 @@
 use crate::cli::SendArgs;
 use crate::config::Config;
-use crate::ingest::EmailMetadata;
+use crate::frontmatter::InboundFrontmatter;
 use crate::mailbox;
 use crate::send;
 use crate::send_protocol::SendRequest;
@@ -330,14 +330,7 @@ impl AimxMcpServer {
         let (reply_to_id, references) = if meta.message_id.is_empty() {
             (None, None)
         } else {
-            let refs = send::build_references(
-                if meta.references.is_empty() {
-                    None
-                } else {
-                    Some(&meta.references)
-                },
-                &meta.message_id,
-            );
+            let refs = send::build_references(meta.references.as_deref(), &meta.message_id);
             (Some(meta.message_id.clone()), Some(refs))
         };
 
@@ -448,7 +441,7 @@ fn list_mailboxes_with_unread(config: &Config) -> Vec<(String, usize, usize, boo
 /// entries and Zola-style bundle directories containing `<stem>.md`.
 pub fn list_emails(
     mailbox_dir: &std::path::Path,
-) -> Result<Vec<EmailMetadata>, Box<dyn std::error::Error>> {
+) -> Result<Vec<InboundFrontmatter>, Box<dyn std::error::Error>> {
     let mut emails = Vec::new();
 
     let entries = match std::fs::read_dir(mailbox_dir) {
@@ -521,7 +514,7 @@ fn folder_dir(config: &Config, mailbox: &str, folder: Folder) -> PathBuf {
     }
 }
 
-pub fn parse_frontmatter(content: &str) -> Option<EmailMetadata> {
+pub fn parse_frontmatter(content: &str) -> Option<InboundFrontmatter> {
     let parts: Vec<&str> = content.splitn(3, "+++").collect();
     if parts.len() < 3 {
         return None;
@@ -531,12 +524,12 @@ pub fn parse_frontmatter(content: &str) -> Option<EmailMetadata> {
 }
 
 pub fn filter_emails(
-    emails: Vec<EmailMetadata>,
+    emails: Vec<InboundFrontmatter>,
     unread: Option<bool>,
     from: Option<&str>,
     since: Option<&str>,
     subject: Option<&str>,
-) -> Result<Vec<EmailMetadata>, String> {
+) -> Result<Vec<InboundFrontmatter>, String> {
     let since_dt = match since {
         Some(s) => Some(
             chrono::DateTime::parse_from_rfc3339(s)
@@ -608,13 +601,13 @@ pub fn set_read_status(
     }
 
     let toml_str = parts[1].trim();
-    let mut meta: EmailMetadata =
+    let mut meta: InboundFrontmatter =
         toml::from_str(toml_str).map_err(|e| format!("Failed to parse frontmatter: {e}"))?;
 
     meta.read = read;
 
-    let new_toml = toml::to_string_pretty(&meta)
-        .map_err(|e| format!("Failed to serialize frontmatter: {e}"))?;
+    let new_toml =
+        toml::to_string(&meta).map_err(|e| format!("Failed to serialize frontmatter: {e}"))?;
     let body = parts[2];
 
     let mut result = String::new();
@@ -691,35 +684,47 @@ mod tests {
         guard
     }
 
-    fn create_test_email(dir: &std::path::Path, id: &str, meta: &EmailMetadata) {
+    fn create_test_email(dir: &std::path::Path, id: &str, meta: &InboundFrontmatter) {
         std::fs::create_dir_all(dir).unwrap();
-        let toml_str = toml::to_string_pretty(meta).unwrap();
+        let toml_str = toml::to_string(meta).unwrap();
         let content = format!("+++\n{toml_str}+++\n\nThis is the body of email {id}.\n");
         std::fs::write(dir.join(format!("{id}.md")), content).unwrap();
     }
 
-    fn sample_meta(id: &str, from: &str, subject: &str, read: bool) -> EmailMetadata {
-        EmailMetadata {
+    fn sample_meta(id: &str, from: &str, subject: &str, read: bool) -> InboundFrontmatter {
+        InboundFrontmatter {
             id: id.to_string(),
             message_id: format!("<{id}@test.com>"),
+            thread_id: "0123456789abcdef".to_string(),
             from: from.to_string(),
             to: "alice@test.com".to_string(),
+            cc: None,
+            reply_to: None,
+            delivered_to: "alice@test.com".to_string(),
             subject: subject.to_string(),
             date: "2025-06-01T12:00:00Z".to_string(),
-            in_reply_to: "".to_string(),
-            references: "".to_string(),
+            received_at: "2025-06-01T12:00:01Z".to_string(),
+            received_from_ip: None,
+            size_bytes: 100,
+            in_reply_to: None,
+            references: None,
             attachments: vec![],
-            mailbox: "alice".to_string(),
-            read,
+            list_id: None,
+            auto_submitted: None,
             dkim: "none".to_string(),
             spf: "none".to_string(),
+            dmarc: "none".to_string(),
+            trusted: "none".to_string(),
+            mailbox: "alice".to_string(),
+            read,
+            labels: vec![],
         }
     }
 
     #[test]
     fn parse_frontmatter_valid() {
         let meta = sample_meta("2025-06-01-001", "sender@example.com", "Hello", false);
-        let toml_str = toml::to_string_pretty(&meta).unwrap();
+        let toml_str = toml::to_string(&meta).unwrap();
         let content = format!("+++\n{toml_str}+++\n\nBody text.\n");
 
         let parsed = parse_frontmatter(&content).unwrap();

--- a/src/smtp/session.rs
+++ b/src/smtp/session.rs
@@ -497,7 +497,8 @@ impl SmtpSession {
             let peer = self.params.peer_addr;
 
             let result = tokio::task::spawn_blocking(move || {
-                crate::ingest::ingest_email(&config, &rcpt_owned, &data).map_err(|e| e.to_string())
+                crate::ingest::ingest_email(&config, &rcpt_owned, &data, peer.ip())
+                    .map_err(|e| e.to_string())
             })
             .await;
 

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,5 +1,5 @@
 use crate::config::Config;
-use crate::ingest::EmailMetadata;
+use crate::frontmatter::InboundFrontmatter;
 use crate::term;
 use std::path::{Path, PathBuf};
 
@@ -102,7 +102,7 @@ fn gather_recent_activity(config: &Config) -> Vec<RecentEmail> {
                 None => continue,
             };
 
-            let meta: EmailMetadata = match toml::from_str(&fm) {
+            let meta: InboundFrontmatter = match toml::from_str(&fm) {
                 Ok(m) => m,
                 Err(_) => continue,
             };
@@ -177,7 +177,7 @@ fn is_unread(path: &Path) -> bool {
         None => return false,
     };
 
-    match toml::from_str::<EmailMetadata>(&frontmatter) {
+    match toml::from_str::<InboundFrontmatter>(&frontmatter) {
         Ok(meta) => !meta.read,
         Err(_) => false,
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1778,7 +1778,7 @@ fn serve_e2e_bcc_recipients() {
     assert_eq!(get_toml_str(alice_table, "mailbox"), "alice");
     assert_eq!(get_toml_str(bob_table, "mailbox"), "bob");
 
-    // BCC address should not appear as a header in the stored email
+    // BCC address should not appear as a Bcc: header in the stored email
     let bob_content = std::fs::read_to_string(&bob_files[0]).unwrap();
     assert!(
         !bob_content.contains("Bcc:")
@@ -1786,9 +1786,12 @@ fn serve_e2e_bcc_recipients() {
             && !bob_content.contains("BCC:"),
         "BCC header line should not be in stored email"
     );
-    assert!(
-        !bob_content.contains("bob@agent.example.com"),
-        "BCC recipient address should not appear in stored email"
+    // delivered_to carries the actual RCPT TO (envelope recipient),
+    // which for BCC is the BCC address. This is correct per FR-13.
+    assert_eq!(
+        get_toml_str(bob_table, "delivered_to"),
+        "bob@agent.example.com",
+        "delivered_to should be the envelope recipient (BCC address)"
     );
     assert_eq!(
         get_toml_str(bob_table, "to"),


### PR DESCRIPTION
## Summary

- **S37-1: InboundFrontmatter struct** -- New `src/frontmatter.rs` module with struct-ordered TOML serialization enforcing the v0.2 field order (Identity -> Parties -> Content -> Threading -> Auth -> Storage). Optional fields use `skip_serializing_if`; always-written fields (dkim, spf, dmarc, trusted, read) are never omitted. Replaces ad-hoc `EmailMetadata` across all consumers (ingest, channel, mcp, status).

- **S37-2: thread_id + new fields** -- `compute_thread_id()` walks In-Reply-To -> References -> own Message-ID, SHA-256 hashes the root, truncates to 16 hex chars. New fields: `received_at` (RFC 3339 UTC), `received_from_ip` (SMTP peer IP threaded from session.rs; 0.0.0.0 sentinel omitted), `size_bytes`, `delivered_to` (RCPT TO), `cc`, `reply_to`, `list_id`, `auto_submitted`, `labels`.

- **S37-3: DMARC verification** -- `AuthResults { dkim, spf, dmarc }` struct populated per ingest. DMARC uses `mail-auth`'s `verify_dmarc` with `psl` crate for domain suffix resolution. Values: `pass` / `fail` / `none`. `dmarc` field always written. `book/configuration.md` updated with verification docs and v0.2 storage layout.

## Test plan

- [ ] `cargo test` -- 559 unit + 51 integration tests pass (610 total)
- [ ] `cargo clippy --all-targets -- -D warnings` clean
- [ ] `cargo fmt -- --check` clean
- [ ] Frontmatter field order regression test prevents reordering
- [ ] Golden output test validates roundtrip serialization
- [ ] thread_id tests: orphan, reply chain, cross-references, missing headers, multiple Message-IDs
- [ ] New fields populated correctly (received_from_ip, delivered_to, size_bytes, list_id, auto_submitted)
- [ ] Optional fields omitted when absent; always-written fields present at defaults
- [ ] DMARC result mapped correctly from mail-auth output
- [ ] BCC integration test updated to verify delivered_to carries envelope recipient