### PR TITLE
[Sprint 39] Agent Primer as Progressive-Disclosure Skill Bundle + Author Metadata

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,19 @@ jobs:
       - name: Run tests
         run: cargo test
 
+      - name: Check author metadata
+        run: |
+          if grep -r '"author"' agents/ | grep -q '"AIMX"'; then
+            echo "ERROR: Found placeholder author string 'AIMX' under agents/"
+            grep -rn '"author"' agents/ | grep '"AIMX"'
+            exit 1
+          fi
+          if grep -r 'chua@example.com' agents/; then
+            echo "ERROR: Found placeholder email under agents/"
+            exit 1
+          fi
+          echo "Author metadata check passed"
+
   verifier-tests:
     runs-on: ubuntu-latest
     defaults:

--- a/agents/claude-code/.claude-plugin/plugin.json
+++ b/agents/claude-code/.claude-plugin/plugin.json
@@ -3,7 +3,7 @@
   "description": "Self-hosted email for AI agents. Provides MCP tools for sending, reading, and managing email stored as Markdown files.",
   "version": "0.1.0",
   "author": {
-    "name": "AIMX",
+    "name": "U-Zyn Chua <chua@uzyn.com>",
     "url": "https://github.com/uzyn/aimx"
   },
   "mcpServers": {

--- a/agents/claude-code/skills/aimx/SKILL.md.header
+++ b/agents/claude-code/skills/aimx/SKILL.md.header
@@ -1,5 +1,6 @@
 ---
 name: aimx
 description: Self-hosted email for AI agents. Send, read, reply to, and manage email via AIMX MCP tools. Invoke when the user asks about sending mail, checking an inbox, replying to a message, or managing mailboxes, or when the conversation references AIMX.
+author: U-Zyn Chua <chua@uzyn.com>
 ---
 

--- a/agents/codex/SKILL.md.header
+++ b/agents/codex/SKILL.md.header
@@ -1,5 +1,6 @@
 ---
 name: aimx
 description: Self-hosted email for AI agents. Send, read, reply to, and manage email via AIMX MCP tools. Invoke when the user asks about sending mail, checking an inbox, replying to a message, or managing mailboxes, or when the conversation references AIMX.
+author: U-Zyn Chua <chua@uzyn.com>
 ---
 

--- a/agents/common/aimx-primer.md
+++ b/agents/common/aimx-primer.md
@@ -6,125 +6,301 @@ filesystem. This document describes how to interact with AIMX. Read it once
 before attempting mail operations; re-read any section you need when a tool
 call fails.
 
-## MCP tools
+For full reference material, see the files in `references/`:
+- `references/mcp-tools.md` — full MCP tool signatures, types, and examples
+- `references/frontmatter.md` — complete frontmatter schema
+- `references/workflows.md` — worked examples for common tasks
+- `references/troubleshooting.md` — error codes and recovery steps
 
-All tools are served by the `aimx` binary over stdio. Nine tools are
-available.
+At runtime, `/var/lib/aimx/README.md` is the authoritative guide to the data
+directory layout, regenerated on each AIMX upgrade.
+
+## Two access surfaces
+
+AIMX gives you two complementary ways to interact with email:
+
+1. **MCP tools** — for all mutations (send, reply, create mailboxes, mark
+   read/unread). The `aimx` MCP server runs over stdio and is launched
+   on-demand by your MCP client.
+2. **Direct filesystem reads** — for reading `.md` email files, scanning
+   directories, or bulk-processing. The data directory is world-readable and
+   its format is stable.
+
+Writes always go through MCP. Never create, modify, or delete `.md` files
+directly — the daemon owns those paths.
+
+## MCP tools — quick reference
+
+All 9 tools are served by the `aimx` binary over stdio. They return strings
+on success and error strings on failure.
 
 ### Mailbox tools
 
-- `mailbox_create(name: string)` — create a new mailbox. `name` is the local
-  part of the email address (e.g. `agent` → `agent@<domain>`).
-- `mailbox_list()` — list all mailboxes with total and unread message counts.
-- `mailbox_delete(name: string)` — delete a mailbox and every email in it.
-  Irreversible.
+- `mailbox_create(name)` — create a new mailbox identity (inbox + sent).
+- `mailbox_list()` — list all mailboxes with message counts.
+- `mailbox_delete(name)` — delete a mailbox and all its mail. Irreversible.
 
 ### Email tools
 
-- `email_list(mailbox: string, unread?: bool, from?: string, since?: string,
-  subject?: string)` — list emails in a mailbox. Filters AND together.
-  `since` is RFC 3339 (e.g. `2025-01-01T00:00:00Z`). `from` is substring
-  match. `subject` is case-insensitive substring match.
-- `email_read(mailbox: string, id: string)` — return the full Markdown file
-  (frontmatter + body) for a single email. `id` has the form
-  `YYYY-MM-DD-NNN` (e.g. `2025-01-01-001`).
-- `email_send(from_mailbox: string, to: string, subject: string, body: string,
-  attachments?: string[])` — compose, DKIM-sign, and deliver an email.
-  `from_mailbox` must be a real mailbox name (not a catchall). `attachments`
-  are absolute file paths.
-- `email_reply(mailbox: string, id: string, body: string)` — reply to an
-  existing email. AIMX sets `In-Reply-To`, `References`, and the `Re:`
-  subject automatically.
-- `email_mark_read(mailbox: string, id: string)` — mark a single email as
-  read.
-- `email_mark_unread(mailbox: string, id: string)` — mark a single email as
-  unread.
+- `email_list(mailbox, folder?, unread?, from?, since?, subject?)` — list
+  emails. `folder` is `"inbox"` (default) or `"sent"`. Filters AND together.
+- `email_read(mailbox, id, folder?)` — return the full Markdown file
+  (frontmatter + body) for one email.
+- `email_send(from_mailbox, to, subject, body, attachments?)` — compose,
+  DKIM-sign, and deliver an email. `from_mailbox` must be a real mailbox.
+- `email_reply(mailbox, id, body)` — reply to an existing email. AIMX sets
+  `In-Reply-To`, `References`, and `Re:` subject automatically.
+- `email_mark_read(mailbox, id, folder?)` — mark a single email as read.
+- `email_mark_unread(mailbox, id, folder?)` — mark a single email as unread.
 
-All tools return strings. Errors are returned as error strings — inspect the
-message and adjust parameters.
+See `references/mcp-tools.md` for full parameter types, return values, and
+worked examples.
 
 ## Storage layout
 
-AIMX stores mail on the local filesystem under a data directory (default
-`/var/lib/aimx/`):
+<!-- FR-50c: the datadir layout is documented explicitly. The real security
+     boundary is DKIM keys at /etc/aimx/ (root-only) and the UDS socket at
+     /run/aimx/send.sock — not filesystem obscurity. -->
+
+AIMX stores mail under a data directory (default `/var/lib/aimx/`):
 
 ```
-/var/lib/aimx/
-├── config.toml
-├── dkim/
-│   ├── private.key
-│   └── public.key
-├── <mailbox>/
-│   ├── YYYY-MM-DD-NNN.md
-│   └── attachments/
-│       └── <filename>
-└── catchall/
-    └── ...
+/var/lib/aimx/                          # world-readable datadir
+├── README.md                           # agent-facing layout guide (auto-generated)
+├── inbox/
+│   ├── <mailbox>/
+│   │   ├── 2026-04-15-143022-meeting-notes.md
+│   │   └── 2026-04-15-153300-invoice-march/     # attachment bundle
+│   │       ├── 2026-04-15-153300-invoice-march.md
+│   │       ├── invoice.pdf
+│   │       └── receipt.png
+│   └── catchall/                       # unknown local parts
+│       └── ...
+└── sent/
+    └── <mailbox>/
+        └── 2026-04-15-160145-re-meeting-notes.md
 ```
 
-- One Markdown file per email, named `YYYY-MM-DD-NNN.md` where `NNN` is a
-  per-day sequence starting at `001`.
-- Attachments are extracted into the mailbox's `attachments/` directory.
-  Filenames are preserved; the frontmatter lists them.
-- `catchall` receives any mail addressed to an unrecognised local part.
-- You may read `.md` files directly from the filesystem when that is more
-  convenient than an MCP call — the format is stable.
+- **Filenames** follow `YYYY-MM-DD-HHMMSS-<slug>.md` (UTC). The slug is
+  derived from the subject: lowercase, non-alphanumeric chars replaced with
+  `-`, collapsed, truncated to 20 chars, empty becomes `no-subject`.
+- **Attachment bundles** — zero attachments produce a flat `.md` file; one or
+  more produce a directory containing `<stem>.md` plus attachment files as
+  siblings (Zola-style bundle).
+- **`catchall`** receives mail addressed to unrecognised local parts.
+- **`inbox/`** holds inbound mail; **`sent/`** holds outbound copies.
 
-## Frontmatter
+Configuration and secrets live separately under `/etc/aimx/` (root-owned,
+not readable by agents):
 
-Each email file begins with a TOML frontmatter block delimited by `+++`
-(three plus signs, not `---`). Fields:
+```
+/etc/aimx/
+├── config.toml      # main config (root:root 640)
+└── dkim/
+    ├── private.key   # DKIM signing key (root:root 600)
+    └── public.key    # publishable (root:root 644)
+```
 
-- `id` — `YYYY-MM-DD-NNN`, matches the filename stem.
-- `message_id` — RFC 5322 `Message-ID` of the email, without angle brackets.
-- `from` — sender address (may include display name).
-- `to` — recipient address (may include display name).
-- `subject` — email subject, or `(no subject)` when absent.
-- `date` — RFC 3339 timestamp when the email was received.
-- `in_reply_to` — parent `Message-ID` if this is a reply, otherwise empty.
-- `references` — space-separated chain of `Message-ID`s for threading, or
-  empty.
-- `attachments` — array of `{name, path, content_type, size}` tables, one per
-  attachment.
-- `mailbox` — name of the mailbox this email was routed to.
-- `read` — `true` or `false`. Set to `false` on ingest.
-- `dkim` — `pass`, `fail`, or `none`. Result of DKIM signature verification
-  during ingest.
-- `spf` — `pass`, `fail`, or `none`. Result of SPF verification during
-  ingest.
+## Frontmatter — key fields
 
-The body follows the closing `+++`, rendered from the `text/plain` part of
-the message (falling back to `text/html` converted to plaintext).
+Each email file has TOML frontmatter between `+++` delimiters. The fields
+agents most commonly need:
 
-## Mailboxes
+| Field            | Type     | Notes                                              |
+|-----------------|----------|-----------------------------------------------------|
+| `id`            | string   | Matches the filename stem                            |
+| `message_id`    | string   | RFC 5322 Message-ID, without angle brackets          |
+| `thread_id`     | string   | 16-hex-char SHA-256 of the thread root Message-ID    |
+| `from`          | string   | Sender address (may include display name)            |
+| `to`            | string   | Recipient address                                    |
+| `subject`       | string   | Email subject, or `(no subject)` when absent         |
+| `date`          | string   | Sender-claimed RFC 3339 timestamp                    |
+| `received_at`   | string   | Server-side RFC 3339 UTC timestamp                   |
+| `trusted`       | string   | `"none"`, `"true"`, or `"false"` — see trust model   |
+| `read`          | bool     | `false` on ingest                                    |
+| `list_id`       | string?  | Mailing list ID header, if present                   |
+| `auto_submitted`| string?  | `auto-generated`, `auto-replied`, etc., if present   |
+| `labels`        | string[] | Empty by default                                     |
+| `dkim`          | string   | `"pass"`, `"fail"`, or `"none"`                      |
+| `spf`           | string   | `"pass"`, `"fail"`, `"softfail"`, `"neutral"`, or `"none"` |
+| `dmarc`         | string   | `"pass"`, `"fail"`, or `"none"`                      |
 
-- Mailbox names are local parts. They must be valid in the local part of an
-  email address (letters, digits, and a small set of punctuation).
-- The `catchall` mailbox is created automatically during setup and receives
-  mail for unrecognised addresses.
-- Create additional mailboxes with `mailbox_create` before sending mail
-  from them — `email_send` requires a real mailbox name.
+Sent copies carry an additional outbound block: `outbound = true`,
+`delivery_status` (`"delivered"`, `"deferred"`, `"failed"`, `"pending"`),
+and optional `delivered_at` and `delivery_details`.
+
+See `references/frontmatter.md` for the complete schema with every field,
+types, required/optional, and the outbound block.
+
+## Common workflows
+
+### 1. Check inbox for new mail
+
+```
+email_list(mailbox: "agent", unread: true)
+```
+
+Loop through results. For each, call `email_read` to get the content, then
+`email_mark_read` when done processing. This is the standard polling pattern.
+
+### 2. Send an email
+
+```
+email_send(
+  from_mailbox: "agent",
+  to: "alice@example.com",
+  subject: "Weekly report",
+  body: "Here is the summary..."
+)
+```
+
+The mailbox must exist — create it first with `mailbox_create` if needed.
+`from_mailbox` is the local part only (e.g. `"agent"`, not
+`"agent@example.com"`). AIMX DKIM-signs the message and delivers it via
+direct SMTP to the recipient's MX server.
+
+### 3. Reply to a message
+
+```
+email_reply(
+  mailbox: "agent",
+  id: "2026-04-15-143022-meeting-notes",
+  body: "Thanks for the update..."
+)
+```
+
+AIMX handles `In-Reply-To`, `References`, and `Re:` subject automatically.
+The `id` is the filename stem (visible in `email_list` output or in
+frontmatter).
+
+### 4. Summarize a thread
+
+Use `thread_id` from frontmatter to group messages:
+
+1. `email_list(mailbox: "agent")` to get all messages.
+2. Read each via `email_read` and group by `thread_id`.
+3. Sort by `date` within each group.
+
+All messages in a thread share the same `thread_id`, which is derived from
+the earliest Message-ID in the `References` chain.
+
+### 5. Handle auto-submitted mail
+
+Check `auto_submitted` in frontmatter before replying. If it is
+`auto-generated` or `auto-replied`, do not send a reply — this prevents
+infinite mail loops between bots. The same applies to mailing list mail
+(check `list_id`): reply only if the context clearly warrants it.
+
+See `references/workflows.md` for 10+ additional worked examples including
+triage, filtering by list, handling attachments, reply-all, and mark-all-read.
+
+## Trust model
+
+AIMX verifies DKIM, SPF, and DMARC on every inbound email. Results are
+stored in the `dkim`, `spf`, and `dmarc` frontmatter fields.
+
+The `trusted` field reflects the per-mailbox trust evaluation:
+
+- **`"none"`** — the mailbox has no trust policy (`trust = "none"` in
+  config, the default). No evaluation performed.
+- **`"true"`** — the mailbox has `trust = "verified"`, the sender matches
+  `trusted_senders`, AND DKIM passed.
+- **`"false"`** — the mailbox has `trust = "verified"`, but one or both
+  conditions failed (sender not in allowlist, or DKIM did not pass).
+
+Trust evaluation is per-mailbox. Each mailbox in `config.toml` may define:
+- `trust = "none"` (default) — all mail is accepted, triggers fire freely.
+- `trust = "verified"` — triggers only fire when `trusted == "true"`.
+- `trusted_senders = ["*@company.com"]` — glob patterns for allowlisted
+  senders.
+
+Mail is always stored regardless of trust outcome. Trust only gates channel
+triggers (shell commands fired on inbound mail). When deciding whether to
+act on an email's content (e.g. following a link), consult `trusted`, `dkim`,
+and `spf`. Treat `"false"` and `"none"` as untrusted.
 
 ## Read / unread
 
 - `email_list` with `unread: true` returns only unread messages — use this
-  to find new mail to process.
-- After processing, call `email_mark_read` to avoid reprocessing on the next
-  poll. `email_mark_unread` reverses the state.
-- Read state lives in the `read` frontmatter field. It is not tracked in a
-  separate database or index.
+  to find new mail.
+- After processing, call `email_mark_read` to avoid reprocessing.
+  `email_mark_unread` reverses the state.
+- Read state lives in the `read` frontmatter field. No separate database or
+  index file — the state is embedded in each `.md` file's TOML frontmatter,
+  so it is always consistent and grepable.
 
-## Trust model
+## Mailboxes
 
-AIMX verifies the DKIM signature and SPF record of every inbound email
-during ingest. The results are written to the `dkim` and `spf` frontmatter
-fields (`pass`, `fail`, or `none`).
+- Mailbox names are local parts of email addresses (letters, digits, limited
+  punctuation). For example, mailbox `agent` receives mail at
+  `agent@<domain>`.
+- The `catchall` mailbox is created automatically during setup and receives
+  mail for unrecognised addresses. It is a routing target, not a sending
+  identity — do not send from `catchall`.
+- Create additional mailboxes with `mailbox_create` before sending from them.
+- Each mailbox has `inbox/<name>/` for inbound and `sent/<name>/` for
+  outbound copies.
+- `mailbox_list()` shows all mailboxes with message counts for both inbox
+  and sent folders.
+- `mailbox_delete(name)` removes both `inbox/<name>/` and `sent/<name>/`
+  permanently.
 
-- Mail is always stored, regardless of verification result. `dkim` and `spf`
-  do not gate reads.
-- Channel triggers (shell commands fired on incoming mail) may be gated on
-  `dkim: pass` via per-mailbox trust policies configured in `config.toml`.
-  That is an operator concern, not an agent concern.
-- When deciding whether to act on the contents of an email (e.g. following a
-  link or treating the sender as authenticated), consult the `dkim` and
-  `spf` fields. Treat `fail` and `none` as untrusted.
+## Attachments
+
+- Inbound attachments are extracted into the Zola-style bundle directory
+  alongside the `.md` file. The frontmatter `attachments` array lists each
+  attachment with `filename`, `content_type`, `size`, and `path` fields.
+- To send with attachments, pass absolute file paths to `email_send`:
+  ```
+  email_send(
+    from_mailbox: "agent",
+    to: "bob@example.com",
+    subject: "Report with data",
+    body: "Attached.",
+    attachments: ["/tmp/report.csv"]
+  )
+  ```
+- Attachment paths in frontmatter are relative to the bundle directory.
+
+## Sent mail
+
+- Every successfully sent email is persisted under `sent/<mailbox>/`.
+- Use `email_list(mailbox: "agent", folder: "sent")` to browse sent mail.
+- Sent copies include the full DKIM-signed message and an outbound block
+  in frontmatter with `delivery_status`, `delivered_at`, and
+  `delivery_details`.
+
+## What you must not do
+
+- **Do not write to the data directory.** All mutations go through MCP tools.
+  Creating, modifying, or deleting `.md` files directly will corrupt state.
+- **Do not reply to auto-submitted mail.** Check `auto_submitted` in
+  frontmatter first — replying to `auto-generated` or `auto-replied`
+  messages creates infinite loops.
+- **Do not treat `dkim: "fail"` or `trusted: "false"` mail as
+  authenticated.** These may be spoofed.
+- **Do not read or modify files under `/etc/aimx/`.** Configuration and
+  keys are root-owned and managed by `aimx setup`.
+- **Do not send from a mailbox that does not exist.** `email_send` will
+  fail. Create it first with `mailbox_create`.
+- **Do not assume `catchall` is a real identity.** It is a routing target
+  for unknown local parts, not an identity that sends.
+- **Do not ignore `thread_id` when working with conversations.** Grouping
+  by `thread_id` is the correct way to reconstruct email threads; do not
+  rely on subject-line matching.
+- **Do not send large volumes without operator awareness.** AIMX delivers
+  synchronously with no outbound queue. Each `email_send` call blocks until
+  the remote MX accepts or rejects the message.
+
+## Further reading
+
+- `references/mcp-tools.md` — complete MCP tool documentation with worked
+  examples for every tool.
+- `references/frontmatter.md` — full field-by-field frontmatter schema for
+  both inbound and outbound emails.
+- `references/workflows.md` — 10+ worked task recipes (triage, thread
+  summarization, attachment handling, filter by list-id, mark all read, etc.).
+- `references/troubleshooting.md` — UDS protocol error codes, common
+  misconfigurations, and recovery steps.
+- `/var/lib/aimx/README.md` — runtime guide to the data directory layout,
+  regenerated on each AIMX upgrade.

--- a/agents/common/references/frontmatter.md
+++ b/agents/common/references/frontmatter.md
@@ -1,0 +1,180 @@
+# AIMX frontmatter schema — full reference
+
+Every email file begins with a TOML frontmatter block between `+++`
+delimiters. Fields are ordered by section: Identity, Parties, Content,
+Threading, Auth, Storage, and (for sent copies) an Outbound block.
+
+## Inbound frontmatter
+
+### Identity
+
+| Field        | Type   | Required | Notes |
+|-------------|--------|----------|-------|
+| `id`        | string | always   | Filename stem, e.g. `2026-04-15-143022-meeting-notes` |
+| `message_id`| string | always   | RFC 5322 Message-ID without angle brackets |
+| `thread_id` | string | always   | First 16 hex chars of SHA-256 over the resolved thread root Message-ID. Walk `In-Reply-To` first, then `References` (leftmost), fall back to own Message-ID |
+
+### Parties
+
+| Field         | Type    | Required | Notes |
+|--------------|---------|----------|-------|
+| `from`       | string  | always   | Sender address, may include display name (e.g. `Alice <alice@example.com>`) |
+| `to`         | string  | always   | Recipient address |
+| `cc`         | string  | optional | Carbon copy recipients. Omitted when empty |
+| `reply_to`   | string  | optional | Reply-To header value. Omitted when empty |
+| `delivered_to`| string | always   | Actual RCPT TO address. Disambiguates list mail from direct mail |
+
+### Content
+
+| Field             | Type      | Required | Notes |
+|------------------|-----------|----------|-------|
+| `subject`        | string    | always   | Email subject, or `(no subject)` when absent |
+| `date`           | string    | always   | Sender-claimed RFC 3339 timestamp |
+| `received_at`    | string    | always   | Server-side RFC 3339 UTC timestamp when AIMX ingested the message |
+| `received_from_ip`| string   | optional | SMTP client IP address. Omitted when unavailable (e.g. piped ingest) |
+| `size_bytes`     | integer   | always   | Raw message size in bytes |
+| `attachments`    | table[]   | optional | Array of attachment metadata tables. Omitted when empty |
+
+Each entry in the `attachments` array:
+
+| Field          | Type    | Notes |
+|---------------|---------|-------|
+| `filename`    | string  | Original filename |
+| `content_type`| string  | MIME type (e.g. `application/pdf`) |
+| `size`        | integer | Attachment size in bytes |
+| `path`        | string  | Relative path within the bundle directory |
+
+### Threading
+
+| Field            | Type    | Required | Notes |
+|-----------------|---------|----------|-------|
+| `in_reply_to`   | string  | optional | Parent Message-ID. Omitted when not a reply |
+| `references`    | string  | optional | Space-separated chain of Message-IDs for threading. Omitted when empty |
+| `list_id`       | string  | optional | `List-Id` header value. Identifies mailing list mail. Omitted when absent |
+| `auto_submitted`| string  | optional | `Auto-Submitted` header value (`auto-generated`, `auto-replied`, etc.). Omitted when absent. Check this before replying to avoid infinite loops |
+
+### Auth
+
+All auth fields are always written. They are never omitted or null so
+"not evaluated" cannot be confused with "absent."
+
+| Field     | Type   | Required | Values | Notes |
+|----------|--------|----------|--------|-------|
+| `dkim`   | string | always   | `"pass"`, `"fail"`, `"none"` | DKIM signature verification result |
+| `spf`    | string | always   | `"pass"`, `"fail"`, `"softfail"`, `"neutral"`, `"none"` | SPF record verification result |
+| `dmarc`  | string | always   | `"pass"`, `"fail"`, `"none"` | DMARC alignment check result |
+| `trusted`| string | always   | `"none"`, `"true"`, `"false"` | Per-mailbox trust evaluation outcome |
+
+#### `trusted` field details
+
+The `trusted` field surfaces the per-mailbox trust evaluation as a single
+value so agents can read the outcome directly without re-deriving it:
+
+- **`"none"`** — the mailbox has `trust = "none"` in its config (the
+  default). No trust evaluation was performed.
+- **`"true"`** — the mailbox has `trust = "verified"`, the sender matches
+  one of the `trusted_senders` glob patterns, AND DKIM passed. This is
+  equivalent to "the email passed the trigger gate."
+- **`"false"`** — the mailbox has `trust = "verified"`, but one or both
+  conditions were not met: the sender was not in the allowlist, or DKIM did
+  not pass (or both).
+
+Per-mailbox trust config in `config.toml`:
+```toml
+[[mailboxes]]
+address = "agent@domain.com"
+trust = "verified"
+trusted_senders = ["*@company.com", "alice@gmail.com"]
+```
+
+### Storage
+
+| Field    | Type     | Required | Notes |
+|---------|----------|----------|-------|
+| `mailbox`| string  | always   | Name of the mailbox this email was routed to |
+| `read`   | bool    | always   | `false` on ingest. Updated by `email_mark_read`/`email_mark_unread` |
+| `labels` | string[]| optional | Empty by default. Omitted when empty |
+
+---
+
+## Outbound frontmatter
+
+Sent copies under `sent/<mailbox>/` use the same field ordering as inbound
+(Identity → Parties → Content → Threading → Auth → Storage) plus an
+additional Outbound block at the end.
+
+### Outbound block
+
+| Field              | Type     | Required | Notes |
+|-------------------|----------|----------|-------|
+| `outbound`        | bool     | always   | Always `true` for sent copies |
+| `delivery_status` | string   | always   | `"delivered"`, `"deferred"`, `"failed"`, or `"pending"` |
+| `bcc`             | string[] | optional | BCC recipients. Only present on sent copies. Omitted when empty |
+| `delivered_at`    | string   | optional | RFC 3339 UTC timestamp when remote MX accepted the message |
+| `delivery_details`| string   | optional | Last remote SMTP response (e.g. `250 OK`) |
+
+### Field-omission rule
+
+Prefer omitting empty optional fields over writing `null`. Exceptions that
+are always written (so "not evaluated" cannot be confused with "absent"):
+`dkim`, `spf`, `dmarc`, `trusted`, `read`, `delivery_status`.
+
+---
+
+## Example: inbound email
+
+```toml
++++
+id = "2026-04-15-143022-meeting-notes"
+message_id = "abc123@example.com"
+thread_id = "a1b2c3d4e5f6a7b8"
+from = "Alice <alice@company.com>"
+to = "agent@yourdomain.com"
+delivered_to = "agent@yourdomain.com"
+subject = "Meeting Notes"
+date = "2026-04-15T14:30:22Z"
+received_at = "2026-04-15T14:30:23Z"
+received_from_ip = "203.0.113.42"
+size_bytes = 2048
+dkim = "pass"
+spf = "pass"
+dmarc = "pass"
+trusted = "true"
+mailbox = "agent"
+read = false
++++
+
+Hi, here are the notes from today's meeting...
+```
+
+## Example: sent email
+
+```toml
++++
+id = "2026-04-15-160145-re-meeting-notes"
+message_id = "def456@yourdomain.com"
+thread_id = "a1b2c3d4e5f6a7b8"
+from = "agent@yourdomain.com"
+to = "alice@company.com"
+delivered_to = "alice@company.com"
+subject = "Re: Meeting Notes"
+date = "2026-04-15T16:01:45Z"
+received_at = ""
+size_bytes = 1024
+dkim = "pass"
+spf = "none"
+dmarc = "none"
+trusted = "none"
+mailbox = "agent"
+read = false
+outbound = true
+delivery_status = "delivered"
+delivered_at = "2026-04-15T16:01:47Z"
+delivery_details = "250 OK"
++++
+
+DKIM-Signature: ...
+From: agent@yourdomain.com
+To: alice@company.com
+...
+```

--- a/agents/common/references/mcp-tools.md
+++ b/agents/common/references/mcp-tools.md
@@ -1,0 +1,253 @@
+# AIMX MCP tools — full reference
+
+All tools are served by the `aimx` binary over stdio (MCP transport). They
+return strings on success and error strings on failure. The MCP server is
+launched on-demand by your MCP client — it is not a long-running process.
+
+## Mailbox tools
+
+### `mailbox_create`
+
+Create a new mailbox. This creates both `inbox/<name>/` and `sent/<name>/`
+directories and registers the address in `config.toml`.
+
+**Parameters:**
+| Name   | Type   | Required | Description |
+|--------|--------|----------|-------------|
+| `name` | string | yes      | Local part of the email address (e.g. `agent` for `agent@domain`) |
+
+**Returns:** Confirmation string.
+
+**Example:**
+```
+mailbox_create(name: "reports")
+→ "Mailbox 'reports' created."
+```
+
+**Errors:**
+- Mailbox already exists.
+- Invalid name (must be valid email local part).
+
+---
+
+### `mailbox_list`
+
+List all mailboxes with total and unread message counts.
+
+**Parameters:** None.
+
+**Returns:** Formatted list of mailboxes with counts.
+
+**Example:**
+```
+mailbox_list()
+→ "agent (inbox: 12 total, 3 unread; sent: 5 total)
+   reports (inbox: 0 total, 0 unread; sent: 0 total)"
+```
+
+---
+
+### `mailbox_delete`
+
+Delete a mailbox and all its mail. This removes both `inbox/<name>/` and
+`sent/<name>/` directories. Irreversible.
+
+**Parameters:**
+| Name   | Type   | Required | Description |
+|--------|--------|----------|-------------|
+| `name` | string | yes      | Mailbox name to delete |
+
+**Returns:** Confirmation string.
+
+**Example:**
+```
+mailbox_delete(name: "old-project")
+→ "Mailbox 'old-project' deleted."
+```
+
+**Errors:**
+- Mailbox does not exist.
+
+---
+
+## Email tools
+
+### `email_list`
+
+List emails in a mailbox with optional filters. All filters AND together.
+
+**Parameters:**
+| Name      | Type    | Required | Description |
+|-----------|---------|----------|-------------|
+| `mailbox` | string  | yes      | Mailbox name |
+| `folder`  | string  | no       | `"inbox"` (default) or `"sent"` |
+| `unread`  | bool    | no       | Filter to only unread emails |
+| `from`    | string  | no       | Filter by sender address (substring match) |
+| `since`   | string  | no       | Filter to emails since this datetime (RFC 3339, e.g. `2026-01-01T00:00:00Z`) |
+| `subject` | string  | no       | Filter by subject (case-insensitive substring match) |
+
+**Returns:** Formatted list of matching emails.
+
+**Example — list unread inbox:**
+```
+email_list(mailbox: "agent", unread: true)
+→ "2026-04-15-143022-meeting-notes | From: alice@company.com | Subject: Meeting Notes | 2026-04-15T14:30:22Z
+   2026-04-15-153300-invoice-march | From: billing@vendor.com | Subject: Invoice March | 2026-04-15T15:33:00Z"
+```
+
+**Example — list sent mail:**
+```
+email_list(mailbox: "agent", folder: "sent")
+→ "2026-04-15-160145-re-meeting-notes | To: alice@company.com | Subject: Re: Meeting Notes | 2026-04-15T16:01:45Z"
+```
+
+**Example — filter by sender since a date:**
+```
+email_list(mailbox: "agent", from: "alice", since: "2026-04-01T00:00:00Z")
+```
+
+---
+
+### `email_read`
+
+Return the full Markdown file (TOML frontmatter + body) for a single email.
+
+**Parameters:**
+| Name      | Type   | Required | Description |
+|-----------|--------|----------|-------------|
+| `mailbox` | string | yes      | Mailbox name |
+| `id`      | string | yes      | Email ID — the filename stem (e.g. `2026-04-15-143022-meeting-notes`) |
+| `folder`  | string | no       | `"inbox"` (default) or `"sent"` |
+
+**Returns:** Full file content as a string (frontmatter + body).
+
+**Example:**
+```
+email_read(mailbox: "agent", id: "2026-04-15-143022-meeting-notes")
+→ "+++
+   id = \"2026-04-15-143022-meeting-notes\"
+   message_id = \"<abc@example.com>\"
+   ...
+   +++
+
+   Hello, here are the meeting notes..."
+```
+
+**Errors:**
+- Email not found.
+- Invalid ID format.
+
+---
+
+### `email_send`
+
+Compose, DKIM-sign, and deliver an email. The message is submitted to
+`aimx serve` via UDS, which signs it with the server's DKIM key and delivers
+directly to the recipient's MX server.
+
+**Parameters:**
+| Name           | Type     | Required | Description |
+|---------------|----------|----------|-------------|
+| `from_mailbox` | string   | yes      | Mailbox name to send from (local part only) |
+| `to`           | string   | yes      | Recipient email address |
+| `subject`      | string   | yes      | Email subject |
+| `body`         | string   | yes      | Email body text |
+| `attachments`  | string[] | no       | Absolute file paths to attach |
+
+**Returns:** Confirmation with Message-ID.
+
+**Example — plain text:**
+```
+email_send(
+  from_mailbox: "agent",
+  to: "alice@example.com",
+  subject: "Status Update",
+  body: "All systems operational."
+)
+→ "Sent. Message-ID: <abc123@domain.com>"
+```
+
+**Example — with attachments:**
+```
+email_send(
+  from_mailbox: "agent",
+  to: "bob@example.com",
+  subject: "Report",
+  body: "Please see attached.",
+  attachments: ["/tmp/report.csv", "/tmp/chart.png"]
+)
+```
+
+**Errors:**
+- Mailbox does not exist.
+- Daemon not running (socket missing).
+- Sender domain mismatch.
+- Delivery failure (remote MX rejected).
+
+---
+
+### `email_reply`
+
+Reply to an existing email. AIMX automatically sets `In-Reply-To`,
+`References`, and prepends `Re:` to the subject.
+
+**Parameters:**
+| Name      | Type   | Required | Description |
+|-----------|--------|----------|-------------|
+| `mailbox` | string | yes      | Mailbox containing the email to reply to |
+| `id`      | string | yes      | Email ID to reply to |
+| `body`    | string | yes      | Reply body text |
+
+**Returns:** Confirmation with Message-ID.
+
+**Example:**
+```
+email_reply(
+  mailbox: "agent",
+  id: "2026-04-15-143022-meeting-notes",
+  body: "Thanks, I'll review the notes."
+)
+→ "Sent. Message-ID: <def456@domain.com>"
+```
+
+---
+
+### `email_mark_read`
+
+Mark a single email as read (sets `read = true` in frontmatter).
+
+**Parameters:**
+| Name      | Type   | Required | Description |
+|-----------|--------|----------|-------------|
+| `mailbox` | string | yes      | Mailbox name |
+| `id`      | string | yes      | Email ID |
+| `folder`  | string | no       | `"inbox"` (default) or `"sent"` |
+
+**Returns:** Confirmation string.
+
+**Example:**
+```
+email_mark_read(mailbox: "agent", id: "2026-04-15-143022-meeting-notes")
+→ "Marked as read."
+```
+
+---
+
+### `email_mark_unread`
+
+Mark a single email as unread (sets `read = false` in frontmatter).
+
+**Parameters:**
+| Name      | Type   | Required | Description |
+|-----------|--------|----------|-------------|
+| `mailbox` | string | yes      | Mailbox name |
+| `id`      | string | yes      | Email ID |
+| `folder`  | string | no       | `"inbox"` (default) or `"sent"` |
+
+**Returns:** Confirmation string.
+
+**Example:**
+```
+email_mark_unread(mailbox: "agent", id: "2026-04-15-143022-meeting-notes")
+→ "Marked as unread."
+```

--- a/agents/common/references/troubleshooting.md
+++ b/agents/common/references/troubleshooting.md
@@ -1,0 +1,143 @@
+# AIMX troubleshooting — error codes and recovery
+
+## UDS send protocol error codes
+
+When `aimx send` or `email_send` fails, the daemon returns an error code and
+reason via the `AIMX/1` wire protocol. Error responses follow the format:
+
+```
+AIMX/1 ERR <CODE> <reason>
+```
+
+### Error codes
+
+| Code       | Meaning | Common cause | Recovery |
+|-----------|---------|--------------|----------|
+| `MAILBOX` | From-mailbox not found | The `from_mailbox` does not exist in `config.toml` | Create the mailbox first with `mailbox_create` |
+| `DOMAIN`  | Sender domain mismatch | The sender domain does not match the configured primary domain | Use the correct domain; check `/etc/aimx/config.toml` |
+| `SIGN`    | DKIM signing failed | DKIM private key missing or corrupted | Re-run `aimx setup` to regenerate keys |
+| `DELIVERY`| Remote MX rejected mail | Recipient server refused the message (permanent) | Check the reason — invalid recipient, blocked sender, policy rejection |
+| `TEMP`    | Temporary delivery failure | Recipient server unavailable or rate-limiting | Retry later; transient network or server issue |
+| `MALFORMED`| Request parsing failed | Malformed `AIMX/1 SEND` request frame | Internal error — ensure `aimx send` version matches `aimx serve` |
+
+### Exit codes for `aimx send`
+
+| Code | Meaning |
+|------|---------|
+| `0`  | OK — message delivered |
+| `1`  | Daemon returned ERR |
+| `2`  | Socket missing, connect failure, or running as root |
+| `3`  | Malformed response from daemon |
+
+## Common misconfigurations
+
+### "aimx daemon not running"
+
+`aimx send` or `email_send` fails with "aimx daemon not running" when the
+UDS socket at `/run/aimx/send.sock` is absent.
+
+**Cause:** `aimx serve` is not running or was not started by systemd.
+
+**Recovery:**
+```bash
+sudo systemctl status aimx
+sudo systemctl start aimx
+# or
+sudo aimx serve
+```
+
+### "sender domain does not match aimx domain"
+
+The `From:` address domain does not match the primary domain configured in
+`/etc/aimx/config.toml`.
+
+**Cause:** Sending from a domain AIMX is not configured for.
+
+**Recovery:** Verify the `domain` field in `config.toml`. AIMX only allows
+sending from the configured primary domain — any local part is accepted, but
+the domain must match exactly (case-insensitive).
+
+### Mailbox not found
+
+`email_send` or `email_reply` fails because the from-mailbox does not exist.
+
+**Cause:** Attempting to send from a mailbox that was not created.
+
+**Recovery:**
+```
+mailbox_create(name: "your-mailbox")
+```
+
+### DKIM signature failure
+
+Outbound mail fails DKIM checks at the recipient. The `dkim` field on
+inbound replies shows `"fail"`.
+
+**Possible causes:**
+- DKIM DNS record (`default._domainkey.domain.com`) is missing or incorrect.
+- DKIM private key at `/etc/aimx/dkim/private.key` was replaced without
+  updating the DNS TXT record.
+- Message was modified in transit (rare with direct SMTP delivery).
+
+**Recovery:**
+1. Re-run `aimx setup` — it will display the DKIM DNS record.
+2. Update the DNS TXT record to match the public key.
+3. Wait for DNS propagation and test again.
+
+### SPF failure on sent mail
+
+Recipient's server rejects mail with SPF `fail`.
+
+**Possible causes:**
+- SPF DNS record does not include the server's IP address.
+- Sending from an IP not covered by the SPF mechanism.
+- IPv6 is enabled but `ip6:` mechanism is missing from SPF.
+
+**Recovery:**
+1. Check the SPF record: `dig TXT domain.com`
+2. Ensure it includes `ip4:<server-ip>` (and `ip6:<server-ipv6>` if
+   `enable_ipv6 = true` is set).
+3. Re-run `aimx setup` to regenerate the correct DNS instructions.
+
+### Email not appearing in inbox
+
+Inbound mail is not showing up in the expected mailbox.
+
+**Possible causes:**
+- Mail was routed to `catchall` because the local part does not match a
+  configured mailbox.
+- Mail was rejected during SMTP session (check `journalctl -u aimx`).
+- `aimx serve` is not running.
+
+**Recovery:**
+1. Check `catchall` inbox: `email_list(mailbox: "catchall")`
+2. Verify the mailbox exists: `mailbox_list()`
+3. Check daemon logs: `journalctl -u aimx -n 50`
+
+### Permission denied reading emails
+
+Cannot read `.md` files from the filesystem directly.
+
+**Cause:** The data directory is world-readable by default, but the process
+may not have traversal permissions on parent directories.
+
+**Recovery:** Ensure the user running the agent has read access to
+`/var/lib/aimx/`. The data directory is `root:root 755` — any local user
+should have read access.
+
+### Large attachment bundle
+
+An email with attachments produces a directory instead of a flat `.md` file.
+
+**Not an error.** AIMX uses Zola-style bundles: when an email has one or
+more attachments, a directory is created containing the `.md` file and
+attachment files as siblings:
+
+```
+2026-04-15-153300-invoice-march/
+├── 2026-04-15-153300-invoice-march.md
+└── invoice.pdf
+```
+
+The `id` for this email is `2026-04-15-153300-invoice-march` (the directory
+name), and `email_read` works with this ID normally.

--- a/agents/common/references/workflows.md
+++ b/agents/common/references/workflows.md
@@ -1,0 +1,242 @@
+# AIMX workflows — worked examples
+
+Practical task recipes for common email operations. Each workflow shows the
+MCP tool calls in order with example parameters.
+
+## 1. Triage inbox
+
+Process all unread mail, categorize by sender, and mark as read:
+
+```
+# Get all unread
+email_list(mailbox: "agent", unread: true)
+
+# For each email in results:
+email_read(mailbox: "agent", id: "<id>")
+# → Parse frontmatter: check `from`, `subject`, `trusted`, `auto_submitted`
+# → Take appropriate action (reply, forward info, log, ignore)
+
+email_mark_read(mailbox: "agent", id: "<id>")
+```
+
+Triage tip: check `auto_submitted` first. If it is `auto-generated` or
+`auto-replied`, skip replying to avoid infinite loops. Check `trusted` to
+gauge sender authenticity.
+
+## 2. Thread summarization
+
+Reconstruct and summarize an email thread:
+
+```
+# List all messages in the mailbox
+email_list(mailbox: "agent")
+
+# Read each message
+email_read(mailbox: "agent", id: "<id>")
+
+# Group by thread_id from frontmatter
+# Sort each group by date (ascending)
+# Summarize the conversation flow
+```
+
+All messages in a thread share the same `thread_id`, derived from the
+earliest Message-ID in the `References`/`In-Reply-To` chain.
+
+## 3. React to auto-submitted mail
+
+Some messages are automated (bounce notices, calendar invites, CI
+notifications). Always check before replying:
+
+```
+email_read(mailbox: "agent", id: "<id>")
+# Check frontmatter:
+#   auto_submitted = "auto-generated"  → do NOT reply
+#   auto_submitted = "auto-replied"    → do NOT reply
+#   auto_submitted is absent           → safe to reply if needed
+```
+
+Replying to auto-submitted mail creates infinite loops. Log or process
+the information silently instead.
+
+## 4. Handle attachments
+
+Read an email that has attachments:
+
+```
+email_read(mailbox: "agent", id: "2026-04-15-153300-invoice-march")
+```
+
+The frontmatter will contain:
+```toml
+[[attachments]]
+filename = "invoice.pdf"
+content_type = "application/pdf"
+size = 45678
+path = "invoice.pdf"
+```
+
+For bundled emails, attachments are siblings of the `.md` file:
+```
+/var/lib/aimx/inbox/agent/2026-04-15-153300-invoice-march/
+├── 2026-04-15-153300-invoice-march.md
+├── invoice.pdf
+└── receipt.png
+```
+
+Read attachment files directly from the filesystem using the path relative
+to the bundle directory.
+
+To send with attachments:
+```
+email_send(
+  from_mailbox: "agent",
+  to: "accounting@example.com",
+  subject: "Processed invoice",
+  body: "See attached processed version.",
+  attachments: ["/tmp/processed-invoice.pdf"]
+)
+```
+
+## 5. Reply-all
+
+AIMX's `email_reply` sends to the original sender. To reply to all
+recipients, use `email_send` with explicit addresses:
+
+```
+# Read the original to get all recipients
+email_read(mailbox: "agent", id: "<id>")
+# Parse frontmatter: from, to, cc
+
+# Compose with all original recipients
+email_send(
+  from_mailbox: "agent",
+  to: "<original-from>, <original-to>, <original-cc>",
+  subject: "Re: <original-subject>",
+  body: "<reply-body>"
+)
+```
+
+Note: when using `email_send` for reply-all, you must manually set the
+subject with `Re:` prefix. Threading headers (`In-Reply-To`, `References`)
+are only set automatically by `email_reply`.
+
+## 6. Filter by list-id
+
+Process only mailing list mail:
+
+```
+email_list(mailbox: "agent")
+
+# For each email:
+email_read(mailbox: "agent", id: "<id>")
+# Check frontmatter: if list_id is present, it's from a mailing list
+# e.g. list_id = "<dev.lists.example.com>"
+
+# Handle list mail differently:
+# - Don't reply to the list unless explicitly needed
+# - Extract information without generating outbound mail
+```
+
+## 7. Ingest a bounce
+
+Bounce notices arrive as regular inbound mail. Identify them by:
+
+- `auto_submitted = "auto-generated"` or `auto_submitted = "auto-replied"`
+- Subject contains "Delivery Status Notification", "Undeliverable", or
+  similar
+- `from` contains `mailer-daemon` or `postmaster`
+
+Do not reply to bounces. Instead:
+1. Read the bounce content to identify the failed recipient.
+2. Update your records or alert the operator.
+3. Mark as read.
+
+```
+email_read(mailbox: "agent", id: "<bounce-id>")
+# Parse body for the original recipient and failure reason
+email_mark_read(mailbox: "agent", id: "<bounce-id>")
+```
+
+## 8. Mark all read
+
+Mark every unread email in a mailbox as read:
+
+```
+email_list(mailbox: "agent", unread: true)
+
+# For each email ID in the results:
+email_mark_read(mailbox: "agent", id: "<id>")
+```
+
+There is no bulk mark-read tool — iterate through each message.
+
+## 9. Check sent mail status
+
+Review delivery status of sent emails:
+
+```
+email_list(mailbox: "agent", folder: "sent")
+
+# For each sent email:
+email_read(mailbox: "agent", id: "<id>", folder: "sent")
+# Check frontmatter:
+#   delivery_status = "delivered"  → accepted by remote MX
+#   delivery_status = "failed"    → rejected, check delivery_details
+#   delivery_status = "deferred"  → temporary failure
+```
+
+## 10. Create a mailbox and send first email
+
+Set up a new agent identity and send the first message:
+
+```
+# Create the mailbox
+mailbox_create(name: "notifications")
+
+# Send the first email
+email_send(
+  from_mailbox: "notifications",
+  to: "admin@example.com",
+  subject: "Notifications mailbox active",
+  body: "This mailbox is now operational."
+)
+
+# Verify delivery
+email_list(mailbox: "notifications", folder: "sent")
+```
+
+## 11. Process mail from a specific sender since a date
+
+Filter and process a targeted subset of mail:
+
+```
+email_list(
+  mailbox: "agent",
+  from: "alice@company.com",
+  since: "2026-04-01T00:00:00Z"
+)
+
+# Read and process each matching email
+email_read(mailbox: "agent", id: "<id>")
+email_mark_read(mailbox: "agent", id: "<id>")
+```
+
+## 12. Direct filesystem read (bulk processing)
+
+When MCP tool calls are too slow for bulk operations, read `.md` files
+directly from the filesystem:
+
+```
+# Scan a mailbox directory
+ls /var/lib/aimx/inbox/agent/
+
+# Read a specific email file
+cat /var/lib/aimx/inbox/agent/2026-04-15-143022-meeting-notes.md
+
+# Parse the TOML frontmatter between +++ delimiters
+# Extract fields like from, subject, trusted, read
+```
+
+The filesystem is world-readable and the format is stable. Use direct reads
+for scanning, grep-based filtering, or when processing hundreds of messages.
+Use MCP tools for mutations (mark read, send, reply, delete).

--- a/agents/gemini/SKILL.md.header
+++ b/agents/gemini/SKILL.md.header
@@ -1,5 +1,6 @@
 ---
 name: aimx
 description: Self-hosted email for AI agents. Send, read, reply to, and manage email via AIMX MCP tools. Invoke when the user asks about sending mail, checking an inbox, replying to a message, or managing mailboxes, or when the conversation references AIMX.
+author: U-Zyn Chua <chua@uzyn.com>
 ---
 

--- a/agents/goose/aimx.yaml.header
+++ b/agents/goose/aimx.yaml.header
@@ -1,3 +1,5 @@
+# author: U-Zyn Chua <chua@uzyn.com>
+# (Goose recipe schema does not support an author field)
 version: "1.0.0"
 title: "AIMX Email"
 description: >

--- a/agents/openclaw/SKILL.md.header
+++ b/agents/openclaw/SKILL.md.header
@@ -1,6 +1,7 @@
 ---
 name: aimx
 description: Self-hosted email for AI agents. Send, read, reply to, and manage email via AIMX MCP tools. Invoke when the user asks about sending mail, checking an inbox, replying to a message, or managing mailboxes, or when the conversation references AIMX.
+author: U-Zyn Chua <chua@uzyn.com>
 version: 1.0.0
 metadata: {"openclaw": {"requires": {"bins": ["aimx"]}}}
 ---

--- a/agents/opencode/SKILL.md.header
+++ b/agents/opencode/SKILL.md.header
@@ -1,5 +1,6 @@
 ---
 name: aimx
 description: Self-hosted email for AI agents. Send, read, reply to, and manage email via AIMX MCP tools. Invoke when the user asks about sending mail, checking an inbox, replying to a message, or managing mailboxes, or when the conversation references AIMX.
+author: U-Zyn Chua <chua@uzyn.com>
 ---
 

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -24,6 +24,12 @@ pub struct AgentSpec {
     /// the user to paste a JSON/JSONC snippet can embed the right
     /// `--data-dir` argument into that snippet.
     pub activation_hint: fn(data_dir: Option<&Path>) -> String,
+    /// When `true`, the installer copies `agents/common/references/*.md`
+    /// alongside the installed SKILL.md. Agents that support progressive
+    /// disclosure (Claude Code, Codex, OpenClaw) load reference files on
+    /// demand. Agents that take a single blob (Goose, Gemini, OpenCode)
+    /// receive only the main primer.
+    pub progressive_disclosure: bool,
 }
 
 /// Static registry of supported agents.
@@ -57,24 +63,28 @@ pub fn registry() -> &'static [AgentSpec] {
             source_subdir: "claude-code",
             dest_template: "$HOME/.claude/plugins/aimx",
             activation_hint: claude_code_hint,
+            progressive_disclosure: true,
         },
         AgentSpec {
             name: "codex",
             source_subdir: "codex",
             dest_template: "$HOME/.codex/skills/aimx",
             activation_hint: codex_hint,
+            progressive_disclosure: true,
         },
         AgentSpec {
             name: "opencode",
             source_subdir: "opencode",
             dest_template: "$XDG_CONFIG_HOME/opencode/skills/aimx",
             activation_hint: opencode_hint,
+            progressive_disclosure: false,
         },
         AgentSpec {
             name: "gemini",
             source_subdir: "gemini",
             dest_template: "$HOME/.gemini/skills/aimx",
             activation_hint: gemini_hint,
+            progressive_disclosure: false,
         },
         AgentSpec {
             name: "goose",
@@ -84,6 +94,7 @@ pub fn registry() -> &'static [AgentSpec] {
             // directory. Destination template points at the file itself.
             dest_template: "$XDG_CONFIG_HOME/goose/recipes",
             activation_hint: goose_hint,
+            progressive_disclosure: false,
         },
         AgentSpec {
             name: "openclaw",
@@ -92,6 +103,7 @@ pub fn registry() -> &'static [AgentSpec] {
             // skill-directory package (no flat SKILL.md at the root).
             dest_template: "$HOME/.openclaw/skills/aimx",
             activation_hint: openclaw_hint,
+            progressive_disclosure: true,
         },
     ]
 }
