### PR TITLE
docs: add manual testing plan

### DIFF
--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -6,7 +6,7 @@ aimx is a self-hosted email server for AI agents. This plan manually verifies an
 
 **Test domain assumption.** Replace `mail.example.com` with your real test domain everywhere below. The plan uses `inbox`, `agent`, and `test` as mailbox names.
 
-**Notation.** `[VPS]` = run on the aimx VPS. `[LOCAL]` = run on your laptop (where `claude` / `codex` are installed). `[GMAIL]` = user action in Gmail web UI.
+**Notation.** `[VPS]` = run on the aimx VPS (the same machine where `claude` / `codex` are installed — aimx is designed for a host dedicated to AI agents). `[GMAIL]` = user action in Gmail web UI. Commands run as root unless the step says otherwise; `aimx send` and `aimx agent-setup` refuse to run as root, so run those as a non-root user on the VPS.
 
 ---
 
@@ -14,9 +14,9 @@ aimx is a self-hosted email server for AI agents. This plan manually verifies an
 
 1. Fresh Linux VPS with public IPv4, port 25 unblocked by the provider.
 2. DNS zone editable for the test domain.
-3. `chua@uzyn.com` mailbox available on your laptop (to observe outbound).
-4. A Gmail account available (to observe inbound external deliverability).
-5. `claude` and `codex` CLIs installed and logged in on your laptop.
+3. Access to the `chua@uzyn.com` mailbox from anywhere (to observe outbound).
+4. A Gmail account (to observe inbound external deliverability).
+5. `claude` and `codex` CLIs installed and logged in **on the VPS**, under a non-root user (the same user that will run `aimx send` and `aimx agent-setup`).
 
 ```bash
 # [VPS] sanity — port 25 not already bound
@@ -197,7 +197,7 @@ sudo journalctl -u aimx -n 200 --no-pager | grep -i 'nobody\|reject\|550'
 **Goal.** The Claude Code skill is installed, the MCP server starts, and Claude can list and send email.
 
 ```bash
-# [LOCAL]
+# [VPS] run as the non-root user that owns the claude install
 aimx agent-setup claude-code
 ls -la ~/.claude/plugins/aimx/
 # expect: plugin.json + skills/ + references/
@@ -206,14 +206,14 @@ ls -la ~/.claude/plugins/aimx/
 Restart Claude Code (exit and relaunch), then test:
 
 ```bash
-# [LOCAL] list inbox via MCP
+# [VPS] list inbox via MCP
 claude -p "Use the aimx MCP tools. Call email_list with mailbox='inbox' and unread=true. Summarize what's there."
 ```
 
 **Acceptance — list.** Claude responds with a summary matching the emails delivered in T3/T5.
 
 ```bash
-# [LOCAL] send via MCP
+# [VPS] send via MCP
 claude -p "Use the aimx MCP tool email_send to send from inbox@mail.example.com to chua@uzyn.com. Subject: 'aimx claude MCP test'. Body: 'Sent via Claude MCP.'"
 ```
 
@@ -225,7 +225,7 @@ claude -p "Use the aimx MCP tool email_send to send from inbox@mail.example.com 
 - Recipient receives the mail with DKIM=pass.
 
 ```bash
-# [LOCAL] read + mark_read
+# [VPS] read + mark_read
 claude -p "List unread mail in 'inbox'. Read the most recent one, summarize in one sentence, then mark it read."
 ```
 
@@ -236,7 +236,7 @@ claude -p "List unread mail in 'inbox'. Read the most recent one, summarize in o
 ## T7 — Codex CLI agent integration
 
 ```bash
-# [LOCAL]
+# [VPS] run as the non-root user that owns the codex install
 aimx agent-setup codex
 ls -la ~/.codex/plugins/aimx/
 ```
