### PR TITLE
[Sprint 40] Datadir README + Journald Docs + Book/ Pass

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,18 +56,22 @@ These are NOT a Cargo workspace — they have independent `Cargo.toml` files and
 
 `main.rs` parses CLI via clap and dispatches to module-level `run()` functions. Each `src/*.rs` module owns one subcommand:
 
-- `setup.rs` — `aimx setup [domain]`: interactive setup wizard. Prompts for domain when omitted, generates TLS cert + DKIM keys, installs systemd/OpenRC service file for `aimx serve`, displays colorized [DNS]/[MCP]/[Deliverability] sections, DNS retry loop, re-entrant detection. Requires root.
-- `ingest.rs` — `aimx ingest`: reads raw `.eml` from stdin (called by `aimx serve` in-process, or via stdin for manual use), parses MIME, writes Markdown with TOML frontmatter (`+++` delimiters), extracts attachments, fires channel triggers.
-- `send.rs` — `aimx send`: thin UDS client. Composes an unsigned RFC 5322 message and submits it to `aimx serve` over `/run/aimx/send.sock` as one `AIMX/1 SEND` request frame. Signing (DKIM) and MX delivery live in `aimx serve`; this module no longer touches the DKIM key or the network. Refuses to run as root. Exit codes: `0` OK, `1` daemon ERR, `2` socket-missing / connect failure / root, `3` malformed response.
-- `send_protocol.rs` / `send_handler.rs` — `AIMX/1 SEND` wire codec and daemon-side signing + delivery handler (Sprint 34).
+- `setup.rs` — `aimx setup [domain]`: interactive setup wizard. Prompts for domain when omitted, generates TLS cert + DKIM keys, installs systemd/OpenRC service file for `aimx serve`, displays colorized [DNS]/[MCP]/[Deliverability] sections, DNS retry loop, re-entrant detection. Writes the datadir README on completion. Requires root.
+- `ingest.rs` — `aimx ingest`: reads raw `.eml` from stdin (called by `aimx serve` in-process, or via stdin for manual use), parses MIME via `mail-parser`, writes Markdown with TOML frontmatter (`+++` delimiters) using `InboundFrontmatter` (section-ordered: Identity → Parties → Content → Threading → Auth → Storage), routes to `inbox/<mailbox>/`, extracts attachments into Zola-style bundles, fires channel triggers.
+- `send.rs` — `aimx send`: thin UDS client. Composes an unsigned RFC 5322 message and submits it to `aimx serve` over `/run/aimx/send.sock` as one `AIMX/1 SEND` request frame. Signing (DKIM) and MX delivery live in `aimx serve`; this module never touches the DKIM key or the network. Refuses to run as root. Exit codes: `0` OK, `1` daemon ERR, `2` socket-missing / connect failure / root, `3` malformed response.
+- `send_protocol.rs` — `AIMX/1 SEND` wire protocol codec. Length-prefixed, binary-safe framing (`AIMX/1 SEND\n`, `From-Mailbox:` header, `Content-Length:` header, body). Parses requests and writes responses. Pure async I/O — no filesystem or network.
+- `send_handler.rs` — daemon-side handler for `AIMX/1 SEND` UDS requests. Domain validation, DKIM signing via shared `Arc<DkimKey>`, delivery via `MailTransport` trait, sent-items persistence to `sent/<mailbox>/` with `OutboundFrontmatter`.
 - `transport.rs` — daemon-side `MailTransport` trait, `LettreTransport` (real MX delivery), `FileDropTransport` (test-only, triggered by `AIMX_TEST_MAIL_DROP`).
 - `mx.rs` — MX resolution: resolves recipient domain to MX hostnames via `hickory-resolver`, falls back to A record per RFC 5321.
-- `mcp.rs` — `aimx mcp`: MCP server over stdio using `rmcp` crate. 9 tools for mailbox/email operations.
-- `channel.rs` — channel manager: match filters + shell command triggers on ingest.
-- `serve.rs` — `aimx serve`: starts the embedded SMTP daemon. Loads config, initializes TLS, runs the SMTP listener via tokio. Options: `--bind`, `--tls-cert`, `--tls-key`. Handles SIGTERM/SIGINT for graceful shutdown.
+- `mcp.rs` — `aimx mcp`: MCP server over stdio using `rmcp` crate. 9 tools for mailbox/email operations. `folder` parameter on read/list tools selects `"inbox"` (default) or `"sent"`.
+- `channel.rs` — channel manager: match filters + shell command triggers on ingest. Fires on inbound only.
+- `serve.rs` — `aimx serve`: starts the embedded SMTP daemon. Loads config, refreshes the datadir README if outdated, initializes TLS, loads the DKIM key into `Arc`, runs the SMTP listener and UDS send listener via tokio. Binds `/run/aimx/send.sock` (mode `0o666`, world-writable). Options: `--bind`, `--tls-cert`, `--tls-key`. Handles SIGTERM/SIGINT for graceful shutdown.
+- `slug.rs` — slug algorithm and filename allocation (Sprint 36 / FR-13b). `slugify()` transforms subjects into filesystem-safe stems; `allocate_filename()` resolves collisions and decides flat vs. bundle layout.
+- `frontmatter.rs` — `InboundFrontmatter` and `OutboundFrontmatter` structs with section-ordered serialization. `compute_thread_id()` derives the 16-hex-char thread root hash. `format_outbound_frontmatter()` for sent copies.
+- `datadir_readme.rs` — baked-in `/var/lib/aimx/README.md` template with version-gated refresh. `write()` (unconditional, called by setup), `refresh_if_outdated()` (called by serve startup).
 - `smtp/` — embedded SMTP server module: `mod.rs` (listener accept loop), `session.rs` (per-connection SMTP state machine: EHLO, MAIL FROM, RCPT TO, DATA, STARTTLS, QUIT, RSET, NOOP), `tls.rs` (STARTTLS upgrade via tokio-rustls), `tests.rs` (unit tests).
 - `verify.rs` — `aimx verify`: checks port 25 connectivity via the verifier service.
