### PR TITLE
[Sprint 42] CLI UX: Config Errors + Setup Race + Version Hash

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,15 @@
+use std::process::Command;
+
+fn main() {
+    let hash = Command::new("git")
+        .args(["rev-parse", "--short=8", "HEAD"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=GIT_HASH={hash}");
+    println!("cargo:rerun-if-changed=.git/HEAD");
+    println!("cargo:rerun-if-changed=.git/refs");
+}

--- a/docs/sprint.md
+++ b/docs/sprint.md
@@ -300,7 +300,7 @@ Completed sprints 1–37 have been archived for context window efficiency.
 
 ---
 
-## Sprint 42 — CLI UX: Config Error Messages + Setup Port-Check Race + Version Hash (Days 118–120.5) [NOT STARTED]
+## Sprint 42 — CLI UX: Config Error Messages + Setup Port-Check Race + Version Hash (Days 118–120.5) [IN PROGRESS]
 
 **Goal:** Fix P0 UX issues that block first-time setup and improve build traceability: (1) commands that require config give a cryptic "os error 2" instead of pointing the user to `aimx setup`, (2) `aimx setup` fails the inbound port 25 check because it races against `aimx serve` startup, and (3) `aimx --version` includes the git commit hash so pre-release builds are distinguishable.
 
@@ -312,11 +312,11 @@ Completed sprints 1–37 have been archived for context window efficiency.
 
 **Priority:** P0
 
-- [ ] `config::load()` (or the call site in `main.rs`) catches `io::ErrorKind::NotFound` on the config file and returns a clear error naming the expected path and suggesting `sudo aimx setup`
-- [ ] Error message includes the actual path attempted (respects `AIMX_CONFIG_DIR` override)
-- [ ] All config-dependent subcommands benefit from the fix (status, mcp, send, mailbox, serve, agent-setup, dkim-keygen) — no raw "os error 2" leaks to the user
-- [ ] Unit test: calling config load with a nonexistent path produces the expected error message, not a raw IO error
-- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+- [x] `config::load()` (or the call site in `main.rs`) catches `io::ErrorKind::NotFound` on the config file and returns a clear error naming the expected path and suggesting `sudo aimx setup`
+- [x] Error message includes the actual path attempted (respects `AIMX_CONFIG_DIR` override)
+- [x] All config-dependent subcommands benefit from the fix (status, mcp, send, mailbox, serve, agent-setup, dkim-keygen) — no raw "os error 2" leaks to the user
+- [x] Unit test: calling config load with a nonexistent path produces the expected error message, not a raw IO error
+- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
 
 #### S42-2: Wait-for-ready loop in `aimx setup` before port checks
 
@@ -324,12 +324,12 @@ Completed sprints 1–37 have been archived for context window efficiency.
 
 **Priority:** P0
 
-- [ ] After `restart_service("aimx")` returns, a wait-for-ready loop polls `127.0.0.1:25` (TCP connect) with ~500ms interval, up to ~5s total
-- [ ] Loop exits early as soon as a connection succeeds (port is bound)
-- [ ] If the loop times out (service didn't bind within 5s), setup proceeds to the port checks without error — the existing "Inbound port 25... FAIL" message covers this case
-- [ ] The wait loop is behind the `SystemOps` trait (or `NetworkOps`) so tests can mock it without real sleeps
-- [ ] Existing setup tests still pass; new test verifies that setup proceeds after the wait loop succeeds
-- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+- [x] After `restart_service("aimx")` returns, a wait-for-ready loop polls `127.0.0.1:25` (TCP connect) with ~500ms interval, up to ~5s total
+- [x] Loop exits early as soon as a connection succeeds (port is bound)
+- [x] If the loop times out (service didn't bind within 5s), setup proceeds to the port checks without error — the existing "Inbound port 25... FAIL" message covers this case
+- [x] The wait loop is behind the `SystemOps` trait (or `NetworkOps`) so tests can mock it without real sleeps
+- [x] Existing setup tests still pass; new test verifies that setup proceeds after the wait loop succeeds
+- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
 
 #### S42-3: Include git commit hash in `aimx --version` output
 
@@ -337,12 +337,12 @@ Completed sprints 1–37 have been archived for context window efficiency.
 
 **Priority:** P1
 
-- [ ] New `build.rs` at the repo root runs `git rev-parse --short=8 HEAD` and sets a `GIT_HASH` env var via `cargo:rustc-env`
-- [ ] If `git` is unavailable or the working directory isn't a repo, `GIT_HASH` is set to `"unknown"` (no build failure)
-- [ ] `cli.rs` composes the clap version string as `format!("{} ({})", env!("CARGO_PKG_VERSION"), env!("GIT_HASH"))` — output: `aimx 0.1.0 (abcd1234)`
-- [ ] When `GIT_HASH` is `"unknown"`, version string omits the parenthetical — output: `aimx 0.1.0`
-- [ ] `build.rs` emits `cargo:rerun-if-changed=.git/HEAD` and `cargo:rerun-if-changed=.git/refs` so the hash updates on new commits without full rebuilds
-- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+- [x] New `build.rs` at the repo root runs `git rev-parse --short=8 HEAD` and sets a `GIT_HASH` env var via `cargo:rustc-env`
+- [x] If `git` is unavailable or the working directory isn't a repo, `GIT_HASH` is set to `"unknown"` (no build failure)
+- [x] `cli.rs` composes the clap version string as `format!("{} ({})", env!("CARGO_PKG_VERSION"), env!("GIT_HASH"))` — output: `aimx 0.1.0 (abcd1234)`
+- [x] When `GIT_HASH` is `"unknown"`, version string omits the parenthetical — output: `aimx 0.1.0`
+- [x] `build.rs` emits `cargo:rerun-if-changed=.git/HEAD` and `cargo:rerun-if-changed=.git/refs` so the hash updates on new commits without full rebuilds
+- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
 
 ---
 
@@ -396,7 +396,7 @@ Completed sprints 1–37 have been archived for context window efficiency.
 | 39 | 109.5–112 | v0.2 Primer Skill Bundle + Author Metadata | `agents/common/aimx-primer.md` split into main + `references/`, install-time suffix + references-copy, `U-Zyn Chua <chua@uzyn.com>` standardized repo-wide | Done |
 | 40 | 112–114.5 | v0.2 Datadir README + Journald + Book/ | Baked-in `/var/lib/aimx/README.md` with version-gate refresh on `aimx serve` startup, `journalctl -u aimx` replaces stale `/var/log/aimx.log`, full `book/` + `CLAUDE.md` pass | Done |
 | 41 | 115–117.5 | Post-v0.2 Backlog Cleanup | Outbound frontmatter fixes, SPF dedup, UDS slow-loris timeout, typed transport errors, DNS error surfacing, test DKIM cache, stale dead_code sweep | Done |
-| 42 | 118–120.5 | CLI UX: Config Errors + Setup Race + Version Hash | Helpful error when config missing, wait-for-ready loop in `aimx setup` before port checks, git commit hash in `aimx --version` | Not Started |
+| 42 | 118–120.5 | CLI UX: Config Errors + Setup Race + Version Hash | Helpful error when config missing, wait-for-ready loop in `aimx setup` before port checks, git commit hash in `aimx --version` | In Progress |
 
 ## Deferred to v2
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,5 +1,18 @@
 use clap::{Parser, Subcommand};
 
+pub fn version_string() -> &'static str {
+    use std::sync::LazyLock;
+    static VERSION: LazyLock<String> = LazyLock::new(|| {
+        let hash = env!("GIT_HASH");
+        if hash == "unknown" || hash.is_empty() {
+            env!("CARGO_PKG_VERSION").to_string()
+        } else {
+            format!("{} ({hash})", env!("CARGO_PKG_VERSION"))
+        }
+    });
+    &VERSION
+}
+
 #[derive(Parser)]
 #[command(
     name = "aimx",
@@ -8,7 +21,7 @@ use clap::{Parser, Subcommand};
                    One command to give your AI agents their own email addresses.\n\
                    Incoming mail is parsed to Markdown. Outbound mail is DKIM-signed.\n\
                    MCP is built in. Channel rules trigger agent actions on incoming mail.",
-    version
+    version = version_string()
 )]
 pub struct Cli {
     /// Data directory override (default: /var/lib/aimx)

--- a/src/config.rs
+++ b/src/config.rs
@@ -98,7 +98,17 @@ fn default_dkim_selector() -> String {
 
 impl Config {
     pub fn load(path: &Path) -> Result<Self, Box<dyn std::error::Error>> {
-        let content = std::fs::read_to_string(path)?;
+        let content = std::fs::read_to_string(path).map_err(|e| {
+            if e.kind() == std::io::ErrorKind::NotFound {
+                format!(
+                    "Config file not found at {} — run 'sudo aimx setup' first",
+                    path.display()
+                )
+                .into()
+            } else {
+                Box::new(e) as Box<dyn std::error::Error>
+            }
+        })?;
         let config: Config = toml::from_str(&content)?;
         Ok(config)
     }
@@ -472,5 +482,41 @@ probe_url = "https://old.example.com/probe"
         let config: Config = toml::from_str(toml_str).unwrap();
         assert_eq!(config.domain, "test.com");
         assert!(config.verify_host.is_none());
+    }
+
+    #[test]
+    fn load_missing_config_gives_helpful_error() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("nonexistent.toml");
+        let err = Config::load(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Config file not found"),
+            "Expected helpful message, got: {msg}"
+        );
+        assert!(
+            msg.contains(&path.display().to_string()),
+            "Expected path in message, got: {msg}"
+        );
+        assert!(
+            msg.contains("sudo aimx setup"),
+            "Expected setup suggestion, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn load_resolved_missing_config_includes_config_dir_path() {
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        let err = Config::load_resolved().unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Config file not found"),
+            "Expected helpful message, got: {msg}"
+        );
+        assert!(
+            msg.contains(&tmp.path().display().to_string()),
+            "Expected config dir path in message, got: {msg}"
+        );
     }
 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -28,6 +28,9 @@ pub trait SystemOps {
     fn check_root(&self) -> bool;
     fn check_port25_occupancy(&self) -> Result<Port25Status, Box<dyn std::error::Error>>;
     fn install_service_file(&self, data_dir: &Path) -> Result<(), Box<dyn std::error::Error>>;
+    /// Poll `127.0.0.1:25` until a TCP connection succeeds or the timeout
+    /// elapses. Returns `true` if the port became reachable, `false` on timeout.
+    fn wait_for_service_ready(&self) -> bool;
 }
 
 pub trait NetworkOps {
@@ -185,6 +188,26 @@ impl SystemOps for RealSystemOps {
             }
         }
         Ok(())
+    }
+
+    fn wait_for_service_ready(&self) -> bool {
+        use std::net::{SocketAddr, TcpStream};
+        use std::time::{Duration, Instant};
+
+        let addr: SocketAddr = "127.0.0.1:25".parse().expect("static address parses");
+        let budget = Duration::from_millis(5_000);
+        let interval = Duration::from_millis(500);
+        let connect_timeout = Duration::from_millis(200);
+        let start = Instant::now();
+        loop {
+            if TcpStream::connect_timeout(&addr, connect_timeout).is_ok() {
+                return true;
+            }
+            if start.elapsed() >= budget {
+                return false;
+            }
+            std::thread::sleep(interval);
+        }
     }
 }
 
