### PR TITLE
[Sprint 43] Pre-launch README sweep + hardening

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,6 +76,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "toml",
+ "unicode-normalization",
  "uuid",
  "wait-timeout",
 ]
@@ -2572,6 +2573,15 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
 
 [[package]]
 name = "unicode-width"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ hickory-resolver = "0.25"
 include_dir = "0.7"
 sha2 = "0.10"
 psl = "2"
+unicode-normalization = "0.1"
 
 [dev-dependencies]
 tempfile = "3"

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Outbound:
 - **Email sending** -- RFC 5322 composition on the client, DKIM signing (RSA-SHA256) and MX delivery inside `aimx serve` (via `/run/aimx/send.sock`), threading support, attachments
 - **MCP server** -- stdio transport for Claude Code and any MCP client: list, read, send, reply, manage mailboxes
 - **Channel manager** -- trigger shell commands on incoming mail with match filters (from, subject, attachments)
-- **Inbound trust** -- DKIM/SPF verification, per-mailbox trust policies, trusted sender allowlists
+- **Inbound trust** -- DKIM / SPF / DMARC verification recorded on every email, per-mailbox trust policies, trusted sender allowlists
 - **Verifier service** -- self-hostable port probe and port 25 listener for setup verification
 
 ## Requirements
@@ -60,15 +60,17 @@ Outbound:
 ## Quick start
 
 ```bash
-# 1. Build and install
-cargo install --path .
+# 1. Build and install the binary into /usr/local/bin
+git clone https://github.com/uzyn/aimx.git
+cd aimx
+cargo build --release
 sudo cp target/release/aimx /usr/local/bin/
 
-# 2. Run setup (generates service file, DKIM keys, DNS guidance)
+# 2. Run setup (writes /etc/aimx/, installs systemd/OpenRC unit, DKIM keygen, DNS guidance)
 sudo aimx setup agent.yourdomain.com
 
 # 3. Follow the interactive prompts to add DNS records
-# 4. Verify the setup
+# 4. Verify inbound + outbound port 25 reachability
 sudo aimx verify
 
 # 5. Check status
@@ -76,6 +78,8 @@ aimx status
 ```
 
 ## Installation
+
+AIMX is built from source. There are no prebuilt binaries or package-manager distributions yet.
 
 ```bash
 git clone https://github.com/uzyn/aimx.git
@@ -174,20 +178,31 @@ Available MCP tools:
 
 ### DKIM key management
 
+DKIM keys live at `/etc/aimx/dkim/{private,public}.key`. The private key is `0600` (root-only); the public key is `0644` (advertised via DNS). `aimx dkim-keygen` writes to that directory, so it must be invoked with `sudo`:
+
 ```bash
-# Generate DKIM keypair
-aimx dkim-keygen
+# Generate DKIM keypair (requires root)
+sudo aimx dkim-keygen
 
 # Force regenerate (overwrites existing)
-aimx dkim-keygen --force
+sudo aimx dkim-keygen --force
 
 # Custom selector
-aimx dkim-keygen --selector mykey
+sudo aimx dkim-keygen --selector mykey
 ```
+
+For tests or dev loops that need to run without root, set `AIMX_CONFIG_DIR` to a writable location first (e.g. `AIMX_CONFIG_DIR=/tmp/aimx-dev aimx dkim-keygen`).
 
 ## Configuration
 
-Configuration is stored in `config.toml` in the data directory (default: `/var/lib/aimx/`).
+Configuration lives at `/etc/aimx/config.toml` (mode `0640`, owner `root:root`). It is created by `aimx setup` and is read by every `aimx` command. The DKIM keypair sits beside it under `/etc/aimx/dkim/`. The **data directory** (`/var/lib/aimx/` by default) holds only mailbox storage.
+
+Two environment overrides exist, and they are independent:
+
+- `--data-dir <PATH>` / `AIMX_DATA_DIR=<PATH>` — relocate the storage directory (`/var/lib/aimx/`). Useful for unusual deployments or for running multiple instances side-by-side.
+- `AIMX_CONFIG_DIR=<PATH>` — relocate the config directory (`/etc/aimx/`, which contains `config.toml` and `dkim/`). Intended for tests and dev loops that need to run without root.
+
+Under a normal install you don't need either — `aimx setup` writes to `/etc/aimx/` and every command picks it up from there.
 
 ### config.toml reference
 
@@ -195,7 +210,9 @@ Configuration is stored in `config.toml` in the data directory (default: `/var/l
 # Domain for this email server (required)
 domain = "agent.yourdomain.com"
 
-# Data directory (default: /var/lib/aimx)
+# Storage directory for mailboxes (default: /var/lib/aimx).
+# Config and DKIM keys live under /etc/aimx/ separately and are NOT
+# governed by this setting — see the Configuration section above.
 data_dir = "/var/lib/aimx"
 
 # DKIM selector name (default: dkim)
@@ -206,6 +223,11 @@ dkim_selector = "dkim"
 # you are self-hosting the verifier service (see `services/verifier/`). aimx appends
 # `/probe` to this base URL internally.
 # verify_host = "https://verify.yourdomain.com"
+
+# Advanced: opt into IPv6 outbound delivery. Default false — outbound goes
+# over IPv4 only, matching the default SPF record. See book/configuration.md
+# for the extra AAAA + `ip6:` SPF records you need when enabling this.
+# enable_ipv6 = true
 
 # Catchall mailbox (receives all unmatched addresses)
 [mailboxes.catchall]
@@ -244,12 +266,12 @@ Available in `on_receive` command templates:
 
 | Variable | Description |
 |----------|-------------|
-| `{filepath}` | Full path to the saved `.md` file |
+| `{filepath}` | Full path to the saved `.md` file (e.g., `/var/lib/aimx/inbox/support/2025-04-15-103000-hello.md`) |
 | `{from}` | Sender email address |
 | `{to}` | Recipient email address |
 | `{subject}` | Email subject |
 | `{mailbox}` | Mailbox name |
-| `{id}` | Email ID (e.g., `2025-01-15-001`) |
+| `{id}` | Email ID / filename stem (e.g., `2025-04-15-103000-hello`) |
 | `{date}` | Email date |
 
 ### Trust policy
@@ -261,48 +283,77 @@ Trust policies control whether channel triggers fire based on sender authenticat
 
 The `trusted_senders` list allows specific senders to bypass DKIM verification. Supports glob patterns.
 
+Every inbound email records the evaluated result in a `trusted` frontmatter field so agents can act on it without re-reading config:
+
+| Value | Meaning |
+|-------|---------|
+| `"none"` | Mailbox `trust` is `none` (default) -- no evaluation performed. |
+| `"true"` | Mailbox `trust` is `verified`, sender matches `trusted_senders`, AND DKIM passed. |
+| `"false"` | Mailbox `trust` is `verified`, any other outcome. |
+
 Email is always stored regardless of trust result. Trust only gates trigger execution.
 
 ## Storage layout
 
 ```
-/var/lib/aimx/
-├── config.toml
-├── dkim/
-│   ├── private.key
-│   └── public.key
-├── catchall/
-│   ├── 2025-01-15-001.md
-│   ├── 2025-01-15-002.md
-│   └── attachments/
-│       └── document.pdf
-└── support/
-    └── ...
+/etc/aimx/                       # Config + secrets (root-owned, mode 0755)
+├── config.toml                  # Configuration (mode 0640, root:root)
+└── dkim/
+    ├── private.key              # RSA private key (mode 0600, root-only)
+    └── public.key               # RSA public key (mode 0644, advertised via DNS)
+
+/run/aimx/                       # Runtime dir (mode 0755, root:root)
+└── send.sock                    # World-writable UDS for aimx send (mode 0666)
+
+/var/lib/aimx/                   # Mailbox storage (world-readable by design)
+├── inbox/                       # inbound mail
+│   ├── catchall/                # default mailbox
+│   │   ├── 2025-04-15-143022-hello.md                  # flat: zero attachments
+│   │   └── 2025-04-15-153300-invoice-march/            # Zola-style bundle
+│   │       ├── 2025-04-15-153300-invoice-march.md
+│   │       ├── invoice.pdf
+│   │       └── receipt.png
+│   └── support/
+│       └── ...
+└── sent/                        # outbound sent copies
+    └── support/
+        └── ...
 ```