@@ -412,7 +424,8 @@ fn install_to_writer(
         )
     })?;
 
-    let files = assemble_plugin_files(source, opts.data_dir)?;
+    let files =
+        assemble_plugin_files_with_disclosure(source, opts.data_dir, spec.progressive_disclosure)?;
     let hint = (spec.activation_hint)(opts.data_dir);
 
     if opts.print {
@@ -445,18 +458,31 @@ fn install_to_writer(
 }
 
 /// Walk the embedded plugin source, transform known files (skill header +
-/// primer, plugin.json), and return the full set of files to write.
+/// primer + optional footer, plugin.json), and return the full set of files
+/// to write.
+///
+/// When `progressive_disclosure` is `true`, the `references/*.md` files from
+/// `agents/common/references/` are included alongside the assembled SKILL.md.
+/// When `false`, only the main primer is included.
 ///
 /// Returns `(relative_path, bytes)` pairs. Relative paths are relative to
 /// the install destination root.
+#[cfg(test)]
 pub fn assemble_plugin_files(
     source: &Dir<'_>,
     data_dir: Option<&Path>,
 ) -> Result<Vec<(PathBuf, Vec<u8>)>, String> {
+    assemble_plugin_files_with_disclosure(source, data_dir, false)
+}
+
+pub fn assemble_plugin_files_with_disclosure(
+    source: &Dir<'_>,
+    data_dir: Option<&Path>,
+    progressive_disclosure: bool,
+) -> Result<Vec<(PathBuf, Vec<u8>)>, String> {
     let mut out: Vec<(PathBuf, Vec<u8>)> = Vec::new();
     collect_entries(source, Path::new(""), &mut out)?;
 
-    // Transformation 1: assemble SKILL.md from SKILL.md.header + common primer.
     let primer = AGENTS_DIR
         .get_file("common/aimx-primer.md")
         .ok_or_else(|| {
@@ -470,6 +496,25 @@ pub fn assemble_plugin_files(
             let target = rel.with_file_name("SKILL.md");
             let mut combined = bytes.clone();
             combined.extend_from_slice(primer);
+
+            // Append optional footer if present (e.g. SKILL.md.footer).
+            let footer_name = "SKILL.md.footer";
+            let footer_path = source
+                .path()
+                .parent()
+                .map(|_| {
+                    // Try to find footer relative to where the header lives
+                    let header_dir = rel.parent().unwrap_or(Path::new(""));
+                    header_dir.join(footer_name)
+                })
+                .unwrap_or_else(|| PathBuf::from(footer_name));
+
+            // Look for the footer in the source directory entries we collected
+            // (they were drained, so check the embedded source directly).
+            if let Some(footer_file) = find_file_in_dir(source, &footer_path) {
+                combined.extend_from_slice(footer_file);
+            }
+
             transformed.push((target, combined));
             continue;
         }
@@ -524,11 +569,46 @@ pub fn assemble_plugin_files(
             continue;
         }
 
+        // Skip .footer files — they are consumed during header+primer assembly
+        // and should not appear as standalone files in the output.
+        if rel
+            .file_name()
+            .is_some_and(|n| n.to_string_lossy().ends_with(".footer"))
+        {
+            continue;
+        }
+
         transformed.push((rel, bytes));
+    }
+
+    if progressive_disclosure && let Some(refs_dir) = AGENTS_DIR.get_dir("common/references") {
+        // Place references/ as a sibling of the assembled SKILL.md.
+        let skill_parent = transformed
+            .iter()
+            .find(|(rel, _)| rel.file_name().is_some_and(|n| n == "SKILL.md"))
+            .map(|(rel, _)| rel.parent().unwrap_or(Path::new("")).to_path_buf())
+            .unwrap_or_default();
+
+        for entry in refs_dir.entries() {
+            if let DirEntry::File(f) = entry {
+                let name = f
+                    .path()
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned())
+                    .unwrap_or_default();
+                let rel = skill_parent.join("references").join(&name);
+                transformed.push((rel, f.contents().to_vec()));
+            }
+        }
     }
 
     transformed.sort_by(|a, b| a.0.cmp(&b.0));
     Ok(transformed)
+}
+
+fn find_file_in_dir<'a>(dir: &'a Dir<'_>, rel_path: &Path) -> Option<&'a [u8]> {
+    let full_path = dir.path().join(rel_path);
+    dir.get_file(&full_path).map(|f| f.contents())
 }
 
 fn collect_entries(
@@ -1436,7 +1516,7 @@ mod tests {
             "recipe: {text}"
         );
         assert!(
-            text.contains("  - `mailbox_create(name: string)`"),
+            text.contains("  - `mailbox_create(name)`"),
             "recipe: {text}"
         );
         // Extensions section references AIMX's stdio MCP server.
@@ -1777,5 +1857,334 @@ mod tests {
             dmode, 0o755,
             ".claude-plugin dir should be 0o755, got {dmode:o}"
         );
+    }
+
+    #[test]
+    fn primer_line_count_within_target_range() {
+        let primer = AGENTS_DIR
+            .get_file("common/aimx-primer.md")
+            .expect("common/aimx-primer.md must exist")
+            .contents();
+        let text = std::str::from_utf8(primer).expect("primer must be valid UTF-8");
+        let line_count = text.lines().count();
+        // Sprint 39 target: 300–500 lines (soft cap).
+        assert!(
+            (300..=500).contains(&line_count),
+            "main primer has {line_count} lines; target range is 300–500"
+        );
+    }
+
+    #[test]
+    fn references_directory_exists_in_embedded_assets() {
+        let refs_dir = AGENTS_DIR.get_dir("common/references");
+        assert!(
+            refs_dir.is_some(),
+            "agents/common/references/ must exist in embedded assets"
+        );
+        let refs_dir = refs_dir.unwrap();
+        let filenames: Vec<String> = refs_dir
+            .entries()
+            .iter()
+            .filter_map(|e| match e {
+                DirEntry::File(f) => f
+                    .path()
+                    .file_name()
+                    .map(|n| n.to_string_lossy().into_owned()),
+                _ => None,
+            })
+            .collect();
+        assert!(filenames.contains(&"mcp-tools.md".to_string()));
+        assert!(filenames.contains(&"frontmatter.md".to_string()));
+        assert!(filenames.contains(&"workflows.md".to_string()));
+        assert!(filenames.contains(&"troubleshooting.md".to_string()));
+    }
+
+    #[test]
+    fn progressive_disclosure_agent_gets_references() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        // Claude Code has progressive_disclosure: true
+        run_with_env(Some("claude-code".into()), false, false, false, None, &env).unwrap();
+
+        let dest = tmp.path().join(".claude/plugins/aimx");
+        let refs = dest.join("skills/aimx/references");
+        assert!(
+            refs.join("mcp-tools.md").exists(),
+            "progressive-disclosure agent should have references/mcp-tools.md"
+        );
+        assert!(refs.join("frontmatter.md").exists());
+        assert!(refs.join("workflows.md").exists());
+        assert!(refs.join("troubleshooting.md").exists());
+
+        // Verify references content is non-empty and matches embedded assets
+        let installed = std::fs::read_to_string(refs.join("mcp-tools.md")).unwrap();
+        let embedded = AGENTS_DIR
+            .get_file("common/references/mcp-tools.md")
+            .unwrap()
+            .contents();
+        assert_eq!(installed.as_bytes(), embedded);
+    }
+
+    #[test]
+    fn non_progressive_disclosure_agent_has_no_references() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        // OpenCode has progressive_disclosure: false
+        run_with_env(Some("opencode".into()), false, false, false, None, &env).unwrap();
+
+        let dest = tmp.path().join(".config/opencode/skills/aimx");
+        assert!(dest.join("SKILL.md").exists());
+        assert!(
+            !dest.join("references").exists(),
+            "non-progressive-disclosure agent should NOT have references/"
+        );
+    }
+
+    #[test]
+    fn codex_progressive_disclosure_installs_references() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        run_with_env(Some("codex".into()), false, false, false, None, &env).unwrap();
+
+        let dest = tmp.path().join(".codex/skills/aimx");
+        assert!(dest.join("SKILL.md").exists());
+        assert!(dest.join("references/mcp-tools.md").exists());
+        assert!(dest.join("references/frontmatter.md").exists());
+        assert!(dest.join("references/workflows.md").exists());
+        assert!(dest.join("references/troubleshooting.md").exists());
+    }
+
+    #[test]
+    fn openclaw_progressive_disclosure_installs_references() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        run_with_env(Some("openclaw".into()), false, false, false, None, &env).unwrap();
+
+        let dest = tmp.path().join(".openclaw/skills/aimx");
+        assert!(dest.join("SKILL.md").exists());
+        assert!(dest.join("references/mcp-tools.md").exists());
+        assert!(dest.join("references/frontmatter.md").exists());
+    }
+
+    #[test]
+    fn gemini_no_references() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        run_with_env(Some("gemini".into()), false, false, false, None, &env).unwrap();
+
+        let dest = tmp.path().join(".gemini/skills/aimx");
+        assert!(dest.join("SKILL.md").exists());
+        assert!(!dest.join("references").exists());
+    }
+
+    #[test]
+    fn goose_no_references() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        run_with_env(Some("goose".into()), false, false, false, None, &env).unwrap();
+
+        let recipe = tmp.path().join(".config/goose/recipes/aimx.yaml");
+        assert!(recipe.exists());
+        assert!(!tmp.path().join(".config/goose/recipes/references").exists());
+    }
+
+    #[test]
+    fn print_mode_shows_references_for_progressive_disclosure() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        let spec = find_agent("codex").unwrap();
+        let opts = InstallOptions {
+            force: false,
+            print: true,
+            data_dir: None,
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        install_to_writer(spec, &opts, &env, &mut buf).unwrap();
+        let printed = String::from_utf8(buf).unwrap();
+
+        assert!(
+            printed.contains("=== references/mcp-tools.md ==="),
+            "print mode should show references for progressive-disclosure agents"
+        );
+        assert!(printed.contains("=== references/frontmatter.md ==="));
+        assert!(printed.contains("=== references/workflows.md ==="));
+        assert!(printed.contains("=== references/troubleshooting.md ==="));
+    }
+
+    #[test]
+    fn print_mode_omits_references_for_non_progressive_disclosure() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        let spec = find_agent("opencode").unwrap();
+        let opts = InstallOptions {
+            force: false,
+            print: true,
+            data_dir: None,
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        install_to_writer(spec, &opts, &env, &mut buf).unwrap();
+        let printed = String::from_utf8(buf).unwrap();
+
+        assert!(
+            !printed.contains("=== references/"),
+            "print mode should NOT show references for non-progressive-disclosure agents"
+        );
+    }
+
+    #[test]
+    fn progressive_disclosure_assignments() {
+        let reg = registry();
+        let by_name = |n: &str| reg.iter().find(|s| s.name == n).unwrap();
+
+        assert!(by_name("claude-code").progressive_disclosure);
+        assert!(by_name("codex").progressive_disclosure);
+        assert!(by_name("openclaw").progressive_disclosure);
+
+        assert!(!by_name("opencode").progressive_disclosure);
+        assert!(!by_name("gemini").progressive_disclosure);
+        assert!(!by_name("goose").progressive_disclosure);
+    }
+
+    #[test]
+    fn author_metadata_in_claude_code_plugin_json() {
+        let plugin_bytes = AGENTS_DIR
+            .get_file("claude-code/.claude-plugin/plugin.json")
+            .expect("plugin.json must exist")
+            .contents();
+        let text = std::str::from_utf8(plugin_bytes).unwrap();
+        assert!(
+            text.contains("U-Zyn Chua"),
+            "plugin.json must have standardized author"
+        );
+        assert!(
+            !text.contains("\"name\": \"AIMX\""),
+            "plugin.json must not have AIMX as author name"
+        );
+    }
+
+    #[test]
+    fn author_metadata_in_all_skill_headers() {
+        for agent in ["claude-code", "codex", "opencode", "gemini", "openclaw"] {
+            let header_path = match agent {
+                "claude-code" => "claude-code/skills/aimx/SKILL.md.header",
+                _ => &format!("{agent}/SKILL.md.header"),
+            };
+            let header = AGENTS_DIR
+                .get_file(header_path)
+                .unwrap_or_else(|| panic!("missing header for {agent}"))
+                .contents();
+            let text = std::str::from_utf8(header).unwrap();
+            assert!(
+                text.contains("author: U-Zyn Chua <chua@uzyn.com>"),
+                "{agent} SKILL.md.header must contain author metadata"
+            );
+        }
+    }
+
+    #[test]
+    fn goose_header_notes_author_gap() {
+        let header = AGENTS_DIR
+            .get_file("goose/aimx.yaml.header")
+            .expect("goose header must exist")
+            .contents();
+        let text = std::str::from_utf8(header).unwrap();
+        assert!(
+            text.contains("U-Zyn Chua"),
+            "goose header must reference the author"
+        );
+        assert!(
+            text.contains("does not support an author field"),
+            "goose header must note the schema gap"
+        );
+    }
+
+    #[test]
+    fn no_aimx_author_placeholder_in_agents() {
+        fn check_dir(dir: &Dir<'_>, path_prefix: &str) {
+            for entry in dir.entries() {
+                match entry {
+                    DirEntry::File(f) => {
+                        if let Ok(text) = std::str::from_utf8(f.contents()) {
+                            let full_path = format!("{}/{}", path_prefix, f.path().display());
+                            assert!(
+                                !text.contains("\"author\": \"AIMX\"")
+                                    && !text.contains("\"name\": \"AIMX\""),
+                                "found placeholder author in {full_path}"
+                            );
+                            assert!(
+                                !text.contains("chua@example.com"),
+                                "found placeholder email in {full_path}"
+                            );
+                        }
+                    }
+                    DirEntry::Dir(sub) => {
+                        check_dir(sub, &format!("{}/{}", path_prefix, sub.path().display()));
+                    }
+                }
+            }
+        }
+        check_dir(&AGENTS_DIR, "agents");
+    }
+
+    #[test]
+    fn primer_documents_storage_layout_plainly() {
+        let primer = AGENTS_DIR
+            .get_file("common/aimx-primer.md")
+            .unwrap()
+            .contents();
+        let text = std::str::from_utf8(primer).unwrap();
+        assert!(
+            text.contains("/var/lib/aimx/"),
+            "primer must document the datadir layout plainly (FR-50c)"
+        );
+        assert!(text.contains("inbox/"));
+        assert!(text.contains("sent/"));
+        assert!(text.contains("FR-50c"));
+    }
+
+    #[test]
+    fn primer_links_references_and_runtime_readme() {
+        let primer = AGENTS_DIR
+            .get_file("common/aimx-primer.md")
+            .unwrap()
+            .contents();
+        let text = std::str::from_utf8(primer).unwrap();
+        assert!(text.contains("references/mcp-tools.md"));
+        assert!(text.contains("references/frontmatter.md"));
+        assert!(text.contains("references/workflows.md"));
+        assert!(text.contains("references/troubleshooting.md"));
+        assert!(text.contains("/var/lib/aimx/README.md"));
+    }
+
+    #[test]
+    fn trusted_field_documented_in_primer_and_reference() {
+        let primer = AGENTS_DIR
+            .get_file("common/aimx-primer.md")
+            .unwrap()
+            .contents();
+        let primer_text = std::str::from_utf8(primer).unwrap();
+        assert!(primer_text.contains("`trusted`"));
+        assert!(primer_text.contains("\"none\""));
+        assert!(primer_text.contains("\"true\""));
+        assert!(primer_text.contains("\"false\""));
+
+        let frontmatter_ref = AGENTS_DIR
+            .get_file("common/references/frontmatter.md")
+            .unwrap()
+            .contents();
+        let ref_text = std::str::from_utf8(frontmatter_ref).unwrap();
+        assert!(ref_text.contains("`trusted`"));
+        assert!(ref_text.contains("\"none\""));
+        assert!(ref_text.contains("\"true\""));
+        assert!(ref_text.contains("\"false\""));
+        assert!(ref_text.contains("trusted_senders"));
     }
 }


