### PR TITLE
fix(ingest): use envelope MAIL FROM and peer IP for SPF

### DIFF
--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -23,9 +23,9 @@ pub fn run(rcpt: &str, config: Config) -> Result<(), Box<dyn std::error::Error>>
     let mut raw = Vec::new();
     std::io::stdin().read_to_end(&mut raw)?;
     // Manual stdin path: no SMTP session, so received_from_ip is the
-    // unspecified sentinel (0.0.0.0).
+    // unspecified sentinel (0.0.0.0) and there is no envelope MAIL FROM.
     let sentinel_ip: IpAddr = "0.0.0.0".parse().unwrap();
-    ingest_email(&config, rcpt, &raw, sentinel_ip)
+    ingest_email(&config, rcpt, &raw, sentinel_ip, None)
 }
 
 pub fn ingest_email(
@@ -33,6 +33,7 @@ pub fn ingest_email(
     rcpt: &str,
     raw: &[u8],
     received_from_ip: IpAddr,
+    envelope_mail_from: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let local_part = extract_local_part(rcpt);
     let mailbox = config.resolve_mailbox(local_part);
@@ -147,7 +148,7 @@ pub fn ingest_email(
     let prepared_attachments = prepare_attachments(&message);
     let has_attachments = !prepared_attachments.is_empty();
 
-    let auth_results = verify_auth(raw);
+    let auth_results = verify_auth(raw, received_from_ip, envelope_mail_from);
 
     let trusted_value = config
         .mailboxes
@@ -260,7 +261,7 @@ fn create_resolver() -> Option<mail_auth::MessageAuthenticator> {
         .ok()
 }
 
-fn verify_auth(raw: &[u8]) -> AuthResults {
+fn verify_auth(raw: &[u8], peer_ip: IpAddr, envelope_mail_from: Option<&str>) -> AuthResults {
     let rt = match tokio::runtime::Runtime::new() {
         Ok(rt) => rt,
         Err(_) => return AuthResults::default(),
@@ -281,11 +282,21 @@ fn verify_auth(raw: &[u8]) -> AuthResults {
 
         let dkim_result = dkim_output_to_string(&dkim_output, auth_msg.is_some());
 
-        let spf_output = build_spf_output(raw, &resolver).await;
+        let (spf_ip, spf_mail_from) = select_spf_inputs(raw, peer_ip, envelope_mail_from);
+        let spf_output = build_spf_output(spf_ip, spf_mail_from.as_deref(), &resolver).await;
         let spf_result = spf_output_to_string(&spf_output);
 
         let dmarc_result = match &auth_msg {
-            Some(msg) => verify_dmarc_async(msg, &dkim_output, &spf_output, raw, &resolver).await,
+            Some(msg) => {
+                verify_dmarc_async(
+                    msg,
+                    &dkim_output,
+                    &spf_output,
+                    spf_mail_from.as_deref(),
+                    &resolver,
+                )
+                .await
+            }
             None => "none".to_string(),
         };
 
@@ -295,6 +306,31 @@ fn verify_auth(raw: &[u8]) -> AuthResults {
             dmarc: dmarc_result,
         }
     })
+}
+
+/// Decide which IP and MAIL FROM to feed into the SPF check.
+///
+/// When the SMTP session gives us an authoritative peer IP and envelope
+/// MAIL FROM (reverse_path), we use those — they're what RFC 7208 actually
+/// requires for SPF. Header parsing is only a best-effort fallback for the
+/// manual `aimx ingest` stdin path, where we have no envelope context.
+fn select_spf_inputs(
+    raw: &[u8],
+    peer_ip: IpAddr,
+    envelope_mail_from: Option<&str>,
+) -> (Option<IpAddr>, Option<String>) {
+    let ip = if peer_ip.is_unspecified() {
+        extract_received_ip(raw)
+    } else {
+        Some(peer_ip)
+    };
+
+    let mail_from = match envelope_mail_from {
+        Some(s) if !s.is_empty() => Some(s.to_string()),
+        _ => extract_mail_from(raw),
+    };
+
+    (ip, mail_from)
 }
 
 fn dkim_output_to_string(results: &[mail_auth::DkimOutput<'_>], parsed: bool) -> String {
@@ -316,17 +352,18 @@ fn dkim_output_to_string(results: &[mail_auth::DkimOutput<'_>], parsed: bool) ->
 }
 
 async fn build_spf_output(
-    raw: &[u8],
+    ip: Option<IpAddr>,
+    mail_from: Option<&str>,
     resolver: &mail_auth::MessageAuthenticator,
 ) -> mail_auth::SpfOutput {
-    let ip = match extract_received_ip(raw) {
+    let ip = match ip {
         Some(ip) => ip,
         None => return mail_auth::SpfOutput::new(String::new()),
     };
 
-    let mail_from = extract_mail_from(raw).unwrap_or_default();
+    let mail_from = mail_from.unwrap_or_default();
 
-    let helo_domain = match spf_domain(&mail_from) {
+    let helo_domain = match spf_domain(mail_from) {
         Some(d) => d.to_string(),
         None => return mail_auth::SpfOutput::new(String::new()),
     };
@@ -336,7 +373,7 @@ async fn build_spf_output(
             ip,
             &helo_domain,
             &helo_domain,
-            &mail_from,
+            mail_from,
         ))
         .await
 }
@@ -356,11 +393,11 @@ async fn verify_dmarc_async(
     auth_msg: &mail_auth::AuthenticatedMessage<'_>,
     dkim_output: &[mail_auth::DkimOutput<'_>],
     spf_output: &mail_auth::SpfOutput,
-    raw: &[u8],
+    mail_from: Option<&str>,
     resolver: &mail_auth::MessageAuthenticator,
 ) -> String {
-    let mail_from = extract_mail_from(raw).unwrap_or_default();
-    let mail_from_domain = spf_domain(&mail_from).unwrap_or("");
+    let mail_from = mail_from.unwrap_or_default();
+    let mail_from_domain = spf_domain(mail_from).unwrap_or("");
 
     let params = mail_auth::dmarc::verify::DmarcParameters {
         message: auth_msg,
@@ -897,7 +934,14 @@ mod tests {
     fn ingest_plain_text() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
+        ingest_email(
+            &config,
+            "alice@test.com",
+            plain_text_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         assert_eq!(entries.len(), 1);
@@ -919,7 +963,14 @@ mod tests {
     fn ingest_writes_to_inbox_subdir() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
+        ingest_email(
+            &config,
+            "alice@test.com",
+            plain_text_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
 
         assert!(tmp.path().join("inbox").join("alice").exists());
         assert!(!tmp.path().join("alice").exists());
@@ -929,7 +980,14 @@ mod tests {
     fn ingest_filename_uses_utc_slug_format() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
+        ingest_email(
+            &config,
+            "alice@test.com",
+            plain_text_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         let name = entries[0]
@@ -954,7 +1012,14 @@ mod tests {
     fn ingest_html_only() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", html_only_eml(), sentinel_ip()).unwrap();
+        ingest_email(
+            &config,
+            "alice@test.com",
+            html_only_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         let content = std::fs::read_to_string(&entries[0]).unwrap();
@@ -999,7 +1064,14 @@ mod tests {
     fn ingest_multipart_prefers_text() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", multipart_eml(), sentinel_ip()).unwrap();
+        ingest_email(
+            &config,
+            "alice@test.com",
+            multipart_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         let content = std::fs::read_to_string(&entries[0]).unwrap();
@@ -1011,7 +1083,14 @@ mod tests {
     fn ingest_routes_unknown_to_catchall() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "unknown@test.com", plain_text_eml(), sentinel_ip()).unwrap();
+        ingest_email(
+            &config,
+            "unknown@test.com",
+            plain_text_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
 
         assert!(inbox(tmp.path(), "catchall").exists());
         let entries = collect_md_files(&inbox(tmp.path(), "catchall"));
@@ -1022,7 +1101,14 @@ mod tests {
     fn frontmatter_valid_toml() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
+        ingest_email(
+            &config,
+            "alice@test.com",
+            plain_text_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         let content = std::fs::read_to_string(&entries[0]).unwrap();
@@ -1053,8 +1139,22 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
 
-        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
-        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
+        ingest_email(
+            &config,
+            "alice@test.com",
+            plain_text_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
+        ingest_email(
+            &config,
+            "alice@test.com",
+            plain_text_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         assert_eq!(entries.len(), 2, "got entries: {entries:?}");
@@ -1065,7 +1165,14 @@ mod tests {
     fn attachment_creates_bundle_directory() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", attachment_eml(), sentinel_ip()).unwrap();
+        ingest_email(
+            &config,
+            "alice@test.com",
+            attachment_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
 
         let alice = inbox(tmp.path(), "alice");
         assert!(!alice.join("attachments").exists());
@@ -1105,6 +1212,7 @@ mod tests {
             "alice@test.com",
             multi_attachment_eml(),
             sentinel_ip(),
+            None,
         )
         .unwrap();
 
@@ -1125,8 +1233,22 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
 
-        ingest_email(&config, "alice@test.com", attachment_eml(), sentinel_ip()).unwrap();
-        ingest_email(&config, "alice@test.com", attachment_eml(), sentinel_ip()).unwrap();
+        ingest_email(
+            &config,
+            "alice@test.com",
+            attachment_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
+        ingest_email(
+            &config,
+            "alice@test.com",
+            attachment_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
 
         let alice = inbox(tmp.path(), "alice");
         let bundles: Vec<_> = std::fs::read_dir(&alice)
@@ -1145,7 +1267,14 @@ mod tests {
     fn no_attachments_flat_markdown() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
+        ingest_email(
+            &config,
+            "alice@test.com",
+            plain_text_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
 
         let alice = inbox(tmp.path(), "alice");
         let dirs: Vec<_> = std::fs::read_dir(&alice)
@@ -1307,7 +1436,7 @@ mod tests {
             malicious content\r\n\
             --evilbound--\r\n";
 
-        ingest_email(&config, "alice@test.com", eml, sentinel_ip()).unwrap();
+        ingest_email(&config, "alice@test.com", eml, sentinel_ip(), None).unwrap();
 
         let alice = inbox(tmp.path(), "alice");
         let bundles: Vec<_> = std::fs::read_dir(&alice)
@@ -1356,7 +1485,7 @@ mod tests {
             #!/bin/sh\r\n\
             --b1--\r\n";
 
-        ingest_email(&config, "alice@test.com", eml, sentinel_ip()).unwrap();
+        ingest_email(&config, "alice@test.com", eml, sentinel_ip(), None).unwrap();
 
         let alice = inbox(tmp.path(), "alice");
         let bundles: Vec<_> = std::fs::read_dir(&alice)
@@ -1438,7 +1567,14 @@ mod tests {
     fn unsigned_email_has_dkim_none_spf_none_dmarc_none() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
+        ingest_email(
+            &config,
+            "alice@test.com",
+            plain_text_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         let content = std::fs::read_to_string(&entries[0]).unwrap();
@@ -1543,7 +1679,14 @@ mod tests {
     fn frontmatter_includes_dkim_spf_dmarc_fields() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
+        ingest_email(
+            &config,
+            "alice@test.com",
+            plain_text_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         let content = std::fs::read_to_string(&entries[0]).unwrap();
@@ -1588,7 +1731,7 @@ mod tests {
         let config = test_config(tmp.path());
         let raw = include_bytes!("../tests/fixtures/gmail_dkim_signed.eml");
 
-        ingest_email(&config, "agent@test.com", raw, sentinel_ip()).unwrap();
+        ingest_email(&config, "agent@test.com", raw, sentinel_ip(), None).unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "catchall"));
         assert_eq!(entries.len(), 1);
@@ -1665,7 +1808,14 @@ mod tests {
         for _ in 0..8 {
             let cfg = Arc::clone(&config);
             handles.push(thread::spawn(move || {
-                ingest_email(&cfg, "alice@test.com", attachment_eml(), sentinel_ip()).unwrap();
+                ingest_email(
+                    &cfg,
+                    "alice@test.com",
+                    attachment_eml(),
+                    sentinel_ip(),
+                    None,
+                )
+                .unwrap();
             }));
         }
         for h in handles {
@@ -1696,8 +1846,22 @@ mod tests {
     fn rapid_same_subject_ingests_get_unique_paths() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
-        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
+        ingest_email(
+            &config,
+            "alice@test.com",
+            plain_text_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
+        ingest_email(
+            &config,
+            "alice@test.com",
+            plain_text_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         assert_eq!(entries.len(), 2);
@@ -1725,11 +1889,61 @@ mod tests {
     }
 
     #[test]
+    fn select_spf_inputs_prefers_envelope_over_headers() {
+        // When the SMTP session hands us a real peer IP and envelope MAIL FROM,
+        // those take precedence over anything we could scrape from Received:
+        // or From: headers. This is the fix for the reported SPF=none bug:
+        // messages delivered from Gmail (peer IP within _spf.google.com) with
+        // envelope sender `chua@uzyn.com` must verify against the authoritative
+        // envelope values, not whatever shows up in the message body.
+        let raw = b"Received: from some.internal.relay.example.com ([10.0.0.1])\r\n\
+            From: Spoofed <spoof@evil.example>\r\n\
+            To: agent@test.com\r\n\
+            \r\n\
+            body\r\n";
+
+        let peer_ip: IpAddr = "209.85.219.48".parse().unwrap();
+        let (ip, mail_from) = select_spf_inputs(raw, peer_ip, Some("chua@uzyn.com"));
+        assert_eq!(ip, Some(peer_ip));
+        assert_eq!(mail_from.as_deref(), Some("chua@uzyn.com"));
+    }
+
+    #[test]
+    fn select_spf_inputs_falls_back_to_headers_for_manual_stdin() {
+        // `aimx ingest` stdin path has no SMTP session, so peer_ip is the
+        // 0.0.0.0 sentinel and envelope_mail_from is None. In that case we
+        // fall back to parsing Received: and From: headers — best-effort,
+        // matching pre-fix behavior.
+        let raw = b"Received: from mail.example.com (mail.example.com [203.0.113.5])\r\n\
+            From: Alice <alice@example.com>\r\n\
+            To: agent@test.com\r\n\
+            \r\n\
+            body\r\n";
+
+        let sentinel: IpAddr = "0.0.0.0".parse().unwrap();
+        let (ip, mail_from) = select_spf_inputs(raw, sentinel, None);
+        assert_eq!(ip, Some("203.0.113.5".parse().unwrap()));
+        assert_eq!(mail_from.as_deref(), Some("alice@example.com"));
+    }
+
+    #[test]
+    fn select_spf_inputs_empty_envelope_string_falls_back() {
+        // Defensive: an empty envelope string (should not happen — session
+        // resets reverse_path to "" after RSET — but be explicit) falls back
+        // to header parsing rather than producing an empty mail_from.
+        let raw = b"From: Alice <alice@example.com>\r\nTo: t@test.com\r\n\r\n";
+        let peer_ip: IpAddr = "203.0.113.5".parse().unwrap();
+        let (ip, mail_from) = select_spf_inputs(raw, peer_ip, Some(""));
+        assert_eq!(ip, Some(peer_ip));
+        assert_eq!(mail_from.as_deref(), Some("alice@example.com"));
+    }
+
+    #[test]
     fn frontmatter_new_fields_populated() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
         let ip: IpAddr = "203.0.113.50".parse().unwrap();
-        ingest_email(&config, "alice@test.com", plain_text_eml(), ip).unwrap();
+        ingest_email(&config, "alice@test.com", plain_text_eml(), ip, None).unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         let content = std::fs::read_to_string(&entries[0]).unwrap();
@@ -1761,7 +1975,14 @@ mod tests {
     fn frontmatter_received_from_ip_omitted_for_sentinel() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
+        ingest_email(
+            &config,
+            "alice@test.com",
+            plain_text_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         let content = std::fs::read_to_string(&entries[0]).unwrap();
@@ -1784,7 +2005,7 @@ mod tests {
 
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", eml, sentinel_ip()).unwrap();
+        ingest_email(&config, "alice@test.com", eml, sentinel_ip(), None).unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         let content = std::fs::read_to_string(&entries[0]).unwrap();
@@ -1808,7 +2029,7 @@ mod tests {
 
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", eml, sentinel_ip()).unwrap();
+        ingest_email(&config, "alice@test.com", eml, sentinel_ip(), None).unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         let content = std::fs::read_to_string(&entries[0]).unwrap();
@@ -1823,7 +2044,14 @@ mod tests {
     fn frontmatter_optional_headers_omitted_when_absent() {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
+        ingest_email(
+            &config,
+            "alice@test.com",
+            plain_text_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         let content = std::fs::read_to_string(&entries[0]).unwrap();
@@ -1843,8 +2071,22 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
 
-        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
-        ingest_email(&config, "alice@test.com", plain_text_eml(), sentinel_ip()).unwrap();
+        ingest_email(
+            &config,
+            "alice@test.com",
+            plain_text_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
+        ingest_email(
+            &config,
+            "alice@test.com",
+            plain_text_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         assert_eq!(entries.len(), 2);

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -312,8 +312,13 @@ fn verify_auth(raw: &[u8], peer_ip: IpAddr, envelope_mail_from: Option<&str>) ->
 ///
 /// When the SMTP session gives us an authoritative peer IP and envelope
 /// MAIL FROM (reverse_path), we use those — they're what RFC 7208 actually
-/// requires for SPF. Header parsing is only a best-effort fallback for the
-/// manual `aimx ingest` stdin path, where we have no envelope context.
+/// requires for SPF. Header parsing is a best-effort fallback triggered
+/// when either value is missing: the manual `aimx ingest` stdin path (no
+/// envelope at all) and RFC 5321 null-sender bounces (`MAIL FROM:<>`),
+/// where `reverse_path` is empty. The null-sender case is strictly wrong
+/// per RFC 7208 §2.4 (SPF should be checked against the HELO/EHLO domain
+/// for a null sender); threading `ehlo_hostname` through to fix that is
+/// tracked as a follow-up.
 fn select_spf_inputs(
     raw: &[u8],
     peer_ip: IpAddr,

--- a/src/smtp/session.rs
+++ b/src/smtp/session.rs
@@ -495,9 +495,15 @@ impl SmtpSession {
             let data = Arc::clone(&data);
             let rcpt_owned = rcpt.clone();
             let peer = self.params.peer_addr;
+            let reverse_path = session_state.reverse_path.clone();
 
             let result = tokio::task::spawn_blocking(move || {
-                crate::ingest::ingest_email(&config, &rcpt_owned, &data, peer.ip())
+                let envelope = if reverse_path.is_empty() {
+                    None
+                } else {
+                    Some(reverse_path.as_str())
+                };
+                crate::ingest::ingest_email(&config, &rcpt_owned, &data, peer.ip(), envelope)
                     .map_err(|e| e.to_string())
             })
             .await;


### PR DESCRIPTION
## Summary

Fixes an SPF bug where inbound messages received via the embedded SMTP daemon were producing `spf = "none"` in the frontmatter even when SPF should clearly pass.

**Reported case:** a message from `chua@uzyn.com` delivered via Gmail (peer IP `209.85.219.48`, within `_spf.google.com`) landed with:
```toml
dkim = "pass"
spf = "none"     # ← should be "pass"
dmarc = "pass"
```

`uzyn.com` has a proper SPF record (`v=spf1 a mx ip4:175.41.131.3 include:_spf.google.com ~all`), so SPF against `209.85.219.48` must pass.

## Root cause

`verify_auth()` ignored the authoritative envelope data from the SMTP session and parsed `Received:` and `From:` headers from the message body instead.

1. **Wrong IP source.** `extract_received_ip(raw)` walks `Received:` headers looking for a bracketed IP. For Gmail-sent messages the topmost `Received:` header is a `by mail-xxx.google.com with SMTP ...` line with no bracketed IP, so the code either skipped it or landed on an internal Google hop — not necessarily the IP that actually connected to us.
2. **Wrong mail_from source.** `extract_mail_from(raw)` returns the **header** `From:` address, but SPF (RFC 7208) is defined against the **envelope** MAIL FROM (the SMTP reverse-path).

Both values were already known authoritatively by the SMTP session (`peer_addr` and `reverse_path`), but they weren't being plumbed through.

## Fix

Thread the SMTP session's peer IP and `reverse_path` through to `ingest_email()` and into `verify_auth()`. When available, these authoritative values are used for SPF (and for DMARC mail-from alignment).

Header parsing remains as a best-effort fallback for the manual `aimx ingest` stdin path, where no SMTP session exists.

## Stories Implemented

### Bug fix: SPF verification uses authoritative envelope data
- [x] `ingest_email()` accepts an `envelope_mail_from: Option<&str>`
- [x] `verify_auth()` accepts `peer_ip` and `envelope_mail_from` and uses them for SPF
- [x] `verify_dmarc_async()` uses the same authoritative mail_from for alignment
- [x] `src/smtp/session.rs` threads `session_state.reverse_path` through `ingest_email`
- [x] Manual `aimx ingest` stdin path passes `None` and keeps header-parsing fallback
- [x] Unit tests for the new `select_spf_inputs()` helper covering envelope-wins, stdin-fallback, and empty-envelope edge cases
- [x] All 648 unit + 53 integration tests pass; `cargo clippy -- -D warnings` clean; `cargo fmt` clean

## Technical Decisions

- **Added a new parameter rather than a struct.** `ingest_email()` has 30+ call sites in tests. A struct would have been a bigger diff without real ergonomic gain at this call count.
- **Kept header parsing as a fallback** (gated on `peer_ip.is_unspecified()` and `envelope_mail_from.is_none()`). This preserves `aimx ingest` stdin behavior, where the operator pipes a raw `.eml` and no envelope context exists. Setting SPF to "none" for that path would be a regression for manual-ingest workflows.
- **Extracted `select_spf_inputs()`** as a pure helper so the precedence logic is directly unit-testable without running a real SPF DNS lookup.

## Review Focus Areas

- `src/ingest.rs:315-338` — `select_spf_inputs()`: is the envelope-vs-header precedence right, including the empty-string defense?
- `src/smtp/session.rs:493-513` — threading `reverse_path` through `spawn_blocking`; the clone is cheap (small `String`) and unavoidable because we move into the blocking task.
- All 30+ test call sites were updated mechanically to pass `None`; nothing should have changed semantically for them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)