+
+Filenames use `YYYY-MM-DD-HHMMSS-<slug>.md` in UTC. Zero attachments produce a flat `.md` file; one or more attachments produce a bundle directory of the same stem with the `.md` and every attachment as siblings (the old `attachments/` subdirectory is gone).
+
+The DKIM private key is `0600` and readable only by root (`aimx serve` loads it at startup and signs in-process). The public key and the datadir are world-readable; AIMX treats DKIM secret isolation as the security boundary, not filesystem ACLs on the mailbox tree.
 
 ### Email format
 
-Emails are stored as Markdown with TOML frontmatter:
+Inbound emails are stored as Markdown with TOML frontmatter:
 
 ```markdown
 +++
-id = "2025-01-15-001"
-message_id = "<abc123@example.com>"
+id = "2025-04-15-143022-hello"
+message_id = "abc123@example.com"
+thread_id = "a1b2c3d4e5f6a7b8"
 from = "Alice <alice@example.com>"
 to = "support@agent.yourdomain.com"
+delivered_to = "support@agent.yourdomain.com"
 subject = "Hello"
-date = "2025-01-15T10:30:00Z"
-in_reply_to = ""
-references = ""
-attachments = []
-mailbox = "support"
-read = false
+date = "2025-04-15T14:30:22Z"
+received_at = "2025-04-15T14:30:23Z"
+received_from_ip = "203.0.113.10"
+size_bytes = 1024
 dkim = "pass"
 spf = "pass"
+dmarc = "pass"
+trusted = "true"
+mailbox = "support"
+read = false
+labels = []
 +++
 
 Hello, this is the email body in plain text.
 ```
+
+Optional fields (`cc`, `reply_to`, `in_reply_to`, `references`, `list_id`, `auto_submitted`, `received_from_ip`) are omitted when empty rather than written as empty strings. Sent copies (under `/var/lib/aimx/sent/<mailbox>/`) add an outbound block with `outbound`, `delivery_status`, `bcc`, `delivered_at`, and `delivery_details`. See [`book/mailboxes.md`](book/mailboxes.md) for the full field reference and outbound schema.
 
 ## Verifier service
 
@@ -350,18 +401,27 @@ To prevent emails from landing in spam:
 3. In Gmail: Settings > Filters > Create filter for `*@yourdomain.com` > Never send to Spam.
 4. Alternatively, reply to an email from the domain -- Gmail learns it is not spam.
 
-## Data directory override
+## Directory overrides
 
-The default data directory is `/var/lib/aimx`. Override with:
+AIMX splits its filesystem footprint across two roots, each with its own override:
+
+- **Storage** (`/var/lib/aimx/`) — mailboxes, inbound and sent. Override with `--data-dir <PATH>` or `AIMX_DATA_DIR=<PATH>`.
+- **Config + DKIM** (`/etc/aimx/`) — `config.toml` plus the DKIM keypair. Override with `AIMX_CONFIG_DIR=<PATH>`.
 
 ```bash
-# CLI flag
-aimx --data-dir /custom/path status
+# Storage override (CLI flag — wins over env var)
+aimx --data-dir /custom/storage status
 
-# Environment variable
-export AIMX_DATA_DIR=/custom/path
+# Storage override (env var)
+export AIMX_DATA_DIR=/custom/storage
 aimx status
+
+# Config + DKIM override (tests and dev loops that can't run as root)
+export AIMX_CONFIG_DIR=/tmp/aimx-dev
+aimx dkim-keygen
 ```
+
+Under a normal install you won't need either — `aimx setup` writes to the canonical locations and everything picks them up from there.
 
 ## License
 

--- a/docs/sprint.md
+++ b/docs/sprint.md
@@ -346,7 +346,7 @@ Completed sprints 1–37 have been archived for context window efficiency.
 
 ---
 
-## Sprint 43 — Pre-launch README Sweep + Hardening (Days 120.5–123) [NOT STARTED]
+## Sprint 43 — Pre-launch README Sweep + Hardening (Days 120.5–123) [IN PROGRESS]
 
 **Goal:** Bring `README.md` up to date with the v0.2 reshape (Sprints 33–40) before public release; fix correctness and UX gaps surfaced by external review: `aimx status` OpenRC support, HTML-body size cap, `Received:` IP parser, transport error classification, attachment-filename safety, and `dkim-keygen` permission errors.
 
@@ -495,7 +495,7 @@ Fix: `sanitize_attachment_filename(raw: &str, index: usize) -> String` — NFC-n
 | 40 | 112–114.5 | v0.2 Datadir README + Journald + Book/ | Baked-in `/var/lib/aimx/README.md` with version-gate refresh on `aimx serve` startup, `journalctl -u aimx` replaces stale `/var/log/aimx.log`, full `book/` + `CLAUDE.md` pass | Done |
 | 41 | 115–117.5 | Post-v0.2 Backlog Cleanup | Outbound frontmatter fixes, SPF dedup, UDS slow-loris timeout, typed transport errors, DNS error surfacing, test DKIM cache, stale dead_code sweep | Done |
 | 42 | 118–120.5 | CLI UX: Config Errors + Setup Race + Version Hash | Helpful error when config missing, wait-for-ready loop in `aimx setup` before port checks, git commit hash in `aimx --version` | Done |
-| 43 | 120.5–123 | Pre-launch README Sweep + Hardening | `README.md` v0.2 sweep, `status` uses `SystemOps`, HTML body size cap, bracketed-only `Received:` IP parse, typed lettre error classification, `dkim-keygen` permission-denied UX, attachment filename safety + NFC normalization | Not Started |
+| 43 | 120.5–123 | Pre-launch README Sweep + Hardening | `README.md` v0.2 sweep, `status` uses `SystemOps`, HTML body size cap, bracketed-only `Received:` IP parse, typed lettre error classification, `dkim-keygen` permission-denied UX, attachment filename safety + NFC normalization | In Progress |
 
 ## Deferred to v2
 

--- a/src/dkim.rs
+++ b/src/dkim.rs
@@ -7,6 +7,26 @@ use std::path::Path;
 
 const DKIM_KEY_BITS: usize = 2048;
 
+/// Wrap an `io::Error` from the DKIM write path with a message naming the
+/// target directory and suggesting `sudo` or the `AIMX_CONFIG_DIR` override.
+///
+/// A hard root check is deliberately avoided: `AIMX_CONFIG_DIR` is the
+/// supported non-root path (used by tests and dev loops) and pointing that
+/// at a user-writable tempdir must continue to work without `sudo`.
+fn wrap_dkim_write_error(dkim_root: &Path, err: std::io::Error) -> Box<dyn std::error::Error> {
+    if err.kind() == std::io::ErrorKind::PermissionDenied {
+        format!(
+            "Permission denied writing to {}. \
+             Run `sudo aimx dkim-keygen`, or set `AIMX_CONFIG_DIR=<writable-path>` \
+             and rerun `aimx dkim-keygen` for development.",
+            dkim_root.display()
+        )
+        .into()
+    } else {
+        err.into()
+    }
+}
+
 /// Resolve `<dkim_root>/{private,public}.key`.
 ///
 /// `dkim_root` is treated as the directory containing the DKIM keys