@@ -1207,6 +1230,14 @@ pub fn run_setup(
         println!("Installing AIMX service...");
         sys.install_service_file(data_dir)?;
         println!("{}", term::success("`aimx serve` started."));
+
+        print!("  Waiting for aimx serve to be ready... ");
+        io::stdout().flush()?;
+        if sys.wait_for_service_ready() {
+            println!("{}", term::pass_badge());
+        } else {
+            println!("timeout (proceeding anyway)");
+        }
     }
 
     // Step 4-5: Port checks (run on both fresh and re-entrant invocations)
@@ -1405,6 +1436,8 @@ mod tests {
         is_root: bool,
         port25_status: Port25Status,
         service_running: bool,
+        service_ready: bool,
+        wait_for_ready_calls: RefCell<u32>,
     }
 
     impl Default for MockSystemOps {
@@ -1417,6 +1450,8 @@ mod tests {
                 is_root: true,
                 port25_status: Port25Status::Free,
                 service_running: false,
+                service_ready: true,
+                wait_for_ready_calls: RefCell::new(0),
             }
         }
     }
@@ -1463,6 +1498,10 @@ mod tests {
         fn install_service_file(&self, _data_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
             *self.service_file_installed.borrow_mut() = true;
             Ok(())
+        }
+        fn wait_for_service_ready(&self) -> bool {
+            *self.wait_for_ready_calls.borrow_mut() += 1;
+            self.service_ready
         }
     }
 