-- `setup.rs` also contains `run_setup` which drives the full interactive setup flow, and `display_deliverability_section` which prints optional Gmail-whitelist instructions. Reverse DNS (PTR) is the operator's responsibility and is out of scope for aimx as of Sprint 33.1.
+- `setup.rs` also contains `run_setup` which drives the full interactive setup flow, and `display_deliverability_section` which prints optional Gmail-whitelist instructions. Reverse DNS (PTR) is the operator's responsibility and is out of scope for aimx.
 
 ### Trait-based testing pattern
 
@@ -84,7 +88,7 @@ These are NOT a Cargo workspace — they have independent `Cargo.toml` files and
 
 ### Email frontmatter format
 
-TOML frontmatter between `+++` delimiters. Fields: `id`, `message_id`, `from`, `to`, `subject`, `date`, `in_reply_to`, `references`, `attachments`, `mailbox`, `read`, `dkim`, `spf`.
+TOML frontmatter between `+++` delimiters. Inbound fields follow section ordering: Identity (`id`, `message_id`, `thread_id`) → Parties (`from`, `to`, `cc`, `reply_to`, `delivered_to`) → Content (`subject`, `date`, `received_at`, `received_from_ip`, `size_bytes`, `attachments`) → Threading (`in_reply_to`, `references`, `list_id`, `auto_submitted`) → Auth (`dkim`, `spf`, `dmarc`, `trusted`) → Storage (`mailbox`, `read`, `labels`). Optional fields are omitted when empty rather than written as `null`. Auth and storage fields are always written. Outbound (sent) copies add an Outbound block: `outbound`, `delivery_status`, `bcc`, `delivered_at`, `delivery_details`.
 
 ### MCP server
 
@@ -98,13 +102,16 @@ Axum HTTP server with `/probe` (EHLO handshake) and `/health` endpoints. Runs a 
 
 - Error handling: `Result<(), Box<dyn std::error::Error>>` for all public `run()` functions. Propagate with `?`.
 - `aimx serve` is the SMTP daemon (long-running process managed by systemd/OpenRC). All other commands are short-lived.
-- `aimx setup` requires root.
+- `aimx setup` requires root. `aimx send` refuses root (it is a thin UDS client that does not need privilege).
 - Integration tests (`tests/integration.rs`) use `assert_cmd` to test the binary as a subprocess with `--data-dir` pointing at temp directories.
 - Test fixtures in `tests/fixtures/` (`.eml` files for ingest testing).
+- Agent-facing plugins live under `agents/<agent>/` and are embedded at compile time. The canonical primer is `agents/common/aimx-primer.md` with reference docs in `agents/common/references/`. The datadir README template is `src/datadir_readme.md.tpl`.
 
 ## Documentation
 
-User-facing guide lives in `book/` (index, getting-started, setup, configuration, mailboxes, channels, mcp, troubleshooting). When making changes that affect CLI behavior, setup output, or MCP tools, update the corresponding guide files too.
+User-facing guide lives in `book/` (index, getting-started, setup, configuration, mailboxes, channels, channel-recipes, mcp, agent-integration, troubleshooting). When making changes that affect CLI behavior, setup output, or MCP tools, update the corresponding guide files too.
 
 - `docs/prd.md` — product requirements document
 - `docs/sprint.md` — sprint plan (do not modify `[DONE]` or `[IN PROGRESS]` sprints)
+- `agents/common/aimx-primer.md` — canonical agent-facing primer (bundled into all agent plugins)
+- `agents/common/references/` — detailed reference docs (frontmatter schema, MCP tools, workflows, troubleshooting)

--- a/agents/claude-code/README.md
+++ b/agents/claude-code/README.md
@@ -12,6 +12,10 @@ time (via `include_dir!`) and installed by `aimx agent-setup claude-code`.
   AIMX primer (`agents/common/aimx-primer.md`); the installer assembles the
   final `SKILL.md` from a YAML header plus that primer so there is one
   source of truth.
+- `skills/aimx/references/` — detailed reference docs (MCP tool signatures,
+  frontmatter schema, workflows, troubleshooting) copied from
+  `agents/common/references/`. Progressive disclosure: Claude Code loads the
+  primer first and reads references on demand.
 
 ## Install
 

--- a/agents/codex/README.md
+++ b/agents/codex/README.md
@@ -10,6 +10,9 @@ into Codex. Contents are bundled into the `aimx` binary at compile time
   Its body is the canonical AIMX primer (`agents/common/aimx-primer.md`);
   the installer assembles the final `SKILL.md` from a YAML header plus
   that primer so there is one source of truth.
+- `references/` at `~/.codex/skills/aimx/references/` — detailed reference
+  docs (MCP tool signatures, frontmatter schema, workflows, troubleshooting)
+  copied from `agents/common/references/`.
 
 ## Install
 

