### PR TITLE
[Sprint 38] trusted Frontmatter + Sent-Items Persistence + Outbound Block

### DIFF
--- a/book/mcp.md
+++ b/book/mcp.md
@@ -157,6 +157,31 @@ Mark an email as unread.
 
 Updates `read = false` in the email's frontmatter.
 
+## Frontmatter reference
+
+Every email stored by AIMX carries a TOML frontmatter block between `+++` delimiters. Inbound emails include:
+
+| Field | Always written | Description |
+|-------|----------------|-------------|
+| `id` | yes | Filename stem (e.g. `2025-04-15-143022-hello`) |
+| `message_id` | yes | RFC 5322 `Message-ID` |
+| `thread_id` | yes | 16-hex-char SHA-256 of the resolved thread root |
+| `from` | yes | Sender address |
+| `to` | yes | Recipient address |
+| `delivered_to` | yes | Actual RCPT TO |
+| `subject` | yes | Subject line |
+| `date` | yes | Sender-claimed datetime (RFC 3339) |
+| `received_at` | yes | Server receipt datetime (RFC 3339 UTC) |
+| `dkim` | yes | `pass`, `fail`, or `none` |
+| `spf` | yes | `pass`, `fail`, or `none` |
+| `dmarc` | yes | `pass`, `fail`, or `none` |
+| `trusted` | yes | `none`, `true`, or `false` -- per-mailbox trust evaluation result (see [Configuration](configuration.md)) |
+| `mailbox` | yes | Target mailbox name |
+| `read` | yes | Read/unread status |
+| `delivery_status` | sent only | `delivered`, `failed`, `deferred`, or `pending` |
+
+Outbound (sent) emails additionally carry `outbound = true`, `delivery_status`, and optionally `delivered_at` and `delivery_details`.
+
 ## Compatible agent frameworks
 
 | Framework | Integration method |

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -84,6 +84,15 @@ pub fn is_sender_trusted(mailbox_config: &MailboxConfig, from: &str) -> bool {
     false
 }
 
+/// Determine whether channel triggers should fire for this email.
+///
+/// v1 semantics (preserved intentionally): for `trust: verified`,
+/// triggers fire when the sender is allowlisted OR DKIM passes. This
+/// is deliberately looser than `trust::evaluate_trust()`, which
+/// requires BOTH allowlisted AND DKIM pass for `trusted = "true"`.
+/// The trigger gate keeps the "allowlisted senders skip verification"
+/// affordance intact; the `trusted` frontmatter field is the strict
+/// evaluation surfaced to agents and operators. See S38-1 rationale.
 pub fn should_execute_triggers(
     mailbox_config: &MailboxConfig,
     metadata: &InboundFrontmatter,

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use std::fmt;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct InboundFrontmatter {
@@ -84,6 +85,147 @@ impl Default for AuthResults {
             dmarc: "none".to_string(),
         }
     }
+}
+
+/// Delivery status for outbound sent files (FR-19c).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeliveryStatus {
+    Delivered,
+    Deferred,
+    Failed,
+    Pending,
+}
+
+impl DeliveryStatus {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            DeliveryStatus::Delivered => "delivered",
+            DeliveryStatus::Deferred => "deferred",
+            DeliveryStatus::Failed => "failed",
+            DeliveryStatus::Pending => "pending",
+        }
+    }
+}
+
+impl fmt::Display for DeliveryStatus {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Serialize for DeliveryStatus {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for DeliveryStatus {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.as_str() {
+            "delivered" => Ok(DeliveryStatus::Delivered),
+            "deferred" => Ok(DeliveryStatus::Deferred),
+            "failed" => Ok(DeliveryStatus::Failed),
+            "pending" => Ok(DeliveryStatus::Pending),
+            other => Err(serde::de::Error::custom(format!(
+                "invalid delivery_status: {other}"
+            ))),
+        }
+    }
+}
+
+/// Outbound frontmatter for sent-copy `.md` files (FR-19c).
+///
+/// Composes the same inbound fields (Identity/Parties/Content/Threading/
+/// Auth/Storage) at the top, plus an outbound block at the end containing
+/// `outbound`, `delivery_status`, and optional `bcc`, `delivered_at`,
+/// `delivery_details`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OutboundFrontmatter {
+    // -- Identity --
+    pub id: String,
+    pub message_id: String,
+    #[serde(default)]
+    pub thread_id: String,
+
+    // -- Parties --
+    pub from: String,
+    pub to: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cc: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reply_to: Option<String>,
+    #[serde(default)]
+    pub delivered_to: String,
+
+    // -- Content --
+    pub subject: String,
+    pub date: String,
+    #[serde(default)]
+    pub received_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub received_from_ip: Option<String>,
+    #[serde(default)]
+    pub size_bytes: usize,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub attachments: Vec<AttachmentMeta>,
+
+    // -- Threading --
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub in_reply_to: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub references: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub list_id: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub auto_submitted: Option<String>,
+
+    // -- Auth --
+    #[serde(default = "default_auth_result")]
+    pub dkim: String,
+    #[serde(default = "default_auth_result")]
+    pub spf: String,
+    #[serde(default = "default_auth_result")]
+    pub dmarc: String,
+    #[serde(default = "default_auth_result")]
+    pub trusted: String,
+
+    // -- Storage --
+    pub mailbox: String,
+    pub read: bool,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub labels: Vec<String>,
+
+    // -- Outbound block --
+    pub outbound: bool,
+    pub delivery_status: DeliveryStatus,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bcc: Option<Vec<String>>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delivered_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub delivery_details: Option<String>,
+}
+
+pub fn format_outbound_frontmatter(meta: &OutboundFrontmatter, body: &str) -> String {
+    let toml_str = toml::to_string(meta).expect("OutboundFrontmatter must serialize to TOML");
+    let mut result = String::new();
+    result.push_str("+++\n");
+    result.push_str(&toml_str);
+    result.push_str("+++\n\n");
+    result.push_str(body);
+
+    if !body.ends_with('\n') {
+        result.push('\n');
+    }
+
+    result
 }
 
 /// Compute a deterministic thread ID from email threading headers.