@@ -1970,6 +2009,114 @@ mod tests {
         assert!(
             !*sys.service_file_installed.borrow(),
             "re-entrant setup must skip `install_service_file`"
+        );
+    }
+
+    #[test]
+    fn fresh_setup_waits_for_service_ready_after_install() {
+        // S42-2: after installing + restarting aimx, setup must poll for the
+        // daemon to bind port 25 before running the outbound/inbound probes.
+        // We force outbound to fail so the run returns early (before the DNS
+        // retry loop, which reads stdin); the assertion is that by that point
+        // `wait_for_service_ready` has been called exactly once, after the
+        // service file install.
+        let tmp = TempDir::new().unwrap();
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
+
+        let sys = MockSystemOps {
+            service_ready: true,
+            ..Default::default()
+        };
+        let net = MockNetworkOps {
+            outbound_port25: false,
+            ..Default::default()
+        };
+
+        let _ = run_setup(Some("example.com"), Some(tmp.path()), &sys, &net);
+
+        assert!(
+            *sys.service_file_installed.borrow(),
+            "fresh setup must call install_service_file"
+        );
+        assert_eq!(
+            *sys.wait_for_ready_calls.borrow(),
+            1,
+            "fresh setup must wait for the service to be ready before port checks"
+        );
+    }
+
+    #[test]
+    fn fresh_setup_proceeds_when_service_ready_times_out() {
+        // S42-2: a timed-out wait must not abort setup — the existing port-check
+        // failure path still surfaces the problem. Force outbound to fail so
+        // run_setup returns without hitting the DNS loop.
+        let tmp = TempDir::new().unwrap();
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
+
+        let sys = MockSystemOps {
+            service_ready: false,
+            ..Default::default()
+        };
+        let net = MockNetworkOps {
+            outbound_port25: false,
+            ..Default::default()
+        };
+
+        let result = run_setup(Some("example.com"), Some(tmp.path()), &sys, &net);
+
+        assert!(
+            *sys.service_file_installed.borrow(),
+            "fresh setup must call install_service_file"
+        );
+        assert_eq!(
+            *sys.wait_for_ready_calls.borrow(),
+            1,
+            "wait_for_service_ready must be called exactly once"
+        );
+        // Setup proceeded past the wait loop and ran the port checks; because
+        // outbound was mocked to fail, it errors out at the port-check summary.
+        let err = result.expect_err("port-check failure must bubble up");
+        assert!(
+            err.to_string().contains("Port 25 checks failed"),
+            "expected port-check failure message, got: {err}"
+        );
+    }
+
+    #[test]
+    fn reentrant_setup_does_not_wait_for_service_ready() {
+        // S42-2: the wait-for-ready loop is gated on the fresh-install branch.
+        // A re-entrant run (cert + DKIM already present, service already
+        // running) must skip both `install_service_file` and the wait loop.
+        let tmp = TempDir::new().unwrap();
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
+
+        let mut existing = HashMap::new();
+        existing.insert(PathBuf::from("/etc/ssl/aimx/cert.pem"), "cert".to_string());
+        existing.insert(
+            crate::config::dkim_dir().join("private.key"),
+            "key".to_string(),
+        );
+
+        let sys = MockSystemOps {
+            existing_files: existing,
+            service_running: true,
+            ..Default::default()
+        };
+        let net = MockNetworkOps {
+            outbound_port25: false,
+            ..Default::default()
+        };
+
+        let _ = run_setup(Some("example.com"), Some(tmp.path()), &sys, &net);
+
+        assert!(
+            !*sys.service_file_installed.borrow(),
+            "re-entrant setup must skip install_service_file"
+        );
+        assert_eq!(
+            *sys.wait_for_ready_calls.borrow(),
+            0,
+            "re-entrant setup must skip the wait-for-ready loop"
         );
     }
 

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -290,6 +290,9 @@ mod tests {
         ) -> Result<(), Box<dyn std::error::Error>> {
             Ok(())
         }