--- a/agents/openclaw/README.md
+++ b/agents/openclaw/README.md
@@ -12,6 +12,9 @@ installed by `aimx agent-setup openclaw`.
   primer (`agents/common/aimx-primer.md`); the installer assembles the
   final `SKILL.md` from a YAML header plus that primer so there is one
   source of truth.
+- `skills/aimx/references/` — detailed reference docs (MCP tool signatures,
+  frontmatter schema, workflows, troubleshooting) copied from
+  `agents/common/references/`.
 
 OpenClaw's MCP configuration lives in `~/.openclaw/openclaw.json` (a
 JSON5 file) under the `mcpServers` key. The installer does **not**

--- a/book/agent-integration.md
+++ b/book/agent-integration.md
@@ -50,14 +50,26 @@ Key properties:
 The matrix below tracks what is available in the current `aimx` binary. It
 grows as more agents are landed in subsequent sprints.
 
-| Agent | Install command | Destination | Activation |
-|-------|-----------------|-------------|------------|
-| Claude Code | `aimx agent-setup claude-code` | `~/.claude/plugins/aimx/` | Restart Claude Code; the plugin is auto-discovered from `~/.claude/plugins/`. |
-| Codex CLI | `aimx agent-setup codex` | `~/.codex/plugins/aimx/` | Restart Codex CLI; the plugin is auto-discovered from `~/.codex/plugins/`. |
-| OpenCode | `aimx agent-setup opencode` | `~/.config/opencode/skills/aimx/` | Paste the printed JSONC block into `opencode.json`, then restart OpenCode. |
-| Gemini CLI | `aimx agent-setup gemini` | `~/.gemini/skills/aimx/` | Merge the printed JSON block into `~/.gemini/settings.json`, then restart Gemini CLI. |
-| Goose | `aimx agent-setup goose` | `~/.config/goose/recipes/aimx.yaml` | Run `goose run --recipe aimx`. The recipe bundles its own MCP extension, so no separate config step. |
-| OpenClaw | `aimx agent-setup openclaw` | `~/.openclaw/skills/aimx/` | Run the printed `openclaw mcp set aimx '...'` command, then restart the OpenClaw gateway. |
+| Agent | Install command | Destination | Activation | Progressive disclosure |
+|-------|-----------------|-------------|------------|------------------------|
+| Claude Code | `aimx agent-setup claude-code` | `~/.claude/plugins/aimx/` | Restart Claude Code; the plugin is auto-discovered from `~/.claude/plugins/`. | Primer as skill + `references/` directory copied as siblings |
+| Codex CLI | `aimx agent-setup codex` | `~/.codex/plugins/aimx/` | Restart Codex CLI; the plugin is auto-discovered from `~/.codex/plugins/`. | Primer as skill + `references/` directory copied as siblings |
+| OpenCode | `aimx agent-setup opencode` | `~/.config/opencode/skills/aimx/` | Paste the printed JSONC block into `opencode.json`, then restart OpenCode. | Single skill file (primer body); references inlined |
+| Gemini CLI | `aimx agent-setup gemini` | `~/.gemini/skills/aimx/` | Merge the printed JSON block into `~/.gemini/settings.json`, then restart Gemini CLI. | Single skill file (primer body); references inlined |
+| Goose | `aimx agent-setup goose` | `~/.config/goose/recipes/aimx.yaml` | Run `goose run --recipe aimx`. The recipe bundles its own MCP extension, so no separate config step. | Single YAML blob (primer as `prompt` block scalar); references inlined |
+| OpenClaw | `aimx agent-setup openclaw` | `~/.openclaw/skills/aimx/` | Run the printed `openclaw mcp set aimx '...'` command, then restart the OpenClaw gateway. | Primer as skill + `references/` directory copied as siblings |
+
+### Progressive disclosure
+
+Every agent receives the same canonical AIMX primer (`agents/common/aimx-primer.md`).
+For agents that support multi-file skill directories (Claude Code, Codex CLI, OpenClaw),
+the installer also copies `agents/common/references/` alongside the skill so the agent
+can load detailed reference material on demand without bloating the initial context.
+
+For agents that use a single file format (OpenCode, Gemini CLI, Goose), the full primer
+is embedded directly in the skill or recipe file. The `references/` content is available
+in the AIMX source tree and at `/var/lib/aimx/README.md` (the auto-generated datadir
+layout guide).
 
 ### Claude Code
 

--- a/book/channel-recipes.md
+++ b/book/channel-recipes.md
@@ -1,5 +1,7 @@
 # Channel Recipes
 
+> **Note on log paths.** The `/var/log/aimx/<agent>.log` paths in the recipes below are user-chosen destinations for trigger script output — they are NOT AIMX's own logs. AIMX itself logs to journald (systemd) or the system logger (OpenRC); see [Troubleshooting — Where are the logs?](troubleshooting.md#where-are-the-logs) for details.
+
 This chapter is the canonical cookbook for wiring AIMX's channel triggers to every supported AI agent. Each section shows a copy-paste `config.toml` snippet, the agent-specific CLI flags that matter for non-interactive invocation, and notes on exit codes, logs, and gotchas.
 
 For the underlying mechanics (match filters, template variables, trust policies), see [Channel Rules & Trust](channels.md). For installing the AIMX plugin/skill into an agent so its MCP tools are discoverable, see [Agent Integration](agent-integration.md).