@@ -566,5 +708,166 @@ mod tests {
         fm.received_from_ip = None;
         let toml_str = toml::to_string(&fm).unwrap();
         assert!(!toml_str.contains("received_from_ip"));
+    }
+
+    fn sample_outbound_frontmatter() -> OutboundFrontmatter {
+        OutboundFrontmatter {
+            id: "2025-01-01-120000-hello".to_string(),
+            message_id: "<abc123@example.com>".to_string(),
+            thread_id: "a1b2c3d4e5f6a7b8".to_string(),
+            from: "alice@example.com".to_string(),
+            to: "bob@gmail.com".to_string(),
+            cc: None,
+            reply_to: None,
+            delivered_to: "bob@gmail.com".to_string(),
+            subject: "Hello".to_string(),
+            date: "2025-01-01T12:00:00Z".to_string(),
+            received_at: "2025-01-01T12:00:01Z".to_string(),
+            received_from_ip: None,
+            size_bytes: 256,
+            attachments: vec![],
+            in_reply_to: None,
+            references: None,
+            list_id: None,
+            auto_submitted: None,
+            dkim: "pass".to_string(),
+            spf: "none".to_string(),
+            dmarc: "none".to_string(),
+            trusted: "none".to_string(),
+            mailbox: "alice".to_string(),
+            read: false,
+            labels: vec![],
+            outbound: true,
+            delivery_status: DeliveryStatus::Delivered,
+            bcc: None,
+            delivered_at: Some("2025-01-01T12:00:05Z".to_string()),
+            delivery_details: Some("250 OK".to_string()),
+        }
+    }
+
+    #[test]
+    fn delivery_status_serialization() {
+        for (variant, expected) in [
+            (DeliveryStatus::Delivered, "\"delivered\""),
+            (DeliveryStatus::Deferred, "\"deferred\""),
+            (DeliveryStatus::Failed, "\"failed\""),
+            (DeliveryStatus::Pending, "\"pending\""),
+        ] {
+            let json = serde_json::to_string(&variant).unwrap();
+            assert_eq!(json, expected);
+            let back: DeliveryStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(variant, back);
+        }
+    }
+
+    #[test]
+    fn outbound_frontmatter_field_order() {
+        let fm = sample_outbound_frontmatter();
+        let toml_str = toml::to_string(&fm).unwrap();
+
+        let actual_keys: Vec<&str> = toml_str
+            .lines()
+            .filter_map(|line| {
+                let key = line.split('=').next()?.trim();
+                if key.starts_with('[') || key.is_empty() {
+                    None
+                } else {
+                    Some(key)
+                }
+            })
+            .collect();
+
+        // Inbound block first, then outbound block at the end
+        let expected_keys = vec![
+            "id",
+            "message_id",
+            "thread_id",
+            "from",
+            "to",
+            "delivered_to",
+            "subject",
+            "date",
+            "received_at",
+            "size_bytes",
+            "dkim",
+            "spf",
+            "dmarc",
+            "trusted",
+            "mailbox",
+            "read",
+            "outbound",
+            "delivery_status",
+            "delivered_at",
+            "delivery_details",
+        ];
+
+        assert_eq!(actual_keys, expected_keys);
+    }
+
+    #[test]
+    fn outbound_delivery_status_always_written() {
+        let mut fm = sample_outbound_frontmatter();
+        fm.delivered_at = None;
+        fm.delivery_details = None;
+        fm.bcc = None;
+        let toml_str = toml::to_string(&fm).unwrap();
+        assert!(toml_str.contains("delivery_status = \"delivered\""));
+        assert!(!toml_str.contains("delivered_at"));
+        assert!(!toml_str.contains("delivery_details"));
+        assert!(!toml_str.contains("bcc"));
+    }
+
+    #[test]
+    fn outbound_golden_test() {
+        let fm = sample_outbound_frontmatter();
+        let output = format_outbound_frontmatter(&fm, "DKIM-Signature: ...\r\nFrom: ...");
+
+        assert!(output.starts_with("+++\n"));
+        assert!(output.contains("\n+++\n\n"));
+
+        // Parse back
+        let parts: Vec<&str> = output.splitn(3, "+++").collect();
+        let toml_str = parts[1].trim();
+        let parsed: OutboundFrontmatter = toml::from_str(toml_str).unwrap();
+        assert_eq!(parsed.id, fm.id);
+        assert!(parsed.outbound);
+        assert_eq!(parsed.delivery_status, DeliveryStatus::Delivered);
+        assert_eq!(parsed.delivered_at.as_deref(), Some("2025-01-01T12:00:05Z"));
+        assert_eq!(parsed.delivery_details.as_deref(), Some("250 OK"));
+    }
+
+    #[test]
+    fn outbound_failed_delivery() {
+        let mut fm = sample_outbound_frontmatter();
+        fm.delivery_status = DeliveryStatus::Failed;
+        fm.delivered_at = None;
+        fm.delivery_details = Some("550 no such user".to_string());
+
+        let toml_str = toml::to_string(&fm).unwrap();
+        assert!(toml_str.contains("delivery_status = \"failed\""));
+        assert!(toml_str.contains("delivery_details = \"550 no such user\""));
+        assert!(!toml_str.contains("delivered_at"));
+    }
+
+    #[test]
+    fn outbound_with_bcc() {
+        let mut fm = sample_outbound_frontmatter();
+        fm.bcc = Some(vec![
+            "secret@example.com".to_string(),
+            "hidden@example.com".to_string(),
+        ]);
+
+        let toml_str = toml::to_string(&fm).unwrap();
+        assert!(toml_str.contains("bcc"));
+        assert!(toml_str.contains("secret@example.com"));
+        assert!(toml_str.contains("hidden@example.com"));
+    }
+
+    #[test]
+    fn outbound_outbound_always_true() {
+        let fm = sample_outbound_frontmatter();
+        assert!(fm.outbound);
+        let toml_str = toml::to_string(&fm).unwrap();
+        assert!(toml_str.contains("outbound = true"));
     }
 }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -4,6 +4,7 @@ use crate::frontmatter::{
     AttachmentMeta, AuthResults, InboundFrontmatter, compute_thread_id, format_frontmatter,
 };
 use crate::slug::{allocate_filename, slugify};