+        fn wait_for_service_ready(&self) -> bool {
+            true
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Sprint 42 fixes two P0 UX issues that block first-time setup and lands one P1 build-traceability improvement:

- **S42-1** — `Config::load()` catches `io::ErrorKind::NotFound` and returns `Config file not found at <path> — run 'sudo aimx setup' first` instead of leaking raw `os error 2`. Applies to every config-dependent subcommand (`status`, `mcp`, `send`, `mailbox`, `serve`, `agent-setup`, `dkim-keygen`). Respects `AIMX_CONFIG_DIR`.
- **S42-2** — After `install_service_file()` restarts `aimx`, setup now polls `127.0.0.1:25` via TCP connect (~500ms interval, ~5s budget) before running the outbound/inbound port 25 probes, closing the race that caused the inbound check to fail on fresh installs. Exits early on first success; on timeout, proceeds to the port checks (the existing `Inbound port 25… FAIL` message still covers that path). Implemented behind `SystemOps::wait_for_service_ready` so tests mock it without real sleeps.
- **S42-3** — New `build.rs` runs `git rev-parse --short=8 HEAD` and exports `GIT_HASH` via `cargo:rustc-env`, with a graceful `"unknown"` fallback when git is unavailable or the tree isn't a repo. `cli.rs` composes the clap version string as `aimx 0.1.0 (abcd1234)` when present, or plain `aimx 0.1.0` when unknown. `rerun-if-changed` on `.git/HEAD` + `.git/refs` keeps the hash fresh without forcing full rebuilds.

## Test plan

- [x] `cargo test` — 619 unit tests + 52 integration tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `aimx --version` prints `aimx 0.1.0 (<8-char-hash>)`
- [x] `AIMX_CONFIG_DIR=/tmp/nope aimx status` prints `Error: Config file not found at /tmp/nope/config.toml — run 'sudo aimx setup' first` (also verified for `mailbox list`, `send`, `dkim-keygen`, `serve`)
- [x] New setup tests assert `wait_for_service_ready` is called exactly once on fresh install and zero times on re-entrant setup, and that a timed-out wait still proceeds to the port-check summary