### PR DESCRIPTION
## Summary

- **S39-1:** Split `agents/common/aimx-primer.md` from a single 131-line file into a 306-line main primer + `references/` directory (`mcp-tools.md`, `frontmatter.md`, `workflows.md`, `troubleshooting.md`). Main primer covers identity/purpose, two access surfaces (MCP for writes, filesystem for reads), 9 MCP tool quick reference with signatures, key frontmatter fields table, 5 inline workflows, trust model overview with `trusted` field details, and safety list. Storage layout documented plainly per FR-50c reversal with inline comment citing the rationale.
- **S39-2:** `AgentSpec` gains `progressive_disclosure: bool`. Install flow copies `references/*.md` alongside `SKILL.md` for progressive-disclosure agents (Claude Code, Codex, OpenClaw) and omits them for single-blob agents (Goose, Gemini, OpenCode). Footer file support added to the concat pipeline. `--print` mode emits both `SKILL.md` and `references/` for progressive-disclosure agents.
- **S39-3:** Author metadata standardized to `U-Zyn Chua <chua@uzyn.com>` across all six agent packages (plugin.json, SKILL.md headers). Goose header notes the recipe schema does not support `author`. CI gains a grep step that fails on placeholder `"AIMX"` author strings or `chua@example.com` under `agents/`.

## Test plan

- [x] `cargo test` — 652 tests pass (601 unit + 51 integration)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] Primer line count within 300–500 range (306 lines)
- [x] Progressive-disclosure agents install `references/` tree
- [x] Non-progressive-disclosure agents do NOT install `references/`
- [x] `--print` mode emits references for progressive-disclosure agents only
- [x] No `"AIMX"` author or placeholder emails remain under `agents/`
- [x] `trusted` field documented in primer quick-reference AND `references/frontmatter.md`
- [x] No stale v1 paths (`/var/lib/aimx/<mailbox>/` outside `inbox/`/`sent/` context)
- [x] CI author grep step added