### PR TITLE
Fix aimx setup: install aimx.service as the final step, after preflight + DNS

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -167,6 +167,11 @@ impl SystemOps for RealSystemOps {
                 let _ = std::process::Command::new("systemctl")
                     .args(["enable", "aimx"])
                     .status();
+                // Clear any stuck "start-limit-hit" state from a prior
+                // failed install attempt so the restart below actually runs.
+                let _ = std::process::Command::new("systemctl")
+                    .args(["reset-failed", "aimx"])
+                    .status();
                 self.restart_service("aimx")?;
             }
             InitSystem::OpenRC => {
@@ -995,12 +1000,14 @@ pub fn finalize_setup(
         println!("DKIM keypair already exists.");
     }
 
+    Ok(())
+}
+
+fn announce_setup_complete(domain: &str) {
     println!(
         "\n{}\n",
         term::success_banner(&format!("Setup complete for {domain}!"))
     );
-
-    Ok(())
 }
 
 /// Create the config dir (default `/etc/aimx`, or `AIMX_CONFIG_DIR` override)
@@ -1201,6 +1208,8 @@ pub fn run_setup(
                 "Existing AIMX configuration detected. Skipping install, proceeding to verification."
             )
         );
+        // Keep config + DKIM state consistent (handles a changed domain on re-entry).
+        finalize_setup(data_dir, &domain, &dkim_selector)?;
     } else {
         // Step 2: Port 25 conflict detection
         match sys.check_port25_occupancy()? {
@@ -1217,7 +1226,7 @@ pub fn run_setup(
             }
         }
 
-        // Step 3: Generate TLS cert and install service file
+        // Step 3: Generate TLS cert
         let cert_dir = Path::new("/etc/ssl/aimx");
         if !sys.file_exists(&cert_dir.join("cert.pem")) {
             println!("Generating self-signed TLS certificate...");
@@ -1227,6 +1236,14 @@ pub fn run_setup(
             println!("TLS certificate already exists.");
         }
 
+        // Step 4: Write config.toml + DKIM keys BEFORE starting the service.
+        // aimx.service exits immediately with "Config file not found" if these
+        // are missing, which systemd then turns into a restart-loop and a
+        // permanently failed unit — causing wait_for_service_ready to time out
+        // and the inbound port-25 check to FAIL with no listener to hit.
+        finalize_setup(data_dir, &domain, &dkim_selector)?;
+
+        // Step 5: Install and start the service (config is now on disk).
         println!("Installing AIMX service...");
         sys.install_service_file(data_dir)?;
         println!("{}", term::success("`aimx serve` started."));
@@ -1236,7 +1253,7 @@ pub fn run_setup(
         if sys.wait_for_service_ready() {
             println!("{}", term::pass_badge());
         } else {
-            println!("timeout (proceeding anyway)");
+            println!("{} (proceeding anyway)", term::fail_badge());
         }
     }
 
@@ -1278,8 +1295,8 @@ pub fn run_setup(
         );
     }
 
-    // Step 6: DKIM keygen and finalize
-    finalize_setup(data_dir, &domain, &dkim_selector)?;
+    // Step 6: Announce success now that the service is running and port 25 is reachable.
+    announce_setup_complete(&domain);
 
     // Step 7: DNS guidance and verification (section [DNS])
     // Single `hostname -I` invocation (S32-4): derive both families from one call.
@@ -1433,6 +1450,14 @@ mod tests {
         existing_files: HashMap<PathBuf, String>,
         restarted_services: RefCell<Vec<String>>,
         service_file_installed: RefCell<bool>,
+        /// True if `/etc/aimx/config.toml` existed on disk at the moment
+        /// `install_service_file` was called. `None` until install is invoked.
+        /// Guards against re-introducing the bug where aimx.service is started
+        /// before config is written and fails with "Config file not found".
+        config_present_at_install: RefCell<Option<bool>>,
+        /// Same idea for the DKIM private key — aimx.service also refuses to
+        /// start without it.
+        dkim_present_at_install: RefCell<Option<bool>>,
         is_root: bool,
         port25_status: Port25Status,
         service_running: bool,
@@ -1447,6 +1472,8 @@ mod tests {
                 existing_files: HashMap::new(),
                 restarted_services: RefCell::new(vec![]),
                 service_file_installed: RefCell::new(false),
+                config_present_at_install: RefCell::new(None),
+                dkim_present_at_install: RefCell::new(None),
                 is_root: true,
                 port25_status: Port25Status::Free,
                 service_running: false,
@@ -1497,6 +1524,14 @@ mod tests {
         }
         fn install_service_file(&self, _data_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
             *self.service_file_installed.borrow_mut() = true;
+            // Snapshot the on-disk state that aimx.service would observe when
+            // systemd exec()s it. Real files — not the mock's `written_files`
+            // map — because finalize_setup writes config.toml + DKIM keys via
+            // the real filesystem (tests isolate via AIMX_CONFIG_DIR).
+            let config_present = crate::config::config_path().exists();
+            let dkim_present = crate::config::dkim_dir().join("private.key").exists();
+            *self.config_present_at_install.borrow_mut() = Some(config_present);
+            *self.dkim_present_at_install.borrow_mut() = Some(dkim_present);
             Ok(())
         }
         fn wait_for_service_ready(&self) -> bool {
@@ -2042,6 +2077,44 @@ mod tests {
             *sys.wait_for_ready_calls.borrow(),
             1,
             "fresh setup must wait for the service to be ready before port checks"
+        );
+    }
+
+    #[test]
+    fn fresh_setup_writes_config_and_dkim_before_installing_service() {
+        // Regression guard: on fresh install, aimx.service was being started
+        // BEFORE finalize_setup wrote /etc/aimx/config.toml and the DKIM key.
+        // The daemon would exit immediately with "Config file not found",
+        // systemd would restart-loop 5x, wait_for_service_ready would time
+        // out, and the inbound port-25 check would FAIL with no listener to
+        // hit. Ensure both artefacts are on disk before install_service_file.
+        let tmp = TempDir::new().unwrap();
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
+
+        let sys = MockSystemOps::default();
+        let net = MockNetworkOps {
+            // Abort before the DNS loop (which reads stdin).
+            outbound_port25: false,
+            ..Default::default()
+        };
+
+        let _ = run_setup(Some("example.com"), Some(tmp.path()), &sys, &net);
+
+        assert!(
+            *sys.service_file_installed.borrow(),
+            "fresh setup must install the service file"
+        );
+        assert_eq!(
+            *sys.config_present_at_install.borrow(),
+            Some(true),
+            "config.toml must exist on disk BEFORE install_service_file runs, \
+             otherwise aimx.service exits with 'Config file not found'"
+        );
+        assert_eq!(
+            *sys.dkim_present_at_install.borrow(),
+            Some(true),
+            "DKIM private key must exist on disk BEFORE install_service_file runs, \
+             otherwise aimx.service exits loading DKIM"
         );
     }
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1497,14 +1497,6 @@ mod tests {
         existing_files: HashMap<PathBuf, String>,
         restarted_services: RefCell<Vec<String>>,
         service_file_installed: RefCell<bool>,
-        /// True if `/etc/aimx/config.toml` existed on disk at the moment
-        /// `install_service_file` was called. `None` until install is invoked.
-        /// Guards against re-introducing the bug where aimx.service is started
-        /// before config is written and fails with "Config file not found".
-        config_present_at_install: RefCell<Option<bool>>,
-        /// Same idea for the DKIM private key — aimx.service also refuses to
-        /// start without it.
-        dkim_present_at_install: RefCell<Option<bool>>,
         is_root: bool,
         port25_status: Port25Status,
         service_running: bool,
@@ -1519,8 +1511,6 @@ mod tests {
                 existing_files: HashMap::new(),
                 restarted_services: RefCell::new(vec![]),
                 service_file_installed: RefCell::new(false),
-                config_present_at_install: RefCell::new(None),
-                dkim_present_at_install: RefCell::new(None),
                 is_root: true,
                 port25_status: Port25Status::Free,
                 service_running: false,
@@ -1571,14 +1561,6 @@ mod tests {
         }
         fn install_service_file(&self, _data_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
             *self.service_file_installed.borrow_mut() = true;
-            // Snapshot the on-disk state that aimx.service would observe when
-            // systemd exec()s it. Real files — not the mock's `written_files`
-            // map — because finalize_setup writes config.toml + DKIM keys via
-            // the real filesystem (tests isolate via AIMX_CONFIG_DIR).
-            let config_present = crate::config::config_path().exists();
-            let dkim_present = crate::config::dkim_dir().join("private.key").exists();
-            *self.config_present_at_install.borrow_mut() = Some(config_present);
-            *self.dkim_present_at_install.borrow_mut() = Some(dkim_present);
             Ok(())
         }
         fn wait_for_service_ready(&self) -> bool {
@@ -2136,19 +2118,19 @@ mod tests {
     }
 
     #[test]
-    fn fresh_setup_writes_config_and_dkim_before_preflight_and_install() {
-        // Two invariants, one test:
-        //   1) finalize_setup (config.toml + DKIM private key) runs before the
-        //      port-25 preflight, so a successful preflight on a fresh install
-        //      leaves the system in a state where aimx.service can actually
-        //      start once install_service_file runs.
-        //   2) If install_service_file does run later, both artefacts are on
-        //      disk at that moment — this is what the old bug violated (aimx
-        //      serve exiting with "Config file not found" and restart-looping).
+    fn fresh_setup_writes_config_and_dkim_before_preflight() {
+        // finalize_setup (config.toml + DKIM private key) must run before the
+        // port-25 preflight, so that by the time install_and_verify_service
+        // runs at the end of setup, aimx.service has a loadable config and a
+        // DKIM key on disk. This is what the original bug violated — aimx
+        // serve was being started before finalize_setup, exiting with
+        // "Config file not found" and restart-looping into permanent failure.
         //
-        // We cannot run the full happy path here without mocking stdin (DNS
-        // retry loop reads it), so we force a preflight failure after
-        // finalize_setup and assert config + DKIM are already on disk by then.
+        // We can't reach install_and_verify_service here without mocking
+        // stdin (DNS retry loop reads it), so we force a preflight failure
+        // and assert both artefacts are already on disk by that point.
+        // Combined with the run_setup source ordering (preflight → DNS →
+        // install), this proves the invariant end-to-end.
         let tmp = TempDir::new().unwrap();
         let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -31,6 +31,18 @@ pub trait SystemOps {
     /// Poll `127.0.0.1:25` until a TCP connection succeeds or the timeout
     /// elapses. Returns `true` if the port became reachable, `false` on timeout.
     fn wait_for_service_ready(&self) -> bool;
+    /// Run `f` while a minimal SMTP responder is bound to `0.0.0.0:25`, then
+    /// tear it down. Used for the port-25 inbound preflight during `aimx setup`
+    /// before the real aimx.service has been installed. The default impl
+    /// performs a real bind (requires root / a free :25); `MockSystemOps`
+    /// overrides this to just invoke `f`, so unit tests don't contend for a
+    /// real port.
+    fn with_temp_smtp_listener(
+        &self,
+        f: &mut dyn FnMut() -> Result<(), Box<dyn std::error::Error>>,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        crate::verify::with_temp_smtp_listener(f)
+    }
 }
 
 pub trait NetworkOps {
@@ -1201,6 +1213,25 @@ pub fn run_setup(
     // Re-entrant detection: if already configured, skip install/configure steps
     let already_configured = is_already_configured(sys, data_dir);
 
+    // Step 2: Port 25 conflict check. Always run — even on re-entrant invocations,
+    // this surfaces an unexpected foreign process bound to :25.
+    let port25_status = sys.check_port25_occupancy()?;
+    match &port25_status {
+        Port25Status::Free => {}
+        Port25Status::Aimx => {
+            if !already_configured {
+                println!("`aimx serve` is already running on port 25. Proceeding with setup.");
+            }
+        }
+        Port25Status::OtherProcess(name) => {
+            return Err(format!(
+                "Port 25 is occupied by {name}. \
+                 Stop the process and run `aimx setup` again."
+            )
+            .into());
+        }
+    }
+
     if already_configured {
         println!(
             "{}",
@@ -1208,24 +1239,7 @@ pub fn run_setup(
                 "Existing AIMX configuration detected. Skipping install, proceeding to verification."
             )
         );
-        // Keep config + DKIM state consistent (handles a changed domain on re-entry).
-        finalize_setup(data_dir, &domain, &dkim_selector)?;
     } else {
-        // Step 2: Port 25 conflict detection
-        match sys.check_port25_occupancy()? {
-            Port25Status::Free => {}
-            Port25Status::Aimx => {
-                println!("`aimx serve` is already running on port 25. Proceeding with setup.");
-            }
-            Port25Status::OtherProcess(name) => {
-                return Err(format!(
-                    "Port 25 is occupied by {name}. \
-                     Stop the process and run `aimx setup` again."
-                )
-                .into());
-            }
-        }
-
         // Step 3: Generate TLS cert
         let cert_dir = Path::new("/etc/ssl/aimx");
         if !sys.file_exists(&cert_dir.join("cert.pem")) {
@@ -1235,70 +1249,25 @@ pub fn run_setup(
         } else {
             println!("TLS certificate already exists.");
         }
-
-        // Step 4: Write config.toml + DKIM keys BEFORE starting the service.
-        // aimx.service exits immediately with "Config file not found" if these
-        // are missing, which systemd then turns into a restart-loop and a
-        // permanently failed unit — causing wait_for_service_ready to time out
-        // and the inbound port-25 check to FAIL with no listener to hit.
-        finalize_setup(data_dir, &domain, &dkim_selector)?;
-
-        // Step 5: Install and start the service (config is now on disk).
-        println!("Installing AIMX service...");
-        sys.install_service_file(data_dir)?;
-        println!("{}", term::success("`aimx serve` started."));
-
-        print!("  Waiting for aimx serve to be ready... ");
-        io::stdout().flush()?;
-        if sys.wait_for_service_ready() {
-            println!("{}", term::pass_badge());
-        } else {
-            println!("{} (proceeding anyway)", term::fail_badge());
-        }
     }
 
-    // Step 4-5: Port checks (run on both fresh and re-entrant invocations)
-    let mut port_failed = false;
+    // Step 4: Write config.toml + DKIM keys. Idempotent on re-entry (handles
+    // domain changes). Must happen before the aimx.service install at the end,
+    // because the daemon refuses to start without a loadable config and DKIM key.
+    finalize_setup(data_dir, &domain, &dkim_selector)?;
 
-    print!("  Outbound port 25... ");
-    io::stdout().flush()?;
-    match check_outbound(net) {
-        PreflightResult::Pass(_) => println!("{}", term::pass_badge()),
-        PreflightResult::Fail(msg) => {
-            println!("{}", term::fail_badge());
-            eprintln!("\n  {msg}");
-            eprintln!("\n  Compatible VPS providers with port 25 open:");
-            for p in COMPATIBLE_PROVIDERS {
-                eprintln!("    - {p}");
-            }
-            port_failed = true;
-        }
+    // Step 5: Port 25 preflight — confirm the VPS allows SMTP traffic before
+    // the user spends time setting up DNS. On a fresh install aimx.service is
+    // not yet bound to :25, so we stand up a minimal SMTP responder for the
+    // duration of the probe and tear it down afterwards. On re-entry (Aimx)
+    // the real daemon is already bound and answers the probe directly.
+    if matches!(port25_status, Port25Status::Aimx) {
+        run_port25_preflight(net)?;
+    } else {
+        sys.with_temp_smtp_listener(&mut || run_port25_preflight(net))?;
     }
 
-    print!("  Inbound port 25... ");
-    io::stdout().flush()?;
-    match check_inbound(net) {
-        PreflightResult::Pass(_) => println!("{}", term::pass_badge()),
-        PreflightResult::Fail(msg) => {
-            println!("{}", term::fail_badge());
-            eprintln!("\n  {msg}");
-            port_failed = true;
-        }
-    }
-
-    if port_failed {
-        return Err(
-            "Port 25 checks failed. Your VPS provider may block SMTP traffic.\n\
-             `aimx serve` started but port 25 is not reachable.\n\
-             Fix the issues above and run `sudo aimx setup` again."
-                .into(),
-        );
-    }
-
-    // Step 6: Announce success now that the service is running and port 25 is reachable.
-    announce_setup_complete(&domain);
-
-    // Step 7: DNS guidance and verification (section [DNS])
+    // Step 6: DNS guidance and verification (section [DNS])
     // Single `hostname -I` invocation (S32-4): derive both families from one call.
     let (ipv4_detected, ipv6_detected) = net.get_server_ips()?;
     let server_ipv4 = ipv4_detected
@@ -1378,6 +1347,84 @@ pub fn run_setup(
     // Write (or refresh) the agent-facing README inside the data directory.
     crate::datadir_readme::write(data_dir)?;
 
+    // Step 8: Install and start aimx.service as the final step, once all
+    // preflight + DNS guidance is out of the way. Setup concludes with the
+    // daemon bound to :25 and verified healthy — or a loud error.
+    if !already_configured {
+        install_and_verify_service(sys, data_dir)?;
+    }
+
+    announce_setup_complete(&domain);
+
+    Ok(())
+}
+
+/// Install the systemd/OpenRC service file, restart the daemon, and poll
+/// `127.0.0.1:25` until it accepts a TCP connection. Errors out if the
+/// daemon doesn't bind within the readiness window — setup's last step
+/// must either leave `aimx serve` running or tell the operator exactly
+/// what went wrong.
+fn install_and_verify_service(
+    sys: &dyn SystemOps,
+    data_dir: &Path,
+) -> Result<(), Box<dyn std::error::Error>> {
+    println!("\nStarting aimx serve...");
+    sys.install_service_file(data_dir)?;
+
+    print!("  Waiting for aimx serve to bind port 25... ");
+    io::stdout().flush()?;
+    if sys.wait_for_service_ready() {
+        println!("{}", term::pass_badge());
+        println!("{}", term::success("`aimx serve` is running."));
+        Ok(())
+    } else {
+        println!("{}", term::fail_badge());
+        Err(
+            "aimx.service did not bind port 25 within the readiness window.\n\
+             Check `sudo journalctl -u aimx` for errors, then run `sudo aimx setup` again."
+                .into(),
+        )
+    }
+}
+
+/// Probe outbound and inbound port 25. Returns `Err` if either leg fails.
+/// Prints a PASS/FAIL line for each check so the operator can see progress.
+fn run_port25_preflight(net: &dyn NetworkOps) -> Result<(), Box<dyn std::error::Error>> {
+    let mut port_failed = false;
+
+    print!("  Outbound port 25... ");
+    io::stdout().flush()?;
+    match check_outbound(net) {
+        PreflightResult::Pass(_) => println!("{}", term::pass_badge()),
+        PreflightResult::Fail(msg) => {
+            println!("{}", term::fail_badge());
+            eprintln!("\n  {msg}");
+            eprintln!("\n  Compatible VPS providers with port 25 open:");
+            for p in COMPATIBLE_PROVIDERS {
+                eprintln!("    - {p}");
+            }
+            port_failed = true;
+        }
+    }
+
+    print!("  Inbound port 25... ");
+    io::stdout().flush()?;
+    match check_inbound(net) {
+        PreflightResult::Pass(_) => println!("{}", term::pass_badge()),
+        PreflightResult::Fail(msg) => {
+            println!("{}", term::fail_badge());
+            eprintln!("\n  {msg}");
+            port_failed = true;
+        }
+    }
+
+    if port_failed {
+        return Err(
+            "Port 25 checks failed. Your VPS provider may block SMTP traffic.\n\
+             Fix the issues above and run `sudo aimx setup` again."
+                .into(),
+        );
+    }
     Ok(())
 }
 
@@ -1537,6 +1584,13 @@ mod tests {
         fn wait_for_service_ready(&self) -> bool {
             *self.wait_for_ready_calls.borrow_mut() += 1;
             self.service_ready
+        }
+        fn with_temp_smtp_listener(
+            &self,
+            f: &mut dyn FnMut() -> Result<(), Box<dyn std::error::Error>>,
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            // Mock: no real bind — the network probe is mocked too.
+            f()
         }
     }
 
@@ -2048,52 +2102,58 @@ mod tests {
     }
 
     #[test]
-    fn fresh_setup_waits_for_service_ready_after_install() {
-        // S42-2: after installing + restarting aimx, setup must poll for the
-        // daemon to bind port 25 before running the outbound/inbound probes.
-        // We force outbound to fail so the run returns early (before the DNS
-        // retry loop, which reads stdin); the assertion is that by that point
-        // `wait_for_service_ready` has been called exactly once, after the
-        // service file install.
-        let tmp = TempDir::new().unwrap();
-        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
-
-        let sys = MockSystemOps {
-            service_ready: true,
-            ..Default::default()
-        };
-        let net = MockNetworkOps {
-            outbound_port25: false,
-            ..Default::default()
-        };
-
-        let _ = run_setup(Some("example.com"), Some(tmp.path()), &sys, &net);
-
-        assert!(
-            *sys.service_file_installed.borrow(),
-            "fresh setup must call install_service_file"
-        );
-        assert_eq!(
-            *sys.wait_for_ready_calls.borrow(),
-            1,
-            "fresh setup must wait for the service to be ready before port checks"
-        );
-    }
-
-    #[test]
-    fn fresh_setup_writes_config_and_dkim_before_installing_service() {
-        // Regression guard: on fresh install, aimx.service was being started
-        // BEFORE finalize_setup wrote /etc/aimx/config.toml and the DKIM key.
-        // The daemon would exit immediately with "Config file not found",
-        // systemd would restart-loop 5x, wait_for_service_ready would time
-        // out, and the inbound port-25 check would FAIL with no listener to
-        // hit. Ensure both artefacts are on disk before install_service_file.
+    fn fresh_setup_defers_install_until_after_preflight() {
+        // `aimx setup` installs aimx.service as the FINAL step, after the
+        // port-25 preflight has passed. If preflight fails we must NOT put a
+        // service file on disk and ask systemd to start a daemon we already
+        // know the network won't route to.
         let tmp = TempDir::new().unwrap();
         let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
 
         let sys = MockSystemOps::default();
         let net = MockNetworkOps {
-            // Abort before the DNS loop (which reads stdin).
+            // Preflight fails at the outbound leg.
+            outbound_port25: false,
+            ..Default::default()
+        };
+
+        let result = run_setup(Some("example.com"), Some(tmp.path()), &sys, &net);
+
+        let err = result.expect_err("preflight failure must bubble up");
+        assert!(
+            err.to_string().contains("Port 25 checks failed"),
+            "expected port-25 error, got: {err}"
+        );
+        assert!(
+            !*sys.service_file_installed.borrow(),
+            "install_service_file must NOT run when the preflight fails"
+        );
+        assert_eq!(
+            *sys.wait_for_ready_calls.borrow(),
+            0,
+            "wait_for_service_ready must NOT run when the preflight fails"
+        );
+    }
+
+    #[test]
+    fn fresh_setup_writes_config_and_dkim_before_preflight_and_install() {
+        // Two invariants, one test:
+        //   1) finalize_setup (config.toml + DKIM private key) runs before the
+        //      port-25 preflight, so a successful preflight on a fresh install
+        //      leaves the system in a state where aimx.service can actually
+        //      start once install_service_file runs.
+        //   2) If install_service_file does run later, both artefacts are on
+        //      disk at that moment — this is what the old bug violated (aimx
+        //      serve exiting with "Config file not found" and restart-looping).
+        //
+        // We cannot run the full happy path here without mocking stdin (DNS
+        // retry loop reads it), so we force a preflight failure after
+        // finalize_setup and assert config + DKIM are already on disk by then.
+        let tmp = TempDir::new().unwrap();
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
+
+        let sys = MockSystemOps::default();
+        let net = MockNetworkOps {
             outbound_port25: false,
             ..Default::default()
         };
@@ -2101,28 +2161,20 @@ mod tests {
         let _ = run_setup(Some("example.com"), Some(tmp.path()), &sys, &net);
 
         assert!(
-            *sys.service_file_installed.borrow(),
-            "fresh setup must install the service file"
+            crate::config::config_path().exists(),
+            "config.toml must exist on disk after finalize_setup"
         );
-        assert_eq!(
-            *sys.config_present_at_install.borrow(),
-            Some(true),
-            "config.toml must exist on disk BEFORE install_service_file runs, \
-             otherwise aimx.service exits with 'Config file not found'"
-        );
-        assert_eq!(
-            *sys.dkim_present_at_install.borrow(),
-            Some(true),
-            "DKIM private key must exist on disk BEFORE install_service_file runs, \
-             otherwise aimx.service exits loading DKIM"
+        assert!(
+            crate::config::dkim_dir().join("private.key").exists(),
+            "DKIM private key must exist on disk after finalize_setup"
         );
     }
 
     #[test]
-    fn fresh_setup_proceeds_when_service_ready_times_out() {
-        // S42-2: a timed-out wait must not abort setup — the existing port-check
-        // failure path still surfaces the problem. Force outbound to fail so
-        // run_setup returns without hitting the DNS loop.
+    fn install_and_verify_service_errors_when_service_never_binds() {
+        // Once preflight + DNS have passed and the final install step runs,
+        // a readiness timeout must surface a loud error — NOT silently
+        // "proceed anyway" and leave the user with a failed systemd unit.
         let tmp = TempDir::new().unwrap();
         let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
 
@@ -2130,29 +2182,34 @@ mod tests {
             service_ready: false,
             ..Default::default()
         };
-        let net = MockNetworkOps {
-            outbound_port25: false,
-            ..Default::default()
-        };
-
-        let result = run_setup(Some("example.com"), Some(tmp.path()), &sys, &net);
-
+        let err = install_and_verify_service(&sys, tmp.path())
+            .expect_err("readiness timeout must be an error");
+        assert!(
+            err.to_string().contains("did not bind port 25"),
+            "expected 'did not bind port 25' in error, got: {err}"
+        );
         assert!(
             *sys.service_file_installed.borrow(),
-            "fresh setup must call install_service_file"
+            "install_service_file must have run before wait_for_service_ready"
         );
         assert_eq!(
             *sys.wait_for_ready_calls.borrow(),
             1,
             "wait_for_service_ready must be called exactly once"
         );
-        // Setup proceeded past the wait loop and ran the port checks; because
-        // outbound was mocked to fail, it errors out at the port-check summary.
-        let err = result.expect_err("port-check failure must bubble up");
-        assert!(
-            err.to_string().contains("Port 25 checks failed"),
-            "expected port-check failure message, got: {err}"
-        );
+    }
+
+    #[test]
+    fn install_and_verify_service_succeeds_when_daemon_binds() {
+        let tmp = TempDir::new().unwrap();
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
+        let sys = MockSystemOps {
+            service_ready: true,
+            ..Default::default()
+        };
+        install_and_verify_service(&sys, tmp.path()).expect("must succeed");
+        assert!(*sys.service_file_installed.borrow());
+        assert_eq!(*sys.wait_for_ready_calls.borrow(), 1);
     }
 
     #[test]

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -22,13 +22,22 @@ pub(crate) fn run_verify(
     let port25 = detect_port25(sys);
 
     if matches!(port25, Port25Status::Free) {
-        return run_with_temp_server(&net);
+        return with_temp_smtp_listener(|| run_with_net(&net, &Port25Status::Free));
     }
 
     run_with_net(&net, &port25)
 }
 
-fn run_with_temp_server(net: &dyn NetworkOps) -> Result<(), Box<dyn std::error::Error>> {
+/// Bind a minimal SMTP listener on `0.0.0.0:25` for the duration of `f`,
+/// then tear it down. Used by the preflight probe during `aimx setup`
+/// (before aimx.service is installed) and by `aimx verify` (when nothing
+/// is holding the port). The listener speaks just enough SMTP — 220 banner,
+/// EHLO/HELO, QUIT — for the remote `/probe` endpoint to confirm the port
+/// is reachable.
+pub(crate) fn with_temp_smtp_listener<F, R>(f: F) -> Result<R, Box<dyn std::error::Error>>
+where
+    F: FnOnce() -> Result<R, Box<dyn std::error::Error>>,
+{
     let rt =
         tokio::runtime::Runtime::new().map_err(|e| format!("Failed to create runtime: {e}"))?;
 
@@ -36,8 +45,8 @@ fn run_with_temp_server(net: &dyn NetworkOps) -> Result<(), Box<dyn std::error::
         Ok(l) => l,
         Err(e) => {
             return Err(format!(
-                "Cannot bind port 25 for verification: {e}\n\
-                 Run with sudo or ensure port 25 is available. `sudo aimx verify`"
+                "Cannot bind port 25 for preflight: {e}\n\
+                 Run with sudo or ensure port 25 is available."
             )
             .into());
         }
@@ -47,7 +56,7 @@ fn run_with_temp_server(net: &dyn NetworkOps) -> Result<(), Box<dyn std::error::
     let _guard = rt.enter();
     let handle = rt.spawn(run_temp_smtp_listener(listener, shutdown_rx));
 
-    let result = run_with_net(net, &Port25Status::Free);
+    let result = f();
 
     let _ = shutdown_tx.send(true);
     rt.block_on(async {
@@ -292,6 +301,12 @@ mod tests {
         }
         fn wait_for_service_ready(&self) -> bool {
             true
+        }
+        fn with_temp_smtp_listener(
+            &self,
+            f: &mut dyn FnMut() -> Result<(), Box<dyn std::error::Error>>,
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            f()
         }
     }
 


### PR DESCRIPTION
## Summary

`sudo aimx setup` was installing and starting `aimx.service` *mid-flow*, then running the port-25 preflight against the running daemon. This had two problems:

1. **The immediate bug reported by the user:** on a fresh install, `install_service_file` ran before `finalize_setup` wrote `/etc/aimx/config.toml` and the DKIM private key. The daemon exited immediately with `Error: Config file not found`, systemd restart-looped it 5× → permanently failed. `wait_for_service_ready` timed out, the inbound port-25 check had no listener to hit, and setup bailed before ever reaching `finalize_setup`. Every retry hit the same wall.
2. **The architectural smell underneath it:** coupling the preflight to a production service being up means a preflight failure leaves a broken systemd unit behind, and a half-configured setup is visible to any inbound SMTP client during DNS propagation. The ordering bug only existed because setup was trying to run the real daemon before setup was actually done.

This PR fixes both — the immediate bug by moving `finalize_setup` earlier, then the architecture by deferring the service install to the very end of setup so setup concludes with either a bound+verified `aimx serve` or a specific error pointing at `journalctl -u aimx`.

## New ordering in `run_setup`

1. Root check + domain
2. Port-25 conflict detection (foreign process → error)
3. TLS cert generation (fresh path only)
4. `finalize_setup` — writes `config.toml` + DKIM key; idempotent, handles domain change on re-entry
5. **Port-25 preflight**
   - Fresh install: bind a minimal SMTP responder on `:25` for the duration of the probe, tear it down afterwards
   - Re-entrant: the real daemon is already bound, probe it directly
6. DNS guidance loop (interactive)
7. MCP + Deliverability sections
8. **`install_and_verify_service`** (fresh path only): install the unit, restart, poll `:25` — error loudly if readiness times out

## Supporting changes

- Extract `verify::with_temp_smtp_listener` as a `pub(crate)` helper (was `run_with_temp_server`, limited to `aimx verify`) so setup's preflight reuses the same EHLO-speaking responder.
- Add `SystemOps::with_temp_smtp_listener` with a real-bind default; override in test mocks so unit tests don't contend for `:25`.
- Extract `install_and_verify_service` so the readiness-timeout error path is unit-testable.
- `wait_for_service_ready` timeout now HARD fails instead of "proceed anyway" — a daemon that didn't come up must surface to the operator, not silently proceed past.
- `systemctl reset-failed aimx` before restart so a prior stuck start-limit state from a broken install doesn't block recovery.

## Test plan

- [x] `cargo test` — 698 passed, 0 failed (main crate + verifier)
- [x] `cargo clippy -- -D warnings` — clean (both crates)
- [x] `cargo fmt -- --check` — clean
- [x] New unit tests:
  - `fresh_setup_defers_install_until_after_preflight` — preflight failure must NOT install the service
  - `fresh_setup_writes_config_and_dkim_before_preflight_and_install` — regression guard for the original bug
  - `install_and_verify_service_errors_when_service_never_binds` — readiness timeout is a hard error
  - `install_and_verify_service_succeeds_when_daemon_binds` — happy path
- [x] **End-to-end on the affected OVH VPS** with the release binary installed:
  - **Fresh** (service stopped, preflight via temp listener): `Outbound port 25… PASS`, `Inbound port 25… PASS` → DNS loop → `Starting aimx serve…` → `Waiting for aimx serve to bind port 25… PASS` → `aimx serve is running.` → `Setup complete for agent.zeroshot.lol!`
  - **Re-entrant** (service already bound): `Existing AIMX configuration detected. Skipping install, proceeding to verification.` → probes the live daemon → skips the install step → `Setup complete`
  - `sudo aimx verify` post-setup confirms `:25` reachable via EHLO probe
  - `aimx.service` reaches `active (running)` and binds `0.0.0.0:25`