--- a/book/channels.md
+++ b/book/channels.md
@@ -1,6 +1,6 @@
 # Channel Rules & Trust
 
-Channel rules trigger shell commands when emails arrive at specific mailboxes. Combined with trust policies, they let you build secure, automated workflows around incoming email.
+Channel rules trigger shell commands when inbound emails arrive at specific mailboxes. They fire on ingest only — outbound (sent) mail does not trigger channel rules. Combined with trust policies, they let you build secure, automated workflows around incoming email.
 
 > For copy-paste agent-specific invocations (Claude Code, Codex CLI, OpenCode, Gemini CLI, Goose, OpenClaw, Aider), see [Channel Recipes](channel-recipes.md).
 

--- a/book/configuration.md
+++ b/book/configuration.md
@@ -40,7 +40,7 @@ This changes where `config.toml` and the DKIM keypair (`dkim/private.key`, `dkim
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `domain` | string | *(required)* | The email domain (e.g. `agent.yourdomain.com`) |
-| `data_dir` | string | `/var/lib/aimx` | Directory for storing config, keys, and mailboxes |
+| `data_dir` | string | `/var/lib/aimx` | Directory for storing mailboxes (config and keys live under `/etc/aimx/`) |
 | `dkim_selector` | string | `dkim` | DKIM selector name used in DNS records |
 | `verify_host` | string | `https://check.aimx.email` | Base URL of the verifier service used by `aimx verify` and `aimx setup`. Can be overridden per-invocation with the `--verify-host` flag. |
 | `enable_ipv6` | bool | `false` | Advanced. Opt into IPv6 outbound delivery. See [IPv6 delivery](#ipv6-delivery-advanced). |

--- a/book/getting-started.md
+++ b/book/getting-started.md
@@ -43,6 +43,12 @@ Verify the binary is installed:
 aimx --version
 ```
 
+## Security model
+
+AIMX stores mail under `/var/lib/aimx/` (world-readable). Any local user or agent can read email files. This is by design: AIMX assumes a single-admin server where all agents are trusted to read each other's mail. Configuration and DKIM secrets live under `/etc/aimx/` (root-owned, not readable by non-root).
+
+All mutations (send, reply, mark-read, create/delete mailboxes) go through the `aimx` MCP server or CLI — never write to the data directory directly. The UDS send socket at `/run/aimx/send.sock` is world-writable; any local user can submit outbound mail through `aimx send`.
+
 ## Setup
 
 Run the interactive setup wizard:

--- a/book/mailboxes.md
+++ b/book/mailboxes.md
@@ -15,7 +15,7 @@ Mailboxes are the core organizational unit in AIMX. Each mailbox maps an email a
 ├── inbox/              # inbound mail lives here
 │   ├── catchall/
 │   └── support/
-└── sent/               # outbound sent copies (populated in a future release)
+└── sent/               # outbound sent copies
     └── support/
 ```
 
@@ -70,19 +70,22 @@ Incoming emails are parsed from raw MIME (`.eml`) and stored as Markdown with TO
 
 ```markdown
 +++
-id = "2025-01-15-001"
-message_id = "<abc123@example.com>"
+id = "2025-04-15-143022-hello"
+message_id = "abc123@example.com"
+thread_id = "a1b2c3d4e5f6a7b8"
 from = "Alice <alice@example.com>"
 to = "support@agent.yourdomain.com"
+delivered_to = "support@agent.yourdomain.com"
 subject = "Hello"
-date = "2025-01-15T10:30:00Z"
-in_reply_to = ""
-references = ""
-attachments = []
-mailbox = "support"
-read = false
+date = "2025-04-15T14:30:22Z"
+received_at = "2025-04-15T14:30:23Z"
+size_bytes = 1024
 dkim = "pass"
 spf = "pass"
+dmarc = "pass"
+trusted = "true"
+mailbox = "support"
+read = false
 +++
 
 Hello, this is the email body in plain text.
@@ -94,19 +97,25 @@ This format is designed to be agent-readable without parsing libraries. An agent
 
 | Field | Type | Description |
 |-------|------|-------------|
-| `id` | string | Unique email ID within the mailbox (the filename stem, e.g. `2025-01-15-103000-meeting`) |
-| `message_id` | string | RFC 5322 Message-ID header |
+| `id` | string | Filename stem (e.g. `2025-04-15-143022-hello`) |
+| `message_id` | string | RFC 5322 Message-ID |
+| `thread_id` | string | 16-hex-char SHA-256 of the thread root Message-ID |
 | `from` | string | Sender address with optional display name |
 | `to` | string | Recipient address |
+| `delivered_to` | string | Actual RCPT TO address |
 | `subject` | string | Email subject line |
-| `date` | string | Email date in RFC 3339 format |
-| `in_reply_to` | string | Message-ID of the email being replied to |
-| `references` | string | Full threading chain of Message-IDs |
+| `date` | string | Sender-claimed date in RFC 3339 format |
+| `received_at` | string | Server-side receipt datetime (RFC 3339 UTC) |
+| `size_bytes` | integer | Raw message size in bytes |
 | `attachments` | array | Attachment metadata (see below) |
+| `in_reply_to` | string | Message-ID of the email being replied to (optional, omitted when empty) |
+| `references` | string | Full threading chain of Message-IDs (optional, omitted when empty) |
+| `dkim` | string | DKIM verification result: `pass`, `fail`, or `none` |
+| `spf` | string | SPF verification result: `pass`, `fail`, `softfail`, `neutral`, or `none` |
+| `dmarc` | string | DMARC alignment result: `pass`, `fail`, or `none` |
+| `trusted` | string | Per-mailbox trust evaluation: `none`, `true`, or `false` |
 | `mailbox` | string | Mailbox name this email was routed to |
 | `read` | bool | Read status (`false` on ingest) |
-| `dkim` | string | DKIM verification result: `pass`, `fail`, or `none` |
-| `spf` | string | SPF verification result: `pass`, `fail`, or `none` |
 
 ### Body extraction
 

--- a/book/mcp.md
+++ b/book/mcp.md
@@ -182,6 +182,13 @@ Every email stored by AIMX carries a TOML frontmatter block between `+++` delimi
 
 Outbound (sent) emails additionally carry `outbound = true`, `delivery_status`, and optionally `delivered_at` and `delivery_details`.
 
+## Agent-facing documentation
+
+Two reference documents help agents understand AIMX:
+
+- **`agents/common/aimx-primer.md`** — the canonical primer bundled into every agent plugin. Covers MCP tools, storage layout, frontmatter, trust model, and common workflows.
+- **`/var/lib/aimx/README.md`** — the runtime datadir guide, regenerated on each AIMX upgrade. Covers the on-disk layout, file naming, slug algorithm, bundle rules, and the UDS send protocol.
+
 ## Compatible agent frameworks
 
 | Framework | Integration method |

--- a/book/setup.md
+++ b/book/setup.md
@@ -182,8 +182,8 @@ aimx status
 **Inbound:** Send an email from an external account (e.g. Gmail) to `catchall@agent.yourdomain.com`, then check:
 
 ```bash
-ls /var/lib/aimx/catchall/
-cat /var/lib/aimx/catchall/*.md
+ls /var/lib/aimx/inbox/catchall/
+cat /var/lib/aimx/inbox/catchall/*.md
 ```
 
 **Outbound:** Send a test email:

--- a/book/troubleshooting.md
+++ b/book/troubleshooting.md
@@ -57,12 +57,35 @@ On Alpine Linux (OpenRC):
 # Check service status
 rc-service aimx status
 
-# View logs
-tail -f /var/log/aimx.log
+# View recent logs (OpenRC logs to the supervise-daemon log output)
+less /var/log/messages
 
 # Restart
 rc-service aimx restart
 ```
+
+## Where are the logs?
+
+AIMX does not write its own log files. Output from `aimx serve` goes to stdout/stderr and is captured by the init system:
+
+**systemd (Ubuntu, Fedora, Debian, etc.)**
+
+The systemd unit declares `StandardOutput=journal` and `StandardError=journal`, so all daemon output is routed to journald:
+
+```bash
+# Follow logs in real time
+journalctl -u aimx -f
+
+# Show today's logs
+journalctl -u aimx --since today
+
+# Show last 200 lines
+journalctl -u aimx -n 200
+```
+
+**OpenRC (Alpine)**
+
+The generated OpenRC init script uses `supervise-daemon`, which routes daemon output to the system logger (typically `/var/log/messages` or syslog). Check your OpenRC logging configuration for the exact destination.
 
 ## DKIM/SPF debugging
 
@@ -77,7 +100,7 @@ The output should contain `v=DKIM1; k=rsa; p=...` matching your public key.
 To see the current public key:
 
 ```bash
-cat /var/lib/aimx/dkim/public.key
+cat /etc/aimx/dkim/public.key
 ```
 
 ### Check SPF record
@@ -101,7 +124,7 @@ Should include `v=DMARC1; p=reject`.
 Read an email's frontmatter to check inbound verification results:
 
 ```bash
-head -20 /var/lib/aimx/catchall/*.md
+head -20 /var/lib/aimx/inbox/catchall/*.md
 ```
 
 Look at the `dkim` and `spf` fields -- they should show `pass` for properly authenticated senders.
@@ -120,14 +143,14 @@ If outbound emails land in spam:
 Verify the DKIM private key has correct permissions:
 
 ```bash
-ls -la /var/lib/aimx/dkim/private.key
+ls -la /etc/aimx/dkim/private.key
 # Should show: -rw------- (mode 0600)
 ```
 
 If permissions are wrong:
 
 ```bash
-sudo chmod 600 /var/lib/aimx/dkim/private.key
+sudo chmod 600 /etc/aimx/dkim/private.key
 ```
 
 ## How verify works
@@ -155,7 +178,7 @@ If verify fails with EHLO probe after setup, the issue is likely in the `aimx se
 | `sudo systemctl status aimx` | Check aimx serve service |
 | `journalctl -u aimx -e` | View aimx serve logs |
 | `dig +short TXT agent.yourdomain.com` | Check DNS records |
-| `cat /var/lib/aimx/dkim/public.key` | View DKIM public key |
+| `cat /etc/aimx/dkim/public.key` | View DKIM public key |
 
 ---
 

--- a/src/datadir_readme.md.tpl
+++ b/src/datadir_readme.md.tpl
@@ -1,0 +1,158 @@
+<!-- aimx-readme-version: 1 -->
+# AIMX data directory
+
+> This file is regenerated on AIMX upgrade. User edits will be overwritten.
+
+This directory (`/var/lib/aimx/` by default) is the data root for AIMX, a
+self-hosted email system for AI agents. Agents may read everything here;
+all mutations go through the `aimx` MCP server or CLI — never write to this
+directory directly.
+
+## Access model
+
+- **Read:** world-readable. Any local user or agent can read email files,
+  scan directories, and inspect frontmatter.
+- **Write:** owned by `aimx serve` (the SMTP daemon). All changes — ingest,
+  send, mark-read, mailbox create/delete — flow through the daemon or the
+  `aimx` MCP server. Direct writes corrupt state.
+
+Configuration and secrets live under `/etc/aimx/` (root-owned, not readable
+by agents).
+
+## Directory layout
+
+```
+/var/lib/aimx/
+├── README.md                                  # this file (auto-generated)
+├── inbox/
+│   ├── catchall/                              # default mailbox for unknown local parts
+│   │   ├── 2026-04-15-143022-hello.md         # flat file: no attachments
+│   │   └── 2026-04-15-153300-invoice-march/   # attachment bundle
+│   │       ├── 2026-04-15-153300-invoice-march.md
+│   │       ├── invoice.pdf
+│   │       └── receipt.png
+│   └── support/                               # named mailbox
+│       └── ...
+└── sent/
+    └── support/                               # outbound sent copies
+        └── 2026-04-15-160145-re-meeting.md
+```
+
+- `inbox/` holds inbound mail, one subdirectory per mailbox.
+- `sent/` holds outbound copies, mirroring the same mailbox names.
+- `catchall` receives mail for unrecognised local parts. It is inbox-only
+  (no `sent/catchall/`) because it is a routing target, not a sending
+  identity.
+
+## File naming
+
+Filenames follow `YYYY-MM-DD-HHMMSS-<slug>.md` in UTC.
+
+### Slug algorithm
+
+1. MIME-decode the `Subject:` header.
+2. Lowercase.
+3. Replace every non-alphanumeric character with `-`.
+4. Collapse runs of `-` to a single `-`.
+5. Trim leading and trailing `-`.
+6. Truncate to 20 characters; re-trim if truncation leaves a trailing `-`.
+7. Empty result becomes `no-subject`.
+
+On filename collision within the same directory, AIMX appends `-2`, `-3`,
+etc., to the slug segment until a free name is found.
+
+## Attachment bundles
+
+- **Zero attachments** — flat file: `<stem>.md`.
+- **One or more attachments** — Zola-style bundle directory: `<stem>/`
+  containing `<stem>.md` plus each attachment as a sibling file.
+
+The frontmatter `attachments` array lists each attachment with `filename`,
+`content_type`, `size`, and `path` (relative to the bundle directory).
+
+## Frontmatter quick reference
+
+Each email file has TOML frontmatter between `+++` delimiters. Key fields:
+
+| Field            | Type     | Always? | Notes                                       |
+|-----------------|----------|---------|----------------------------------------------|
+| `id`            | string   | yes     | Matches the filename stem                    |
+| `message_id`    | string   | yes     | RFC 5322 Message-ID                          |
+| `thread_id`     | string   | yes     | 16-hex SHA-256 of thread root Message-ID     |
+| `from`          | string   | yes     | Sender address (may include display name)    |
+| `to`            | string   | yes     | Recipient address                            |
+| `delivered_to`  | string   | yes     | Actual RCPT TO address                       |
+| `subject`       | string   | yes     | Subject line                                 |
+| `date`          | string   | yes     | Sender-claimed RFC 3339 timestamp            |
+| `received_at`   | string   | yes     | Server-side RFC 3339 UTC timestamp           |
+| `dkim`          | string   | yes     | `"pass"`, `"fail"`, or `"none"`              |
+| `spf`           | string   | yes     | `"pass"`, `"fail"`, `"softfail"`, `"neutral"`, or `"none"` |
+| `dmarc`         | string   | yes     | `"pass"`, `"fail"`, or `"none"`              |
+| `trusted`       | string   | yes     | `"none"`, `"true"`, or `"false"`             |
+| `read`          | bool     | yes     | `false` on ingest                            |
+| `in_reply_to`   | string   | opt     | Parent Message-ID                            |
+| `references`    | string   | opt     | Space-separated Message-ID chain             |
+| `list_id`       | string   | opt     | Mailing list ID, if present                  |
+| `auto_submitted`| string   | opt     | `auto-generated`, `auto-replied`, etc.       |
+
+Sent copies additionally carry `outbound = true`, `delivery_status`
+(`"delivered"`, `"deferred"`, `"failed"`, `"pending"`), and optional
+`delivered_at` and `delivery_details`.
+
+For the complete schema, see `agents/common/references/frontmatter.md` in
+the AIMX source tree.
+
+## Trust, DKIM, SPF, and DMARC
+
+AIMX verifies DKIM, SPF, and DMARC on every inbound email. Results are
+stored in frontmatter as `dkim`, `spf`, and `dmarc` fields. All three are
+always written — never omitted — so "none" means "not applicable or no
+record published," not "the check was skipped."
+
+The `trusted` field summarises the per-mailbox trust evaluation:
+
+- `"none"` — mailbox has `trust = "none"` (the default). No evaluation.
+- `"true"` — mailbox has `trust = "verified"`, sender matches
+  `trusted_senders`, AND DKIM passed.
+- `"false"` — mailbox has `trust = "verified"`, but conditions were not met.
+
+Trust only gates channel triggers. All email is stored regardless.
+
+## Thread grouping
+
+Messages in the same thread share a `thread_id`. The value is the first
+16 hex characters of SHA-256 over the resolved thread root `Message-ID`
+(walk `In-Reply-To` first, then `References` leftmost; fall back to the
+message's own `Message-ID`). Group by `thread_id` and sort by `date` to
+reconstruct conversations.
+
+## Auto-submitted and list mail
+
+Check `auto_submitted` in frontmatter before replying — if it is
+`auto-generated` or `auto-replied`, do not reply. This prevents infinite
+loops between bots. Similarly, check `list_id` for mailing list mail and
+reply only when the context warrants it.
+
+## Sending mail
+
+`aimx send` (CLI) and `email_send` / `email_reply` (MCP) compose an
+unsigned RFC 5322 message and submit it to `aimx serve` over the Unix
+domain socket at `/run/aimx/send.sock`. The daemon DKIM-signs the message
+and delivers it directly to the recipient's MX server. The client never
+reads the DKIM private key and does not need root.
+
+The wire protocol is `AIMX/1 SEND` — a length-prefixed frame carrying a
+`From-Mailbox` header and the raw RFC 5322 body. The response is a
+single-line `AIMX/1 OK <message-id>` or `AIMX/1 ERR <code> <reason>`.
+
+## MCP server
+
+The `aimx` MCP server (launched via `aimx mcp`) provides 9 tools for
+mailbox and email operations over stdio:
+
+- `mailbox_list`, `mailbox_create`, `mailbox_delete`
+- `email_list`, `email_read`, `email_send`, `email_reply`
+- `email_mark_read`, `email_mark_unread`
+
+All mutations — send, reply, mark-read, create/delete mailbox — must go
+through the MCP server or `aimx` CLI. Do not modify files directly.

--- a/src/datadir_readme.rs
+++ b/src/datadir_readme.rs
@@ -1,0 +1,134 @@
+// VERSION BUMP: increment VERSION and update src/datadir_readme.md.tpl whenever
+// the template changes. The first line of the template must be
+// `<!-- aimx-readme-version: N -->` where N matches VERSION below.
+
+use std::path::Path;
+
+pub const TEMPLATE: &str = include_str!("datadir_readme.md.tpl");
+pub const VERSION: u32 = 1;
+
+fn version_line() -> String {
+    format!("<!-- aimx-readme-version: {VERSION} -->")
+}
+
+pub fn write(data_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let dest = data_dir.join("README.md");
+    std::fs::write(&dest, TEMPLATE)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&dest, std::fs::Permissions::from_mode(0o644))?;
+    }
+    Ok(())
+}
+
+pub fn refresh_if_outdated(data_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    let dest = data_dir.join("README.md");
+    let expected = version_line();
+
+    let needs_write = match std::fs::read_to_string(&dest) {
+        Ok(contents) => match contents.lines().next() {
+            Some(first_line) => first_line.trim() != expected,
+            None => true,
+        },
+        Err(_) => true,
+    };
+
+    if needs_write {
+        write(data_dir)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn template_starts_with_version_comment() {
+        let first_line = TEMPLATE.lines().next().unwrap();
+        assert_eq!(
+            first_line.trim(),
+            format!("<!-- aimx-readme-version: {VERSION} -->")
+        );
+    }
+
+    #[test]
+    fn write_creates_file() {
+        let tmp = TempDir::new().unwrap();
+        write(tmp.path()).unwrap();
+        let dest = tmp.path().join("README.md");
+        assert!(dest.exists());
+        let content = std::fs::read_to_string(&dest).unwrap();
+        assert_eq!(content, TEMPLATE);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_sets_mode_644() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = TempDir::new().unwrap();
+        write(tmp.path()).unwrap();
+        let mode = std::fs::metadata(tmp.path().join("README.md"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o644);
+    }
+
+    #[test]
+    fn refresh_noop_when_version_matches() {
+        let tmp = TempDir::new().unwrap();
+        write(tmp.path()).unwrap();
+        let dest = tmp.path().join("README.md");
+        let before = std::fs::metadata(&dest).unwrap().modified().unwrap();
+        // Sleep briefly so mtime would differ if the file were rewritten.
+        std::thread::sleep(std::time::Duration::from_millis(50));
+        refresh_if_outdated(tmp.path()).unwrap();
+        let after = std::fs::metadata(&dest).unwrap().modified().unwrap();
+        assert_eq!(
+            before, after,
+            "file should not be rewritten when version matches"
+        );
+    }
+
+    #[test]
+    fn refresh_overwrites_when_version_differs() {
+        let tmp = TempDir::new().unwrap();
+        let dest = tmp.path().join("README.md");
+        std::fs::write(&dest, "<!-- aimx-readme-version: 0 -->\nstale content\n").unwrap();
+        refresh_if_outdated(tmp.path()).unwrap();
+        let content = std::fs::read_to_string(&dest).unwrap();
+        assert_eq!(content, TEMPLATE);
+    }
+
+    #[test]
+    fn refresh_overwrites_when_first_line_missing() {
+        let tmp = TempDir::new().unwrap();
+        let dest = tmp.path().join("README.md");
+        std::fs::write(&dest, "").unwrap();
+        refresh_if_outdated(tmp.path()).unwrap();
+        let content = std::fs::read_to_string(&dest).unwrap();
+        assert_eq!(content, TEMPLATE);
+    }
+
+    #[test]
+    fn refresh_overwrites_when_first_line_malformed() {
+        let tmp = TempDir::new().unwrap();
+        let dest = tmp.path().join("README.md");
+        std::fs::write(&dest, "not a version comment\nsome content\n").unwrap();
+        refresh_if_outdated(tmp.path()).unwrap();
+        let content = std::fs::read_to_string(&dest).unwrap();
+        assert_eq!(content, TEMPLATE);
+    }
+
+    #[test]
+    fn refresh_creates_file_when_missing() {
+        let tmp = TempDir::new().unwrap();
+        refresh_if_outdated(tmp.path()).unwrap();
+        let content = std::fs::read_to_string(tmp.path().join("README.md")).unwrap();
+        assert_eq!(content, TEMPLATE);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,6 +2,7 @@ mod agent_setup;
 mod channel;
 mod cli;
 mod config;
+mod datadir_readme;
 mod dkim;
 mod frontmatter;
 mod ingest;

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -63,6 +63,16 @@ async fn run_serve(
     key_path: &str,
     tls_explicit: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    // Refresh the agent-facing README if the baked-in version differs from
+    // what is on disk. Runs before any listener is bound so the file is
+    // up-to-date by the time agents read it.
+    if let Err(e) = crate::datadir_readme::refresh_if_outdated(&config.data_dir) {
+        eprintln!(
+            "{} Failed to refresh datadir README: {e}",
+            term::warn("Warning:")
+        );
+    }
+
     let cert = std::path::Path::new(cert_path);
     let key = std::path::Path::new(key_path);
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1327,6 +1327,9 @@ pub fn run_setup(
     // Section [Deliverability Improvement (Optional)]
     display_deliverability_section(&domain);
 
+    // Write (or refresh) the agent-facing README inside the data directory.
+    crate::datadir_readme::write(data_dir)?;
+
     Ok(())
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2246,6 +2246,41 @@ fn send_uds_end_to_end_delivers_signed_message() {
     );
 }
 
+#[test]
+fn serve_e2e_stale_readme_refreshed_at_startup() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let port = find_free_port();
+
+    // Plant a stale README with an outdated version comment.
+    let readme_path = tmp.path().join("README.md");
+    std::fs::write(
+        &readme_path,
+        "<!-- aimx-readme-version: 0 -->\nstale content\n",
+    )
+    .unwrap();
+    let before = std::fs::read_to_string(&readme_path).unwrap();
+    assert!(before.contains("stale content"));
+
+    let child = start_serve(tmp.path(), port);
+
+    // By the time start_serve returns the TCP listener is bound, which is
+    // *after* refresh_if_outdated runs in serve startup.  The README should
+    // now contain the current template, not the stale content.
+    let after = std::fs::read_to_string(&readme_path).unwrap();
+    assert!(
+        after.starts_with("<!-- aimx-readme-version: 1 -->"),
+        "README should start with current version comment after serve startup; got: {}",
+        after.lines().next().unwrap_or("<empty>")
+    );
+    assert!(
+        !after.contains("stale content"),
+        "stale content should be replaced after serve startup"
+    );
+
+    stop_serve(child);
+}
+
 #[cfg(unix)]
 #[test]
 fn send_without_daemon_reports_missing_socket() {


### PR DESCRIPTION
## Summary

- **S40-1:** New `src/datadir_readme.rs` module with baked-in `README.md` template for the data directory. Version-gated refresh: `aimx setup` calls `write()` unconditionally, `aimx serve` startup calls `refresh_if_outdated()` (overwrites only if the version comment on the first line differs). Template covers directory layout, file naming, slug algorithm, bundle rules, frontmatter quick reference, trust model, thread grouping, send protocol, and MCP pointer. 8 unit tests.
- **S40-2:** Replaced stale `/var/log/aimx.log` references in `book/troubleshooting.md` with `journalctl -u aimx` commands. Added "Where are the logs?" subsection covering systemd (journald) and OpenRC (supervise-daemon). Added header note to `book/channel-recipes.md` distinguishing user-chosen trigger-log paths from AIMX's own logs.
- **S40-3:** Updated every `book/` chapter for v0.2: `getting-started.md` (security model note), `configuration.md` (data_dir description), `setup.md` (inbox/ paths), `mailboxes.md` (v0.2 frontmatter fields, sent copies note), `mcp.md` (primer + datadir README pointers), `channels.md` (inbound-only note), `agent-integration.md` (progressive disclosure column). Rewrote `CLAUDE.md` module descriptions (added `send_protocol`, `send_handler`, `slug`, `frontmatter`, `datadir_readme`; updated `send`, `serve`, `ingest`). Updated agent READMEs (claude-code, codex, openclaw) with references/ directory mentions.

## Test plan

- [x] 8 new unit tests for `datadir_readme` module: write creates file, write sets mode 0o644, refresh no-op when version matches, refresh overwrites when version differs/missing/malformed, refresh creates when missing, template starts with version comment
- [x] All 612 unit tests pass
- [x] All 51 integration tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Grep confirms `/var/log/aimx.log` appears nowhere under `book/`, `docs/` (except sprint.md which references the change), or `README.md`
- [x] Grep confirms no stale `/var/lib/aimx/<mailbox>/` paths (without `inbox/` or `sent/` prefix) in `book/`
- [x] Grep confirms no `sudo aimx send` in `book/`