@@ -33,7 +53,7 @@ pub fn generate_keypair(dkim_root: &Path, force: bool) -> Result<(), Box<dyn std
         return Err("DKIM keys already exist. Use --force to overwrite.".into());
     }
 
-    std::fs::create_dir_all(dkim_root)?;
+    std::fs::create_dir_all(dkim_root).map_err(|e| wrap_dkim_write_error(dkim_root, e))?;
 
     // Force-overwrite path: remove pre-existing files so `create_new(true)`
     // succeeds with the tightened mode. (Otherwise `OpenOptions` would
@@ -41,7 +61,7 @@ pub fn generate_keypair(dkim_root: &Path, force: bool) -> Result<(), Box<dyn std
     if force {
         for p in [&private_path, &public_path] {
             if p.exists() {
-                std::fs::remove_file(p)?;
+                std::fs::remove_file(p).map_err(|e| wrap_dkim_write_error(dkim_root, e))?;
             }
         }
     }
@@ -50,13 +70,37 @@ pub fn generate_keypair(dkim_root: &Path, force: bool) -> Result<(), Box<dyn std
     let private_key = RsaPrivateKey::new(&mut rng, DKIM_KEY_BITS)?;
 
     let private_pem = private_key.to_pkcs1_pem(LineEnding::LF)?;
-    write_file_with_mode(&private_path, private_pem.as_bytes(), 0o600)?;
+    write_file_with_mode(&private_path, private_pem.as_bytes(), 0o600)
+        .map_err(|e| wrap_dkim_write_error_from_boxed(dkim_root, e))?;
 
     let public_key = RsaPublicKey::from(&private_key);
     let public_pem = public_key.to_public_key_pem(LineEnding::LF)?;
-    write_file_with_mode(&public_path, public_pem.as_bytes(), 0o644)?;
+    write_file_with_mode(&public_path, public_pem.as_bytes(), 0o644)
+        .map_err(|e| wrap_dkim_write_error_from_boxed(dkim_root, e))?;
 
     Ok(())
+}
+
+/// Like [`wrap_dkim_write_error`] but accepts a boxed error coming out of
+/// [`write_file_with_mode`]. If the underlying cause is an
+/// `io::ErrorKind::PermissionDenied`, rewrap with the friendly message;
+/// otherwise pass through unchanged.
+fn wrap_dkim_write_error_from_boxed(
+    dkim_root: &Path,
+    err: Box<dyn std::error::Error>,
+) -> Box<dyn std::error::Error> {
+    if let Some(io_err) = err.downcast_ref::<std::io::Error>()
+        && io_err.kind() == std::io::ErrorKind::PermissionDenied
+    {
+        return format!(
+            "Permission denied writing to {}. \
+             Run `sudo aimx dkim-keygen`, or set `AIMX_CONFIG_DIR=<writable-path>` \
+             and rerun `aimx dkim-keygen` for development.",
+            dkim_root.display()
+        )
+        .into();
+    }
+    err
 }
 
 /// Create `path` with `bytes` as contents and the given Unix mode applied
@@ -262,6 +306,68 @@ mod tests {
         let new = std::fs::read_to_string(tmp.path().join("private.key")).unwrap();
 
         assert_ne!(original, new);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn generate_keypair_permission_denied_suggests_sudo_or_aimx_config_dir() {
+        use std::os::unix::fs::PermissionsExt;
+
+        // Skip when running as root — `chmod 0o500` is bypassed by CAP_DAC_OVERRIDE
+        // / euid 0, so we can't force PermissionDenied.
+        if unsafe { libc::geteuid() } == 0 {
+            eprintln!("skipping: test must run as non-root");
+            return;
+        }
+
+        let tmp = TempDir::new().unwrap();
+        let parent = tmp.path().join("ro-config");
+        std::fs::create_dir_all(&parent).unwrap();
+
+        // Strip write permission on the parent. `create_dir_all(dkim_root)`
+        // inside `generate_keypair` will then fail with PermissionDenied.
+        let dkim_root = parent.join("dkim");
+        std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+        let result = generate_keypair(&dkim_root, false);
+
+        // Always restore so TempDir cleanup can succeed.
+        let _ = std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(0o755));
+
+        let err = result.expect_err("generate_keypair must fail on a read-only parent");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("Permission denied"),
+            "error must mention permission denial: {msg}"
+        );
+        assert!(
+            msg.contains(&dkim_root.display().to_string()),
+            "error must name the target directory: {msg}"
+        );
+        assert!(
+            msg.contains("sudo") || msg.contains("AIMX_CONFIG_DIR"),
+            "error must suggest sudo or AIMX_CONFIG_DIR: {msg}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn generate_keypair_non_permission_io_error_passes_through() {
+        // A non-permission IO error (here: `dkim_root` is an existing *file*,
+        // not a directory — `create_dir_all` returns NotADirectory /
+        // AlreadyExists, not PermissionDenied) must NOT be rewrapped with
+        // the sudo guidance.
+        let tmp = TempDir::new().unwrap();
+        let bogus = tmp.path().join("not-a-dir");
+        std::fs::write(&bogus, b"").unwrap();
+
+        let result = generate_keypair(&bogus, false);
+        let err = result.expect_err("must fail");
+        let msg = err.to_string();
+        assert!(
+            !msg.contains("sudo") && !msg.contains("AIMX_CONFIG_DIR"),
+            "non-PermissionDenied errors must surface their native message: {msg}"
+        );
     }
 
     #[test]

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -426,6 +426,14 @@ fn extract_received_ip(raw: &[u8]) -> Option<IpAddr> {
     None
 }
 