@@ -244,7 +244,7 @@ ls -la ~/.codex/plugins/aimx/
 Follow any printed `codex mcp add ...` step verbatim, then restart Codex.
 
 ```bash
-# [LOCAL]
+# [VPS]
 codex exec "Use the aimx MCP tools. Call email_list with mailbox='inbox' and unread=true. Summarize."
 
 codex exec "Use the aimx MCP tool email_send to send from inbox@mail.example.com to chua@uzyn.com. Subject: 'aimx codex MCP test'. Body: 'Sent via Codex MCP.'"

--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -1,0 +1,456 @@
+# aimx Manual Testing Plan
+
+## Context
+
+aimx is a self-hosted email server for AI agents. This plan manually verifies an end-to-end install on a fresh VPS: setup, inbound/outbound mail, agent integrations (Claude Code + Codex CLI), channel triggers, and the trust model. Every test below is copy-pasteable — run top-to-bottom on the VPS as root unless noted. Tests that need external help (sending from Gmail, receiving at `chua@uzyn.com`) call that out explicitly and include a prompt to hand off to a human collaborator.
+
+**Test domain assumption.** Replace `mail.example.com` with your real test domain everywhere below. The plan uses `inbox`, `agent`, and `test` as mailbox names.
+
+**Notation.** `[VPS]` = run on the aimx VPS. `[LOCAL]` = run on your laptop (where `claude` / `codex` are installed). `[GMAIL]` = user action in Gmail web UI.
+
+---
+
+## T0 — Pre-flight
+
+1. Fresh Linux VPS with public IPv4, port 25 unblocked by the provider.
+2. DNS zone editable for the test domain.
+3. `chua@uzyn.com` mailbox available on your laptop (to observe outbound).
+4. A Gmail account available (to observe inbound external deliverability).
+5. `claude` and `codex` CLIs installed and logged in on your laptop.
+
+```bash
+# [VPS] sanity — port 25 not already bound
+sudo ss -tlnp sport :25
+# expect: no rows
+```
+
+---
+
+## T1 — Fresh setup & service start
+
+**Goal.** `aimx setup` produces a working config, DKIM key, TLS cert, and enabled service.
+
+```bash
+# [VPS]
+sudo aimx setup mail.example.com
+```
+
+**Interactive steps to answer.**
+- Confirm domain when prompted.
+- Accept default verify host (`https://check.aimx.email`).
+- When asked to install the service, choose yes.
+- Capture the printed DKIM TXT record (the `dkim._domainkey.mail.example.com` line).
+
+**Then publish DNS.** In your DNS provider, add:
+- `A mail.example.com → <VPS ipv4>`
+- `MX mail.example.com → mail.example.com. (priority 10)`
+- `TXT dkim._domainkey.mail.example.com` → the printed DKIM value
+- `TXT mail.example.com → "v=spf1 a mx ~all"`
+
+**Start the service and verify.**
+
+```bash
+# [VPS]
+sudo systemctl daemon-reload
+sudo systemctl enable --now aimx
+sudo systemctl status aimx --no-pager
+
+sudo ss -tlnp sport :25          # aimx listening on :25
+ls -la /run/aimx/send.sock       # UDS present, mode 0666
+sudo aimx status                 # summary output
+sudo aimx verify                 # port 25 reachability probe
+```
+
+**Acceptance criteria.**
+- `systemctl status aimx` → `active (running)`.
+- `ss` shows aimx on `:25`.
+- `/run/aimx/send.sock` exists with mode `srw-rw-rw-`.
+- `aimx verify` reports port 25 reachable.
+- `/etc/aimx/config.toml` exists and contains your domain.
+- `/etc/aimx/dkim/private.key` is `0600 root:root`.
+- `/var/lib/aimx/README.md` was generated.
+- DKIM DNS lookup returns the published key: `dig +short TXT dkim._domainkey.mail.example.com`.
+
+---
+
+## T2 — Create mailboxes
+
+```bash
+# [VPS]
+sudo aimx mailbox list
+sudo aimx mailbox create inbox
+sudo aimx mailbox create agent
+sudo aimx mailbox create test
+sudo aimx mailbox list
+ls /var/lib/aimx/inbox/
+```
+
+**Acceptance.** Three mailbox directories exist under `/var/lib/aimx/inbox/` and `/var/lib/aimx/sent/`.
+
+---
+
+## T3 — Inbound email (external send from Gmail)
+
+**Goal.** Real inbound mail over SMTP lands as a Markdown file with correct frontmatter and passes DKIM/SPF/DMARC.
+
+**Handoff to human.**
+
+> Please send a test email from your Gmail account:
+> - **To:** `inbox@mail.example.com`
+> - **Subject:** `aimx inbound test 1`
+> - **Body:** anything; include 1 PDF or image attachment to exercise the bundle path.
+
+```bash
+# [VPS] watch the inbox directory while the email is in flight
+watch -n 1 'ls -la /var/lib/aimx/inbox/inbox/'
+
+# After it arrives:
+ls /var/lib/aimx/inbox/inbox/
+# Read the newest file (flat .md or bundle dir)
+sudo find /var/lib/aimx/inbox/inbox/ -name '*.md' -newer /tmp -print
+sudo cat /var/lib/aimx/inbox/inbox/<newest>
+```
+
+**Acceptance criteria.**
+- File named `YYYY-MM-DD-HHMMSS-aimx-inbound-test-1.md` (or bundle dir of same name with `.md` inside).
+- TOML frontmatter between `+++` delimiters contains:
+  - `from = "<your-gmail>"`, `to = "inbox@mail.example.com"`, `subject = "aimx inbound test 1"`
+  - `message_id`, `thread_id` (16-hex), `received_at`, `size_bytes`
+  - `dkim = "pass"`, `spf = "pass"`, `dmarc = "pass"` (Gmail signs everything)
+  - `mailbox = "inbox"`, `read = false`
+- If you attached a file: bundle directory contains the attachment, and frontmatter lists it under `[[attachments]]` with a correct `path`.
+- Body below `+++` is plain text (HTML was converted).
+
+**Gmail deliverability check.** In the Gmail "sent" view, open the message header and confirm no bounce. If delivery silently failed, check `sudo journalctl -u aimx -n 200 --no-pager`.
+
+---
+
+## T4 — Outbound email (send to chua@uzyn.com)
+
+**Goal.** `aimx send` delivers via MX, gets DKIM-signed, lands in `sent/`, and arrives in the recipient's inbox (not spam).
+
+```bash
+# [VPS] run as a non-root user (aimx send refuses root)
+aimx send \
+  --from inbox@mail.example.com \
+  --to chua@uzyn.com \
+  --subject "aimx outbound test 1" \
+  --body "This message was sent by aimx send over MX."
+```
+
+**Expected stdout.** `AIMX/1 OK <message-id>` and exit code `0`.
+
+**Handoff to human.**
+
+> Please check `chua@uzyn.com` for a message titled `aimx outbound test 1`. Paste the full headers back so we can confirm: (a) it landed in Inbox not Spam, (b) DKIM=pass, SPF=pass, DMARC=pass, (c) `Authentication-Results` shows `mail.example.com`.
+
+**Acceptance criteria.**
+- Exit code `0`; message ID printed.
+- `/var/lib/aimx/sent/inbox/` contains a new `.md` with outbound frontmatter: `outbound = true`, `delivery_status = "delivered"`, `delivered_at`.
+- Recipient-side headers show DKIM=pass, SPF=pass, DMARC=pass.
+- Message appears in Inbox, not Spam.
+
+**Failure branches to test.**
+
+```bash
+# Root refusal (exit 2)
+sudo aimx send --from inbox@mail.example.com --to chua@uzyn.com --subject x --body x
+# expect: error about running as root, exit 2
+
+# Socket missing (exit 2) — simulate by stopping the daemon briefly
+sudo systemctl stop aimx
+aimx send --from inbox@mail.example.com --to chua@uzyn.com --subject x --body x
+# expect: "daemon not running" guidance, exit 2
+sudo systemctl start aimx
+
+# Unknown mailbox (daemon ERR, exit 1)
+aimx send --from bogus@mail.example.com --to chua@uzyn.com --subject x --body x
+# expect: AIMX/1 ERR MAILBOX ..., exit 1
+```
+
+---
+
+## T5 — Inbound routing into specific mailboxes
+
+**Goal.** Different local parts route to their own mailboxes; catch-all or rejection behavior is predictable.
+
+**Handoff to human.** Send three emails from Gmail in sequence:
+1. To `agent@mail.example.com`, subject `route-test-agent`.
+2. To `test@mail.example.com`, subject `route-test-test`.
+3. To `nobody@mail.example.com`, subject `route-test-nobody` (unknown mailbox).
+
+```bash
+# [VPS]
+ls /var/lib/aimx/inbox/agent/
+ls /var/lib/aimx/inbox/test/
+sudo journalctl -u aimx -n 200 --no-pager | grep -i 'nobody\|reject\|550'
+```
+
+**Acceptance.**
+- `agent/` and `test/` each contain the respective message.
+- The `nobody@` message is either (a) rejected at SMTP (check Gmail for a bounce), or (b) routed to a configured catch-all. Document which behavior you observe so the expectation is explicit.
+
+---
+
+## T6 — Claude Code agent integration
+
+**Goal.** The Claude Code skill is installed, the MCP server starts, and Claude can list and send email.
+
+```bash
+# [LOCAL]
+aimx agent-setup claude-code
+ls -la ~/.claude/plugins/aimx/
+# expect: plugin.json + skills/ + references/
+```
+
+Restart Claude Code (exit and relaunch), then test:
+
+```bash
+# [LOCAL] list inbox via MCP
+claude -p "Use the aimx MCP tools. Call email_list with mailbox='inbox' and unread=true. Summarize what's there."
+```
+
+**Acceptance — list.** Claude responds with a summary matching the emails delivered in T3/T5.
+
+```bash
+# [LOCAL] send via MCP
+claude -p "Use the aimx MCP tool email_send to send from inbox@mail.example.com to chua@uzyn.com. Subject: 'aimx claude MCP test'. Body: 'Sent via Claude MCP.'"
+```
+
+**Handoff.** Confirm receipt at `chua@uzyn.com`.
+
+**Acceptance — send.**
+- Claude reports a successful send with a message ID.
+- `/var/lib/aimx/sent/inbox/` gains a new `.md` with `outbound = true`.
+- Recipient receives the mail with DKIM=pass.
+
+```bash
+# [LOCAL] read + mark_read
+claude -p "List unread mail in 'inbox'. Read the most recent one, summarize in one sentence, then mark it read."
+```
+
+**Acceptance — read/mark.** The read-flag updates in the mailbox file: `grep '^read' /var/lib/aimx/inbox/inbox/<file>.md` shows `read = true`.
+
+---
+
+## T7 — Codex CLI agent integration
+
+```bash
+# [LOCAL]
+aimx agent-setup codex
+ls -la ~/.codex/plugins/aimx/
+```
+
+Follow any printed `codex mcp add ...` step verbatim, then restart Codex.
+
+```bash
+# [LOCAL]
+codex exec "Use the aimx MCP tools. Call email_list with mailbox='inbox' and unread=true. Summarize."
+
+codex exec "Use the aimx MCP tool email_send to send from inbox@mail.example.com to chua@uzyn.com. Subject: 'aimx codex MCP test'. Body: 'Sent via Codex MCP.'"
+
+codex exec "List unread mail in mailbox 'inbox'. Read the most recent one, summarize it, then mark it read."
+```
+
+**Acceptance.** Same as T6: list returns real emails, send produces a delivered `.md` in `sent/inbox/`, recipient receives it DKIM-signed, mark-read flips the `read` field.
+
+---
+
+## T8 — Channel trigger fires on TRUSTED sender
+
+**Goal.** A configured `on_receive` shell command runs when a trusted sender emails, and receives the expanded template variables.
+
+Edit `/etc/aimx/config.toml` to add:
+
+```toml
+[mailboxes.test]
+address = "test@mail.example.com"
+trust = "verified"
+trusted_senders = ["chua@uzyn.com"]
+
+[[mailboxes.test.on_receive]]
+type = "cmd"
+command = '''
+touch /tmp/aimx-trigger-{id}.flag
+printf 'from=%s\nsubject=%s\nfilepath=%s\n' '{from}' '{subject}' '{filepath}' >> /tmp/aimx-trigger.log
+'''
+```
+
+```bash
+# [VPS]
+sudo systemctl restart aimx
+rm -f /tmp/aimx-trigger*.flag /tmp/aimx-trigger.log
+```
+
+**Handoff.** Send an email from `chua@uzyn.com` (from your laptop — trusted sender) to `test@mail.example.com` with subject `trigger-trusted`.
+
+```bash
+# [VPS]
+ls /tmp/aimx-trigger-*.flag
+cat /tmp/aimx-trigger.log
+sudo grep '^trusted' /var/lib/aimx/inbox/test/*trigger-trusted*.md
+```
+
+**Acceptance.**
+- A `/tmp/aimx-trigger-<id>.flag` file was created.
+- `/tmp/aimx-trigger.log` shows the expected `from=`, `subject=`, `filepath=` lines.
+- The stored `.md` frontmatter has `trusted = "true"` and `dkim = "pass"`.
+
+---
+
+## T9 — Channel trigger does NOT fire on UNTRUSTED sender
+
+Keep the T8 config. Clear state:
+
+```bash
+# [VPS]
+rm -f /tmp/aimx-trigger*.flag /tmp/aimx-trigger.log
+```
+
+**Handoff.** Send from a Gmail address NOT in `trusted_senders` (e.g. the Gmail used in T3) to `test@mail.example.com` with subject `trigger-untrusted`.
+
+```bash
+# [VPS]
+ls /tmp/aimx-trigger-*.flag 2>/dev/null || echo "no flag — PASS"
+sudo ls /var/lib/aimx/inbox/test/ | grep trigger-untrusted
+sudo grep '^trusted' /var/lib/aimx/inbox/test/*trigger-untrusted*.md
+```
+
+**Acceptance.**
+- No flag file was created.
+- The email IS still stored in the mailbox (delivery is independent of trigger).
+- Frontmatter `trusted = "false"` (mailbox is `verified` but sender not on allowlist, even if DKIM passed).
+
+> **Subtlety to note.** The channel-trigger gate is looser than the `trusted` frontmatter field: a trigger fires when the sender is on `trusted_senders` OR DKIM passes. Because Gmail's DKIM passes, a stricter test of "untrusted means no trigger" requires a sender whose DKIM fails (rare from real providers). If the trigger DOES fire despite the sender being off-allowlist, that is expected behavior under current v1 semantics — document what you observe and decide whether to tighten the gate in a follow-up.
+
+---
+
+## T10 — Outbound mail does NOT fire triggers
+
+```bash
+# [VPS]
+rm -f /tmp/aimx-trigger*.flag /tmp/aimx-trigger.log
+
+# [VPS, as non-root]
+aimx send --from test@mail.example.com --to chua@uzyn.com \
+  --subject "outbound-should-not-trigger" --body "test"
+
+ls /tmp/aimx-trigger-*.flag 2>/dev/null || echo "no flag — PASS"
+```
+
+**Acceptance.** No flag file. Triggers fire only on **inbound** (port 25), never on `aimx send`.
+
+---
+
+## T11 — Trust model: success, failure, and definition
+
+This test formalizes what "trusted" means. Reference: `src/trust.rs` (`evaluate_trust`).
+
+**Definition (record this in the test log).**
+- `trusted = "none"` when the mailbox has `trust = "none"` (no evaluation performed).
+- `trusted = "true"` when `trust = "verified"` AND sender matches a `trusted_senders` glob AND DKIM verifies (`dkim = "pass"`).
+- `trusted = "false"` when `trust = "verified"` AND either the sender is not on the allowlist OR DKIM did not pass.
+
+**Success case (already covered by T8).** `/var/lib/aimx/inbox/test/*trigger-trusted*.md` → `trusted = "true"`.
+
+**Failure case — sender off allowlist.** Covered by T9 → `trusted = "false"`.
+
+**Failure case — trust=verified with DKIM pass but wrong sender.** Also covered by T9.
+
+**Policy=none baseline.** Use the `inbox` mailbox from T2 (which has default `trust` behavior — confirm it's `none` by checking `/etc/aimx/config.toml`). Re-read any message delivered in T3:
+
+```bash
+sudo grep '^trusted' /var/lib/aimx/inbox/inbox/*.md
+# expect: trusted = "none"
+```
+
+**Acceptance.** All three states (`none`, `"true"`, `"false"`) observed across T8/T9/T11 frontmatter.
+
+---
+
+## T12 — Reboot survival
+
+```bash
+# [VPS]
+sudo reboot
+```
+
+Wait 60s, reconnect, then:
+
+```bash
+# [VPS]
+systemctl status aimx --no-pager   # active (running)
+ss -tlnp sport :25                 # bound
+ls /run/aimx/send.sock             # present
+aimx status
+```
+
+**Handoff.** Send one more email from Gmail to `inbox@mail.example.com` with subject `post-reboot`.
+
+```bash
+ls /var/lib/aimx/inbox/inbox/ | grep post-reboot
+```
+
+**Acceptance.**
+- Service auto-started on boot (no manual intervention).
+- `/run/aimx/send.sock` was re-created (provided by `RuntimeDirectory=aimx`).
+- A post-reboot inbound email is successfully ingested.
+- A post-reboot `aimx send` from a non-root shell also succeeds.
+
+---
+
+## T13 — Re-run setup (re-entrance)
+
+```bash
+# [VPS]
+sudo aimx setup mail.example.com
+```
+
+**Acceptance.**
+- Setup detects existing config/DKIM and does NOT overwrite keys without consent.
+- `/var/lib/aimx/README.md` was refreshed if the binary is newer.
+- `aimx serve` continues running with no interruption (or restarts cleanly).
+
+---
+
+## Teardown (optional)
+
+```bash
+sudo systemctl disable --now aimx
+sudo rm -rf /etc/aimx /var/lib/aimx /run/aimx /etc/ssl/aimx
+sudo rm -f /etc/systemd/system/aimx.service
+sudo systemctl daemon-reload
+rm -rf ~/.claude/plugins/aimx ~/.codex/plugins/aimx
+```
+
+---
+
+## Summary checklist
+
+- [ ] T1 — Setup + service start + DNS live
+- [ ] T2 — Mailboxes created
+- [ ] T3 — Inbound from Gmail lands with DKIM/SPF/DMARC=pass
+- [ ] T4 — Outbound to `chua@uzyn.com` delivered, DKIM-signed, non-spam
+- [ ] T5 — Routing: `agent@`, `test@`, unknown local-part behavior observed
+- [ ] T6 — Claude Code: list + send + read/mark via MCP
+- [ ] T7 — Codex CLI: list + send + read/mark via MCP
+- [ ] T8 — Trigger fires on trusted sender
+- [ ] T9 — Trigger does NOT fire on untrusted sender
+- [ ] T10 — Trigger does NOT fire on outbound
+- [ ] T11 — Trust model: `none`, `"true"`, `"false"` all observed
+- [ ] T12 — Reboot survival
+- [ ] T13 — Setup re-entrance
+
+## Files referenced during tests
+
+- `/etc/aimx/config.toml` — domain, mailboxes, triggers
+- `/etc/aimx/dkim/{private,public}.key` — DKIM keys
+- `/etc/ssl/aimx/{cert,key}.pem` — TLS cert
+- `/etc/systemd/system/aimx.service` — service unit
+- `/var/lib/aimx/inbox/<mailbox>/` — received mail
+- `/var/lib/aimx/sent/<mailbox>/` — sent copies
+- `/var/lib/aimx/README.md` — datadir layout guide
+- `/run/aimx/send.sock` — UDS for `aimx send`
+- `~/.claude/plugins/aimx/` — Claude Code plugin
+- `~/.codex/plugins/aimx/` — Codex plugin
+- `sudo journalctl -u aimx -f` — daemon logs

--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -35,11 +35,10 @@ sudo ss -tlnp sport :25
 sudo aimx setup mail.example.com
 ```
 
-**Interactive steps to answer.**
-- Confirm domain when prompted.
-- Accept default verify host (`https://check.aimx.email`).
-- When asked to install the service, choose yes.
-- Capture the printed DKIM TXT record (the `dkim._domainkey.mail.example.com` line).
+**What setup prints (no interactive prompts when the domain is passed as an argument).**
+- Passing the domain on the command line skips the domain prompt. Verify host and service installation are non-interactive (CLI flags / unconditional).
+- Capture the printed DKIM TXT record (the `dkim._domainkey.mail.example.com` line) — you will publish this to DNS below.
+- Note the `[DNS]`, `[MCP]`, and `[Deliverability]` sections; keep the terminal scrollback for reference.
 
 **Then publish DNS.** In your DNS provider, add:
 - `A mail.example.com → <VPS ipv4>`
@@ -85,7 +84,7 @@ sudo aimx mailbox list
 ls /var/lib/aimx/inbox/
 ```
 
-**Acceptance.** Three mailbox directories exist under `/var/lib/aimx/inbox/` and `/var/lib/aimx/sent/`.
+**Acceptance.** Four mailbox directories exist under `/var/lib/aimx/inbox/` and `/var/lib/aimx/sent/`: `catchall/` (created by `aimx setup` as the default fallback — see `src/setup.rs`), plus `inbox/`, `agent/`, and `test/` just created. The `catchall` mailbox also appears in `aimx mailbox list` and in `/etc/aimx/config.toml`.
 
 ---
 
@@ -101,13 +100,17 @@ ls /var/lib/aimx/inbox/
 > - **Body:** anything; include 1 PDF or image attachment to exercise the bundle path.
 
 ```bash
+# [VPS] Drop a mark file BEFORE asking the human to hit send, so we can
+# use it as a stable "-newer" reference. /tmp's mtime is not stable.
+touch /tmp/.aimx-t3-mark
+
 # [VPS] watch the inbox directory while the email is in flight
 watch -n 1 'ls -la /var/lib/aimx/inbox/inbox/'
 
 # After it arrives:
 ls /var/lib/aimx/inbox/inbox/
 # Read the newest file (flat .md or bundle dir)
-sudo find /var/lib/aimx/inbox/inbox/ -name '*.md' -newer /tmp -print
+sudo find /var/lib/aimx/inbox/inbox/ -name '*.md' -newer /tmp/.aimx-t3-mark -print
 sudo cat /var/lib/aimx/inbox/inbox/<newest>
 ```
 
@@ -166,13 +169,17 @@ sudo systemctl start aimx
 # Unknown mailbox (daemon ERR, exit 1)
 aimx send --from bogus@mail.example.com --to chua@uzyn.com --subject x --body x
 # expect: AIMX/1 ERR MAILBOX ..., exit 1
+#
+# Note: if you instead see `AIMX/1 ERR DOMAIN ...`, your From: domain does
+# not match the configured aimx domain. Check the `domain =` line in
+# /etc/aimx/config.toml and re-try with a local-part under that domain.
 ```
 
 ---
 
 ## T5 — Inbound routing into specific mailboxes
 
-**Goal.** Different local parts route to their own mailboxes; catch-all or rejection behavior is predictable.
+**Goal.** Different local parts route to their own mailboxes; unknown local-parts fall through to the `catchall` mailbox (no SMTP reject in v1).
 
 **Handoff to human.** Send three emails from Gmail in sequence:
 1. To `agent@mail.example.com`, subject `route-test-agent`.
@@ -183,12 +190,16 @@ aimx send --from bogus@mail.example.com --to chua@uzyn.com --subject x --body x
 # [VPS]
 ls /var/lib/aimx/inbox/agent/
 ls /var/lib/aimx/inbox/test/
-sudo journalctl -u aimx -n 200 --no-pager | grep -i 'nobody\|reject\|550'
+# Unknown local-parts route silently to the `catchall` mailbox created by
+# `aimx setup` (see `Config::resolve_mailbox` in src/config.rs). There is
+# no SMTP-level 550 for an unknown local-part in v1.
+ls /var/lib/aimx/inbox/catchall/ | grep route-test-nobody
+sudo cat /var/lib/aimx/inbox/catchall/*route-test-nobody*.md | head -40
 ```
 
 **Acceptance.**
 - `agent/` and `test/` each contain the respective message.
-- The `nobody@` message is either (a) rejected at SMTP (check Gmail for a bounce), or (b) routed to a configured catch-all. Document which behavior you observe so the expectation is explicit.
+- The `nobody@` message appears under `/var/lib/aimx/inbox/catchall/` with correct frontmatter (this is the v1 catch-all behavior — there is no SMTP reject for unknown local-parts).
 
 ---
 
@@ -200,7 +211,12 @@ sudo journalctl -u aimx -n 200 --no-pager | grep -i 'nobody\|reject\|550'
 # [VPS] run as the non-root user that owns the claude install
 aimx agent-setup claude-code
 ls -la ~/.claude/plugins/aimx/
-# expect: plugin.json + skills/ + references/
+# expect (dot-directory is only visible with -la):
+#   .claude-plugin/plugin.json
+#   skills/aimx/SKILL.md
+#   skills/aimx/references/*.md
+ls -la ~/.claude/plugins/aimx/.claude-plugin/
+ls    ~/.claude/plugins/aimx/skills/aimx/
 ```
 
 Restart Claude Code (exit and relaunch), then test:
@@ -238,10 +254,20 @@ claude -p "List unread mail in 'inbox'. Read the most recent one, summarize in o
 ```bash
 # [VPS] run as the non-root user that owns the codex install
 aimx agent-setup codex
-ls -la ~/.codex/plugins/aimx/
+ls -la ~/.codex/skills/aimx/
+# expect: SKILL.md + references/*.md
+#
+# Note: Codex CLI does NOT auto-discover plugins under ~/.codex/plugins/
+# (validated against Codex CLI 0.117.0). MCP wiring lives in
+# ~/.codex/config.toml and is populated by the `codex mcp add` step below.
 ```
 
-Follow any printed `codex mcp add ...` step verbatim, then restart Codex.
+Follow the printed `codex mcp add aimx -- /usr/local/bin/aimx mcp` step verbatim, then restart Codex. Confirm registration with:
+
+```bash
+grep -A2 '\[mcp_servers.aimx\]' ~/.codex/config.toml
+# expect: command = "/usr/local/bin/aimx" and args = ["mcp"]
+```
 
 ```bash
 # [VPS]
@@ -260,7 +286,7 @@ codex exec "List unread mail in mailbox 'inbox'. Read the most recent one, summa
 
 **Goal.** A configured `on_receive` shell command runs when a trusted sender emails, and receives the expanded template variables.
 
-Edit `/etc/aimx/config.toml` to add:
+Edit `/etc/aimx/config.toml` to **update the existing `[mailboxes.test]` section** (created by `aimx mailbox create test` in T2). Set `trust` and `trusted_senders` on the existing table, and append the `on_receive` sub-table under it:
 
 ```toml
 [mailboxes.test]
@@ -275,6 +301,8 @@ touch /tmp/aimx-trigger-{id}.flag
 printf 'from=%s\nsubject=%s\nfilepath=%s\n' '{from}' '{subject}' '{filepath}' >> /tmp/aimx-trigger.log
 '''
 ```
+
+> Do NOT paste this as a second block. TOML does not allow two `[mailboxes.test]` tables in the same file — having both the T2-created block and a new block produces undefined parse behavior. Replace the fields on the existing table in-place.
 
 ```bash
 # [VPS]
@@ -298,7 +326,7 @@ sudo grep '^trusted' /var/lib/aimx/inbox/test/*trigger-trusted*.md
 
 ---
 
-## T9 — Channel trigger does NOT fire on UNTRUSTED sender
+## T9 — Off-allowlist sender: trigger gate vs. `trusted` field
 
 Keep the T8 config. Clear state:
 
@@ -311,17 +339,17 @@ rm -f /tmp/aimx-trigger*.flag /tmp/aimx-trigger.log
 
 ```bash
 # [VPS]
-ls /tmp/aimx-trigger-*.flag 2>/dev/null || echo "no flag — PASS"
+ls /tmp/aimx-trigger-*.flag 2>/dev/null
 sudo ls /var/lib/aimx/inbox/test/ | grep trigger-untrusted
 sudo grep '^trusted' /var/lib/aimx/inbox/test/*trigger-untrusted*.md
 ```
 
-**Acceptance.**
-- No flag file was created.
-- The email IS still stored in the mailbox (delivery is independent of trigger).
-- Frontmatter `trusted = "false"` (mailbox is `verified` but sender not on allowlist, even if DKIM passed).
+**Acceptance (v1 semantics — trigger gate is wider than the `trusted` field).**
+- A `/tmp/aimx-trigger-<id>.flag` file **is** created, because Gmail's DKIM passes and the v1 trigger gate fires on "allowlisted OR DKIM-pass" (see `src/channel.rs::should_execute_triggers` and the parity test in `src/trust.rs`).
+- The email is stored in the mailbox with frontmatter `trusted = "false"` — the `trusted` field is strictly stronger (requires allowlisted AND DKIM-pass), so an off-allowlist Gmail sender yields `trusted = "false"` even though the trigger fired.
+- The `.md` contains `dkim = "pass"` but `trusted = "false"`.
 
-> **Subtlety to note.** The channel-trigger gate is looser than the `trusted` frontmatter field: a trigger fires when the sender is on `trusted_senders` OR DKIM passes. Because Gmail's DKIM passes, a stricter test of "untrusted means no trigger" requires a sender whose DKIM fails (rare from real providers). If the trigger DOES fire despite the sender being off-allowlist, that is expected behavior under current v1 semantics — document what you observe and decide whether to tighten the gate in a follow-up.
+> **Subtlety confirmed.** This test demonstrates the documented asymmetry: the channel-trigger gate is deliberately wider than the `trusted` frontmatter field. To observe "untrusted → no trigger fires", you would need a sender whose DKIM fails, which is rare from real providers. If you want that stricter behavior, that is a future tightening (tracked as a v1.x follow-up). Today, this output is **expected**, not a regression.
 
 ---
 
@@ -375,7 +403,7 @@ sudo grep '^trusted' /var/lib/aimx/inbox/inbox/*.md
 sudo reboot
 ```
 
-Wait 60s, reconnect, then:
+Wait until SSH reconnects (typically ~30-90s depending on provider), then:
 
 ```bash
 # [VPS]
@@ -416,11 +444,23 @@ sudo aimx setup mail.example.com
 ## Teardown (optional)
 
 ```bash
+# systemd hosts:
 sudo systemctl disable --now aimx
-sudo rm -rf /etc/aimx /var/lib/aimx /run/aimx /etc/ssl/aimx
 sudo rm -f /etc/systemd/system/aimx.service
 sudo systemctl daemon-reload
-rm -rf ~/.claude/plugins/aimx ~/.codex/plugins/aimx
+
+# OpenRC hosts (substitute for the systemd block above):
+#   sudo rc-service aimx stop
+#   sudo rc-update del aimx
+#   sudo rm -f /etc/init.d/aimx
+
+# Shared cleanup (both init systems):
+sudo rm -rf /etc/aimx /var/lib/aimx /run/aimx /etc/ssl/aimx
+rm -rf ~/.claude/plugins/aimx ~/.codex/skills/aimx
+
+# Codex MCP registration lives in ~/.codex/config.toml — remove it with:
+#   codex mcp remove aimx
+# (or hand-edit ~/.codex/config.toml to drop the [mcp_servers.aimx] table).
 ```
 
 ---
@@ -435,7 +475,7 @@ rm -rf ~/.claude/plugins/aimx ~/.codex/plugins/aimx
 - [ ] T6 — Claude Code: list + send + read/mark via MCP
 - [ ] T7 — Codex CLI: list + send + read/mark via MCP
 - [ ] T8 — Trigger fires on trusted sender
-- [ ] T9 — Trigger does NOT fire on untrusted sender
+- [ ] T9 — Off-allowlist sender: trigger fires via DKIM-pass, `trusted = "false"`
 - [ ] T10 — Trigger does NOT fire on outbound
 - [ ] T11 — Trust model: `none`, `"true"`, `"false"` all observed
 - [ ] T12 — Reboot survival
@@ -451,6 +491,6 @@ rm -rf ~/.claude/plugins/aimx ~/.codex/plugins/aimx
 - `/var/lib/aimx/sent/<mailbox>/` — sent copies
 - `/var/lib/aimx/README.md` — datadir layout guide
 - `/run/aimx/send.sock` — UDS for `aimx send`
-- `~/.claude/plugins/aimx/` — Claude Code plugin
-- `~/.codex/plugins/aimx/` — Codex plugin
+- `~/.claude/plugins/aimx/` — Claude Code plugin (manifest at `.claude-plugin/plugin.json`, skill at `skills/aimx/SKILL.md`)
+- `~/.codex/skills/aimx/` — Codex skill (Codex CLI does NOT auto-discover `~/.codex/plugins/`; MCP wiring is in `~/.codex/config.toml` via `codex mcp add`)
 - `sudo journalctl -u aimx -f` — daemon logs


### PR DESCRIPTION
## Summary
- Adds `docs/manual-test.md`, a copy-pasteable end-to-end manual testing plan for aimx on a fresh VPS.
- Covers T1–T13: setup + service start, mailboxes, inbound/outbound mail, routing, Claude Code + Codex CLI MCP integration, channel triggers (trusted/untrusted/outbound-does-not-fire), trust model definition, reboot survival, and setup re-entrance.
- Includes explicit `[VPS]` / `[LOCAL]` / handoff markers so tests that need external Gmail sends or receipt at `chua@uzyn.com` are clearly delegated.

## Test plan
- [ ] Human operator walks through T0 → T13 on a fresh VPS and records which acceptance criteria pass
- [ ] Capture any discrepancies between documented `trusted`-field semantics and actual behavior observed in T9 (the "trigger gate is looser than trusted field" subtlety)
- [ ] Feed regressions found during the walkthrough back into follow-up issues