+use crate::trust;
 use mail_parser::{MessageParser, MimeHeaders};
 use std::io::Read;
 use std::net::IpAddr;
@@ -148,6 +149,12 @@ pub fn ingest_email(
 
     let auth_results = verify_auth(raw);
 
+    let trusted_value = config
+        .mailboxes
+        .get(&mailbox)
+        .map(|mb| trust::evaluate_trust(mb, &auth_results, &from))
+        .unwrap_or(trust::TrustedValue::None);
+
     let received_at = chrono::Utc::now().to_rfc3339();
     let size_bytes = raw.len();
 
@@ -218,7 +225,7 @@ pub fn ingest_email(
         dkim: auth_results.dkim,
         spf: auth_results.spf,
         dmarc: auth_results.dmarc,
-        trusted: "none".to_string(),
+        trusted: trusted_value.as_str().to_string(),
         mailbox: mailbox.clone(),
         read: false,
         labels: vec![],

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -63,13 +63,14 @@ pub fn create_mailbox(config: &Config, name: &str) -> Result<(), Box<dyn std::er
     Ok(())
 }
 
-pub fn list_mailboxes(config: &Config) -> Vec<(String, usize)> {
+pub fn list_mailboxes(config: &Config) -> Vec<(String, usize, usize)> {
     let names = discover_mailbox_names(config);
-    let mut result: Vec<(String, usize)> = names
+    let mut result: Vec<(String, usize, usize)> = names
         .into_iter()
         .map(|name| {
-            let count = count_messages(&config.inbox_dir(&name));
-            (name, count)
+            let inbox_count = count_messages(&config.inbox_dir(&name));
+            let sent_count = count_messages(&config.sent_dir(&name));
+            (name, inbox_count, sent_count)
         })
         .collect();
     result.sort_by(|a, b| a.0.cmp(&b.0));
@@ -176,12 +177,12 @@ fn list(config: &Config) -> Result<(), Box<dyn std::error::Error>> {
 
     let header_pad = 20usize.saturating_sub("MAILBOX".len());
     println!(
-        "{}{:pad$} MESSAGES",
+        "{}{:pad$} INBOX    SENT",
         term::header("MAILBOX"),
         "",
         pad = header_pad,
     );
-    for (name, count) in mailboxes {
+    for (name, inbox_count, sent_count) in mailboxes {
         let name_pad = 20usize.saturating_sub(name.chars().count());
         let suffix = if is_registered(config, &name) {
             String::new()
@@ -189,10 +190,11 @@ fn list(config: &Config) -> Result<(), Box<dyn std::error::Error>> {
             format!(" {}", term::warn("(unregistered)"))
         };
         println!(
-            "{}{:pad$} {}{}",
+            "{}{:pad$} {:<8} {}{}",
             term::highlight(&name),
             "",
-            count,
+            inbox_count,
+            sent_count,
             suffix,
             pad = name_pad,
         );
@@ -317,7 +319,8 @@ mod tests {
         let result = list_mailboxes(&config);
         assert_eq!(result.len(), 1);
         assert_eq!(result[0].0, "catchall");
-        assert_eq!(result[0].1, 2);
+        assert_eq!(result[0].1, 2); // inbox count
+        assert_eq!(result[0].2, 0); // sent count
     }
 
     #[test]
@@ -341,12 +344,12 @@ mod tests {
         std::fs::write(stray.join("2025-01-01-120000-z.md"), "x").unwrap();
 
         let result = list_mailboxes(&config);
-        let names: Vec<&str> = result.iter().map(|(n, _)| n.as_str()).collect();
+        let names: Vec<&str> = result.iter().map(|(n, _, _)| n.as_str()).collect();
         assert!(names.contains(&"alice"), "registered alice listed");
         assert!(names.contains(&"catchall"), "catchall always listed");
         assert!(names.contains(&"stray"), "stray inbox dir surfaced");
 
-        let stray_row = result.iter().find(|(n, _)| n == "stray").unwrap();
+        let stray_row = result.iter().find(|(n, _, _)| n == "stray").unwrap();
         assert_eq!(stray_row.1, 1, "stray dir counts its messages");
         assert!(!is_registered(&config, "stray"));
         assert!(is_registered(&config, "alice"));
@@ -370,7 +373,8 @@ mod tests {
         std::fs::write(bundle.join("att.txt"), "att").unwrap();
 
         let result = list_mailboxes(&config);
-        assert_eq!(result[0].1, 2, "bundle and flat each count once");
+        assert_eq!(result[0].1, 2, "bundle and flat each count once (inbox)");
+        assert_eq!(result[0].2, 0, "no sent messages");
     }
 
     #[test]
@@ -425,7 +429,8 @@ mod tests {
         let config = test_config(tmp.path());
         let result = list_mailboxes(&config);
         assert_eq!(result.len(), 1);
-        assert_eq!(result[0].1, 0);
+        assert_eq!(result[0].1, 0); // inbox
+        assert_eq!(result[0].2, 0); // sent
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ mod smtp;
 mod status;
 mod term;
 mod transport;
+mod trust;
 mod verify;
 
 use clap::Parser;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -134,9 +134,9 @@ impl AimxMcpServer {
 
         let result: Vec<String> = mailboxes
             .iter()
-            .map(|(name, total, unread, registered)| {
+            .map(|(name, total, unread, sent_count, registered)| {
                 let suffix = if *registered { "" } else { " (unregistered)" };
-                format!("{name}: {total} messages ({unread} unread){suffix}")
+                format!("{name}: {total} messages ({unread} unread), {sent_count} sent{suffix}")
             })
             .collect();
         Ok(result.join("\n"))
@@ -417,22 +417,24 @@ pub async fn run(data_dir: Option<&std::path::Path>) -> Result<(), Box<dyn std::
     Ok(())
 }
 
-/// Return `(name, total, unread, registered)` for every mailbox the
-/// daemon knows about — both registered ones in `config.mailboxes` and
+/// Return `(name, total, unread, sent_count, registered)` for every mailbox
+/// the daemon knows about — both registered ones in `config.mailboxes` and
 /// stray `inbox/<name>/` directories left by backup restores or
 /// out-of-band tooling. Sorted by name.
-fn list_mailboxes_with_unread(config: &Config) -> Vec<(String, usize, usize, bool)> {
-    let mut result: Vec<(String, usize, usize, bool)> = mailbox::discover_mailbox_names(config)
-        .into_iter()
-        .map(|name| {
-            let dir = config.inbox_dir(&name);
-            let emails = list_emails(&dir).unwrap_or_default();
-            let total = emails.len();
-            let unread = emails.iter().filter(|e| !e.read).count();
-            let registered = mailbox::is_registered(config, &name);
-            (name, total, unread, registered)
-        })
-        .collect();
+fn list_mailboxes_with_unread(config: &Config) -> Vec<(String, usize, usize, usize, bool)> {
+    let mut result: Vec<(String, usize, usize, usize, bool)> =
+        mailbox::discover_mailbox_names(config)
+            .into_iter()
+            .map(|name| {
+                let dir = config.inbox_dir(&name);
+                let emails = list_emails(&dir).unwrap_or_default();
+                let total = emails.len();
+                let unread = emails.iter().filter(|e| !e.read).count();
+                let sent_count = mailbox::count_messages(&config.sent_dir(&name));
+                let registered = mailbox::is_registered(config, &name);
+                (name, total, unread, sent_count, registered)
+            })
+            .collect();
     result.sort_by(|a, b| a.0.cmp(&b.0));
     result
 }
@@ -1025,9 +1027,10 @@ mod tests {
 
         let result = list_mailboxes_with_unread(&config);
         let alice = result.iter().find(|m| m.0 == "alice").unwrap();
-        assert_eq!(alice.1, 2); // total
+        assert_eq!(alice.1, 2); // total inbox
         assert_eq!(alice.2, 1); // unread
-        assert!(alice.3, "alice is registered in config");
+        assert_eq!(alice.3, 0); // sent count
+        assert!(alice.4, "alice is registered in config");
     }
 
     #[test]
@@ -1048,13 +1051,14 @@ mod tests {
             .iter()
             .find(|m| m.0 == "stray")
             .expect("stray dir must surface in mailbox_list");
-        assert_eq!(stray_row.1, 1); // total
+        assert_eq!(stray_row.1, 1); // total inbox
         assert_eq!(stray_row.2, 0); // unread (meta.read=true)
-        assert!(!stray_row.3, "stray is not registered in config");
+        assert_eq!(stray_row.3, 0); // sent
+        assert!(!stray_row.4, "stray is not registered in config");
 
         // catchall and alice still surface as registered.
-        assert!(result.iter().any(|m| m.0 == "catchall" && m.3));
-        assert!(result.iter().any(|m| m.0 == "alice" && m.3));
+        assert!(result.iter().any(|m| m.0 == "catchall" && m.4));
+        assert!(result.iter().any(|m| m.0 == "alice" && m.4));
     }
 
     #[test]

--- a/src/send_handler.rs
+++ b/src/send_handler.rs
@@ -2,22 +2,36 @@
 //!
 //! This module contains the per-connection business logic that runs inside
 //! `aimx serve` after a request frame has been decoded: domain validation,
-//! DKIM signing, and delivery. Framing is the [`send_protocol`] module's
-//! responsibility — this one deals only in parsed `SendRequest`s.
+//! DKIM signing, delivery, and sent-items persistence. Framing is the
+//! [`send_protocol`] module's responsibility — this one deals only in parsed
+//! `SendRequest`s.
 //!
 //! The handler is deliberately testable: real MX delivery is abstracted
 //! behind the [`MailTransport`](crate::transport::MailTransport) trait so
 //! tests can inject a mock.
 
 use std::collections::HashSet;
-use std::sync::Arc;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
 
 use rsa::RsaPrivateKey;
 use uuid::Uuid;
 
 use crate::dkim;
+use crate::frontmatter::{
+    DeliveryStatus, OutboundFrontmatter, compute_thread_id, format_outbound_frontmatter,
+};
 use crate::send_protocol::{ErrCode, SendRequest, SendResponse};
+use crate::slug::{allocate_filename, slugify};
 use crate::transport::MailTransport;
+
+/// Process-scoped lock guarding the outbound critical section: filename
+/// allocation + file/directory creation. The daemon is the single writer
+/// to `<data_dir>/sent/`, so a process Mutex is sufficient. The lock is
+/// held only for the metadata check + `fs::File::create` — the actual
+/// file write happens outside the lock. Symmetric to `INGEST_WRITE_LOCK`
+/// in `ingest.rs`.
+static SENT_WRITE_LOCK: Mutex<()> = Mutex::new(());
 
 /// Context shared across every per-connection send.
 ///
@@ -38,6 +52,9 @@ pub struct SendContext {
     /// Transport used for final MX delivery. In production this is a
     /// `LettreTransport`; tests inject a mock.
     pub transport: Arc<dyn MailTransport + Send + Sync>,
+    /// Data directory root (`/var/lib/aimx` by default). Sent files are
+    /// written to `<data_dir>/sent/<from_mailbox>/`.
+    pub data_dir: PathBuf,
 }
 
 /// Execute one submitted send end-to-end and return the wire response.
@@ -68,7 +85,18 @@ where
         };
     }
 
-    let headers = scan_headers(&req.body, &["From", "To", "Message-ID"]);
+    let headers = scan_headers(
+        &req.body,
+        &[
+            "From",
+            "To",
+            "Message-ID",
+            "Subject",
+            "In-Reply-To",
+            "References",
+            "Date",
+        ],
+    );
 
     let from_header = match headers.get("From") {
         Some(v) => v.clone(),
@@ -156,11 +184,52 @@ where
         }
     };
 
+    let subject = headers.get("Subject").cloned().unwrap_or_default();
+    let in_reply_to = headers.get("In-Reply-To").cloned();
+    let references_val = headers.get("References").cloned();
+
     match ctx.transport.send(&from_header, &recipient_bare, &signed) {
-        Ok(_server) => SendResponse::Ok { message_id },
+        Ok(_server) => {
+            let delivered_at = chrono::Utc::now().to_rfc3339();
+            persist_sent_file(
+                ctx,
+                &req.from_mailbox,
+                &message_id,
+                &from_header,
+                &to_header,
+                &subject,
+                in_reply_to.as_deref(),
+                references_val.as_deref(),
+                &signed,
+                DeliveryStatus::Delivered,
+                Some(&delivered_at),
+                None,
+            );
+            SendResponse::Ok { message_id }
+        }
         Err(e) => {
             let msg = e.to_string();
             let code = classify_transport_error(&msg);
+            // TEMP errors: do NOT persist. The client sees the transient
+            // error and may retry, so writing a "failed" record would be
+            // premature. Only permanent delivery failures (DELIVERY) get
+            // persisted.
+            if code == ErrCode::Delivery {
+                persist_sent_file(
+                    ctx,
+                    &req.from_mailbox,
+                    &message_id,
+                    &from_header,
+                    &to_header,
+                    &subject,
+                    in_reply_to.as_deref(),
+                    references_val.as_deref(),
+                    &signed,
+                    DeliveryStatus::Failed,
+                    None,
+                    Some(&msg),
+                );
+            }
             SendResponse::Err { code, reason: msg }
         }
     }
@@ -288,6 +357,121 @@ fn classify_transport_error(msg: &str) -> ErrCode {
     }
 }
 
+#[allow(clippy::too_many_arguments)]
+fn persist_sent_file(
+    ctx: &SendContext,
+    from_mailbox: &str,
+    message_id: &str,
+    from_header: &str,
+    to_header: &str,
+    subject: &str,
+    in_reply_to: Option<&str>,
+    references: Option<&str>,
+    signed_bytes: &[u8],
+    delivery_status: DeliveryStatus,
+    delivered_at: Option<&str>,
+    delivery_details: Option<&str>,
+) {
+    let sent_dir = ctx.data_dir.join("sent").join(from_mailbox);
+    if let Err(e) = std::fs::create_dir_all(&sent_dir) {
+        eprintln!(
+            "[send] failed to create sent dir {}: {e}",
+            sent_dir.display()
+        );
+        return;
+    }
+
+    let slug = slugify(subject);
+    let timestamp = chrono::Utc::now();
+    let has_attachments = false; // Outbound via UDS is text-only for now (v0.2).
+
+    let thread_id = compute_thread_id(message_id, in_reply_to, references);
+
+    let date = chrono::Utc::now().to_rfc3339();
+
+    let meta = OutboundFrontmatter {
+        id: String::new(), // filled after allocation
+        message_id: message_id.to_string(),
+        thread_id,
+        from: from_header.to_string(),
+        to: to_header.to_string(),
+        cc: None,
+        reply_to: None,
+        delivered_to: to_header.to_string(),
+        subject: subject.to_string(),
+        date,
+        received_at: String::new(),
+        received_from_ip: None,
+        size_bytes: signed_bytes.len(),
+        attachments: vec![],
+        in_reply_to: in_reply_to.map(|s| s.to_string()),
+        references: references.map(|s| s.to_string()),
+        list_id: None,
+        auto_submitted: None,
+        dkim: "pass".to_string(),
+        spf: "none".to_string(),
+        dmarc: "none".to_string(),
+        trusted: "none".to_string(),
+        mailbox: from_mailbox.to_string(),
+        read: false,
+        labels: vec![],
+        outbound: true,
+        delivery_status,
+        bcc: None,
+        delivered_at: delivered_at.map(|s| s.to_string()),
+        delivery_details: delivery_details.map(|s| s.to_string()),
+    };
+
+    // Critical section: allocate filename + create the file atomically.
+    let (md_path, id) = {
+        let _guard = SENT_WRITE_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        let md_path = allocate_filename(&sent_dir, timestamp, &slug, has_attachments);
+        let parent_dir = md_path.parent().unwrap_or(&sent_dir);
+
+        if let Err(e) = std::fs::create_dir_all(parent_dir) {
+            eprintln!(
+                "[send] failed to create parent dir {}: {e}",
+                parent_dir.display()
+            );
+            return;
+        }
+
+        let id = md_path
+            .file_stem()
+            .and_then(|s| s.to_str())
+            .unwrap_or_default()
+            .to_string();
+
+        // Touch the file to claim the path before releasing the lock.
+        if let Err(e) = std::fs::File::create_new(&md_path) {
+            eprintln!(
+                "[send] failed to create sent file {}: {e}",
+                md_path.display()
+            );
+            return;
+        }
+
+        (md_path, id)
+    };
+
+    // Write the actual content outside the lock.
+    let mut meta = meta;
+    meta.id = id;
+
+    let body = String::from_utf8_lossy(signed_bytes);
+    let content = format_outbound_frontmatter(&meta, &body);
+
+    if let Err(e) = std::fs::write(&md_path, content) {
+        eprintln!(
+            "[send] failed to write sent file {}: {e}",
+            md_path.display()
+        );
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -321,6 +505,13 @@ mod tests {
     }
 
     fn test_ctx(transport: Arc<dyn MailTransport + Send + Sync>) -> SendContext {
+        test_ctx_with_data_dir(transport, None)
+    }
+
+    fn test_ctx_with_data_dir(
+        transport: Arc<dyn MailTransport + Send + Sync>,
+        data_dir: Option<std::path::PathBuf>,
+    ) -> SendContext {
         use tempfile::TempDir;
         let tmp = TempDir::new().unwrap();
         dkim::generate_keypair(tmp.path(), false).unwrap();
@@ -328,12 +519,14 @@ mod tests {
         let mut boxes = HashSet::new();
         boxes.insert("catchall".to_string());
         boxes.insert("alice".to_string());
+        let dir = data_dir.unwrap_or_else(|| tmp.path().to_path_buf());
         SendContext {
             dkim_key: Arc::new(key),
             primary_domain: "example.com".to_string(),
             dkim_selector: "dkim".to_string(),
             registered_mailboxes: boxes,
             transport,
+            data_dir: dir,
         }
     }
 
@@ -701,5 +894,127 @@ mod tests {
             }
             other => panic!("expected Err(SIGN), got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn successful_send_persists_sent_file() {
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Ok,
+        });
+        let ctx = test_ctx_with_data_dir(mock, Some(data_dir.path().to_path_buf()));
+        let req = SendRequest {
+            from_mailbox: "alice".to_string(),
+            body: body("alice@example.com"),
+        };
+        let resp = handle_send(req, &ctx).await;
+        assert!(matches!(resp, SendResponse::Ok { .. }), "{resp:?}");
+
+        let sent_dir = data_dir.path().join("sent").join("alice");
+        assert!(sent_dir.exists(), "sent dir should be created");
+
+        let entries: Vec<_> = std::fs::read_dir(&sent_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert_eq!(entries.len(), 1, "one sent file");
+
+        let content = std::fs::read_to_string(entries[0].path()).unwrap();
+        assert!(content.contains("delivery_status = \"delivered\""));
+        assert!(content.contains("outbound = true"));
+        assert!(content.contains("delivered_at ="));
+        assert!(content.contains("DKIM-Signature:"));
+        assert!(content.contains("dkim = \"pass\""));
+    }
+
+    #[tokio::test]
+    async fn permanent_failure_persists_sent_file_with_failed_status() {
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Err("Rejected by mx.example.com: 550 no such user".to_string()),
+        });
+        let ctx = test_ctx_with_data_dir(mock, Some(data_dir.path().to_path_buf()));
+        let req = SendRequest {
+            from_mailbox: "alice".to_string(),
+            body: body("alice@example.com"),
+        };
+        let resp = handle_send(req, &ctx).await;
+        assert!(matches!(resp, SendResponse::Err { .. }), "{resp:?}");
+
+        let sent_dir = data_dir.path().join("sent").join("alice");
+        let entries: Vec<_> = std::fs::read_dir(&sent_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert_eq!(entries.len(), 1, "failed send persists a file");
+
+        let content = std::fs::read_to_string(entries[0].path()).unwrap();
+        assert!(content.contains("delivery_status = \"failed\""));
+        assert!(content.contains("delivery_details ="));
+        assert!(content.contains("550 no such user"));
+    }
+
+    #[tokio::test]
+    async fn temp_error_does_not_persist_sent_file() {
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Err("All MX servers for gmail.com unreachable: ...".to_string()),
+        });
+        let ctx = test_ctx_with_data_dir(mock, Some(data_dir.path().to_path_buf()));
+        let req = SendRequest {
+            from_mailbox: "alice".to_string(),
+            body: body("alice@example.com"),
+        };
+        let resp = handle_send(req, &ctx).await;
+        assert!(matches!(resp, SendResponse::Err { .. }), "{resp:?}");
+
+        let sent_dir = data_dir.path().join("sent").join("alice");
+        if sent_dir.exists() {
+            let entries: Vec<_> = std::fs::read_dir(&sent_dir)
+                .unwrap()
+                .filter_map(|e| e.ok())
+                .collect();
+            assert_eq!(entries.len(), 0, "TEMP errors should not persist");
+        }
+    }
+
+    #[tokio::test]
+    async fn sent_file_frontmatter_roundtrips() {
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Ok,
+        });
+        let ctx = test_ctx_with_data_dir(mock, Some(data_dir.path().to_path_buf()));
+        let req = SendRequest {
+            from_mailbox: "alice".to_string(),
+            body: body("alice@example.com"),
+        };
+        let resp = handle_send(req, &ctx).await;
+        assert!(matches!(resp, SendResponse::Ok { .. }));
+
+        let sent_dir = data_dir.path().join("sent").join("alice");
+        let entries: Vec<_> = std::fs::read_dir(&sent_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        let content = std::fs::read_to_string(entries[0].path()).unwrap();
+
+        // Parse frontmatter back
+        let parts: Vec<&str> = content.splitn(3, "+++").collect();
+        assert!(parts.len() >= 3);
+        let toml_str = parts[1].trim();
+        let parsed: crate::frontmatter::OutboundFrontmatter = toml::from_str(toml_str).unwrap();
+        assert!(parsed.outbound);
+        assert_eq!(
+            parsed.delivery_status,
+            crate::frontmatter::DeliveryStatus::Delivered
+        );
+        assert_eq!(parsed.mailbox, "alice");
+        assert_eq!(parsed.message_id, "<abc@example.com>");
+        assert!(parsed.delivered_at.is_some());
     }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -123,6 +123,7 @@ async fn run_serve(
         dkim_selector: config.dkim_selector.clone(),
         registered_mailboxes: config.mailboxes.keys().cloned().collect(),
         transport,
+        data_dir: config.data_dir.clone(),
     });
 
     let server = SmtpServer::new(config);
@@ -824,6 +825,7 @@ mod tests {
                 dkim_selector: "dkim".to_string(),
                 registered_mailboxes: mboxes,
                 transport,
+                data_dir: tmp.path().to_path_buf(),
             });
 
             let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
@@ -906,6 +908,7 @@ mod tests {
                 dkim_selector: "dkim".to_string(),
                 registered_mailboxes: mboxes,
                 transport,
+                data_dir: tmp.path().to_path_buf(),
             });
 
             let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -1,0 +1,314 @@
+use crate::config::MailboxConfig;
+use crate::frontmatter::AuthResults;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// Result of per-mailbox trust evaluation, surfaced as the `trusted`
+/// frontmatter field on every inbound email (FR-37b).
+///
+/// Three-valued:
+///
+/// - `None` -- mailbox `trust` is `none` (default). No evaluation performed.
+/// - `True` -- mailbox `trust` is `verified`, sender matches
+///   `trusted_senders`, AND DKIM passed.
+/// - `False` -- mailbox `trust` is `verified`, any other outcome.
+///
+/// Serializes to lowercase `"none"`, `"true"`, `"false"`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TrustedValue {
+    None,
+    True,
+    False,
+}
+
+impl TrustedValue {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            TrustedValue::None => "none",
+            TrustedValue::True => "true",
+            TrustedValue::False => "false",
+        }
+    }
+}
+
+impl fmt::Display for TrustedValue {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+impl Serialize for TrustedValue {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serializer.serialize_str(self.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for TrustedValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        match s.as_str() {
+            "none" => Ok(TrustedValue::None),
+            "true" => Ok(TrustedValue::True),
+            "false" => Ok(TrustedValue::False),
+            other => Err(serde::de::Error::custom(format!(
+                "invalid trusted value: {other}"
+            ))),
+        }
+    }
+}
+
+/// Evaluate the trust outcome for an inbound email against a mailbox's
+/// trust policy.
+///
+/// Logic:
+/// - `trust: none` -> `TrustedValue::None` (no evaluation)
+/// - `trust: verified` AND sender matches `trusted_senders` AND DKIM pass
+///   -> `TrustedValue::True`
+/// - `trust: verified`, any other outcome -> `TrustedValue::False`
+///
+/// Note: this is stricter than the channel-trigger gate in `channel.rs`,
+/// which fires when the sender is allowlisted OR DKIM passes. The
+/// `trusted` field requires BOTH. See `channel::should_execute_triggers`
+/// for the v1 gate semantics and the rationale comment there.
+pub fn evaluate_trust(mailbox: &MailboxConfig, auth: &AuthResults, from: &str) -> TrustedValue {
+    if mailbox.trust == "none" {
+        return TrustedValue::None;
+    }
+
+    if mailbox.trust == "verified" {
+        let sender_allowlisted = is_sender_in_trusted_senders(mailbox, from);
+        let dkim_passed = auth.dkim == "pass";
+
+        if sender_allowlisted && dkim_passed {
+            return TrustedValue::True;
+        }
+        return TrustedValue::False;
+    }
+
+    // Unknown trust value: fail closed (same as channel.rs).
+    TrustedValue::False
+}
+
+fn extract_email_for_match(from: &str) -> String {
+    if let Some(start) = from.find('<')
+        && let Some(end) = from.find('>')
+    {
+        return from[start + 1..end].to_lowercase();
+    }
+    from.to_lowercase()
+}
+
+fn is_sender_in_trusted_senders(mailbox: &MailboxConfig, from: &str) -> bool {
+    let from_lower = extract_email_for_match(from);
+    for pattern in &mailbox.trusted_senders {
+        if glob_match::glob_match(pattern, &from_lower) {
+            return true;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::MailboxConfig;
+    use crate::frontmatter::AuthResults;
+
+    fn mailbox_none() -> MailboxConfig {
+        MailboxConfig {
+            address: "*@test.com".to_string(),
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            on_receive: vec![],
+        }
+    }
+
+    fn mailbox_verified(trusted_senders: Vec<String>) -> MailboxConfig {
+        MailboxConfig {
+            address: "secure@test.com".to_string(),
+            trust: "verified".to_string(),
+            trusted_senders,
+            on_receive: vec![],
+        }
+    }
+
+    fn auth(dkim: &str) -> AuthResults {
+        AuthResults {
+            dkim: dkim.to_string(),
+            spf: "none".to_string(),
+            dmarc: "none".to_string(),
+        }
+    }
+
+    #[test]
+    fn trust_none_returns_none() {
+        let mb = mailbox_none();
+        let result = evaluate_trust(&mb, &auth("pass"), "anyone@example.com");
+        assert_eq!(result, TrustedValue::None);
+        assert_eq!(result.as_str(), "none");
+    }
+
+    #[test]
+    fn trust_none_returns_none_even_with_dkim_fail() {
+        let mb = mailbox_none();
+        let result = evaluate_trust(&mb, &auth("fail"), "anyone@example.com");
+        assert_eq!(result, TrustedValue::None);
+    }
+
+    #[test]
+    fn verified_allowlisted_dkim_pass_returns_true() {
+        let mb = mailbox_verified(vec!["*@gmail.com".to_string()]);
+        let result = evaluate_trust(&mb, &auth("pass"), "alice@gmail.com");
+        assert_eq!(result, TrustedValue::True);
+        assert_eq!(result.as_str(), "true");
+    }
+
+    #[test]
+    fn verified_allowlisted_dkim_fail_returns_false() {
+        let mb = mailbox_verified(vec!["*@gmail.com".to_string()]);
+        let result = evaluate_trust(&mb, &auth("fail"), "alice@gmail.com");
+        assert_eq!(result, TrustedValue::False);
+        assert_eq!(result.as_str(), "false");
+    }
+
+    #[test]
+    fn verified_not_allowlisted_dkim_pass_returns_false() {
+        let mb = mailbox_verified(vec!["*@company.com".to_string()]);
+        let result = evaluate_trust(&mb, &auth("pass"), "alice@gmail.com");
+        assert_eq!(result, TrustedValue::False);
+    }
+
+    #[test]
+    fn verified_not_allowlisted_dkim_fail_returns_false() {
+        let mb = mailbox_verified(vec!["*@company.com".to_string()]);
+        let result = evaluate_trust(&mb, &auth("fail"), "alice@gmail.com");
+        assert_eq!(result, TrustedValue::False);
+    }
+
+    #[test]
+    fn verified_empty_trusted_senders_dkim_pass_returns_false() {
+        let mb = mailbox_verified(vec![]);
+        let result = evaluate_trust(&mb, &auth("pass"), "alice@gmail.com");
+        assert_eq!(result, TrustedValue::False);
+    }
+
+    #[test]
+    fn verified_dkim_none_returns_false() {
+        let mb = mailbox_verified(vec!["*@gmail.com".to_string()]);
+        let result = evaluate_trust(&mb, &auth("none"), "alice@gmail.com");
+        assert_eq!(result, TrustedValue::False);
+    }
+
+    #[test]
+    fn verified_exact_sender_match() {
+        let mb = mailbox_verified(vec!["alice@gmail.com".to_string()]);
+        let result = evaluate_trust(&mb, &auth("pass"), "alice@gmail.com");
+        assert_eq!(result, TrustedValue::True);
+    }
+
+    #[test]
+    fn verified_display_name_in_from() {
+        let mb = mailbox_verified(vec!["*@gmail.com".to_string()]);
+        let result = evaluate_trust(&mb, &auth("pass"), "Alice Smith <alice@gmail.com>");
+        assert_eq!(result, TrustedValue::True);
+    }
+
+    #[test]
+    fn unknown_trust_value_returns_false() {
+        let mb = MailboxConfig {
+            address: "test@test.com".to_string(),
+            trust: "typo".to_string(),
+            trusted_senders: vec![],
+            on_receive: vec![],
+        };
+        let result = evaluate_trust(&mb, &auth("pass"), "alice@gmail.com");
+        assert_eq!(result, TrustedValue::False);
+    }
+
+    #[test]
+    fn serialization_roundtrip() {
+        for variant in [TrustedValue::None, TrustedValue::True, TrustedValue::False] {
+            let json = serde_json::to_string(&variant).unwrap();
+            let back: TrustedValue = serde_json::from_str(&json).unwrap();
+            assert_eq!(variant, back);
+        }
+    }
+
+    /// Parity test: for a `trust: verified` mailbox, `trusted == "true"` IFF
+    /// the channel-trigger gate would fire.
+    ///
+    /// The channel gate (v1 semantics) fires when:
+    /// - sender is allowlisted, OR
+    /// - DKIM passes
+    ///
+    /// The `trusted` field (FR-37b) is `"true"` when:
+    /// - sender is allowlisted AND DKIM passes
+    ///
+    /// So `trusted == "true"` is strictly stronger than the trigger gate.
+    /// When `trusted == "true"`, the trigger gate also fires (both conditions
+    /// met). This test confirms that agreement.
+    #[test]
+    fn parity_trusted_true_implies_trigger_fires() {
+        use crate::channel;
+        use crate::frontmatter::InboundFrontmatter;
+
+        let mb = mailbox_verified(vec!["*@gmail.com".to_string()]);
+
+        let test_cases = vec![
+            ("alice@gmail.com", "pass"),
+            ("alice@gmail.com", "fail"),
+            ("alice@gmail.com", "none"),
+            ("alice@yahoo.com", "pass"),
+            ("alice@yahoo.com", "fail"),
+            ("alice@yahoo.com", "none"),
+        ];
+
+        for (from, dkim_result) in test_cases {
+            let auth_results = auth(dkim_result);
+            let trusted = evaluate_trust(&mb, &auth_results, from);
+
+            let meta = InboundFrontmatter {
+                id: "test".to_string(),
+                message_id: "<test@test.com>".to_string(),
+                thread_id: "0123456789abcdef".to_string(),
+                from: from.to_string(),
+                to: "agent@test.com".to_string(),
+                cc: None,
+                reply_to: None,
+                delivered_to: "agent@test.com".to_string(),
+                subject: "Test".to_string(),
+                date: "2025-01-01T00:00:00Z".to_string(),
+                received_at: "2025-01-01T00:00:01Z".to_string(),
+                received_from_ip: None,
+                size_bytes: 100,
+                in_reply_to: None,
+                references: None,
+                attachments: vec![],
+                list_id: None,
+                auto_submitted: None,
+                dkim: dkim_result.to_string(),
+                spf: "none".to_string(),
+                dmarc: "none".to_string(),
+                trusted: trusted.as_str().to_string(),
+                mailbox: "secure".to_string(),
+                read: false,
+                labels: vec![],
+            };
+
+            let trigger_would_fire = channel::should_execute_triggers(&mb, &meta);
+
+            if trusted == TrustedValue::True {
+                assert!(
+                    trigger_would_fire,
+                    "trusted=true but trigger would NOT fire for from={from}, dkim={dkim_result}"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **S38-1: `trusted` frontmatter field** -- New `src/trust.rs` module with `TrustedValue` enum and `evaluate_trust()`. Computes per-mailbox trust at ingest time: `trust:none` -> `"none"`, `trust:verified` + allowlisted + DKIM pass -> `"true"`, otherwise -> `"false"`. Channel trigger gate preserved at v1 semantics (allowlisted OR DKIM pass). Parity test confirms agreement.

- **S38-2: Outbound frontmatter block** -- `OutboundFrontmatter` struct in `frontmatter.rs` with `DeliveryStatus` enum (`delivered`/`deferred`/`failed`/`pending`). Composes all inbound fields plus outbound block (`outbound`, `delivery_status`, `bcc`, `delivered_at`, `delivery_details`). `delivery_status` always written; optional fields follow omission rules.

- **S38-3: Sent-items persistence** -- `send_handler.rs` persists DKIM-signed message to `sent/<mailbox>/<stem>.md` after successful delivery or permanent failure. `Mutex<()>` guards filename allocation; file write outside the lock. TEMP errors skip persistence. `mailbox_list` CLI and MCP now report sent counts.

## Test plan

- [x] `evaluate_trust()` unit tests cover all arms: trust:none, verified+allowlisted+pass, allowlisted+fail, not-allowlisted+pass, not-allowlisted+fail
- [x] Parity test: `trusted == "true"` implies channel trigger would fire
- [x] `DeliveryStatus` serialization roundtrip test
- [x] `OutboundFrontmatter` field ordering golden test
- [x] Outbound golden test validates `format_outbound_frontmatter` roundtrip
- [x] Successful send persists sent file with `delivery_status: "delivered"`
- [x] Permanent failure persists sent file with `delivery_status: "failed"` and `delivery_details`
- [x] TEMP errors do NOT persist sent file
- [x] Sent file frontmatter roundtrips through TOML parse
- [x] `cargo test` (583 unit + 51 integration = 634 total), `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` all clean