+/// Parse a connecting-client IP from a `Received:` header.
+///
+/// Trusts **only** the bracketed-form address (`[1.2.3.4]` / `[2001:db8::1]`)
+/// — the RFC 5321 canonical marker for the client IP recorded by the receiving
+/// MTA. Any IP embedded in free-text comments, HELO strings, or
+/// `received from hostname` prose is ignored, because those fields are
+/// attacker-controlled: the sender can write anything into the HELO/EHLO
+/// command or a hostname that happens to contain a dotted-quad. See S43-4.
 fn parse_ip_from_received(line: &str) -> Option<IpAddr> {
     let mut chars = line.chars().peekable();
     while let Some(c) = chars.next() {
@@ -436,15 +444,6 @@ fn parse_ip_from_received(line: &str) -> Option<IpAddr> {
             {
                 return Some(ip);
             }
-        }
-    }
-
-    for word in line.split_whitespace() {
-        let trimmed = word.trim_matches(|c: char| !c.is_ascii_digit() && c != '.' && c != ':');
-        if let Ok(ip) = trimmed.parse::<IpAddr>()
-            && !ip.is_loopback()
-        {
-            return Some(ip);
         }
     }
 
@@ -474,16 +473,51 @@ fn extract_local_part(rcpt: &str) -> &str {
     rcpt.split('@').next().unwrap_or(rcpt)
 }
 
+/// Maximum bytes of HTML input passed to `html2text::from_read`.
+///
+/// SMTP `max_message_size` already caps raw DATA at 25 MB, but pathological
+/// HTML (deeply nested tables, runaway CSS) within that envelope can still
+/// burn significant CPU in the conversion layer. 2 MB is far above any
+/// realistic marketing HTML (< 500 KB typical) so legitimate messages are
+/// unaffected; anything larger is truncated and a visible marker is appended
+/// to the rendered body.
+pub(crate) const HTML_CONVERSION_CAP: usize = 2 * 1024 * 1024;
+const HTML_TRUNCATION_MARKER: &str = "\n\n[...HTML body truncated at 2 MB for rendering...]";
+
 fn extract_body(message: &mail_parser::Message) -> String {
     if let Some(text) = message.body_text(0) {
         return text.to_string();
     }
 
     if let Some(html) = message.body_html(0) {
-        return html2text::from_read(html.as_bytes(), 80).unwrap_or_else(|_| html.to_string());
+        return render_html_body(html.as_bytes());
     }
 
     String::new()
+}
+
+/// Convert an HTML body to plain text via `html2text`, capping input size to
+/// [`HTML_CONVERSION_CAP`] to bound CPU. When the input is truncated, the
+/// rendered output ends with a visible marker so agents (and humans) see
+/// that the body was cut.
+pub(crate) fn render_html_body(html: &[u8]) -> String {
+    if html.is_empty() {
+        return String::new();
+    }
+
+    let (input, truncated) = if html.len() > HTML_CONVERSION_CAP {
+        (&html[..HTML_CONVERSION_CAP], true)
+    } else {
+        (html, false)
+    };
+
+    let mut rendered =
+        html2text::from_read(input, 80).unwrap_or_else(|_| String::from_utf8_lossy(input).into());
+
+    if truncated {
+        rendered.push_str(HTML_TRUNCATION_MARKER);
+    }
+    rendered
 }
 
 struct PreparedAttachment {
@@ -495,21 +529,14 @@ struct PreparedAttachment {
 fn prepare_attachments(message: &mail_parser::Message) -> Vec<PreparedAttachment> {
     let mut result = Vec::new();
 
-    for attachment in message.attachments() {
-        let raw_name = match attachment.attachment_name() {
-            Some(name) => name.to_string(),
-            None => continue,
-        };
+    for (index, attachment) in message.attachments().enumerate() {
+        let raw_name = attachment.attachment_name().unwrap_or("").to_string();
 
-        let filename = Path::new(&raw_name)
-            .file_name()
-            .and_then(|f| f.to_str())
-            .unwrap_or("")
-            .to_string();
-
-        if filename.is_empty() {
-            continue;
-        }
+        // `sanitize_attachment_filename` always returns a non-empty, filesystem-
+        // safe name (falling back to `attachment-<index>` for empty / unsafe
+        // input). The sanitized value is the single source of truth for both
+        // the on-disk bundle file and the `attachments = [...]` frontmatter.
+        let filename = sanitize_attachment_filename(&raw_name, index);
 
         let content_type = attachment
             .content_type()
@@ -530,6 +557,116 @@ fn prepare_attachments(message: &mail_parser::Message) -> Vec<PreparedAttachment
     }
 
     result
+}
+
+/// Cap for sanitized attachment filenames, in bytes. Leaves comfortable
+/// headroom under the typical Linux/macOS `NAME_MAX = 255` after any
+/// future prefix/suffix. Truncation happens on a UTF-8 char boundary.
+const ATTACHMENT_FILENAME_MAX_BYTES: usize = 200;
+
+/// Sanitize an attachment filename from an untrusted inbound email.
+///
+/// The raw filename coming out of `mail-parser` is attacker-controlled. On
+/// top of `Path::file_name()` (which strips directory components), this
+/// helper additionally:
+/// - NFC-normalizes so visually-identical names don't split into NFC/NFD
+///   variants (filesystem collision + agent confusion).
+/// - Strips control characters (C0, DEL) and bidi / invisible Unicode
+///   controls (RLO, LRO, PDF, ZWJ, ZWNJ, BOM, LRM, RLM, LRE, RLE, etc.)
+///   so a filename can't hide its extension or rewrite itself in agent
+///   logs.
+/// - Replaces `/` and `\` with `_` so a malformed name can never escape
+///   the bundle directory even if the Path::file_name() guard is lost in
+///   a refactor (defense in depth).
+/// - Collapses runs of unsafe characters to a single `_`.
+/// - Trims leading/trailing whitespace, `.`, and `-`. Leading `-` matters
+///   because downstream CLI tools (`rm`, `find`, `curl`) may interpret a
+///   filename beginning with `-` as a flag.
+/// - Caps the byte length at [`ATTACHMENT_FILENAME_MAX_BYTES`] on a UTF-8
+///   char boundary so the filesystem's `NAME_MAX` is not hit.
+/// - Falls back to `attachment-<index>` when the result would be empty
+///   (e.g. the whole name was control chars).
+pub(crate) fn sanitize_attachment_filename(raw: &str, index: usize) -> String {
+    use unicode_normalization::UnicodeNormalization;
+
+    // First line of defense: pick the filename component only. `mail-parser`
+    // already unescapes headers, so `../../etc/passwd` arrives as a literal
+    // string; `Path::file_name` on `"../../etc/passwd"` returns `"passwd"`,
+    // which neutralizes naive path-traversal. `\\` on Unix is NOT a path
+    // separator, so Windows-style paths need explicit handling — do it
+    // below after normalization.
+    let base = Path::new(raw)
+        .file_name()
+        .and_then(|f| f.to_str())
+        .unwrap_or("");
+
+    // NFC-normalize so NFD-form names collapse into their NFC siblings.
+    let normalized: String = base.nfc().collect();
+
+    let mut out = String::with_capacity(normalized.len());
+    let mut last_was_underscore = false;
+    for ch in normalized.chars() {
+        let unsafe_char = is_filename_unsafe(ch);
+        if unsafe_char {
+            if !last_was_underscore {
+                out.push('_');
+                last_was_underscore = true;
+            }
+        } else {
+            out.push(ch);
+            last_was_underscore = false;
+        }
+    }
+
+    // Trim leading/trailing whitespace, dots, dashes, and collapse-underscores.
+    // A leading `-` is flag-like to many CLI tools; a leading `.` yields a
+    // hidden file; a leading `_` would often just be a residue of the
+    // unsafe-char collapse step above and adds no information.
+    let trim_chars = |c: char| c.is_whitespace() || c == '.' || c == '-' || c == '_';
+    let trimmed = out.trim_matches(trim_chars);
+    let mut trimmed = trimmed.to_string();
+
+    // Byte-cap on a UTF-8 char boundary.
+    if trimmed.len() > ATTACHMENT_FILENAME_MAX_BYTES {
+        let mut end = ATTACHMENT_FILENAME_MAX_BYTES;
+        while end > 0 && !trimmed.is_char_boundary(end) {
+            end -= 1;
+        }
+        trimmed.truncate(end);
+        // Post-truncation: re-trim trailing separators exposed by the cut.
+        let retrimmed = trimmed.trim_end_matches(trim_chars);
+        trimmed = retrimmed.to_string();
+    }
+
+    if trimmed.is_empty() {
+        return format!("attachment-{index}");
+    }
+    trimmed
+}
+
+/// Characters never allowed in a sanitized attachment filename.
+fn is_filename_unsafe(ch: char) -> bool {
+    // Path separators (defense in depth — `Path::file_name` already strips
+    // these, but on Unix `\\` is NOT a path separator so we must reject it
+    // explicitly to keep a consistent shape across platforms and protect
+    // downstream Windows consumers).
+    if ch == '/' || ch == '\\' {
+        return true;
+    }
+    // NUL and all C0 control characters + DEL.
+    if ch == '\0' || ch.is_control() {
+        return true;
+    }
+    // Bidirectional and other invisible-control Unicode code points.
+    // These can hide an extension, re-order visible glyphs, or be used to
+    // spoof extensions in agent / operator logs.
+    matches!(
+        ch,
+        '\u{200B}'..='\u{200F}'   // ZWSP / ZWJ / ZWNJ / LRM / RLM
+            | '\u{202A}'..='\u{202E}' // LRE / RLE / PDF / LRO / RLO
+            | '\u{2066}'..='\u{2069}' // LRI / RLI / FSI / PDI
+            | '\u{FEFF}'              // BOM / ZWNBSP
+    )
 }
 
 fn write_attachments(
@@ -827,6 +964,38 @@ mod tests {
     }
 
     #[test]
+    fn render_html_body_under_cap_is_full_conversion() {
+        let html = b"<html><body><h1>Hello</h1><p>World</p></body></html>";
+        let rendered = render_html_body(html);
+        assert!(rendered.contains("Hello"));
+        assert!(rendered.contains("World"));
+        assert!(
+            !rendered.contains("HTML body truncated"),
+            "under-cap input must not produce a truncation marker: {rendered}"
+        );
+    }
+
+    #[test]
+    fn render_html_body_empty_is_empty() {
+        assert_eq!(render_html_body(b""), "");
+    }
+
+    #[test]
+    fn render_html_body_over_cap_appends_marker() {
+        // Build 2 MB + 1 KB of harmless HTML. Anything over the cap triggers
+        // truncation regardless of content.
+        let filler = "<p>x</p>".repeat((HTML_CONVERSION_CAP / 8) + 128);
+        let html = format!("<html><body>{filler}</body></html>");
+        assert!(html.len() > HTML_CONVERSION_CAP);
+        let rendered = render_html_body(html.as_bytes());
+        assert!(
+            rendered.contains("HTML body truncated at 2 MB for rendering"),
+            "over-cap input must end with a truncation marker: (len={})",
+            rendered.len()
+        );
+    }
+
+    #[test]
     fn ingest_multipart_prefers_text() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
@@ -1000,6 +1169,121 @@ mod tests {
     }
 
     #[test]
+    fn sanitize_filename_embedded_nul() {
+        // NUL must never appear in a sanitized filename; its removal must
+        // not leave a bare `_` as the whole name.
+        let out = sanitize_attachment_filename("bad\0name.txt", 0);
+        assert!(!out.contains('\0'));
+        assert!(out.contains("name.txt"));
+    }
+
+    #[test]
+    fn sanitize_filename_cr_lf_stripped() {
+        let out = sanitize_attachment_filename("report\r\nline2.pdf", 0);
+        assert!(!out.contains('\r') && !out.contains('\n'));
+        assert!(out.ends_with(".pdf"));
+    }
+
+    #[test]
+    fn sanitize_filename_path_traversal_stripped() {
+        // `Path::file_name` already collapses `../../etc/passwd` to `passwd`,
+        // but this is defense in depth: even if the input arrived whole, the
+        // separators would collapse to `_`s.
+        let out = sanitize_attachment_filename("../../etc/passwd", 0);
+        assert!(!out.contains('/'));
+        assert!(out == "passwd" || out.contains("passwd"));
+    }
+
+    #[test]
+    fn sanitize_filename_leading_dash_stripped() {
+        // `-rf` as a filename is dangerous to naive downstream `rm` wrappers.
+        // The leading `-` must be stripped.
+        let out = sanitize_attachment_filename("-rf", 0);
+        assert!(!out.starts_with('-'));
+        // May be "rf" or may fall back to attachment-0 if the whole name
+        // was trimmed away; both are safe.
+        assert!(out == "rf" || out == "attachment-0");
+    }
+
+    #[test]
+    fn sanitize_filename_500_char_truncated_under_cap_on_char_boundary() {
+        let raw: String = "a".repeat(500);
+        let out = sanitize_attachment_filename(&raw, 0);
+        assert!(
+            out.len() <= ATTACHMENT_FILENAME_MAX_BYTES,
+            "sanitized name must be ≤{ATTACHMENT_FILENAME_MAX_BYTES} bytes: {}",
+            out.len()
+        );
+        // UTF-8 boundary — ASCII is trivially aligned; just sanity check.
+        assert!(out.is_char_boundary(out.len()));
+    }
+
+    #[test]
+    fn sanitize_filename_empty_after_sanitize_falls_back() {
+        // A name made entirely of control characters sanitizes to empty,
+        // which must fall back to `attachment-<index>`.
+        let all_controls = "\0\0\r\n\x01\x02";
+        assert_eq!(
+            sanitize_attachment_filename(all_controls, 3),
+            "attachment-3"
+        );
+        assert_eq!(sanitize_attachment_filename("", 0), "attachment-0");
+    }
+
+    #[test]
+    fn sanitize_filename_windows_style_backslash() {
+        // On Unix, `\\` is NOT a path separator, so `Path::file_name` keeps
+        // `a\\b\\c.pdf` as-is. The sanitizer must still strip the backslashes
+        // so the filename doesn't confuse Windows consumers or shell escapes.
+        let out = sanitize_attachment_filename("a\\b\\c.pdf", 0);
+        assert!(!out.contains('\\'));
+        assert!(out.ends_with(".pdf"));
+    }
+
+    #[test]
+    fn sanitize_filename_nfd_normalized_to_nfc() {
+        // NFD "é" (e + combining acute) normalizes to precomposed NFC "é"
+        // so filesystem collisions between NFC/NFD siblings can't happen
+        // downstream.
+        let nfd = "caf\u{0065}\u{0301}.pdf";
+        let out = sanitize_attachment_filename(nfd, 0);
+        assert!(
+            out.contains("caf\u{00E9}"),
+            "NFD must collapse to precomposed é: {out}"
+        );
+    }
+
+    #[test]
+    fn sanitize_filename_bidi_override_stripped() {
+        // An RLO (U+202E) embedded in the filename can reorder glyphs in
+        // logs/agent output so `file.txt` displays as `file.gpj`. The
+        // sanitizer must strip all bidi overrides.
+        let bidi = "safe\u{202E}fdp.pdf";
+        let out = sanitize_attachment_filename(bidi, 0);
+        assert!(!out.chars().any(|c| c == '\u{202E}'));
+    }
+
+    #[test]
+    fn sanitize_filename_zero_width_joiner_stripped() {
+        let zwj = "inv\u{200D}oice.pdf";
+        let out = sanitize_attachment_filename(zwj, 0);
+        assert!(!out.chars().any(|c| c == '\u{200D}'));
+    }
+
+    #[test]
+    fn sanitize_filename_unsafe_runs_collapse_to_single_underscore() {
+        // Multiple unsafe chars in a row must collapse to one `_`, not spray
+        // `____` across the filename.
+        let out = sanitize_attachment_filename("a////b\\\\c.pdf", 0);
+        // Count runs of `_` — each should be length 1.
+        let has_long_run = out.split(|c: char| c != '_').any(|s| s.len() > 1);
+        assert!(
+            !has_long_run,
+            "unsafe-char runs must collapse to a single `_`: {out}"
+        );
+    }
+
+    #[test]
     fn attachment_path_traversal_sanitized() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
@@ -1035,6 +1319,82 @@ mod tests {
         let bundle = bundles[0].path();
         assert!(bundle.join("evil").exists());
         assert!(!tmp.path().join("etc").exists());
+    }
+
+    #[test]
+    fn attachment_malicious_names_sanitized_integration() {
+        // S43-7 integration: two attachments with hostile names.
+        // - `../../etc/passwd` — path-traversal attempt.
+        // - `\x00rce.sh` — embedded NUL + potentially flag-looking name.
+        // Both must land INSIDE the bundle directory with names that
+        // contain no path separators and no NUL bytes. `tmp/etc/` must
+        // not exist — nothing escaped the bundle.
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+
+        let eml = b"From: sender@example.com\r\n\
+            To: alice@test.com\r\n\
+            Subject: Malicious\r\n\
+            Date: Thu, 01 Jan 2025 12:00:00 +0000\r\n\
+            Message-ID: <evil2@example.com>\r\n\
+            MIME-Version: 1.0\r\n\
+            Content-Type: multipart/mixed; boundary=\"b1\"\r\n\
+            \r\n\
+            --b1\r\n\
+            Content-Type: text/plain; charset=utf-8\r\n\
+            \r\n\
+            Body.\r\n\
+            --b1\r\n\
+            Content-Type: text/plain; name=\"../../etc/passwd\"\r\n\
+            Content-Disposition: attachment; filename=\"../../etc/passwd\"\r\n\
+            \r\n\
+            passwd-contents\r\n\
+            --b1\r\n\
+            Content-Type: application/x-sh; name=\"\x00rce.sh\"\r\n\
+            Content-Disposition: attachment; filename=\"\x00rce.sh\"\r\n\
+            \r\n\
+            #!/bin/sh\r\n\
+            --b1--\r\n";
+
+        ingest_email(&config, "alice@test.com", eml, sentinel_ip()).unwrap();
+
+        let alice = inbox(tmp.path(), "alice");
+        let bundles: Vec<_> = std::fs::read_dir(&alice)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.path().is_dir())
+            .collect();
+        assert_eq!(bundles.len(), 1);
+        let bundle = bundles[0].path();
+
+        // Nothing escaped.
+        assert!(
+            !tmp.path().join("etc").exists(),
+            "attachment sanitization must prevent `etc/` escape"
+        );
+
+        // Walk the bundle and assert every file is safe.
+        let entries: Vec<_> = std::fs::read_dir(&bundle)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        let mut saw_attachment_file = false;
+        for e in entries {
+            let name = e.file_name().to_string_lossy().into_owned();
+            // `<stem>.md` is the email body itself.
+            if name.ends_with(".md") {
+                continue;
+            }
+            saw_attachment_file = true;
+            assert!(!name.contains('/'), "leaked path separator in {name}");
+            assert!(!name.contains('\\'), "leaked backslash in {name}");
+            assert!(!name.contains('\0'), "leaked NUL in {name}");
+            assert!(!name.starts_with('-'), "leading dash in {name}");
+        }
+        assert!(
+            saw_attachment_file,
+            "expected at least one sanitized attachment file in the bundle"
+        );
     }
 
     #[test]
@@ -1108,6 +1468,54 @@ mod tests {
         let line = "Received: from mail.example.com ([2001:db8::1])";
         let ip = parse_ip_from_received(line);
         assert_eq!(ip, Some("2001:db8::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn parse_ip_from_received_rejects_bare_ip_in_comment() {
+        // S43-4: previously the whitespace-split fallback would happily pick
+        // up an IP embedded in a HELO or a free-text comment. That fallback
+        // is gone — only the bracketed RFC 5321 form is trusted.
+        let line = "Received: from evil.example.com (HELO mail.legit 1.2.3.4 via clever.host)";
+        assert_eq!(parse_ip_from_received(line), None);
+    }
+
+    #[test]
+    fn parse_ip_from_received_rejects_hostname_with_dotted_quad() {
+        // A hostname like `host-1.2.3.4.example.com` must NOT be parsed as
+        // an IP — the old fallback was susceptible to this.
+        let line = "Received: from host-1.2.3.4.example.com by mx.local";
+        assert_eq!(parse_ip_from_received(line), None);
+    }
+
+    #[test]
+    fn parse_ip_from_received_rejects_ipv6_in_free_text() {
+        // Same principle for IPv6: no brackets → no trust.
+        let line = "Received: from mail.example.com (claims 2001:db8::abcd)";
+        assert_eq!(parse_ip_from_received(line), None);
+    }
+
+    #[test]
+    fn parse_ip_from_received_real_fixture_shapes() {
+        // Three canonical `Received:` header shapes pulled from real
+        // inbound mail. All three use the bracketed form.
+        let gmail = "Received: from mail-sor-f41.google.com (mail-sor-f41.google.com. [209.85.220.41]) by mx.local";
+        assert_eq!(
+            parse_ip_from_received(gmail),
+            Some("209.85.220.41".parse().unwrap())
+        );
+
+        let microsoft = "Received: from NAM10-BN7-obe.outbound.protection.outlook.com ([40.107.93.79]) by mx.local";
+        assert_eq!(
+            parse_ip_from_received(microsoft),
+            Some("40.107.93.79".parse().unwrap())
+        );
+
+        let postfix =
+            "Received: from mta.example.com (unknown [198.51.100.7]) by mx.local with ESMTPS";
+        assert_eq!(
+            parse_ip_from_received(postfix),
+            Some("198.51.100.7".parse().unwrap())
+        );
     }
 
     #[test]

--- a/src/slug.rs
+++ b/src/slug.rs
@@ -18,15 +18,25 @@ const SLUG_EMPTY_FALLBACK: &str = "no-subject";
 /// Callers pass the already-MIME-decoded subject (e.g. the `&str` returned
 /// by `mail_parser::Message::subject`, which decodes RFC 2047 encoded words
 /// transparently). The transformation is:
-/// 1. Lowercase (Unicode-aware).
-/// 2. Every non-alphanumeric character becomes `-`.
-/// 3. Runs of `-` collapse to one.
-/// 4. Leading/trailing `-` are trimmed.
-/// 5. Truncated to 20 characters (counted as Unicode scalar values, then
+/// 1. NFC-normalize (so NFC and NFD encodings of the same visible subject
+///    produce identical slugs — see S43-7).
+/// 2. Lowercase (Unicode-aware).
+/// 3. Every non-alphanumeric character becomes `-`.
+/// 4. Runs of `-` collapse to one.
+/// 5. Leading/trailing `-` are trimmed.
+/// 6. Truncated to 20 characters (counted as Unicode scalar values, then
 ///    re-trimmed in case truncation left a trailing `-`).
-/// 6. Empty result becomes `no-subject`.
+/// 7. Empty result becomes `no-subject`.
 pub fn slugify(subject: &str) -> String {
-    let lowered: String = subject.to_lowercase();
+    use unicode_normalization::UnicodeNormalization;
+
+    // NFC-normalize first so decomposed (NFD) forms of the same visible
+    // subject produce the same slug. Without this, `"Héllo"` written as
+    // `H` + `e` + combining-acute and `"Héllo"` written as `H` + precomposed
+    // `é` would yield different slugs even though humans and mail clients
+    // treat them as identical. See S43-7.
+    let normalized: String = subject.nfc().collect();
+    let lowered: String = normalized.to_lowercase();
 
     let mut out = String::with_capacity(lowered.len());
     let mut last_was_dash = false;
@@ -176,6 +186,19 @@ mod tests {
     #[test]
     fn slugify_numbers_preserved() {
         assert_eq!(slugify("Invoice #123 for 2025"), "invoice-123-for-2025");
+    }
+
+    #[test]
+    fn slugify_nfd_and_nfc_match() {
+        // S43-7: NFD and NFC forms of the same visible subject must slug to
+        // the same value. Without the NFC-normalization step they split into
+        // different slugs because `to_lowercase()` is not composition-aware.
+        // "Hé" written two ways:
+        //   * NFC:  "H\u{00E9}"         (precomposed é)
+        //   * NFD:  "H\u{0065}\u{0301}" (e + combining acute)
+        let nfc = "H\u{00E9}llo";
+        let nfd = "H\u{0065}\u{0301}llo";
+        assert_eq!(slugify(nfc), slugify(nfd));
     }
 
     #[test]

--- a/src/status.rs
+++ b/src/status.rs
@@ -1,5 +1,6 @@
 use crate::config::Config;
 use crate::frontmatter::InboundFrontmatter;
+use crate::setup::{RealSystemOps, SystemOps};
 use crate::term;
 use std::path::{Path, PathBuf};
 
@@ -29,8 +30,14 @@ pub struct RecentEmail {
 }
 
 pub fn gather_status(config: &Config) -> StatusInfo {
+    gather_status_with_ops(config, &RealSystemOps)
+}
+
+/// Injectable seam for testing: takes a `SystemOps` implementation so tests
+/// can mock `is_service_running` without shelling out to `systemctl`/`rc-service`.
+pub fn gather_status_with_ops<S: SystemOps>(config: &Config, sys: &S) -> StatusInfo {
     let dkim_key_present = crate::config::dkim_dir().join("private.key").exists();
-    let smtp_running = check_smtp_running();
+    let smtp_running = sys.is_service_running("aimx");
 
     let mut mailboxes: Vec<MailboxStatus> = config
         .mailboxes
@@ -120,13 +127,6 @@ fn gather_recent_activity(config: &Config) -> Vec<RecentEmail> {
     all.sort_by(|a, b| b.date.cmp(&a.date));
     all.truncate(5);
     all
-}
-
-fn check_smtp_running() -> bool {
-    std::process::Command::new("systemctl")
-        .args(["is-active", "--quiet", "aimx"])
-        .status()
-        .is_ok_and(|s| s.success())
 }
 
 fn count_messages(dir: &Path) -> (usize, usize) {
@@ -272,6 +272,93 @@ pub fn run(config: Config) -> Result<(), Box<dyn std::error::Error>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::setup::Port25Status;
+
+    /// Minimal mock that only exercises `is_service_running`. All other
+    /// `SystemOps` methods panic — they must not be reached by `gather_status`.
+    struct FakeServiceOps {
+        running: bool,
+    }
+
+    impl SystemOps for FakeServiceOps {
+        fn write_file(
+            &self,
+            _path: &Path,
+            _content: &str,
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            unreachable!("gather_status must not touch write_file")
+        }
+        fn file_exists(&self, _path: &Path) -> bool {
+            unreachable!("gather_status must not touch file_exists")
+        }
+        fn restart_service(&self, _service: &str) -> Result<(), Box<dyn std::error::Error>> {
+            unreachable!("gather_status must not touch restart_service")
+        }
+        fn is_service_running(&self, service: &str) -> bool {
+            assert_eq!(service, "aimx", "status must query the aimx service");
+            self.running
+        }
+        fn generate_tls_cert(
+            &self,
+            _cert_dir: &Path,
+            _domain: &str,
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            unreachable!("gather_status must not touch generate_tls_cert")
+        }
+        fn get_aimx_binary_path(&self) -> Result<PathBuf, Box<dyn std::error::Error>> {
+            unreachable!("gather_status must not touch get_aimx_binary_path")
+        }
+        fn check_root(&self) -> bool {
+            unreachable!("gather_status must not touch check_root")
+        }
+        fn check_port25_occupancy(&self) -> Result<Port25Status, Box<dyn std::error::Error>> {
+            unreachable!("gather_status must not touch check_port25_occupancy")
+        }
+        fn install_service_file(&self, _data_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+            unreachable!("gather_status must not touch install_service_file")
+        }
+        fn wait_for_service_ready(&self) -> bool {
+            unreachable!("gather_status must not touch wait_for_service_ready")
+        }
+    }
+
+    fn empty_config(data_dir: &Path) -> Config {
+        Config {
+            domain: "test.com".to_string(),
+            data_dir: data_dir.to_path_buf(),
+            dkim_selector: "dkim".to_string(),
+            mailboxes: std::collections::HashMap::new(),
+            verify_host: None,
+            enable_ipv6: false,
+        }
+    }
+
+    #[test]
+    fn gather_status_reports_running_when_systemops_returns_true() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
+
+        let config = empty_config(tmp.path());
+        let info = gather_status_with_ops(&config, &FakeServiceOps { running: true });
+        assert!(info.smtp_running);
+    }
+
+    #[test]
+    fn gather_status_reports_not_running_when_systemops_returns_false() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
+
+        let config = empty_config(tmp.path());
+        let info = gather_status_with_ops(&config, &FakeServiceOps { running: false });
+        assert!(!info.smtp_running);
+    }
+
+    // Manual verification note (S43-2): on OpenRC hosts (Alpine) the real
+    // `RealSystemOps::is_service_running` dispatches to `rc-service aimx status`
+    // via `crate::serve::service::is_service_running_command`. The previous
+    // hardcoded `systemctl is-active` call always returned false on OpenRC.
+    // With this refactor, `aimx status` now reports the correct state on
+    // both systemd and OpenRC hosts.
 
     #[test]
     fn format_status_no_mailboxes() {

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -254,18 +254,40 @@ impl LettreTransport {
             .timeout(Some(std::time::Duration::from_secs(60)))
             .build();
 
-        transport.send_raw(envelope, message).map_err(|e| {
-            let msg = e.to_string();
-            if msg.contains("Connection refused") {
-                TransportError::Temp(format!("Connection refused by {host}"))
-            } else if msg.contains("timed out") || msg.contains("Timeout") {
-                TransportError::Temp(format!("Connection timed out to {host}"))
-            } else {
-                TransportError::Permanent(format!("Rejected by {host}: {msg}"))
-            }
-        })?;
+        transport
+            .send_raw(envelope, message)
+            .map_err(|e| classify_lettre_error(host, &e))?;
 
         Ok(host.to_string())
+    }
+}
+
+/// Classify a `lettre::transport::smtp::Error` into a typed `TransportError`.
+///
+/// Mapping (documented so future lettre upgrades don't silently drift):
+/// - `is_permanent()` → `Permanent` (SMTP 5xx reply; recipient rejected the
+///   message outright — do not retry)
+/// - `is_transient()` → `Temp` (SMTP 4xx reply; recipient asked us to retry)
+/// - `is_timeout()` → `Temp` (connect or read timeout)
+/// - `is_transport_shutdown()` → `Temp` (pool shut down)
+/// - TLS failure (`is_tls()`) → `Temp` (usually recoverable by retry or a
+///   different MX host)
+/// - `is_response()` / `is_client()` → `Temp` (protocol hiccup; the message
+///   was not rejected on its merits)
+/// - anything else (network/connection/unknown) → `Temp`
+///
+/// Previously this classification was substring-matched against
+/// `e.to_string()`, which was brittle across lettre versions; see S43-5.
+fn classify_lettre_error(host: &str, e: &lettre::transport::smtp::Error) -> TransportError {
+    let msg = e.to_string();
+    if e.is_permanent() {
+        TransportError::Permanent(format!("Rejected by {host}: {msg}"))
+    } else if e.is_timeout() {
+        TransportError::Temp(format!("Connection timed out to {host}"))
+    } else {
+        // Transient SMTP (4xx), TLS, transport-shutdown, response/client
+        // parse errors, and raw network/connection failures all map to Temp.
+        TransportError::Temp(format!("{host}: {msg}"))
     }
 }
 
@@ -427,6 +449,16 @@ mod tests {
         );
         assert!(LettreTransport::extract_domain("nodomain").is_err());
     }
+
+    // Note (S43-5): `classify_lettre_error` maps `lettre::transport::smtp::Error`
+    // variants to our typed `TransportError`. `smtp::Error` has no public
+    // constructor — its `new()`, `code()`, `response()`, `client()`, `network()`,
+    // `connection()`, `tls()`, and `transport_shutdown()` helpers are all
+    // `pub(crate)`. That means we can't build a synthetic `smtp::Error` for a
+    // branch-by-branch unit test; behaviour is covered end-to-end by the
+    // `LettreTransport` path (`send_handler` integration tests drive real sends
+    // against localhost and observe the typed error). The mapping is documented
+    // above `classify_lettre_error`.
 
     #[test]
     fn dns_failure_produces_distinct_error_from_no_a_record() {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -423,6 +423,60 @@ fn dkim_keygen_force_overwrite() {
     assert_ne!(original, new);
 }
 
+#[cfg(unix)]
+#[test]
+fn dkim_keygen_permission_denied_error_mentions_path_and_override() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // Skip when running as root — chmod 0o500 is bypassed by CAP_DAC_OVERRIDE.
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping: test must run as non-root");
+        return;
+    }
+
+    // `AIMX_CONFIG_DIR` points at a read-only directory. `aimx dkim-keygen`
+    // then tries to create `<ro>/dkim/` and hits PermissionDenied. The error
+    // message must name the target path and suggest `sudo` or `AIMX_CONFIG_DIR`.
+    let tmp = TempDir::new().unwrap();
+    let config_dir = tmp.path().join("ro-config");
+    std::fs::create_dir_all(&config_dir).unwrap();
+    let config_content = format!(
+        "domain = \"agent.example.com\"\ndata_dir = \"{}\"\n\n[mailboxes.catchall]\naddress = \"*@agent.example.com\"\n",
+        tmp.path().display()
+    );
+    std::fs::write(config_dir.join("config.toml"), &config_content).unwrap();
+    // Remove write permission so `create_dir_all(<ro-config>/dkim)` inside
+    // `generate_keypair` fails with PermissionDenied.
+    std::fs::set_permissions(&config_dir, std::fs::Permissions::from_mode(0o500)).unwrap();
+
+    let output = Command::cargo_bin("aimx")
+        .unwrap()
+        .env("AIMX_CONFIG_DIR", &config_dir)
+        .arg("dkim-keygen")
+        .output()
+        .expect("spawn aimx");
+
+    // Restore permissions for TempDir cleanup.
+    let _ = std::fs::set_permissions(&config_dir, std::fs::Permissions::from_mode(0o755));
+
+    assert!(
+        !output.status.success(),
+        "dkim-keygen must fail on read-only config dir"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let combined = format!("{stderr}{}", String::from_utf8_lossy(&output.stdout));
+    let dkim_path = config_dir.join("dkim");
+    assert!(
+        combined.contains(&dkim_path.display().to_string())
+            || combined.contains(&config_dir.display().to_string()),
+        "error must mention the attempted path; got: {combined}"
+    );
+    assert!(
+        combined.contains("sudo") || combined.contains("AIMX_CONFIG_DIR"),
+        "error must suggest sudo or AIMX_CONFIG_DIR; got: {combined}"
+    );
+}
+
 fn aimx_binary_path() -> std::path::PathBuf {
     assert_cmd::cargo::cargo_bin("aimx")
 }


### PR DESCRIPTION
## Summary

Sprint 43 brings README.md up to date with the v0.2 reshape (Sprints 33–40) and ships the external-review hardening items flagged for pre-launch.

## Stories

- **S43-1 — README pre-launch sweep.** Storage layout now reflects `/etc/aimx/` config+DKIM split with `/var/lib/aimx/{inbox,sent}/<mailbox>/` Zola-style bundles. Email-format example rewritten with every current inbound field in `frontmatter.rs` section order; outbound block pointer added. Trust section now covers the `trusted` frontmatter field. `AIMX_CONFIG_DIR` documented separately from `--data-dir` / `AIMX_DATA_DIR`. DKIM-keygen section calls out root requirement + `AIMX_CONFIG_DIR` dev path. Repo grep for bare `/var/lib/aimx/<mailbox>/` (no `inbox/`/`sent/`) returns zero hits in README.md.
- **S43-2 — `aimx status` uses `SystemOps::is_service_running`.** `status::gather_status` dispatches through the `SystemOps` abstraction instead of hardcoding `systemctl is-active`. OpenRC hosts (Alpine/Gentoo) now correctly report the daemon's running state. Injectable via `gather_status_with_ops`; mock tests cover both true and false branches.
- **S43-3 — HTML body size cap.** New `HTML_CONVERSION_CAP = 2 MiB` applied before `html2text::from_read`. Over-cap inputs are truncated on a safe prefix and a visible marker `[...HTML body truncated at 2 MB for rendering...]` is appended. Under-cap behaviour identical to today. Three unit tests (under, over, empty).
- **S43-4 — `parse_ip_from_received` bracketed-only.** Whitespace-split fallback removed; only the RFC 5321 bracketed form populates `received_from_ip`. New tests cover free-text IP in comments, hostname-with-dotted-quad, IPv6-in-prose, and three canonical real-mail shapes (Gmail, Outlook, Postfix).
- **S43-5 — Typed lettre error classification.** `LettreTransport::send` now uses `smtp::Error::is_permanent()` / `is_timeout()` instead of substring-matching `Display`. Mapping documented inline. `smtp::Error` has no public constructor so per-branch unit tests aren't possible; behaviour is covered by the existing end-to-end transport paths (documented in the test module).
- **S43-6 — `aimx dkim-keygen` permission-denied UX.** `io::ErrorKind::PermissionDenied` from the DKIM write path is wrapped with a message naming the target directory and suggesting `sudo aimx dkim-keygen` or `AIMX_CONFIG_DIR=<path>`. Other IO errors pass through untouched. Unit tests (unix) + integration test drive both the friendly-wrapped branch and the pass-through branch.
- **S43-7 — Attachment filename safety + NFC normalization.** New `sanitize_attachment_filename(raw, index)` NFC-normalizes, strips control chars / bidi overrides / ZWJ / BOM / path separators / leading dash and dot, collapses unsafe runs to `_`, byte-caps at 200 on a UTF-8 boundary, falls back to `attachment-<index>` on empty. The sanitized name is the single source of truth for both the on-disk bundle file and the `attachments = [...]` frontmatter. `slug::slugify` now NFC-normalizes before ASCII folding so NFD and NFC forms of the same subject slug identically. Unit tests cover NUL, CR/LF, traversal, leading `-rf`, 500-char truncation, empty-after-sanitize fallback, Windows-style `\\`, NFD, bidi RLO, ZWJ, and unsafe-run collapse. Integration test ingests an `.eml` with `../../etc/passwd` and `\x00rce.sh` attachments and asserts no escape.

## Test plan

- [x] `cargo test` — 643 unit + 53 integration tests, all pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `services/verifier/` untouched (no rebuild needed)
- [ ] Manual smoke on an OpenRC host (Alpine) — `aimx status` should now report the service correctly once the unit is installed. Verification note is in the `status.rs` test module; a manual smoke is optional.