### PR TITLE
[Sprint 47] Post-v1 Non-blocking Cleanup

### DIFF
--- a/docs/sprint.md
+++ b/docs/sprint.md
@@ -433,7 +433,7 @@ or
 
 - [ ] Consolidate `validate_mailbox_name` into a single canonical helper (one of `src/mailbox.rs`, `src/mailbox_handler.rs`, or `src/config.rs` — whichever already owns mailbox-name invariants), tighten to reject whitespace and any character outside a safe local-part class (`[a-z0-9._-]`, case-folded), and thread both call sites through it
 - [ ] New unit tests cover: `"hello world"` rejected, `"a b"` rejected, `"..foo"` rejected, `""` rejected, `"good-mailbox.1"` accepted
-- [ ] `write_config_atomic`: either adopt a TOML-editing crate (e.g. `toml_edit`) that preserves comments and unknown stanzas, OR document the current behavior with a comment + add a test asserting a known-unknown stanza survives (whichever the implementer judges less risky for v1)
+- [ ] `write_config_atomic`: either adopt a TOML-editing crate (e.g. `toml_edit`) that preserves comments and unknown stanzas, OR document the current behavior with a comment + add a test asserting a known-unknown stanza survives (whichever the implementer judges less risky for v1) <!-- Chose the document-current-behaviour path. The "stanza survives" wording conflates the two paths; on the documented path the stanza is dropped (v1 contract). Test `unknown_stanza_is_dropped_on_rewrite` pins this so any future regression toward a preserving editor without updating the doc comment will trip. -->
 - [ ] `create_failure_at_disk_write_leaves_handle_and_disk_unchanged`: rewrite to make the temp write succeed and the rename fail (read-only target dir on the parent, or equivalent), so the test genuinely exercises the rollback-on-rename-failure branch; assertion remains: disk + handle unchanged
 - [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
 

--- a/docs/sprint.md
+++ b/docs/sprint.md
@@ -168,7 +168,7 @@ Fix: `sanitize_attachment_filename(raw: &str, index: usize) -> String` — NFC-n
 
 ---
 
-## Sprint 44 — Post-launch Security + Quick Fixes (Days 123–125.5) [NOT STARTED]
+## Sprint 44 — Post-launch Security + Quick Fixes (Days 123–125.5) [DONE]
 
 **Goal:** Close the four highest-priority findings from the 2026-04-17 manual test run with small, targeted patches: shell-injection fix in channel triggers (security), operator-visible DKIM sanity check at daemon startup, corrected Claude Code plugin hint, and a restart-hint on `aimx mailbox create`. Also fix the docs nit that caused forwarded-message noise in the test log. Finding #2 (SPF envelope MAIL FROM) already shipped in commit `cd22428` and is excluded. Finding #10 is mostly an operator-side DNS republish; only its two small code add-ons (startup DKIM sanity check + louder setup warning) are in scope here.
 
@@ -184,14 +184,15 @@ Fix: `sanitize_attachment_filename(raw: &str, index: usize) -> String` — NFC-n
 
 **Priority:** P0 (security)
 
-- [ ] `src/channel.rs`: `substitute_template` rewritten to only expand `{id}` and `{date}`; `shell_escape_value` deleted
-- [ ] Command spawn point uses `Command::new("sh").arg("-c").arg(&script).env("AIMX_FROM", …).env("AIMX_SUBJECT", …).env("AIMX_TO", …).env("AIMX_MAILBOX", …).env("AIMX_FILEPATH", …)` — every user-controlled field goes via env
-- [ ] Config loader rejects any `on_receive.cmd` containing `{from}`/`{subject}`/`{to}`/`{mailbox}`/`{filepath}` with an error naming the offending mailbox + the env-var migration
-- [ ] `book/channel-recipes.md` rewritten to use `"$AIMX_FROM"`, `"$AIMX_SUBJECT"`, etc. for every recipe (all agents + the shell-log example)
-- [ ] `docs/manual-test.md` T8 recipe updated to the env-var pattern
-- [ ] New unit tests covering injection attempts: `U-Zyn Chua <chua@uzyn.com>` (angle-bracket redirect, the T8 repro), `` `whoami` ``, `$(rm -rf /)`, `foo; ls`, `foo\nbar`, subject with embedded single/double quotes — all must run the intended command with the payload safely landing in the env var
-- [ ] New unit test: config with a legacy placeholder in `on_receive.cmd` fails to load with the migration error
-- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+- [x] `src/channel.rs`: `substitute_template` rewritten to only expand `{id}` and `{date}`; `shell_escape_value` deleted
+- [x] Command spawn point uses `Command::new("sh").arg("-c").arg(&script).env("AIMX_FROM", …).env("AIMX_SUBJECT", …).env("AIMX_TO", …).env("AIMX_MAILBOX", …).env("AIMX_FILEPATH", …)` — every user-controlled field goes via env
+- [x] Config loader rejects any `on_receive.cmd` containing `{from}`/`{subject}`/`{to}`/`{mailbox}`/`{filepath}` with an error naming the offending mailbox + the env-var migration
+- [x] `book/channel-recipes.md` rewritten to use `"$AIMX_FROM"`, `"$AIMX_SUBJECT"`, etc. for every recipe (all agents + the shell-log example)
+- [x] `docs/manual-test.md` T8 recipe updated to the env-var pattern
+- [x] New unit tests covering injection attempts: `U-Zyn Chua <chua@uzyn.com>` (angle-bracket redirect, the T8 repro), `` `whoami` ``, `$(rm -rf /)`, `foo; ls`, `foo\nbar`, subject with embedded single/double quotes — all must run the intended command with the payload safely landing in the env var
+- [x] New unit test: config with a legacy placeholder in `on_receive.cmd` fails to load with the migration error
+- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+- [x] Extra: `shell-escape` crate removed from `Cargo.toml`; `book/channels.md`, `book/configuration.md`, `docs/manual-setup.md`, `docs/prd.md` FR-30, `docs/idea.md` all swept; integration test `ingest_rejects_legacy_placeholder_config_at_cli` added
 
 #### S44-2: DKIM DNS sanity check at daemon startup + louder setup warning
 
@@ -199,13 +200,13 @@ Fix: `sanitize_attachment_filename(raw: &str, index: usize) -> String` — NFC-n
 
 **Priority:** P0
 
-- [ ] Helper `public_key_spki_base64(path: &Path) -> Result<String>` in `src/dkim.rs` (extract from existing setup code if already derived there; otherwise new); unit-tested against a fixture key
-- [ ] `src/serve.rs` startup: after DKIM key load and before binding listeners, resolve TXT `dkim._domainkey.{config.domain}` via the existing resolver; if DNS resolution fails, log at `warn` and continue (transient, non-fatal); if DNS `p=` differs from on-disk SPKI, log a multi-line warning to stderr + journal stating mismatch detected, receiver DKIM will fail, and suggesting `aimx setup` to republish DNS
-- [ ] Startup never blocks or exits on mismatch — daemon proceeds to bind SMTP + UDS listeners normally
-- [ ] `src/setup.rs verify_dkim` mismatch branch: render the FAIL line via `term::error_red` (or existing semantic helper) and append a second line: "⚠ Outbound DKIM signatures will FAIL verification at receivers until DNS matches."
-- [ ] Integration test: spin `aimx serve` with a mocked resolver returning a mismatched `p=`; assert the startup log contains the mismatch warning; assert the daemon still binds both listeners and accepts mail
-- [ ] Integration test: spin `aimx serve` with a resolver that fails the DKIM TXT lookup; assert startup logs a `warn` and continues
-- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+- [x] Helper `public_key_spki_base64(path: &Path) -> Result<String>` in `src/dkim.rs` (extract from existing setup code if already derived there; otherwise new); unit-tested against a fixture key
+- [x] `src/serve.rs` startup: after DKIM key load and before binding listeners, resolve TXT `dkim._domainkey.{config.domain}` via the existing resolver; if DNS resolution fails, log at `warn` and continue (transient, non-fatal); if DNS `p=` differs from on-disk SPKI, log a multi-line warning to stderr + journal stating mismatch detected, receiver DKIM will fail, and suggesting `aimx setup` to republish DNS
+- [x] Startup never blocks or exits on mismatch — daemon proceeds to bind SMTP + UDS listeners normally
+- [x] `src/setup.rs verify_dkim` mismatch branch: render the FAIL line via `term::error_red` (or existing semantic helper) and append a second line: "⚠ Outbound DKIM signatures will FAIL verification at receivers until DNS matches."
+- [x] Integration test: spin `aimx serve` with a mocked resolver returning a mismatched `p=`; assert the startup log contains the mismatch warning; assert the daemon still binds both listeners and accepts mail <!-- Partial: substituted with unit-test coverage via `DkimTxtResolver` trait + mock resolver exercising `run_dkim_startup_check` / `log_dkim_startup_check` across Match/Mismatch/NoRecord/NoPTag/ResolveError branches + pure `evaluate_dkim_startup` branch tests. Reviewer accepted deferral. Full end-to-end on live `run_serve` deferred as non-blocker. -->
+- [x] Integration test: spin `aimx serve` with a resolver that fails the DKIM TXT lookup; assert startup logs a `warn` and continues <!-- Partial: ResolveError branch exercised via fake resolver returning error; end-to-end daemon-level integration deferred. -->
+- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
 
 #### S44-3: `aimx agent-setup claude-code` hint fix
 
@@ -213,11 +214,12 @@ Fix: `sanitize_attachment_filename(raw: &str, index: usize) -> String` — NFC-n
 
 **Priority:** P1
 
-- [ ] `claude_code_hint` rewritten to instruct the operator to run `claude mcp add --scope user aimx /usr/local/bin/aimx mcp`, mirroring Codex's hint structure (install-location line, blank line, command line, blank line, restart note)
-- [ ] Existing `src/agent_setup.rs` tests that assert on the hint string updated; new assertion that the hint contains `claude mcp add --scope user aimx`
-- [ ] `book/agent-integration.md` Claude Code section updated to document the `claude mcp add` step explicitly (remove the "auto-discovered" claim that current docs may mirror)
-- [ ] `agents/claude-code/README.md` updated similarly
-- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+- [x] `claude_code_hint` rewritten to instruct the operator to run `claude mcp add --scope user aimx /usr/local/bin/aimx mcp`, mirroring Codex's hint structure (install-location line, blank line, command line, blank line, restart note)
+- [x] Existing `src/agent_setup.rs` tests that assert on the hint string updated; new assertion that the hint contains `claude mcp add --scope user aimx`
+- [x] `book/agent-integration.md` Claude Code section updated to document the `claude mcp add` step explicitly (remove the "auto-discovered" claim that current docs may mirror)
+- [x] `agents/claude-code/README.md` updated similarly
+- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+- [x] Extra: `--data-dir` override threaded through the hint with POSIX single-quote escaping
 
 #### S44-4: `aimx mailbox create` / `delete` prints service-restart hint
 
@@ -225,11 +227,12 @@ Fix: `sanitize_attachment_filename(raw: &str, index: usize) -> String` — NFC-n
 
 **Priority:** P2
 
-- [ ] After `println!("Mailbox '{name}' created.")` in `src/mailbox.rs`, print a follow-up hint line pointing the operator at `sudo systemctl restart aimx` (or the OpenRC equivalent) to activate the new mailbox; use the existing `SystemOps` abstraction if it exposes a service-manager hint, otherwise hard-code systemd-first wording with a note about OpenRC
-- [ ] Same hint printed after `Mailbox '{name}' deleted.`
-- [ ] Existing `src/mailbox.rs` tests updated to assert on the hint's presence; new test for the delete path
-- [ ] `book/mailboxes.md` documents the restart requirement so the hint isn't surprising; note Sprint 46 will remove it
-- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+- [x] After `println!("Mailbox '{name}' created.")` in `src/mailbox.rs`, print a follow-up hint line pointing the operator at `sudo systemctl restart aimx` (or the OpenRC equivalent) to activate the new mailbox; use the existing `SystemOps` abstraction if it exposes a service-manager hint, otherwise hard-code systemd-first wording with a note about OpenRC
+- [x] Same hint printed after `Mailbox '{name}' deleted.`
+- [x] Existing `src/mailbox.rs` tests updated to assert on the hint's presence; new test for the delete path
+- [x] `book/mailboxes.md` documents the restart requirement so the hint isn't surprising; note Sprint 46 will remove it
+- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+- [x] Extra: `restart_hint_command` / `restart_hint_lines` helpers dispatch on `serve::service::detect_init_system()` (systemd / OpenRC / Unknown falls back to systemd)
 
 #### S44-5: `docs/manual-test.md` — specify "compose new" for email steps
 
@@ -237,12 +240,12 @@ Fix: `sanitize_attachment_filename(raw: &str, index: usize) -> String` — NFC-n
 
 **Priority:** P3
 
-- [ ] T3, T5, T8, T9 steps in `docs/manual-test.md` updated to specify "compose a new email" rather than "send a test email", with an explicit note against forwarding/replying to prior threads for clean frontmatter
-- [ ] No code changes; `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` still clean
+- [x] T3, T5, T8, T9 steps in `docs/manual-test.md` updated to specify "compose a new email" rather than "send a test email", with an explicit note against forwarding/replying to prior threads for clean frontmatter
+- [x] No code changes; `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` still clean
 
 ---
 
-## Sprint 45 — Strict Outbound + MCP Writes via Daemon (Days 125.5–128) [NOT STARTED]
+## Sprint 45 — Strict Outbound + MCP Writes via Daemon (Days 125.5–128) [DONE]
 
 **Goal:** Remove the privilege-separation and correctness gaps on the send path: (a) `aimx send` stops reading `/etc/aimx/config.toml` entirely — the daemon resolves the sender mailbox from its in-memory `Config`; (b) outbound is tightened to reject both foreign-domain From and any From whose local part doesn't map to an explicitly configured non-wildcard mailbox; (c) MCP write ops (`email_mark_read`, `email_mark_unread`) stop touching mailbox files directly and route through new UDS state-mutation verbs on `aimx serve`. This closes findings #4, #5, and #8 from the 2026-04-17 manual test run. Mailbox CRUD over UDS (finding #1 tier-2) is Sprint 46.
 
@@ -261,15 +264,15 @@ Fix: `sanitize_attachment_filename(raw: &str, index: usize) -> String` — NFC-n
 
 **Priority:** P0
 
-- [ ] `src/send_protocol.rs`: remove `From-Mailbox:` from the SEND request encoder and parser; pre-launch, no compat shim
-- [ ] `src/send_handler.rs handle_send_inner`: parse `From:` from the raw message, call `resolve_from_mailbox(&self.config, &from)`; on miss or domain mismatch, return `AIMX/1 ERR <code> …` per FR-18c code set (threaded with S45-2)
-- [ ] `src/send.rs run`: delete the `Config::load` / `resolve_from_mailbox` call path; client only composes the raw message and opens UDS
-- [ ] `src/main.rs`: drop the config-load step before `send::run` dispatch (send becomes a path that needs no config file access)
-- [ ] `src/setup.rs`: confirm `/etc/aimx/config.toml` install mode is `0640 root:root` (manual-test workaround is obsolete once the client doesn't read it)
-- [ ] `src/send.rs` unit tests for mailbox resolution move to `src/send_handler.rs`
-- [ ] New integration test: run `aimx send` as a non-root user against a `0640` config; assert success and verify the client never opens the config file (strace-style check optional; at minimum assert the Permission denied error from the manual-test session no longer reproduces)
-- [ ] `book/mailboxes.md` and `CLAUDE.md` updated — `aimx send` is no longer documented as reading config
-- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+- [x] `src/send_protocol.rs`: remove `From-Mailbox:` from the SEND request encoder and parser; pre-launch, no compat shim <!-- Note: legacy `From-Mailbox:` header is silently ignored on the parser side for forward-compatibility rather than rejected — pre-launch risk is zero either way. -->
+- [x] `src/send_handler.rs handle_send_inner`: parse `From:` from the raw message, call `resolve_from_mailbox(&self.config, &from)`; on miss or domain mismatch, return `AIMX/1 ERR <code> …` per FR-18c code set (threaded with S45-2)
+- [x] `src/send.rs run`: delete the `Config::load` / `resolve_from_mailbox` call path; client only composes the raw message and opens UDS
+- [x] `src/main.rs`: drop the config-load step before `send::run` dispatch (send becomes a path that needs no config file access)
+- [x] `src/setup.rs`: confirm `/etc/aimx/config.toml` install mode is `0640 root:root` (manual-test workaround is obsolete once the client doesn't read it)
+- [x] `src/send.rs` unit tests for mailbox resolution move to `src/send_handler.rs`
+- [x] New integration test: run `aimx send` as a non-root user against a `0640` config; assert success and verify the client never opens the config file (strace-style check optional; at minimum assert the Permission denied error from the manual-test session no longer reproduces)
+- [x] `book/mailboxes.md` and `CLAUDE.md` updated — `aimx send` is no longer documented as reading config
+- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
 
 #### S45-2: Strict outbound — concrete mailbox + configured domain only
 
@@ -277,14 +280,14 @@ Fix: `sanitize_attachment_filename(raw: &str, index: usize) -> String` — NFC-n
 
 **Priority:** P0
 
-- [ ] `src/send.rs resolve_from_mailbox` (or its new home in `src/send_handler.rs` after S45-1): delete the wildcard fallback branch (`mb.address.starts_with('*')`)
-- [ ] Before the mailbox lookup, explicitly verify `From:` domain (case-insensitive) equals `config.domain`; on mismatch return `AIMX/1 ERR DOMAIN sender domain '<x>' does not match aimx domain '<config.domain>'`
-- [ ] Mailbox-miss path returns `AIMX/1 ERR MAILBOX no mailbox matches From: <addr>` with guidance pointing at `aimx mailbox create`
-- [ ] `book/mailboxes.md` documents the inbound-only semantics of catchall and the concrete-mailbox requirement for outbound; remove any prior implication that catchall can sign outbound
-- [ ] `book/channels.md` cross-reference updated if it referenced the old wildcard behavior
-- [ ] Existing tests that asserted wildcard outbound success are flipped to assert the ERR path
-- [ ] New tests: foreign-domain From (rejected with DOMAIN error); concrete-mailbox send under the configured domain (succeeds); bogus local-part under the configured domain (rejected with MAILBOX error); case-insensitive domain match (`From: x@Agent.Example.Com` matches `domain = "agent.example.com"`)
-- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+- [x] `src/send.rs resolve_from_mailbox` (or its new home in `src/send_handler.rs` after S45-1): delete the wildcard fallback branch (`mb.address.starts_with('*')`)
+- [x] Before the mailbox lookup, explicitly verify `From:` domain (case-insensitive) equals `config.domain`; on mismatch return `AIMX/1 ERR DOMAIN sender domain '<x>' does not match aimx domain '<config.domain>'`
+- [x] Mailbox-miss path returns `AIMX/1 ERR MAILBOX no mailbox matches From: <addr>` with guidance pointing at `aimx mailbox create`
+- [x] `book/mailboxes.md` documents the inbound-only semantics of catchall and the concrete-mailbox requirement for outbound; remove any prior implication that catchall can sign outbound
+- [x] `book/channels.md` cross-reference updated if it referenced the old wildcard behavior
+- [x] Existing tests that asserted wildcard outbound success are flipped to assert the ERR path
+- [x] New tests: foreign-domain From (rejected with DOMAIN error); concrete-mailbox send under the configured domain (succeeds); bogus local-part under the configured domain (rejected with MAILBOX error); case-insensitive domain match (`From: x@Agent.Example.Com` matches `domain = "agent.example.com"`)
+- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
 
 #### S45-3: UDS protocol scaffolding — `MARK-READ` and `MARK-UNREAD` verbs
 
@@ -309,12 +312,12 @@ or
 
 **Priority:** P0
 
-- [ ] Request parser recognises three verbs (`SEND`, `MARK-READ`, `MARK-UNREAD`) and produces a tagged enum; unknown verb returns `ERR PROTOCOL unknown verb '<x>'`
-- [ ] Writer helpers mirror `write_request` for each new verb (client side), with typed argument structs
-- [ ] Response codes stay in the FR-18c set (`OK`, `ERR` with codes from `MAILBOX | DOMAIN | SIGN | DELIVERY | TEMP | MALFORMED | PROTOCOL`); `PROTOCOL` added for codec-level failures
-- [ ] Codec unit tests per new verb: happy-path round-trip, malformed header lines, missing required headers (`Mailbox`, `Id`, `Folder`), unknown `Folder` value, empty-body requirement enforced
-- [ ] Optional file rename to `src/uds_protocol.rs` (update `mod.rs` and all imports if done)
-- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+- [x] Request parser recognises three verbs (`SEND`, `MARK-READ`, `MARK-UNREAD`) and produces a tagged enum; unknown verb returns `ERR PROTOCOL unknown verb '<x>'`
+- [x] Writer helpers mirror `write_request` for each new verb (client side), with typed argument structs
+- [x] Response codes stay in the FR-18c set (`OK`, `ERR` with codes from `MAILBOX | DOMAIN | SIGN | DELIVERY | TEMP | MALFORMED | PROTOCOL`); `PROTOCOL` added for codec-level failures <!-- Also added `NOTFOUND` and `IO` codes for MARK-verb handler paths (id not found; file/frontmatter rewrite failure). -->
+- [x] Codec unit tests per new verb: happy-path round-trip, malformed header lines, missing required headers (`Mailbox`, `Id`, `Folder`), unknown `Folder` value, empty-body requirement enforced
+- [x] Optional file rename to `src/uds_protocol.rs` (update `mod.rs` and all imports if done) <!-- Kept as `send_protocol.rs`; module doc updated to reflect the shared SEND/MARK codec. -->
+- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
 
 #### S45-4: MCP write ops route through daemon; per-mailbox concurrency guard
 
@@ -322,19 +325,20 @@ or
 
 **Priority:** P0
 
-- [ ] `src/mcp.rs email_mark_read`: become a thin UDS client — open `/run/aimx/send.sock`, send `MARK-READ`, parse `AIMX/1 OK` / `AIMX/1 ERR <reason>`, surface helpful errors (e.g. "aimx daemon not running — start with `sudo systemctl start aimx`")
-- [ ] `src/mcp.rs email_mark_unread`: same pattern via `MARK-UNREAD`
-- [ ] New `src/state_handler.rs` (or extend `src/send_handler.rs` — judgment call) with `handle_mark_read`, `handle_mark_unread` implementations that do the actual frontmatter rewrite, reusing the existing frontmatter serializer
-- [ ] Daemon acquires a per-mailbox `RwLock<()>` for the duration of the frontmatter rewrite; stored on the daemon state (keyed by mailbox name, lazily-inserted); ingest's append path also takes the same lock so MARK-READ and inbound ingest on the same mailbox cannot interleave a half-written file
-- [ ] ERR paths covered: mailbox not configured, id not found, folder invalid, write failure
-- [ ] Integration test: `email_mark_read` invoked as non-root succeeds; frontmatter `read = true` is persisted; file retains its original ownership (root:root 0644)
-- [ ] Integration test: concurrent ingest + `MARK-READ` on the same mailbox don't corrupt either file (use tokio `tokio::join!` or spawn pair)
-- [ ] `book/mcp.md` mentions the daemon-mediated write path so users understand why `aimx serve` must be running for MCP writes
-- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+- [x] `src/mcp.rs email_mark_read`: become a thin UDS client — open `/run/aimx/send.sock`, send `MARK-READ`, parse `AIMX/1 OK` / `AIMX/1 ERR <reason>`, surface helpful errors (e.g. "aimx daemon not running — start with `sudo systemctl start aimx`")
+- [x] `src/mcp.rs email_mark_unread`: same pattern via `MARK-UNREAD`
+- [x] New `src/state_handler.rs` (or extend `src/send_handler.rs` — judgment call) with `handle_mark_read`, `handle_mark_unread` implementations that do the actual frontmatter rewrite, reusing the existing frontmatter serializer
+- [x] Daemon acquires a per-mailbox `RwLock<()>` for the duration of the frontmatter rewrite; stored on the daemon state (keyed by mailbox name, lazily-inserted); ingest's append path also takes the same lock so MARK-READ and inbound ingest on the same mailbox cannot interleave a half-written file <!-- Partial: per-mailbox `tokio::sync::RwLock` guards MARK; ingest continues to use the existing process-wide `INGEST_WRITE_LOCK` (std::sync::Mutex). Safety today comes from the two paths writing disjoint files (ingest creates a new `.md`; MARK rewrites an existing one). Reviewer accepted. Writer-unification moved to backlog and tracked across Sprint 45/46. -->
+- [x] ERR paths covered: mailbox not configured, id not found, folder invalid, write failure
+- [x] Integration test: `email_mark_read` invoked as non-root succeeds; frontmatter `read = true` is persisted; file retains its original ownership (root:root 0644)
+- [x] Integration test: concurrent ingest + `MARK-READ` on the same mailbox don't corrupt either file (use tokio `tokio::join!` or spawn pair)
+- [x] `book/mcp.md` mentions the daemon-mediated write path so users understand why `aimx serve` must be running for MCP writes
+- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+- [x] Extra: `parse_ack_response` tightened to reject trailing garbage on `AIMX/1 OK` (MARK verbs); malformed-frontmatter MARK tests added; `resolve_email_path` deduplicated between `mcp.rs` and `state_handler.rs`
 
 ---
 
-## Sprint 46 — Mailbox CRUD via UDS (Daemon Picks Up Changes Live) (Days 128–130.5) [NOT STARTED]
+## Sprint 46 — Mailbox CRUD via UDS (Daemon Picks Up Changes Live) (Days 128–130.5) [DONE]
 
 **Goal:** Make `aimx mailbox create` / `delete` route through the daemon over UDS so the daemon's in-memory `Config` updates atomically with `config.toml` on disk. Inbound mail to a just-created mailbox routes correctly on the very next SMTP session — no `systemctl restart aimx` required. This closes finding #1 tier-2 from the 2026-04-17 manual test run (the silent-misroute behavior Sprint 44's hint warned about) and finishes the daemon-as-single-writer architecture started in Sprint 45.
 
@@ -358,16 +362,16 @@ or
 
 **Priority:** P1
 
-- [ ] `src/send_protocol.rs` (or `uds_protocol.rs`): add `MAILBOX-CREATE` verb parser + writer
-- [ ] `src/state_handler.rs` `handle_mailbox_create`: validate name; read current config.toml; append stanza; write-temp-then-rename to atomically update disk; create the two directories; swap `RwLock<Arc<Config>>`; return `AIMX/1 OK` on success; on any validation or IO failure return a typed `ERR`
-- [ ] `src/mailbox.rs create`: attempt UDS `MAILBOX-CREATE` first; on socket-missing (`ENOENT`/`ECONNREFUSED`/`EACCES`) fall back to direct `config.toml` edit + restart-hint print (Sprint 44 behavior); when UDS succeeds, suppress the restart hint
-- [ ] The rest of the daemon (send handler, ingest path) reads Config via the `RwLock<Arc<Config>>` accessor — verify all existing `config.mailboxes.get(…)` call sites thread through correctly
-- [ ] Integration test: daemon running → `aimx mailbox create foo` via UDS → immediately send Gmail to `foo@domain` → assert the .md lands in `inbox/foo/` (not catchall), no restart required
-- [ ] Integration test: daemon stopped → `aimx mailbox create foo` falls back to direct config edit + restart-hint present in stdout
-- [ ] Integration test: concurrent `MAILBOX-CREATE foo` + inbound mail targeting a pre-existing mailbox — neither blocks the other for longer than the write-lock critical section (~microseconds)
-- [ ] Name-validation tests: `..`, empty string, `/`-containing, duplicate name (already exists) — each returns a distinct `ERR` with the reason
-- [ ] `book/mailboxes.md` updated — restart is no longer required when daemon is running
-- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+- [x] `src/send_protocol.rs` (or `uds_protocol.rs`): add `MAILBOX-CREATE` verb parser + writer
+- [x] `src/state_handler.rs` `handle_mailbox_create`: validate name; read current config.toml; append stanza; write-temp-then-rename to atomically update disk; create the two directories; swap `RwLock<Arc<Config>>`; return `AIMX/1 OK` on success; on any validation or IO failure return a typed `ERR` <!-- Landed in a new `src/mailbox_handler.rs` rather than `state_handler.rs`; functionally equivalent. Uses a new `ConfigHandle` (`Arc<RwLock<Arc<Config>>>`) shared across every daemon context; a process-wide `CONFIG_WRITE_LOCK` serializes concurrent CREATE/DELETE across different mailbox names (closes a lost-update race caught in Cycle 1 review). -->
+- [x] `src/mailbox.rs create`: attempt UDS `MAILBOX-CREATE` first; on socket-missing (`ENOENT`/`ECONNREFUSED`/`EACCES`) fall back to direct `config.toml` edit + restart-hint print (Sprint 44 behavior); when UDS succeeds, suppress the restart hint
+- [x] The rest of the daemon (send handler, ingest path) reads Config via the `RwLock<Arc<Config>>` accessor — verify all existing `config.mailboxes.get(…)` call sites thread through correctly
+- [x] Integration test: daemon running → `aimx mailbox create foo` via UDS → immediately send Gmail to `foo@domain` → assert the .md lands in `inbox/foo/` (not catchall), no restart required
+- [x] Integration test: daemon stopped → `aimx mailbox create foo` falls back to direct config edit + restart-hint present in stdout
+- [x] Integration test: concurrent `MAILBOX-CREATE foo` + inbound mail targeting a pre-existing mailbox — neither blocks the other for longer than the write-lock critical section (~microseconds) <!-- Concurrent-create regression test (`concurrent_create_different_names_both_stanzas_survive`, 16 names on multi-thread runtime) added in Cycle 2 to close the lost-update race. -->
+- [x] Name-validation tests: `..`, empty string, `/`-containing, duplicate name (already exists) — each returns a distinct `ERR` with the reason
+- [x] `book/mailboxes.md` updated — restart is no longer required when daemon is running
+- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
 
 #### S46-2: UDS `MAILBOX-DELETE` — safety check + daemon swap
 
@@ -375,14 +379,76 @@ or
 
 **Priority:** P1
 
-- [ ] `src/send_protocol.rs` (or `uds_protocol.rs`): add `MAILBOX-DELETE` verb parser + writer
-- [ ] `src/state_handler.rs` `handle_mailbox_delete`: verify mailbox exists; scan `inbox/<name>/` and `sent/<name>/` for any files — if non-empty return `AIMX/1 ERR NONEMPTY mailbox <name> has <n> files; archive or remove them first`; on success remove the stanza via write-temp-then-rename and swap `Config`
-- [ ] `src/mailbox.rs delete`: attempt UDS `MAILBOX-DELETE` first; fall back to direct edit + restart-hint when socket absent
-- [ ] Refuse to delete the `catchall` mailbox via UDS (matches existing CLI guardrail); direct-edit fallback preserves whatever the current rule is
-- [ ] Integration test: daemon running → create mailbox `qux` → delete via UDS → assert `[mailboxes.qux]` is gone from config.toml and the daemon rejects subsequent inbound to `qux@domain` (routes to catchall)
-- [ ] Integration test: mailbox with files → `MAILBOX-DELETE` returns `ERR NONEMPTY`; operator then clears files and retry succeeds
-- [ ] `book/mailboxes.md` documents the NONEMPTY safety behavior and the symmetric live-update semantics
-- [ ] Sprint 44's restart-hint suppression applies to the delete path too
+- [x] `src/send_protocol.rs` (or `uds_protocol.rs`): add `MAILBOX-DELETE` verb parser + writer
+- [x] `src/state_handler.rs` `handle_mailbox_delete`: verify mailbox exists; scan `inbox/<name>/` and `sent/<name>/` for any files — if non-empty return `AIMX/1 ERR NONEMPTY mailbox <name> has <n> files; archive or remove them first`; on success remove the stanza via write-temp-then-rename and swap `Config` <!-- Landed in `src/mailbox_handler.rs` alongside handle_mailbox_create. Empty directories are left on disk (operator owns cleanup); the success message on CLI and MCP notes the leftover dirs. -->
+- [x] `src/mailbox.rs delete`: attempt UDS `MAILBOX-DELETE` first; fall back to direct edit + restart-hint when socket absent
+- [x] Refuse to delete the `catchall` mailbox via UDS (matches existing CLI guardrail); direct-edit fallback preserves whatever the current rule is
+- [x] Integration test: daemon running → create mailbox `qux` → delete via UDS → assert `[mailboxes.qux]` is gone from config.toml and the daemon rejects subsequent inbound to `qux@domain` (routes to catchall)
+- [x] Integration test: mailbox with files → `MAILBOX-DELETE` returns `ERR NONEMPTY`; operator then clears files and retry succeeds
+- [x] `book/mailboxes.md` documents the NONEMPTY safety behavior and the symmetric live-update semantics
+- [x] Sprint 44's restart-hint suppression applies to the delete path too
+- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+- [x] Extra: `agents/common/references/mcp-tools.md` updated to document NONEMPTY, catchall guardrail, and leftover-directory behavior on delete
+
+---
+
+## Sprint 47 — Post-v1 Non-blocking Cleanup (Days 130.5–133) [IN PROGRESS]
+
+**Goal:** Close the 8 non-blocking improvements accumulated across Sprints 44–46 reviews. All are low-risk hardening items — a defense-in-depth pass before v1 tag. No new features; no PRD changes. Grouped into four thematic stories.
+
+**Dependencies:** Sprint 46 (merged).
+
+**Design notes:**
+- All items already live in the Non-blocking Review Backlog with full context. This sprint lifts them into first-class stories and resolves them.
+- Stories can be implemented independently; no intra-sprint order required.
+- S47-4 (writer unification) is the most architecturally substantive — merges Sprint 45's per-mailbox `tokio::sync::RwLock` map with Sprint 36's process-wide `INGEST_WRITE_LOCK` (`std::sync::Mutex`) into a single per-mailbox lock covering both ingest and MARK-* paths. Everything else is small-surface.
+
+#### S47-1: DKIM startup check — end-to-end integration test + runtime-flavor contract
+
+**Context:** Sprint 44 delivered the DKIM startup check with trait-based unit coverage across all five `DkimStartupCheck` branches, but no integration test exercises the wiring in `run_serve` itself. Separately, `HickoryDkimResolver::resolve_dkim_txt` in `src/serve.rs` couples to a multi-threaded tokio runtime via `block_in_place` + `Handle::current().block_on(...)`. This works in `run_serve` (multi-thread flavor), but a future caller on a current-thread runtime would silently break. Pick one of two fixes for the runtime coupling: debug-assert the flavor at entry, or async-ify the trait so the call site just `.await`s.
+
+**Priority:** P3
+
+- [ ] New integration test in `tests/integration.rs` spins `aimx serve` against a mock `DkimTxtResolver` and asserts the startup log contains the expected mismatch warning in the `Mismatch` case and a `warn`-level message in the `ResolveError` case; assert both listeners bind afterwards
+- [ ] `HickoryDkimResolver::resolve_dkim_txt` either (a) adds `debug_assert!(matches!(Handle::current().runtime_flavor(), RuntimeFlavor::MultiThread))` with a short comment explaining why, or (b) `async fn resolve_dkim_txt` so `run_serve` can `.await` — whichever fits cleaner
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S47-2: Exhaustiveness & defense-in-depth hardening
+
+**Context:** Two small type-safety / defense-in-depth items from Sprint 44's review. `restart_hint_command` in `src/mailbox.rs` uses a `_` fallback arm that collapses `InitSystem::Systemd` and `InitSystem::Unknown` into the same branch — a future `InitSystem` variant would silently fall through without a compile warning. `execute_triggers` in `src/channel.rs` selectively `.env()`s the `AIMX_*` vars but inherits the rest of the parent-process env — no reachable exploit today, but `.env_clear()` before the selective `.env()` calls (re-adding `PATH`, `HOME`, plus the `AIMX_*` set) is a one-line defense-in-depth upgrade.
+
+**Priority:** P3
+
+- [ ] `restart_hint_command`: replace the `_` fallback with an explicit `InitSystem::Unknown =>` arm (or mark `InitSystem` `#[non_exhaustive]`) so adding a new init-system variant fails to compile until the match is updated
+- [ ] Add a test that destructures every current `InitSystem` variant and asserts the expected hint string (so the exhaustive check is validated at compile time, not only in production)
+- [ ] `execute_triggers` in `src/channel.rs`: call `.env_clear()` on the `Command`, then re-add `PATH`, `HOME`, plus the five `AIMX_*` vars; short inline comment explaining why
+- [ ] New unit test asserts an unrelated env var set on the parent process (e.g. `AIMX_LEAK_TEST=sentinel`) does NOT appear in the trigger's environment
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S47-3: Validation tightening + TOML-rewrite preservation + stronger rename-failure test
+
+**Context:** Three Sprint 46 items in the same area. (a) `validate_mailbox_name` (duplicated in `src/mailbox.rs` and `src/mailbox_handler.rs`) accepts whitespace and other RFC-5322-unsafe local parts — e.g. `"hello world"` makes it through but then produces an invalid email address when interpolated. (b) `write_config_atomic` in `src/mailbox_handler.rs` drops unknown TOML fields and erases comments on rewrite (pre-existing, symmetric to `Config::save`); addressable with a pass-through serde representation or a TOML-edit crate. (c) `create_failure_at_disk_write_leaves_handle_and_disk_unchanged` forces failure via a nonexistent parent directory, which fails at `File::create` and never exercises the `rename(2)` failure branch — tighten the test so the temp write succeeds and the rename fails (e.g. read-only target directory).
+
+**Priority:** P3
+
+- [ ] Consolidate `validate_mailbox_name` into a single canonical helper (one of `src/mailbox.rs`, `src/mailbox_handler.rs`, or `src/config.rs` — whichever already owns mailbox-name invariants), tighten to reject whitespace and any character outside a safe local-part class (`[a-z0-9._-]`, case-folded), and thread both call sites through it
+- [ ] New unit tests cover: `"hello world"` rejected, `"a b"` rejected, `"..foo"` rejected, `""` rejected, `"good-mailbox.1"` accepted
+- [ ] `write_config_atomic`: either adopt a TOML-editing crate (e.g. `toml_edit`) that preserves comments and unknown stanzas, OR document the current behavior with a comment + add a test asserting a known-unknown stanza survives (whichever the implementer judges less risky for v1)
+- [ ] `create_failure_at_disk_write_leaves_handle_and_disk_unchanged`: rewrite to make the temp write succeed and the rename fail (read-only target dir on the parent, or equivalent), so the test genuinely exercises the rollback-on-rename-failure branch; assertion remains: disk + handle unchanged
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S47-4: Unify ingest + MARK writers under one per-mailbox lock
+
+**Context:** Sprint 45 left the daemon with two independent lock models: MARK-* uses a per-mailbox `tokio::sync::RwLock` map (in `src/state_handler.rs`), and inbound ingest uses a single process-wide `std::sync::Mutex` (`INGEST_WRITE_LOCK` in `src/ingest.rs`). Safety today comes from the two paths writing disjoint files (ingest creates a new `.md` stem; MARK rewrites an existing one), and the Sprint 45 review accepted that rationale. But both paths do "read → modify → write" on files under the same mailbox tree, and any future story that touches both sides (e.g. a MARK verb that deletes or an ingest path that re-opens an existing file) will lose the invariant. Unify: both ingest and MARK-* acquire the same per-mailbox write lock for the duration of their critical section. Document the lock hierarchy (outer: per-mailbox; inner: process-wide `CONFIG_WRITE_LOCK` for mailbox CRUD) to prevent deadlocks.
+
+**Priority:** P2
+
+- [ ] Introduce a single shared per-mailbox lock map (most likely in `src/state_handler.rs` or a new `src/mailbox_locks.rs`) keyed by mailbox name, exposed via an `Arc<Mutex<HashMap<String, Arc<tokio::sync::Mutex<()>>>>>` accessor pattern (or an `ArcSwap<HashMap<..>>` if hot-path reads dominate)
+- [ ] `ingest.rs`: replace the `INGEST_WRITE_LOCK` with an async acquisition of the per-mailbox lock before the file-allocation + write critical section; remove the old global mutex
+- [ ] `state_handler.rs` MARK-* handlers: acquire the same per-mailbox lock (replacing the current `RwLock` map) before read-modify-write of the target `.md` file
+- [ ] Update the module-level comment in `src/state_handler.rs` (currently documents the two-lock regime) to reflect the unified model; point to the lock hierarchy (per-mailbox lock outer, `CONFIG_WRITE_LOCK` inner)
+- [ ] Integration test: concurrent ingest + `MARK-READ` on the same mailbox AND on the same target file (once the file exists) — assert no torn writes and no half-written frontmatter on either side
+- [ ] Integration test: concurrent `MAILBOX-CREATE` + ingest to the just-created mailbox — assert ordering holds (the config-write happens, then ingest sees the new mailbox; no deadlock on the two locks)
 - [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
 
 ---
@@ -439,9 +505,10 @@ or
 | 41 | 115–117.5 | Post-v0.2 Backlog Cleanup | Outbound frontmatter fixes, SPF dedup, UDS slow-loris timeout, typed transport errors, DNS error surfacing, test DKIM cache, stale dead_code sweep | Done |
 | 42 | 118–120.5 | CLI UX: Config Errors + Setup Race + Version Hash | Helpful error when config missing, wait-for-ready loop in `aimx setup` before port checks, git commit hash in `aimx --version` | Done |
 | 43 | 120.5–123 | Pre-launch README Sweep + Hardening | `README.md` v0.2 sweep, `status` uses `SystemOps`, HTML body size cap, bracketed-only `Received:` IP parse, typed lettre error classification, `dkim-keygen` permission-denied UX, attachment filename safety + NFC normalization | Done |
-| 44 | 123–125.5 | Post-launch Security + Quick Fixes | Env-var channel-trigger expansion (shell-injection fix), DKIM DNS sanity check at daemon startup + louder setup warning, Claude Code agent-setup hint fix, `aimx mailbox create/delete` restart hint, manual-test.md compose-new clarification | Not started |
-| 45 | 125.5–128 | Strict Outbound + MCP Writes via Daemon | `aimx send` stops reading config.toml (daemon resolves From), strict outbound (concrete mailbox + configured domain only, wildcard is inbound-only), UDS `MARK-READ`/`MARK-UNREAD` verbs + MCP write ops via daemon with per-mailbox RwLock | Not started |
-| 46 | 128–130.5 | Mailbox CRUD via UDS (Daemon Picks Up Changes Live) | UDS `MAILBOX-CREATE`/`MAILBOX-DELETE` verbs + daemon hot-swaps `Arc<Config>`, `aimx mailbox create/delete` route through daemon first and suppress restart hint on success, directory lifecycle + NONEMPTY safety on delete | Not started |
+| 44 | 123–125.5 | Post-launch Security + Quick Fixes | Env-var channel-trigger expansion (shell-injection fix), DKIM DNS sanity check at daemon startup + louder setup warning, Claude Code agent-setup hint fix, `aimx mailbox create/delete` restart hint, manual-test.md compose-new clarification | Done |
+| 45 | 125.5–128 | Strict Outbound + MCP Writes via Daemon | `aimx send` stops reading config.toml (daemon resolves From), strict outbound (concrete mailbox + configured domain only, wildcard is inbound-only), UDS `MARK-READ`/`MARK-UNREAD` verbs + MCP write ops via daemon with per-mailbox RwLock | Done |
+| 46 | 128–130.5 | Mailbox CRUD via UDS (Daemon Picks Up Changes Live) | UDS `MAILBOX-CREATE`/`MAILBOX-DELETE` verbs + daemon hot-swaps `Arc<Config>`, `aimx mailbox create/delete` route through daemon first and suppress restart hint on success, directory lifecycle + NONEMPTY safety on delete | Done |
+| 47 | 130.5–133 | Post-v1 Non-blocking Cleanup | DKIM startup integration test + runtime-flavor contract, exhaustive `InitSystem` match + `.env_clear()` defense-in-depth, `validate_mailbox_name` tightening + `write_config_atomic` preservation + stronger rename-failure test, unify ingest + MARK writers under one per-mailbox lock | In progress |
 
 ## Deferred to v2
 
@@ -481,10 +548,14 @@ Concrete items with clear implementation direction. Will be triaged into a clean
 - [x] **(Sprint 36, PR #66)** `mailbox_list` reads `config.mailboxes.keys()` instead of scanning `inbox/*/` — stray dirs not in config are invisible. — _Not a bug: config-authoritative mailbox list is the intended design (2026-04-16)._
 - [x] **(Sprint 36, PR #66)** Concurrent-ingest race on bundle directories — two ingests with the same subject/second can cross-contaminate attachment files. — _Deferred by user decision (2026-04-16). Unlikely in practice; locking design needed._
 - [x] **(Sprint 34, PR #64)** `LettreTransport::send` parses full `To:` header as `lettre::Address` — fails on display-name or multi-recipient form. — _Already fixed: `send_handler.rs:148` now uses `extract_bare_address(&to_header)` to normalize before transport._
-- [ ] **(Sprint 46, PR #81)** `write_config_atomic` in `src/mailbox_handler.rs` drops unknown TOML fields and erases comments on rewrite. Pre-existing — symmetric to `Config::save`. Addressable with a pass-through serde representation or a TOML-edit crate that preserves unrecognized stanzas. _Flagged 2026-04-18._
-- [ ] **(Sprint 46, PR #81)** `validate_mailbox_name` in both `src/mailbox.rs` and `src/mailbox_handler.rs` accepts whitespace and other RFC-5322-unsafe local parts (e.g. `"hello world"`), which then interpolate as invalid email addresses. Pre-existing. Tighten to match a local-part safe character class. _Flagged 2026-04-18._
-- [ ] **(Sprint 46, PR #81)** `create_failure_at_disk_write_leaves_handle_and_disk_unchanged` in `src/mailbox_handler.rs` forces failure via a nonexistent parent directory, which fails at `File::create` and therefore never exercises the `rename(2)` failure branch. Strengthen with a read-only target (or similar) that makes the temp write succeed and the rename fail. _Flagged 2026-04-18._
-- [ ] **(Sprint 45, PR #78 → Sprint 46, PR #81)** MARK-* and inbound ingest are not serialized against each other — they rely on allocating disjoint filenames. Unify both writers under a single per-mailbox lock (discussed in `src/state_handler.rs` header comment). _Flagged 2026-04-18._
+- [x] **(Sprint 44, PR #79)** DKIM startup check lacks an end-to-end integration test against live `run_serve`. _Triaged into Sprint 47 (S47-1)._
+- [x] **(Sprint 44, PR #79)** `HickoryDkimResolver::resolve_dkim_txt` depends on multi-threaded tokio runtime; debug-assert or async-ify. _Triaged into Sprint 47 (S47-1)._
+- [x] **(Sprint 44, PR #79)** `restart_hint_command` uses `_` fallback arm collapsing `InitSystem::Systemd` and `InitSystem::Unknown`. _Triaged into Sprint 47 (S47-2)._
+- [x] **(Sprint 44, PR #79)** `execute_triggers` inherits parent-process env; consider `.env_clear()` + selective re-add. _Triaged into Sprint 47 (S47-2)._
+- [x] **(Sprint 46, PR #81)** `write_config_atomic` drops unknown TOML fields and erases comments on rewrite. _Triaged into Sprint 47 (S47-3)._
+- [x] **(Sprint 46, PR #81)** `validate_mailbox_name` accepts whitespace and RFC-5322-unsafe local parts. _Triaged into Sprint 47 (S47-3)._
+- [x] **(Sprint 46, PR #81)** `create_failure_at_disk_write_leaves_handle_and_disk_unchanged` never exercises the rename failure branch. _Triaged into Sprint 47 (S47-3)._
+- [x] **(Sprint 45, PR #78 → Sprint 46, PR #81)** MARK-* and inbound ingest are not serialized against each other; unify writers under one per-mailbox lock. _Triaged into Sprint 47 (S47-4)._
 
 ### Deferred Feature Sprints
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -133,11 +133,24 @@ pub fn execute_triggers(mailbox_config: &MailboxConfig, ctx: &TriggerContext) {
         // The shell expands `$AIMX_FROM` literally — attacker-controlled
         // payload in `From:` can no longer break out of quotes, add extra
         // commands, or exploit `$()`/backticks.
+        //
+        // Defense in depth: `.env_clear()` wipes the parent-process env
+        // before we selectively re-add `PATH`/`HOME` and the `AIMX_*`
+        // variables. A stray `LD_PRELOAD` / `SSH_AUTH_SOCK` / credential
+        // env var set on the daemon process cannot leak into a trigger
+        // subshell. `PATH` is preserved so common commands (`curl`,
+        // `python`, ...) still resolve; `HOME` is preserved so tools that
+        // read per-user config files still work for the service account.
         let filepath = ctx.filepath.to_string_lossy().into_owned();
         let mut command = Command::new("sh");
+        command.env_clear().arg("-c").arg(&expanded);
+        if let Some(path) = std::env::var_os("PATH") {
+            command.env("PATH", path);
+        }
+        if let Some(home) = std::env::var_os("HOME") {
+            command.env("HOME", home);
+        }
         command
-            .arg("-c")
-            .arg(&expanded)
             .env("AIMX_FROM", &ctx.metadata.from)
             .env("AIMX_SUBJECT", &ctx.metadata.subject)
             .env("AIMX_TO", &ctx.metadata.to)
@@ -699,6 +712,63 @@ mod tests {
         let content = std::fs::read_to_string(&output_file).unwrap();
         assert!(content.contains("alice@gmail.com"), "got: {content:?}");
         assert!(content.contains("Hello World"), "got: {content:?}");
+    }
+
+    #[test]
+    fn execute_triggers_clears_parent_env() {
+        // S47-2: `execute_triggers` calls `.env_clear()` before selectively
+        // re-adding `PATH`/`HOME`/`AIMX_*`. An unrelated env var set on the
+        // parent process must NOT be visible inside the trigger subshell.
+        //
+        // This test intentionally uses a unique variable name and is not
+        // parallelized against other env-var-touching tests because
+        // `std::env::set_var` mutates process-global state. Each assertion
+        // is scoped to what this test owns.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let log = tmp.path().join("env.log");
+        let meta = sample_metadata();
+        let filepath = tmp.path().join("test.md");
+        let ctx = sample_ctx(&filepath, &meta);
+
+        // Set a sentinel on the parent process. If env_clear is working the
+        // sentinel must be empty in the child.
+        unsafe {
+            std::env::set_var("AIMX_LEAK_TEST", "sentinel-should-not-leak");
+        }
+
+        let config = MailboxConfig {
+            address: "*@test.com".to_string(),
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            on_receive: vec![OnReceiveRule {
+                rule_type: "cmd".to_string(),
+                command: format!(
+                    "printf 'leak=[%s] path_set=%s\\n' \"$AIMX_LEAK_TEST\" \
+                     \"${{PATH:+yes}}\" > {}",
+                    log.to_string_lossy()
+                ),
+                r#match: None,
+            }],
+        };
+
+        execute_triggers(&config, &ctx);
+
+        // Clean up the sentinel before assertions so a test failure doesn't
+        // leave the process env dirty for downstream tests in the same crate.
+        unsafe {
+            std::env::remove_var("AIMX_LEAK_TEST");
+        }
+
+        let content = std::fs::read_to_string(&log).unwrap();
+        assert!(
+            content.contains("leak=[]"),
+            "AIMX_LEAK_TEST must not leak into the trigger env: {content:?}"
+        );
+        // PATH was re-added selectively so everyday shell tools still work.
+        assert!(
+            content.contains("path_set=yes"),
+            "PATH must be preserved for the trigger: {content:?}"
+        );
     }
 
     /// Helper: fire a single-shot trigger that writes `$AIMX_*` env vars to

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -714,6 +714,29 @@ mod tests {
         assert!(content.contains("Hello World"), "got: {content:?}");
     }
 
+    /// RAII guard that sets an env var on construction and removes it on
+    /// drop. Used by `execute_triggers_clears_parent_env` so a panicking
+    /// assertion still cleans up the sentinel — `std::env::set_var` is
+    /// process-global, and leaking a sentinel across tests is nasty.
+    struct EnvVarGuard {
+        name: &'static str,
+    }
+    impl EnvVarGuard {
+        fn set(name: &'static str, value: &str) -> Self {
+            unsafe {
+                std::env::set_var(name, value);
+            }
+            Self { name }
+        }
+    }
+    impl Drop for EnvVarGuard {
+        fn drop(&mut self) {
+            unsafe {
+                std::env::remove_var(self.name);
+            }
+        }
+    }
+
     #[test]
     fn execute_triggers_clears_parent_env() {
         // S47-2: `execute_triggers` calls `.env_clear()` before selectively
@@ -722,19 +745,18 @@ mod tests {
         //
         // This test intentionally uses a unique variable name and is not
         // parallelized against other env-var-touching tests because
-        // `std::env::set_var` mutates process-global state. Each assertion
-        // is scoped to what this test owns.
+        // `std::env::set_var` mutates process-global state. The RAII
+        // `EnvVarGuard` ensures the sentinel is removed even if an
+        // assertion panics.
         let tmp = tempfile::TempDir::new().unwrap();
         let log = tmp.path().join("env.log");
         let meta = sample_metadata();
         let filepath = tmp.path().join("test.md");
         let ctx = sample_ctx(&filepath, &meta);
 
-        // Set a sentinel on the parent process. If env_clear is working the
-        // sentinel must be empty in the child.
-        unsafe {
-            std::env::set_var("AIMX_LEAK_TEST", "sentinel-should-not-leak");
-        }
+        // Set a sentinel on the parent process. The guard removes it on
+        // drop — panic-safe.
+        let _sentinel = EnvVarGuard::set("AIMX_LEAK_TEST", "sentinel-should-not-leak");
 
         let config = MailboxConfig {
             address: "*@test.com".to_string(),
@@ -753,12 +775,6 @@ mod tests {
 
         execute_triggers(&config, &ctx);
 
-        // Clean up the sentinel before assertions so a test failure doesn't
-        // leave the process env dirty for downstream tests in the same crate.
-        unsafe {
-            std::env::remove_var("AIMX_LEAK_TEST");
-        }
-
         let content = std::fs::read_to_string(&log).unwrap();
         assert!(
             content.contains("leak=[]"),
@@ -769,6 +785,7 @@ mod tests {
             content.contains("path_set=yes"),
             "PATH must be preserved for the trigger: {content:?}"
         );
+        // `_sentinel` dropped here → `AIMX_LEAK_TEST` removed.
     }
 
     /// Helper: fire a single-shot trigger that writes `$AIMX_*` env vars to

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -3,21 +3,14 @@ use crate::config::Config;
 use crate::frontmatter::{
     AttachmentMeta, AuthResults, InboundFrontmatter, compute_thread_id, format_frontmatter,
 };
+use crate::mailbox_locks::MailboxLocks;
 use crate::slug::{allocate_filename, slugify};
 use crate::trust;
 use mail_parser::{MessageParser, MimeHeaders};
 use std::io::Read;
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
-use std::sync::Mutex;
-
-/// Process-scoped lock guarding the inbound critical section: filename
-/// allocation, bundle directory creation, attachment writes, and the
-/// final `.md` write. The aimx daemon is the single writer to
-/// `<data_dir>/inbox/`, so a process Mutex is sufficient — no
-/// filesystem-level lock needed. Symmetric to the outbound `Mutex<()>`
-/// planned for FR-19b.
-static INGEST_WRITE_LOCK: Mutex<()> = Mutex::new(());
+use std::sync::Arc;
 
 pub fn run(rcpt: &str, config: Config) -> Result<(), Box<dyn std::error::Error>> {
     let mut raw = Vec::new();
@@ -25,11 +18,25 @@ pub fn run(rcpt: &str, config: Config) -> Result<(), Box<dyn std::error::Error>>
     // Manual stdin path: no SMTP session, so received_from_ip is the
     // unspecified sentinel (0.0.0.0) and there is no envelope MAIL FROM.
     let sentinel_ip: IpAddr = "0.0.0.0".parse().unwrap();
-    ingest_email(&config, rcpt, &raw, sentinel_ip, None)
+    // Sprint 47: the manual stdin caller owns a fresh lock map — it's a
+    // short-lived process with a single ingest so contention isn't
+    // possible. The daemon path shares its map across all writers.
+    let locks = Arc::new(MailboxLocks::new());
+    ingest_email(&config, &locks, rcpt, &raw, sentinel_ip, None)
 }
 
+/// Inbound ingest entry point.
+///
+/// Sprint 47 (S47-4) unified the inbound write path with the MARK-* /
+/// MAILBOX-* write paths under a single per-mailbox
+/// `tokio::sync::Mutex<()>` from [`MailboxLocks`]. The critical section
+/// below is taken via `blocking_lock()` because `ingest_email` runs from
+/// a synchronous context (manual stdin path, or the SMTP session's
+/// `spawn_blocking` worker) — `blocking_lock()` is sound on a blocking
+/// thread, but never from an async runtime thread (which would panic).
 pub fn ingest_email(
     config: &Config,
+    locks: &MailboxLocks,
     rcpt: &str,
     raw: &[u8],
     received_from_ip: IpAddr,
@@ -168,9 +175,17 @@ pub fn ingest_email(
     let slug = slugify(&subject);
     let timestamp = chrono::Utc::now();
 
-    let _guard = INGEST_WRITE_LOCK
-        .lock()
-        .unwrap_or_else(|poisoned| poisoned.into_inner());
+    // S47-4: the per-mailbox lock shared with MARK-* and MAILBOX-* is
+    // the outer lock of the two-tier hierarchy (see
+    // `crate::mailbox_locks`). Acquired via `blocking_lock()` because
+    // `ingest_email` runs from a synchronous context (stdin caller, or
+    // the SMTP session's `spawn_blocking` worker). The lock covers the
+    // full filename-allocation + bundle-creation + attachment-write +
+    // final `.md` write sequence — readers of the mailbox directory
+    // observe either the pre-state or the post-state, never a half-
+    // written bundle.
+    let lock = locks.lock_for(&mailbox);
+    let _guard = lock.blocking_lock();
 
     let md_path = allocate_filename(&inbox_dir, timestamp, &slug, has_attachments);
     let parent_dir = md_path
@@ -812,6 +827,14 @@ mod tests {
         "0.0.0.0".parse().unwrap()
     }
 
+    /// Sprint 47 (S47-4): most tests exercise a single ingest in
+    /// isolation, so they own a fresh `MailboxLocks`. Tests that
+    /// exercise concurrent ingest + MARK on the same mailbox (see the
+    /// integration suite) pass in a shared `MailboxLocks` instead.
+    fn test_locks() -> MailboxLocks {
+        MailboxLocks::new()
+    }
+
     fn plain_text_eml() -> &'static [u8] {
         b"From: sender@example.com\r\n\
           To: alice@test.com\r\n\
@@ -941,6 +964,7 @@ mod tests {
         let config = test_config(tmp.path());
         ingest_email(
             &config,
+            &test_locks(),
             "alice@test.com",
             plain_text_eml(),
             sentinel_ip(),
@@ -970,6 +994,7 @@ mod tests {
         let config = test_config(tmp.path());
         ingest_email(
             &config,
+            &test_locks(),
             "alice@test.com",
             plain_text_eml(),
             sentinel_ip(),
@@ -987,6 +1012,7 @@ mod tests {
         let config = test_config(tmp.path());
         ingest_email(
             &config,
+            &test_locks(),
             "alice@test.com",
             plain_text_eml(),
             sentinel_ip(),
@@ -1019,6 +1045,7 @@ mod tests {
         let config = test_config(tmp.path());
         ingest_email(
             &config,
+            &test_locks(),
             "alice@test.com",
             html_only_eml(),
             sentinel_ip(),
@@ -1071,6 +1098,7 @@ mod tests {
         let config = test_config(tmp.path());
         ingest_email(
             &config,
+            &test_locks(),
             "alice@test.com",
             multipart_eml(),
             sentinel_ip(),
@@ -1090,6 +1118,7 @@ mod tests {
         let config = test_config(tmp.path());
         ingest_email(
             &config,
+            &test_locks(),
             "unknown@test.com",
             plain_text_eml(),
             sentinel_ip(),
@@ -1108,6 +1137,7 @@ mod tests {
         let config = test_config(tmp.path());
         ingest_email(
             &config,
+            &test_locks(),
             "alice@test.com",
             plain_text_eml(),
             sentinel_ip(),
@@ -1146,6 +1176,7 @@ mod tests {
 
         ingest_email(
             &config,
+            &test_locks(),
             "alice@test.com",
             plain_text_eml(),
             sentinel_ip(),
@@ -1154,6 +1185,7 @@ mod tests {
         .unwrap();
         ingest_email(
             &config,
+            &test_locks(),
             "alice@test.com",
             plain_text_eml(),
             sentinel_ip(),
@@ -1172,6 +1204,7 @@ mod tests {
         let config = test_config(tmp.path());
         ingest_email(
             &config,
+            &test_locks(),
             "alice@test.com",
             attachment_eml(),
             sentinel_ip(),
@@ -1214,6 +1247,7 @@ mod tests {
         let config = test_config(tmp.path());
         ingest_email(
             &config,
+            &test_locks(),
             "alice@test.com",
             multi_attachment_eml(),
             sentinel_ip(),
@@ -1240,6 +1274,7 @@ mod tests {
 
         ingest_email(
             &config,
+            &test_locks(),
             "alice@test.com",
             attachment_eml(),
             sentinel_ip(),
@@ -1248,6 +1283,7 @@ mod tests {
         .unwrap();
         ingest_email(
             &config,
+            &test_locks(),
             "alice@test.com",
             attachment_eml(),
             sentinel_ip(),
@@ -1274,6 +1310,7 @@ mod tests {
         let config = test_config(tmp.path());
         ingest_email(
             &config,
+            &test_locks(),
             "alice@test.com",
             plain_text_eml(),
             sentinel_ip(),
@@ -1441,7 +1478,15 @@ mod tests {
             malicious content\r\n\
             --evilbound--\r\n";
 
-        ingest_email(&config, "alice@test.com", eml, sentinel_ip(), None).unwrap();
+        ingest_email(
+            &config,
+            &test_locks(),
+            "alice@test.com",
+            eml,
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
 
         let alice = inbox(tmp.path(), "alice");
         let bundles: Vec<_> = std::fs::read_dir(&alice)
@@ -1490,7 +1535,15 @@ mod tests {
             #!/bin/sh\r\n\
             --b1--\r\n";
 
-        ingest_email(&config, "alice@test.com", eml, sentinel_ip(), None).unwrap();
+        ingest_email(
+            &config,
+            &test_locks(),
+            "alice@test.com",
+            eml,
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
 
         let alice = inbox(tmp.path(), "alice");
         let bundles: Vec<_> = std::fs::read_dir(&alice)
@@ -1574,6 +1627,7 @@ mod tests {
         let config = test_config(tmp.path());
         ingest_email(
             &config,
+            &test_locks(),
             "alice@test.com",
             plain_text_eml(),
             sentinel_ip(),
@@ -1686,6 +1740,7 @@ mod tests {
         let config = test_config(tmp.path());
         ingest_email(
             &config,
+            &test_locks(),
             "alice@test.com",
             plain_text_eml(),
             sentinel_ip(),
@@ -1736,7 +1791,15 @@ mod tests {
         let config = test_config(tmp.path());
         let raw = include_bytes!("../tests/fixtures/gmail_dkim_signed.eml");
 
-        ingest_email(&config, "agent@test.com", raw, sentinel_ip(), None).unwrap();
+        ingest_email(
+            &config,
+            &test_locks(),
+            "agent@test.com",
+            raw,
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "catchall"));
         assert_eq!(entries.len(), 1);
@@ -1808,13 +1871,16 @@ mod tests {
 
         let tmp = TempDir::new().unwrap();
         let config = Arc::new(test_config(tmp.path()));
+        let locks = Arc::new(MailboxLocks::new());
 
         let mut handles = Vec::new();
         for _ in 0..8 {
             let cfg = Arc::clone(&config);
+            let locks = Arc::clone(&locks);
             handles.push(thread::spawn(move || {
                 ingest_email(
                     &cfg,
+                    &locks,
                     "alice@test.com",
                     attachment_eml(),
                     sentinel_ip(),
@@ -1853,6 +1919,7 @@ mod tests {
         let config = test_config(tmp.path());
         ingest_email(
             &config,
+            &test_locks(),
             "alice@test.com",
             plain_text_eml(),
             sentinel_ip(),
@@ -1861,6 +1928,7 @@ mod tests {
         .unwrap();
         ingest_email(
             &config,
+            &test_locks(),
             "alice@test.com",
             plain_text_eml(),
             sentinel_ip(),
@@ -1948,7 +2016,15 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
         let ip: IpAddr = "203.0.113.50".parse().unwrap();
-        ingest_email(&config, "alice@test.com", plain_text_eml(), ip, None).unwrap();
+        ingest_email(
+            &config,
+            &test_locks(),
+            "alice@test.com",
+            plain_text_eml(),
+            ip,
+            None,
+        )
+        .unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         let content = std::fs::read_to_string(&entries[0]).unwrap();
@@ -1982,6 +2058,7 @@ mod tests {
         let config = test_config(tmp.path());
         ingest_email(
             &config,
+            &test_locks(),
             "alice@test.com",
             plain_text_eml(),
             sentinel_ip(),
@@ -2010,7 +2087,15 @@ mod tests {
 
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", eml, sentinel_ip(), None).unwrap();
+        ingest_email(
+            &config,
+            &test_locks(),
+            "alice@test.com",
+            eml,
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         let content = std::fs::read_to_string(&entries[0]).unwrap();
@@ -2034,7 +2119,15 @@ mod tests {
 
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
-        ingest_email(&config, "alice@test.com", eml, sentinel_ip(), None).unwrap();
+        ingest_email(
+            &config,
+            &test_locks(),
+            "alice@test.com",
+            eml,
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
 
         let entries = collect_md_files(&inbox(tmp.path(), "alice"));
         let content = std::fs::read_to_string(&entries[0]).unwrap();
@@ -2051,6 +2144,7 @@ mod tests {
         let config = test_config(tmp.path());
         ingest_email(
             &config,
+            &test_locks(),
             "alice@test.com",
             plain_text_eml(),
             sentinel_ip(),
@@ -2078,6 +2172,7 @@ mod tests {
 
         ingest_email(
             &config,
+            &test_locks(),
             "alice@test.com",
             plain_text_eml(),
             sentinel_ip(),
@@ -2086,6 +2181,7 @@ mod tests {
         .unwrap();
         ingest_email(
             &config,
+            &test_locks(),
             "alice@test.com",
             plain_text_eml(),
             sentinel_ip(),

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -12,24 +12,42 @@ pub fn run(cmd: MailboxCommand, config: Config) -> Result<(), Box<dyn std::error
     }
 }
 
-fn validate_mailbox_name(name: &str) -> Result<(), Box<dyn std::error::Error>> {
+/// Canonical mailbox-name validator. Rejects anything that would be
+/// unsafe as a file-system path component *or* as the local-part of the
+/// resulting email address (`<name>@<domain>`).
+///
+/// A valid mailbox name is non-empty, matches `[a-z0-9._-]+` (case-folded —
+/// no uppercase), and contains no leading/trailing `.` or consecutive `..`.
+/// This is stricter than RFC 5322 allows but matches what modern MTAs
+/// actually accept without quoting, which is what we care about in
+/// practice.
+///
+/// Used both by the CLI path (`aimx mailbox create`) and by the UDS
+/// handler (`MAILBOX-CREATE`/`MAILBOX-DELETE`). Keeping a single source of
+/// truth prevents drift between the two.
+pub(crate) fn validate_mailbox_name(name: &str) -> Result<(), String> {
     if name.is_empty() {
         return Err("Mailbox name cannot be empty".into());
     }
     if name.contains("..") {
         return Err("Mailbox name cannot contain '..'".into());
     }
-    if name.contains('/') || name.contains('\\') {
-        return Err("Mailbox name cannot contain path separators".into());
+    if name.starts_with('.') || name.ends_with('.') {
+        return Err("Mailbox name cannot start or end with '.'".into());
     }
-    if name.contains('\0') {
-        return Err("Mailbox name cannot contain null bytes".into());
+    for c in name.chars() {
+        let ok = c.is_ascii_lowercase() || c.is_ascii_digit() || c == '.' || c == '_' || c == '-';
+        if !ok {
+            return Err(format!(
+                "Mailbox name contains invalid character {c:?}; allowed: [a-z0-9._-]"
+            ));
+        }
     }
     Ok(())
 }
 
 pub fn create_mailbox(config: &Config, name: &str) -> Result<(), Box<dyn std::error::Error>> {
-    validate_mailbox_name(name)?;
+    validate_mailbox_name(name).map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
 
     if config.mailboxes.contains_key(name) {
         return Err(format!("Mailbox '{name}' already exists").into());
@@ -259,13 +277,18 @@ fn delete(config: &Config, name: &str, yes: bool) -> Result<(), Box<dyn std::err
 /// and OpenRC for the *restart* verb beyond `serve::service`'s existing
 /// dispatch tables; keeping it inline keeps the hint readable without
 /// threading the full init-system check through more modules.
+///
+/// Every `InitSystem` variant is matched explicitly so adding a new one
+/// (e.g. `Runit`, `S6`) fails to compile until the new arm is supplied —
+/// no silent fall-through via `_`.
 pub(crate) fn restart_hint_command(init: &crate::serve::service::InitSystem) -> &'static str {
+    use crate::serve::service::InitSystem;
     match init {
-        crate::serve::service::InitSystem::OpenRC => "sudo rc-service aimx restart",
-        // Systemd and Unknown both land here — systemd is far more common,
-        // and on an unknown init the systemd wording is a better fallback
-        // than saying nothing (operator can translate once).
-        _ => "sudo systemctl restart aimx",
+        InitSystem::Systemd => "sudo systemctl restart aimx",
+        InitSystem::OpenRC => "sudo rc-service aimx restart",
+        // On an unknown init the systemd wording is a better fallback than
+        // saying nothing (systemd is far more common; operator can translate).
+        InitSystem::Unknown => "sudo systemctl restart aimx",
     }
 }
 
@@ -336,6 +359,38 @@ mod tests {
         let guard = ConfigDirOverride::set(tmp);
         config.save(&crate::config::config_path()).unwrap();
         guard
+    }
+
+    #[test]
+    fn validate_mailbox_name_rejects_whitespace_and_bad_chars() {
+        // S47-3: tighter validation closes a hole where names like
+        // "hello world" made it past the old validator and produced an
+        // invalid email address when interpolated into `<name>@<domain>`.
+        assert!(validate_mailbox_name("hello world").is_err());
+        assert!(validate_mailbox_name("a b").is_err());
+        assert!(validate_mailbox_name("\ttab").is_err());
+        assert!(validate_mailbox_name("..foo").is_err());
+        assert!(validate_mailbox_name("").is_err());
+        assert!(validate_mailbox_name(".leading").is_err());
+        assert!(validate_mailbox_name("trailing.").is_err());
+        assert!(validate_mailbox_name("foo/bar").is_err());
+        assert!(validate_mailbox_name("foo\\bar").is_err());
+        assert!(validate_mailbox_name("foo\0bar").is_err());
+        // Uppercase rejected — the class is case-folded.
+        assert!(validate_mailbox_name("Alice").is_err());
+        // RFC-5322 would allow `+` in the local part (Gmail plus-addressing
+        // etc.) but we keep the class tight to prevent surprises further
+        // downstream.
+        assert!(validate_mailbox_name("alice+bob").is_err());
+    }
+
+    #[test]
+    fn validate_mailbox_name_accepts_safe_names() {
+        assert!(validate_mailbox_name("good-mailbox.1").is_ok());
+        assert!(validate_mailbox_name("catchall").is_ok());
+        assert!(validate_mailbox_name("alice").is_ok());
+        assert!(validate_mailbox_name("a").is_ok());
+        assert!(validate_mailbox_name("a.b_c-1").is_ok());
     }
 
     #[test]
@@ -542,7 +597,12 @@ mod tests {
 
         let result = create_mailbox(&config, "foo/bar");
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("path separator"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("invalid character")
+        );
     }
 
     #[test]
@@ -553,7 +613,12 @@ mod tests {
 
         let result = create_mailbox(&config, "foo\\bar");
         assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("path separator"));
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("invalid character")
+        );
     }
 
     // ----- S44-4 restart hint ------------------------------------------
@@ -601,6 +666,28 @@ mod tests {
             restart_hint_command(&crate::serve::service::InitSystem::Unknown),
             "sudo systemctl restart aimx"
         );
+    }
+
+    #[test]
+    fn restart_hint_command_is_exhaustive_over_init_system() {
+        // The `match` inside `restart_hint_command` is exhaustive: every
+        // `InitSystem` variant has an explicit arm (no `_` fall-through). This
+        // test destructures every current variant so adding a new variant
+        // without touching this function would fail the exhaustive pattern
+        // check below at compile time. If you're here because this stopped
+        // compiling, you probably just added a new `InitSystem` variant — add
+        // its arm to `restart_hint_command` (and extend the assertions below).
+        use crate::serve::service::InitSystem;
+        let all = [InitSystem::Systemd, InitSystem::OpenRC, InitSystem::Unknown];
+        for variant in &all {
+            // Force an explicit destructure — the `_` catch-all is forbidden.
+            let expected: &'static str = match variant {
+                InitSystem::Systemd => "sudo systemctl restart aimx",
+                InitSystem::OpenRC => "sudo rc-service aimx restart",
+                InitSystem::Unknown => "sudo systemctl restart aimx",
+            };
+            assert_eq!(restart_hint_command(variant), expected, "{variant:?}");
+        }
     }
 
     #[test]

--- a/src/mailbox_handler.rs
+++ b/src/mailbox_handler.rs
@@ -24,17 +24,17 @@
 //!    first and the rename failed, we would be handing inbound mail a
 //!    routing table that doesn't match disk.
 //!
-//! Locking: a per-mailbox `RwLock<()>` (acquired via `StateContext`) is
-//! taken for the duration of the write so a MARK-* request on the same
-//! mailbox can't see the file system half-created / half-deleted. In
-//! addition, a **process-wide** [`CONFIG_WRITE_LOCK`] serializes the
-//! `load → modify → write → store` critical section across *all* mailbox
-//! names — without it, two concurrent `MAILBOX-CREATE alice` +
-//! `MAILBOX-CREATE bob` requests hold disjoint per-mailbox locks and can
-//! interleave their loads + writes, clobbering one stanza on disk and in
-//! memory. The global mutex closes that lost-update race while still
-//! letting MARK-* and inbound ingest (which don't touch `config.toml`)
-//! proceed independently.
+//! Locking: acquired in the order the
+//! [`crate::mailbox_locks`] module documents. The **outer** per-mailbox
+//! `tokio::sync::Mutex<()>` (shared with inbound ingest and MARK-* as of
+//! Sprint 47) is taken for the duration of the write so no other writer
+//! on the same mailbox can see the file system half-created /
+//! half-deleted. The **inner** process-wide [`CONFIG_WRITE_LOCK`]
+//! serializes the `load → modify → write → store` critical section
+//! across *all* mailbox names — without it, two concurrent
+//! `MAILBOX-CREATE alice` + `MAILBOX-CREATE bob` requests hold disjoint
+//! per-mailbox locks and can interleave their loads + writes, clobbering
+//! one stanza on disk and in memory. Always outer → inner.
 
 use std::io::Write;
 use std::path::{Path, PathBuf};
@@ -83,7 +83,7 @@ pub async fn handle_mailbox_crud(
     mb_ctx: &MailboxContext,
     req: &MailboxCrudRequest,
 ) -> AckResponse {
-    if let Err(e) = validate_mailbox_name(&req.name) {
+    if let Err(e) = crate::mailbox::validate_mailbox_name(&req.name) {
         return AckResponse::Err {
             code: ErrCode::Validation,
             reason: e,
@@ -91,7 +91,7 @@ pub async fn handle_mailbox_crud(
     }
 
     let lock = state_ctx.lock_for(&req.name);
-    let _guard = lock.write().await;
+    let _guard = lock.lock().await;
 
     // Serialize the load → modify → write → store critical section across
     // *all* mailbox names. The per-mailbox lock above keeps MARK-* on the
@@ -107,25 +107,6 @@ pub async fn handle_mailbox_crud(
     } else {
         handle_delete(state_ctx, mb_ctx, &req.name)
     }
-}
-
-/// Name-validation mirror of `mailbox::validate_mailbox_name`. Duplicated
-/// here (rather than re-exported) so the daemon-side enforcement is
-/// local — a caller can't silently skip it by calling into the handler.
-fn validate_mailbox_name(name: &str) -> Result<(), String> {
-    if name.is_empty() {
-        return Err("Mailbox name cannot be empty".into());
-    }
-    if name.contains("..") {
-        return Err("Mailbox name cannot contain '..'".into());
-    }
-    if name.contains('/') || name.contains('\\') {
-        return Err("Mailbox name cannot contain path separators".into());
-    }
-    if name.contains('\0') {
-        return Err("Mailbox name cannot contain null bytes".into());
-    }
-    Ok(())
 }
 
 fn handle_create(state_ctx: &StateContext, mb_ctx: &MailboxContext, name: &str) -> AckResponse {
@@ -257,6 +238,17 @@ fn count_files_if_exists(dir: &Path) -> usize {
 /// filesystem targets, so readers see either the old snapshot or the new
 /// one — never a truncated file. On failure the temp file is cleaned up
 /// best-effort so subsequent retries don't trip over stale state.
+///
+/// **Unknown-key / comment behaviour (v1):** this function re-serializes
+/// the `Config` struct through `toml::to_string_pretty`, which means any
+/// TOML fields the operator added that are **not** modeled in the `Config`
+/// struct are dropped on rewrite, and any human-authored comments are
+/// erased. This is symmetric with the pre-existing `Config::save` path
+/// and matches the v1 assumption that `config.toml` is machine-authored
+/// (the only supported edits are through `aimx setup` / `aimx mailbox
+/// create|delete`). Adopting a preserving editor (e.g. `toml_edit`) is
+/// tracked for v2; see the test `unknown_stanza_is_dropped_on_rewrite`
+/// below for the contract check.
 pub(crate) fn write_config_atomic(path: &Path, config: &Config) -> std::io::Result<()> {
     let serialized = toml::to_string_pretty(config)
         .map_err(|e| std::io::Error::other(format!("toml serialize: {e}")))?;
@@ -510,15 +502,27 @@ mod tests {
 
     #[tokio::test]
     async fn create_failure_at_disk_write_leaves_handle_and_disk_unchanged() {
+        // S47-3: this test used to force failure by pointing config_path
+        // at a non-existent parent directory — which tripped
+        // `File::create` before the temp write even started, so the
+        // rename-rollback branch was never exercised. The rewritten form
+        // below makes the temp write succeed (parent is writable) and the
+        // subsequent `rename(2)` fail because the target path is a
+        // **non-empty directory**. `rename("foo.tmp", "config.toml/")`
+        // with a non-empty directory as the target returns `EISDIR` /
+        // `ENOTEMPTY` on Linux + macOS, which is what the real failure
+        // mode looks like in production (e.g. a filesystem error mid-rename).
         let tmp = TempDir::new().unwrap();
         let (state_ctx, mb_ctx) = contexts(&tmp);
 
-        // Substitute a read-only config.toml path by replacing the parent
-        // directory with a non-writable one. We simulate atomic-rename
-        // failure by pointing `config_path` at a location whose parent
-        // doesn't exist — `File::create` will fail.
-        let bad_path = tmp.path().join("nonexistent").join("config.toml");
-        let bad_ctx = MailboxContext::new(bad_path.clone(), mb_ctx.config_handle.clone());
+        // `config.toml` as a non-empty *directory* — the temp write to
+        // `.config.toml.tmp.<pid>` succeeds, then rename-over fails.
+        let dir_path = tmp.path().join("configdir").join("config.toml");
+        std::fs::create_dir_all(&dir_path).unwrap();
+        // Put a file inside so the directory is non-empty (rename semantics
+        // over an empty directory differ on some kernels).
+        std::fs::write(dir_path.join("blocker"), "x").unwrap();
+        let bad_ctx = MailboxContext::new(dir_path.clone(), mb_ctx.config_handle.clone());
 
         let req = MailboxCrudRequest {
             name: "alice".into(),
@@ -535,6 +539,56 @@ mod tests {
         // half a mailbox behind.
         assert!(!tmp.path().join("inbox").join("alice").exists());
         assert!(!tmp.path().join("sent").join("alice").exists());
+
+        // No `.config.toml.tmp.<pid>` was left behind — the rollback path
+        // cleans up the temp file after a rename failure.
+        let parent = dir_path.parent().unwrap();
+        let strays: Vec<_> = std::fs::read_dir(parent)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .map(|e| e.file_name().to_string_lossy().to_string())
+            .filter(|n| n.contains(".tmp."))
+            .collect();
+        assert!(
+            strays.is_empty(),
+            "no stray temp file should remain after rename failure: {strays:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_stanza_is_dropped_on_rewrite() {
+        // S47-3: this pins the **documented** v1 behaviour of
+        // `write_config_atomic`. The rewrite goes through
+        // `toml::to_string_pretty(&Config)`, so any stanza the operator
+        // added that isn't modeled in `Config` is not preserved. If this
+        // test starts failing because the behaviour changed (e.g. we
+        // adopted `toml_edit`), update the doc comment on
+        // `write_config_atomic` and flip this assertion accordingly.
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+
+        let base = base_config(tmp.path());
+        let serialized = toml::to_string_pretty(&base).unwrap();
+        let with_unknown = format!(
+            "# operator-added comment\n\
+             {serialized}\n\
+             [experimental.extra]\n\
+             opaque_value = 42\n"
+        );
+        std::fs::write(&path, with_unknown).unwrap();
+
+        // Rewrite through the canonical path.
+        write_config_atomic(&path, &base).unwrap();
+
+        let after = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            !after.contains("operator-added comment"),
+            "v1 documented behaviour: rewrite erases human comments. Got: {after:?}"
+        );
+        assert!(
+            !after.contains("experimental"),
+            "v1 documented behaviour: rewrite drops unknown stanzas. Got: {after:?}"
+        );
     }
 
     #[tokio::test]

--- a/src/mailbox_locks.rs
+++ b/src/mailbox_locks.rs
@@ -1,0 +1,131 @@
+//! Per-mailbox write lock map shared by every path that mutates a
+//! mailbox's on-disk tree.
+//!
+//! # Why a shared lock
+//!
+//! Sprint 36 gave the inbound ingest path a process-wide
+//! `std::sync::Mutex<()>` (`INGEST_WRITE_LOCK`) to serialize filename
+//! allocation + bundle-directory writes. Sprint 45 added MARK-READ /
+//! MARK-UNREAD with its own per-mailbox `tokio::sync::RwLock` map in
+//! [`crate::state_handler`]. Both paths do "read → modify → write" on
+//! files under the same mailbox tree — but they never acquired the *same*
+//! lock, because the writers targeted disjoint files (ingest creates a
+//! fresh `YYYY-MM-DD-HHMMSS-<slug>.md`; MARK rewrites an existing stem).
+//!
+//! That invariant was defensible but fragile: any future verb that
+//! re-opens an existing `.md` on the ingest side, or that creates files
+//! on the MARK side, would quietly lose correctness. Sprint 47
+//! (S47-4) unifies both writers under a single per-mailbox lock so the
+//! safety argument no longer depends on file-path disjointness.
+//!
+//! # Lock hierarchy
+//!
+//! Always acquire in this order; never the reverse:
+//!
+//! 1. **Outer** — per-mailbox [`tokio::sync::Mutex<()>`] from this map.
+//!    Held for the full read-modify-write critical section on any file
+//!    in `<data_dir>/inbox/<mailbox>/` or `<data_dir>/sent/<mailbox>/`.
+//! 2. **Inner** — process-wide `CONFIG_WRITE_LOCK`
+//!    (`std::sync::Mutex<()>` in [`crate::mailbox_handler`]). Held only
+//!    for the `load → modify → write → store` sequence on
+//!    `config.toml`. `MAILBOX-CREATE` / `MAILBOX-DELETE` acquire the
+//!    outer lock first, then the inner one, so a concurrent MARK on the
+//!    same mailbox can never observe a half-written config while it
+//!    holds the outer lock.
+//!
+//! The outer → inner order is the only safe one: the config write is
+//! short and bounded, so holding it while a longer ingest critical
+//! section waits on the per-mailbox lock would be a straight-up
+//! priority-inversion. Inverting would deadlock: two concurrent
+//! `MAILBOX-CREATE` on different names both take the config lock, then
+//! race for their per-mailbox locks.
+//!
+//! # Contention notes
+//!
+//! The map-level `std::sync::Mutex` around the hashmap is held only for
+//! the brief insert-if-absent step; the per-mailbox Mutex is what
+//! callers actually wait on. Hot paths (ingest under heavy inbound
+//! load) take one map-level lock cycle plus one per-mailbox lock per
+//! message — cheap in practice.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use tokio::sync::Mutex as AsyncMutex;
+
+/// Shared per-mailbox lock map. Every writer — inbound ingest, MARK-*,
+/// MAILBOX-* — acquires its mailbox's lock before touching files under
+/// that mailbox's tree.
+pub struct MailboxLocks {
+    // `std::sync::Mutex` around the map itself because the insert-if-
+    // absent step is synchronous and uncontended. The per-mailbox
+    // `AsyncMutex` is what callers actually hold across `.await` points.
+    locks: Mutex<HashMap<String, Arc<AsyncMutex<()>>>>,
+}
+
+impl MailboxLocks {
+    pub fn new() -> Self {
+        Self {
+            locks: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Return (lazy-inserting if needed) the per-mailbox lock handle.
+    /// The caller decides whether to `.lock().await` (async contexts)
+    /// or `.blocking_lock()` (sync contexts like blocking `ingest_email`
+    /// under `spawn_blocking`).
+    pub fn lock_for(&self, mailbox: &str) -> Arc<AsyncMutex<()>> {
+        let mut map = self
+            .locks
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        map.entry(mailbox.to_string())
+            .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+            .clone()
+    }
+}
+
+impl Default for MailboxLocks {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn lock_for_same_mailbox_returns_same_mutex() {
+        let locks = MailboxLocks::new();
+        let a = locks.lock_for("alice");
+        let b = locks.lock_for("alice");
+        // Same underlying Arc => same semaphore => `Arc::ptr_eq`.
+        assert!(Arc::ptr_eq(&a, &b));
+    }
+
+    #[test]
+    fn lock_for_different_mailboxes_returns_distinct_mutex() {
+        let locks = MailboxLocks::new();
+        let a = locks.lock_for("alice");
+        let b = locks.lock_for("bob");
+        assert!(!Arc::ptr_eq(&a, &b));
+    }
+
+    #[tokio::test]
+    async fn async_lock_serializes_two_holders() {
+        let locks = Arc::new(MailboxLocks::new());
+        let l1 = locks.lock_for("alice");
+        let g1 = l1.lock().await;
+
+        // Second waiter times out fast when the first holder is still up.
+        let l2 = locks.lock_for("alice");
+        let res = tokio::time::timeout(std::time::Duration::from_millis(50), l2.lock()).await;
+        assert!(res.is_err(), "second lock must block while first is held");
+
+        drop(g1);
+        // Now acquirable.
+        let _g2 = tokio::time::timeout(std::time::Duration::from_millis(100), l2.lock())
+            .await
+            .expect("second lock must acquire once first is dropped");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod frontmatter;
 mod ingest;
 mod mailbox;
 mod mailbox_handler;
+mod mailbox_locks;
 mod mcp;
 mod mx;
 mod platform;

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -31,6 +31,47 @@ impl DkimTxtResolver for HickoryDkimResolver {
         &self,
         fqdn: &str,
     ) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
+        // S47-1: `block_in_place` + `Handle::current().block_on(...)` only
+        // works from a multi-threaded tokio runtime. `aimx serve` always
+        // uses the multi-thread flavour via `tokio::runtime::Runtime::new()`,
+        // but a future caller that switches to the current-thread flavour
+        // would hit a runtime panic on the first DKIM TXT lookup. Debug-
+        // assert the flavour at entry so the coupling is documented and
+        // caught in test builds rather than at startup in production.
+        use tokio::runtime::RuntimeFlavor;
+        debug_assert!(
+            matches!(
+                tokio::runtime::Handle::current().runtime_flavor(),
+                RuntimeFlavor::MultiThread
+            ),
+            "HickoryDkimResolver::resolve_dkim_txt requires a multi-thread tokio runtime \
+             because it uses `block_in_place` + `Handle::block_on`. `aimx serve` meets this \
+             contract; if you're calling it from a current-thread runtime, async-ify the \
+             trait instead."
+        );
+
+        // S47-1 (test-only): `AIMX_TEST_DKIM_RESOLVER_OVERRIDE` lets the
+        // integration test spin a real `aimx serve` against a canned
+        // resolver result without touching DNS. Format:
+        //   `"ok:<txt1>||<txt2>"`  — resolver returns Ok(vec![...])
+        //   `"err:<message>"`       — resolver returns Err
+        //   `"no-record"`           — resolver returns Ok(vec![]) (empty)
+        // Gated by the env var so production binaries never short-circuit.
+        if let Some(override_val) = std::env::var_os("AIMX_TEST_DKIM_RESOLVER_OVERRIDE") {
+            let s = override_val.to_string_lossy().into_owned();
+            if let Some(err_msg) = s.strip_prefix("err:") {
+                return Err(err_msg.to_string().into());
+            }
+            if s == "no-record" {
+                return Ok(Vec::new());
+            }
+            if let Some(rest) = s.strip_prefix("ok:") {
+                let records: Vec<String> = rest.split("||").map(|s| s.to_string()).collect();
+                return Ok(records);
+            }
+            // Unrecognized format — let the real resolver run.
+        }
+
         // Synchronous helper: the startup check runs inside the tokio
         // runtime but treats the DNS lookup as a one-shot with a short
         // deadline. Build an inline resolver rather than reusing the mx
@@ -341,10 +382,20 @@ async fn run_serve(
         data_dir: data_dir.clone(),
     });
 
+    // Sprint 47: a single `MailboxLocks` map is shared across every
+    // writer (inbound ingest, MARK-*, MAILBOX-*) so they all serialize
+    // on the same per-mailbox `tokio::sync::Mutex<()>`. See
+    // `crate::mailbox_locks` for the lock hierarchy.
+    let mailbox_locks = Arc::new(crate::mailbox_locks::MailboxLocks::new());
+
     // Shared state context for MARK-READ / MARK-UNREAD verbs (Sprint 45)
     // and the per-mailbox write lock used by MAILBOX-CREATE / MAILBOX-DELETE
-    // (Sprint 46).
-    let state_ctx = Arc::new(StateContext::new(data_dir.clone(), config_handle.clone()));
+    // (Sprint 46), plus inbound ingest (Sprint 47).
+    let state_ctx = Arc::new(StateContext::with_locks(
+        data_dir.clone(),
+        config_handle.clone(),
+        Arc::clone(&mailbox_locks),
+    ));
 
     // Sprint 46: MailboxContext owns the on-disk config.toml path + the
     // handle it writes through.
@@ -353,7 +404,8 @@ async fn run_serve(
         config_handle.clone(),
     ));
 
-    let server = SmtpServer::with_handle(config_handle.clone());
+    let server = SmtpServer::with_handle(config_handle.clone())
+        .with_mailbox_locks(Arc::clone(&mailbox_locks));
     let server = if tls_available {
         server.with_tls(cert, key)?
     } else {

--- a/src/smtp/mod.rs
+++ b/src/smtp/mod.rs
@@ -12,6 +12,7 @@ use tokio::sync::Semaphore;
 #[cfg(test)]
 use crate::config::Config;
 use crate::config::ConfigHandle;
+use crate::mailbox_locks::MailboxLocks;
 
 pub const DEFAULT_MAX_MESSAGE_SIZE: usize = 25 * 1024 * 1024; // 25 MB
 pub const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(300); // 5 min
@@ -31,6 +32,13 @@ pub struct SmtpServer {
     total_timeout: Duration,
     max_connections: usize,
     max_commands_before_data: usize,
+    /// Sprint 47 (S47-4): shared with `StateContext` and `MailboxContext`
+    /// so inbound ingest, MARK-*, and MAILBOX-* all serialize on the
+    /// same per-mailbox `tokio::sync::Mutex<()>`. Defaults to a
+    /// freshly-constructed map for tests that only exercise the SMTP
+    /// path; `aimx serve` calls `with_mailbox_locks` to inject the
+    /// daemon-wide map.
+    mailbox_locks: Arc<MailboxLocks>,
 }
 
 impl SmtpServer {
@@ -53,7 +61,16 @@ impl SmtpServer {
             total_timeout: DEFAULT_TOTAL_TIMEOUT,
             max_connections: DEFAULT_MAX_CONNECTIONS,
             max_commands_before_data: DEFAULT_MAX_COMMANDS_BEFORE_DATA,
+            mailbox_locks: Arc::new(MailboxLocks::new()),
         }
+    }
+
+    /// Share an existing `MailboxLocks` map with this SMTP server.
+    /// `aimx serve` calls this so inbound ingest, MARK-*, and MAILBOX-*
+    /// all take the same per-mailbox lock.
+    pub fn with_mailbox_locks(mut self, locks: Arc<MailboxLocks>) -> Self {
+        self.mailbox_locks = locks;
+        self
     }
 
     pub fn with_tls(
@@ -131,6 +148,7 @@ impl SmtpServer {
                     let total_timeout = self.total_timeout;
                     let max_commands = self.max_commands_before_data;
 
+                    let mailbox_locks = Arc::clone(&self.mailbox_locks);
                     tokio::spawn(async move {
                         let _permit = permit;
                         let params = session::SessionParams {
@@ -142,6 +160,7 @@ impl SmtpServer {
                             idle_timeout,
                             total_timeout,
                             max_commands_before_data: max_commands,
+                            mailbox_locks,
                         };
                         let session = session::SmtpSession::new(params);
                         if let Err(e) = session.handle(stream).await {

--- a/src/smtp/session.rs
+++ b/src/smtp/session.rs
@@ -6,6 +6,7 @@ use tokio::io::{AsyncBufReadExt, AsyncRead, AsyncWrite, AsyncWriteExt, BufReader
 use tokio_rustls::TlsAcceptor;
 
 use crate::config::ConfigHandle;
+use crate::mailbox_locks::MailboxLocks;
 
 const MAX_COMMAND_LINE_LENGTH: usize = 1024;
 
@@ -36,6 +37,10 @@ pub struct SessionParams {
     pub idle_timeout: Duration,
     pub total_timeout: Duration,
     pub max_commands_before_data: usize,
+    /// Sprint 47 (S47-4): shared per-mailbox write-lock map. The SMTP
+    /// session passes it into `ingest_email` so inbound writes serialize
+    /// against the MARK-* and MAILBOX-* paths that hold the same lock.
+    pub mailbox_locks: Arc<MailboxLocks>,
 }
 
 pub struct SmtpSession {
@@ -503,6 +508,7 @@ impl SmtpSession {
             let rcpt_owned = rcpt.clone();
             let peer = self.params.peer_addr;
             let reverse_path = session_state.reverse_path.clone();
+            let locks = Arc::clone(&self.params.mailbox_locks);
 
             let result = tokio::task::spawn_blocking(move || {
                 let envelope = if reverse_path.is_empty() {
@@ -510,8 +516,15 @@ impl SmtpSession {
                 } else {
                     Some(reverse_path.as_str())
                 };
-                crate::ingest::ingest_email(&config, &rcpt_owned, &data, peer.ip(), envelope)
-                    .map_err(|e| e.to_string())
+                crate::ingest::ingest_email(
+                    &config,
+                    &locks,
+                    &rcpt_owned,
+                    &data,
+                    peer.ip(),
+                    envelope,
+                )
+                .map_err(|e| e.to_string())
             })
             .await;
 

--- a/src/state_handler.rs
+++ b/src/state_handler.rs
@@ -7,27 +7,32 @@
 //! the invoking non-root user) routes through these verbs instead of
 //! touching the files directly.
 //!
-//! Concurrency model: a per-mailbox `RwLock<()>` guards the "read →
-//! rewrite" critical section against other MARK calls on the same
-//! mailbox. The map is lazily populated so tests that never touch a
-//! mailbox never allocate a lock for it.
+//! # Concurrency model (unified in Sprint 47 / S47-4)
 //!
-//! Note: this lock is **independent** of the process-wide
-//! `ingest::INGEST_WRITE_LOCK` (a blocking `std::sync::Mutex`). MARK and
-//! inbound ingest do not serialize against each other — safety relies on
-//! the fact that ingest allocates a fresh filename (timestamp + slug)
-//! while MARK rewrites an existing file, so the two paths write to
-//! disjoint paths in practice. Unifying both writers under a single
-//! per-mailbox lock is tracked in the Non-blocking Review Backlog for a
-//! future sprint.
+//! MARK-*, inbound ingest, and MAILBOX-* all acquire the **same**
+//! per-mailbox `tokio::sync::Mutex<()>` from the shared
+//! [`crate::mailbox_locks::MailboxLocks`] map before touching any file
+//! under that mailbox's tree. The shared lock replaces the pre-Sprint-47
+//! split regime (ingest's process-wide `std::sync::Mutex` +
+//! state_handler's own per-mailbox `tokio::sync::RwLock` map) whose
+//! safety relied on the two paths writing disjoint filenames.
+//!
+//! Lock hierarchy (see [`crate::mailbox_locks`] for the full rationale):
+//!
+//! ```text
+//!   outer: per-mailbox mailbox_locks::MailboxLocks  (tokio::sync::Mutex)
+//!   inner: process-wide mailbox_handler::CONFIG_WRITE_LOCK (std::sync::Mutex)
+//! ```
+//!
+//! Always acquire outer → inner, never the reverse.
 
-use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::sync::{Arc, Mutex};
-use tokio::sync::RwLock;
+use std::sync::Arc;
+use tokio::sync::Mutex as AsyncMutex;
 
 use crate::config::ConfigHandle;
 use crate::frontmatter::InboundFrontmatter;
+use crate::mailbox_locks::MailboxLocks;
 use crate::mcp::resolve_email_path;
 use crate::send_protocol::{AckResponse, ErrCode, MarkFolder, MarkRequest};
 
@@ -49,31 +54,41 @@ pub struct StateContext {
     /// than at startup); MAILBOX-* uses it to append / remove stanzas and
     /// hot-swap the in-memory snapshot.
     pub config_handle: ConfigHandle,
-    /// Per-mailbox lock map. `Mutex` because the map-level mutation
-    /// (lazy insert) is short; the per-mailbox `RwLock` handles the
-    /// actual file write ordering.
-    locks: Mutex<HashMap<String, Arc<RwLock<()>>>>,
+    /// Shared per-mailbox write-lock map. Inbound ingest, MARK-*, and
+    /// MAILBOX-* all serialize through these locks (see
+    /// [`crate::mailbox_locks`]).
+    pub locks: Arc<MailboxLocks>,
 }
 
 impl StateContext {
+    /// Fresh lock map — convenient for tests. Production callers share
+    /// the daemon-wide map via [`StateContext::with_locks`].
+    #[cfg(test)]
     pub fn new(data_dir: PathBuf, config_handle: ConfigHandle) -> Self {
+        Self::with_locks(data_dir, config_handle, Arc::new(MailboxLocks::new()))
+    }
+
+    /// Construct a `StateContext` that shares an existing
+    /// [`MailboxLocks`] map with other daemon-side contexts. Used by
+    /// `run_serve` so the SMTP session (inbound ingest) and the UDS
+    /// handlers all take the same lock per mailbox.
+    pub fn with_locks(
+        data_dir: PathBuf,
+        config_handle: ConfigHandle,
+        locks: Arc<MailboxLocks>,
+    ) -> Self {
         Self {
             data_dir,
             config_handle,
-            locks: Mutex::new(HashMap::new()),
+            locks,
         }
     }
 
     /// Acquire (lazy-inserting if needed) the per-mailbox write lock.
-    /// Returned guard is released when dropped.
-    pub(crate) fn lock_for(&self, mailbox: &str) -> Arc<RwLock<()>> {
-        let mut map = self
-            .locks
-            .lock()
-            .unwrap_or_else(|poisoned| poisoned.into_inner());
-        map.entry(mailbox.to_string())
-            .or_insert_with(|| Arc::new(RwLock::new(())))
-            .clone()
+    /// Returned `Arc` owns the lock; callers `.lock().await` (async) or
+    /// `.blocking_lock()` (inside `spawn_blocking`) it.
+    pub(crate) fn lock_for(&self, mailbox: &str) -> Arc<AsyncMutex<()>> {
+        self.locks.lock_for(mailbox)
     }
 }
 
@@ -103,15 +118,11 @@ fn folder_dir(data_dir: &Path, mailbox: &str, folder: MarkFolder) -> PathBuf {
     data_dir.join(sub).join(mailbox)
 }
 
-/// Handle a `MARK-READ` / `MARK-UNREAD` request. Takes the per-mailbox
-/// write lock so concurrent MARK calls on the same mailbox serialize
-/// around the read → rewrite critical section. Does **not** serialize
-/// against inbound ingest (which uses a separate process-wide
-/// `INGEST_WRITE_LOCK`); the two writers are safe today only because
-/// they target disjoint paths — ingest writes freshly-allocated
-/// filenames while MARK rewrites existing files. Unifying both writers
-/// under a shared per-mailbox lock is in the Non-blocking Review
-/// Backlog for a future sprint.
+/// Handle a `MARK-READ` / `MARK-UNREAD` request. Takes the shared
+/// per-mailbox write lock (see [`crate::mailbox_locks`]) for the full
+/// read → rewrite critical section. Sprint 47 unified this lock with the
+/// inbound-ingest writer so MARK and ingest now serialize against each
+/// other — not just against other MARK calls.
 pub async fn handle_mark(ctx: &StateContext, req: &MarkRequest) -> AckResponse {
     if let Err(e) = validate_id(&req.id) {
         return e;
@@ -132,7 +143,7 @@ pub async fn handle_mark(ctx: &StateContext, req: &MarkRequest) -> AckResponse {
     }
 
     let lock = ctx.lock_for(&req.mailbox);
-    let _guard = lock.write().await;
+    let _guard = lock.lock().await;
 
     let mailbox_dir = folder_dir(&ctx.data_dir, &req.mailbox, req.folder);
     let filepath = match resolve_email_path(&mailbox_dir, &req.id) {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3301,17 +3301,35 @@ fn concurrent_mailbox_create_and_ingest_does_not_deadlock() {
 
     // Guard against deadlock: require both threads to finish within a
     // bounded wall-clock budget. We use a watchdog thread to panic if
-    // the sum exceeds 20s — tests normally complete in <1s.
-    let watchdog = std::thread::spawn(|| {
-        std::thread::sleep(std::time::Duration::from_secs(20));
-        // If this runs, the joins below are still pending → deadlock.
-        panic!("Sprint 47 deadlock watchdog fired: MAILBOX-CREATE + ingest did not converge");
-    });
+    // the sum exceeds 20s — tests normally complete in <1s. The flag
+    // lets us dismiss the watchdog promptly on success instead of
+    // leaving a detached thread sleeping for 20s then panicking in the
+    // background (see Sprint 47 review).
+    let watchdog_cancel = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let watchdog = {
+        let cancel = std::sync::Arc::clone(&watchdog_cancel);
+        std::thread::spawn(move || {
+            let deadline = std::time::Instant::now() + std::time::Duration::from_secs(20);
+            while std::time::Instant::now() < deadline {
+                if cancel.load(std::sync::atomic::Ordering::Acquire) {
+                    return;
+                }
+                std::thread::sleep(std::time::Duration::from_millis(100));
+            }
+            if cancel.load(std::sync::atomic::Ordering::Acquire) {
+                return;
+            }
+            // If this runs, the joins below are still pending → deadlock.
+            panic!("Sprint 47 deadlock watchdog fired: MAILBOX-CREATE + ingest did not converge");
+        })
+    };
 
     create_handle.join().unwrap();
     ingest_handle.join().unwrap();
-    // Successful joins reached here — dismiss the watchdog.
-    drop(watchdog);
+    // Successful joins reached here — dismiss the watchdog promptly so
+    // it exits rather than lingering in the background.
+    watchdog_cancel.store(true, std::sync::atomic::Ordering::Release);
+    watchdog.join().unwrap();
 
     // config.toml reflects the create.
     let config_text = std::fs::read_to_string(tmp.path().join("config.toml")).unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2929,3 +2929,449 @@ fn mailbox_delete_via_uds_refuses_nonempty_and_succeeds_after_cleanup() {
 
     stop_serve(daemon);
 }
+
+// ---------------------------------------------------------------------------
+// Sprint 47 (S47-1): DKIM startup check wired into `run_serve`. These tests
+// exercise the full daemon against a canned resolver override so the check
+// runs through the real code path (not just the evaluator unit tests) and
+// we can assert the startup log rendering and that the listeners still bind
+// after a non-`Match` outcome.
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+fn start_serve_with_env(tmp: &Path, port: u16, extra_env: &[(&str, &str)]) -> std::process::Child {
+    let runtime = tmp.join("run");
+    std::fs::create_dir_all(&runtime).ok();
+    let mut cmd = StdCommand::new(aimx_binary_path());
+    cmd.env("AIMX_CONFIG_DIR", tmp)
+        .env("AIMX_RUNTIME_DIR", &runtime);
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+    let mut child = cmd
+        .arg("--data-dir")
+        .arg(tmp)
+        .arg("serve")
+        .arg("--bind")
+        .arg(format!("127.0.0.1:{port}"))
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn aimx serve");
+
+    let started = std::time::Instant::now();
+    loop {
+        if started.elapsed() > std::time::Duration::from_secs(10) {
+            child.kill().unwrap();
+            panic!("aimx serve did not start within 10s");
+        }
+        if std::net::TcpStream::connect(format!("127.0.0.1:{port}")).is_ok() {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    child
+}
+
+/// Collect the stderr a spawned `aimx serve` has buffered so far. We send
+/// SIGTERM, wait for exit, then drain stderr — the startup-warning log
+/// lines are well before the shutdown banner, so they are always captured
+/// in full.
+#[cfg(unix)]
+fn stop_serve_capture_stderr(mut child: std::process::Child) -> String {
+    use std::io::Read as _;
+    unsafe {
+        libc::kill(child.id() as libc::pid_t, libc::SIGTERM);
+    }
+    let _ = child.wait_timeout(std::time::Duration::from_secs(10));
+    let mut buf = String::new();
+    if let Some(mut stderr) = child.stderr.take() {
+        let _ = stderr.read_to_string(&mut buf);
+    }
+    buf
+}
+
+/// Strip ANSI escape sequences so the substring assertions below don't
+/// break when `term::warn`/`term::error` decorate output for a TTY.
+fn strip_ansi(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    let mut chars = s.chars().peekable();
+    while let Some(c) = chars.next() {
+        if c == '\x1b' && chars.peek() == Some(&'[') {
+            chars.next();
+            while let Some(&nc) = chars.peek() {
+                chars.next();
+                if nc.is_ascii_alphabetic() {
+                    break;
+                }
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
+#[cfg(unix)]
+#[test]
+fn dkim_startup_check_mismatch_logs_warning_and_binds_listeners() {
+    // `AIMX_TEST_DKIM_RESOLVER_OVERRIDE=ok:...` short-circuits the real
+    // DNS lookup so the startup check sees a canned `p=` value that does
+    // not match the on-disk public key. The daemon must log a multi-line
+    // ERROR warning and still bind both the SMTP and UDS listeners.
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+
+    let port = find_free_port();
+    let child = start_serve_with_env(
+        tmp.path(),
+        port,
+        &[(
+            "AIMX_TEST_DKIM_RESOLVER_OVERRIDE",
+            "ok:v=DKIM1; k=rsa; p=COMPLETELY-DIFFERENT-KEY",
+        )],
+    );
+
+    // The TCP listener is already accepting connections (start_serve_with_env
+    // waits for that). Confirm the UDS listener bound too.
+    let sock = tmp.path().join("run").join("send.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS send socket never appeared despite DKIM mismatch (should be non-fatal)"
+    );
+
+    let stderr = strip_ansi(&stop_serve_capture_stderr(child));
+    assert!(
+        stderr.contains("ERROR:") && stderr.contains("DKIM key mismatch"),
+        "expected mismatch ERROR in stderr, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("aimx setup"),
+        "mismatch warning must tell operator how to fix: {stderr}"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn dkim_startup_check_resolve_error_logs_warning_and_binds_listeners() {
+    // `AIMX_TEST_DKIM_RESOLVER_OVERRIDE=err:...` forces the resolver to
+    // return an error, simulating NXDOMAIN / timeout / offline DNS. The
+    // daemon must log a `warn`-level message but never treat this as
+    // fatal — DNS may not have propagated yet after a fresh setup.
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+
+    let port = find_free_port();
+    let child = start_serve_with_env(
+        tmp.path(),
+        port,
+        &[("AIMX_TEST_DKIM_RESOLVER_OVERRIDE", "err:simulated NXDOMAIN")],
+    );
+
+    let sock = tmp.path().join("run").join("send.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS send socket never appeared after ResolveError (should be non-fatal)"
+    );
+
+    let stderr = strip_ansi(&stop_serve_capture_stderr(child));
+    assert!(
+        stderr.contains("Warning:") && stderr.contains("DKIM DNS sanity check skipped"),
+        "expected resolve-error warn in stderr, got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("simulated NXDOMAIN"),
+        "resolve error message must surface the underlying DNS error: {stderr}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Sprint 47 (S47-4): unified per-mailbox write lock covering inbound ingest,
+// MARK-*, and MAILBOX-*. These integration tests stress the lock boundary:
+//   1. Concurrent ingest bursts + MARK-READ on the same mailbox — no torn
+//      writes, every `.md` file has a clean `+++ ... +++` frontmatter and
+//      parses as TOML.
+//   2. Concurrent MAILBOX-CREATE + ingest addressed to the new mailbox —
+//      the two locks (outer per-mailbox, inner CONFIG_WRITE_LOCK) must not
+//      deadlock, the config write lands before the ingest routes, and the
+//      inbound message ends up in the new mailbox (or catchall, but never
+//      corrupt) with the daemon still healthy.
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+#[test]
+fn concurrent_ingest_burst_and_mark_same_mailbox_no_torn_writes() {
+    // Fire N inbound messages concurrently with M MARK-READ calls
+    // against the same mailbox. With the unified per-mailbox
+    // `tokio::sync::Mutex<()>` shared between ingest and the MARK
+    // handler, every `.md` file on disk must end with a clean
+    // frontmatter block. Pre-Sprint-47, ingest held a different lock
+    // (`INGEST_WRITE_LOCK`) than MARK-*'s per-mailbox RwLock, so a
+    // future writer that re-opened an existing file would race.
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+
+    let alice_dir = inbox(tmp.path(), "alice");
+    // Pre-seed two emails so MARK-READ has stable targets while new
+    // inbound ingests are landing in the same directory.
+    for id in ["2025-06-01-seed1", "2025-06-01-seed2"] {
+        create_email_file(&alice_dir, id, "sender@example.com", "Pre-seed", false);
+    }
+
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+
+    let runtime = tmp.path().join("run");
+    let sock = runtime.join("send.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS send socket never appeared"
+    );
+
+    // Fire 6 concurrent inbound SMTP transactions.
+    let mut smtp_handles = Vec::new();
+    for i in 0..6 {
+        smtp_handles.push(std::thread::spawn(move || {
+            let email = format!(
+                "From: other@example.com\r\n\
+                 To: alice@agent.example.com\r\n\
+                 Subject: Burst {i}\r\n\
+                 Date: Mon, 01 Jan 2024 00:00:00 +0000\r\n\
+                 Message-ID: <burst-{i}@example.com>\r\n\
+                 \r\n\
+                 burst body {i}\r\n",
+            );
+            smtp_send_email(
+                port,
+                "other@example.com",
+                &["alice@agent.example.com"],
+                &email,
+            );
+        }));
+    }
+
+    // Fire concurrent MARK-READ calls on the seeded files via MCP.
+    let mut mark_handles = Vec::new();
+    for id in ["2025-06-01-seed1", "2025-06-01-seed2"] {
+        let tmp_path = tmp.path().to_path_buf();
+        let runtime = runtime.clone();
+        let id = id.to_string();
+        mark_handles.push(std::thread::spawn(move || {
+            let mut child = StdCommand::new(aimx_binary_path())
+                .env("AIMX_CONFIG_DIR", &tmp_path)
+                .env("AIMX_RUNTIME_DIR", &runtime)
+                .arg("--data-dir")
+                .arg(&tmp_path)
+                .arg("mcp")
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped())
+                .spawn()
+                .expect("Failed to spawn aimx mcp");
+            let stdin = child.stdin.take().unwrap();
+            let stdout = child.stdout.take().unwrap();
+            let mut client = McpClient {
+                child,
+                stdin,
+                reader: BufReader::new(stdout),
+                id: 0,
+            };
+            client.initialize();
+            let resp = client.call_tool(
+                "email_mark_read",
+                serde_json::json!({"mailbox": "alice", "id": id}),
+            );
+            let text = get_tool_text(&resp);
+            assert!(text.contains("marked as read"), "{text}");
+            client.shutdown();
+        }));
+    }
+
+    for h in smtp_handles {
+        h.join().unwrap();
+    }
+    for h in mark_handles {
+        h.join().unwrap();
+    }
+
+    // All .md files in the mailbox must have intact frontmatter.
+    let mds = find_md_files(&alice_dir);
+    assert!(
+        mds.len() >= 8,
+        "expected >=8 .md files (2 seed + 6 burst); got {}",
+        mds.len()
+    );
+    for md in &mds {
+        let content = std::fs::read_to_string(md).unwrap();
+        assert!(
+            content.starts_with("+++"),
+            "torn write detected in {}: content did not start with '+++'",
+            md.display()
+        );
+        let parts: Vec<&str> = content.splitn(3, "+++").collect();
+        assert_eq!(
+            parts.len(),
+            3,
+            "torn write in {}: expected 3 +++ parts, got {}",
+            md.display(),
+            parts.len()
+        );
+        // Frontmatter must parse as TOML — a half-written file would
+        // almost certainly produce a parse error.
+        let _parsed: toml::Value = toml::from_str(parts[1].trim()).unwrap_or_else(|e| {
+            panic!(
+                "frontmatter in {} failed to parse as TOML: {e}\n{}",
+                md.display(),
+                parts[1]
+            )
+        });
+    }
+
+    // Both seeded files were successfully marked read — MARK-READ did
+    // not get corrupted by a racing ingest.
+    for id in ["2025-06-01-seed1", "2025-06-01-seed2"] {
+        let content = std::fs::read_to_string(alice_dir.join(format!("{id}.md"))).unwrap();
+        assert!(
+            content.contains("read = true"),
+            "MARK-READ did not persist for {id}: {content}"
+        );
+    }
+
+    stop_serve(daemon);
+}
+
+#[cfg(unix)]
+#[test]
+fn concurrent_mailbox_create_and_ingest_does_not_deadlock() {
+    // MAILBOX-CREATE takes the outer per-mailbox lock, then the inner
+    // process-wide CONFIG_WRITE_LOCK (see `crate::mailbox_locks`).
+    // Inbound ingest to the same mailbox takes only the outer lock.
+    // This test races the two to confirm (a) no deadlock occurs and
+    // (b) the daemon is still responsive afterwards — the message
+    // lands somewhere consistent (either the new mailbox if the
+    // create completed first, or catchall if ingest ran first).
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let runtime = tmp.path().join("run");
+    let sock = runtime.join("send.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS send socket never appeared"
+    );
+
+    // Kick off the two operations concurrently and cap the total wait
+    // — a deadlock would manifest as a join that never returns.
+    let create_handle = {
+        let tmp_path = tmp.path().to_path_buf();
+        let runtime = runtime.clone();
+        std::thread::spawn(move || {
+            let status = StdCommand::new(aimx_binary_path())
+                .env("AIMX_CONFIG_DIR", &tmp_path)
+                .env("AIMX_RUNTIME_DIR", &runtime)
+                .arg("--data-dir")
+                .arg(&tmp_path)
+                .arg("mailbox")
+                .arg("create")
+                .arg("newton")
+                .status()
+                .expect("mailbox create did not complete");
+            assert!(status.success(), "mailbox create failed: {status:?}");
+        })
+    };
+
+    let ingest_handle = std::thread::spawn(move || {
+        let email = concat!(
+            "From: sender@example.com\r\n",
+            "To: newton@agent.example.com\r\n",
+            "Subject: Newton race\r\n",
+            "Date: Mon, 01 Jan 2024 00:00:00 +0000\r\n",
+            "Message-ID: <newton-race@example.com>\r\n",
+            "\r\n",
+            "race body\r\n",
+        );
+        smtp_send_email(
+            port,
+            "sender@example.com",
+            &["newton@agent.example.com"],
+            email,
+        );
+    });
+
+    // Guard against deadlock: require both threads to finish within a
+    // bounded wall-clock budget. We use a watchdog thread to panic if
+    // the sum exceeds 20s — tests normally complete in <1s.
+    let watchdog = std::thread::spawn(|| {
+        std::thread::sleep(std::time::Duration::from_secs(20));
+        // If this runs, the joins below are still pending → deadlock.
+        panic!("Sprint 47 deadlock watchdog fired: MAILBOX-CREATE + ingest did not converge");
+    });
+
+    create_handle.join().unwrap();
+    ingest_handle.join().unwrap();
+    // Successful joins reached here — dismiss the watchdog.
+    drop(watchdog);
+
+    // config.toml reflects the create.
+    let config_text = std::fs::read_to_string(tmp.path().join("config.toml")).unwrap();
+    assert!(
+        config_text.contains("[mailboxes.newton]"),
+        "mailbox create must land on disk: {config_text}"
+    );
+
+    // The message went to either newton (if create won) or catchall
+    // (if ingest won) — but never disappeared and never produced a
+    // torn file.
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    let newton = find_md_files(&inbox(tmp.path(), "newton"));
+    let catchall = find_md_files(&inbox(tmp.path(), "catchall"));
+    assert!(
+        newton.len() + catchall.len() >= 1,
+        "ingest lost the message: newton={} catchall={}",
+        newton.len(),
+        catchall.len()
+    );
+    for md in newton.iter().chain(catchall.iter()) {
+        let content = std::fs::read_to_string(md).unwrap();
+        assert!(
+            content.starts_with("+++"),
+            "torn write in {}: does not start with '+++'",
+            md.display()
+        );
+        let parts: Vec<&str> = content.splitn(3, "+++").collect();
+        assert_eq!(parts.len(), 3, "{}", md.display());
+        let _: toml::Value = toml::from_str(parts[1].trim())
+            .unwrap_or_else(|e| panic!("{} failed to parse: {e}", md.display()));
+    }
+
+    // Daemon still responsive after the race — send a follow-up
+    // message and confirm it lands (the deadlock canary).
+    let followup = concat!(
+        "From: sender@example.com\r\n",
+        "To: alice@agent.example.com\r\n",
+        "Subject: Post-race\r\n",
+        "Date: Mon, 01 Jan 2024 00:00:00 +0000\r\n",
+        "Message-ID: <post-race@example.com>\r\n",
+        "\r\n",
+        "still alive\r\n",
+    );
+    smtp_send_email(
+        port,
+        "sender@example.com",
+        &["alice@agent.example.com"],
+        followup,
+    );
+    std::thread::sleep(std::time::Duration::from_millis(500));
+    let alice = find_md_files(&inbox(tmp.path(), "alice"));
+    assert!(
+        alice.iter().any(|p| {
+            std::fs::read_to_string(p)
+                .map(|c| c.contains("Post-race"))
+                .unwrap_or(false)
+        }),
+        "daemon unresponsive after the race — follow-up message never landed"
+    );
+
+    stop_serve(daemon);
+}


### PR DESCRIPTION
## Sprint Goal
Close the eight non-blocking improvements accumulated across Sprints 44-46 reviews — defense-in-depth, test-coverage, and architectural-cleanup work. No user-visible features; no PRD changes.

## Stories Implemented

### [S47-1] DKIM startup check — end-to-end integration test + runtime-flavor contract
- [x] `HickoryDkimResolver::resolve_dkim_txt` now `debug_assert!`s the tokio runtime flavor is `MultiThread` at entry (its `block_in_place` + `Handle::block_on` call graph requires it). Short doc comment explains the rationale.
- [x] New `AIMX_TEST_DKIM_RESOLVER_OVERRIDE` env var (test-only, never set in prod) short-circuits the real DNS lookup so integration tests can drive `run_serve` end-to-end against a canned resolver result (`ok:…`, `err:…`, or `no-record`).
- [x] Two integration tests spin `aimx serve` against the override:
  - `dkim_startup_check_mismatch_logs_warning_and_binds_listeners` — Mismatch emits the multi-line ERROR message and both listeners still bind.
  - `dkim_startup_check_resolve_error_logs_warning_and_binds_listeners` — ResolveError emits a Warning-level message and both listeners still bind.
- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` all clean.

### [S47-2] Exhaustiveness & defense-in-depth hardening
- [x] `restart_hint_command` replaces the `_` fallback with an explicit `InitSystem::{Systemd, OpenRC, Unknown}` match — adding a new variant now fails to compile until the arm is supplied.
- [x] New `restart_hint_command_is_exhaustive_over_init_system` test destructures every current variant, validating the exhaustive check at compile time.
- [x] `channel::execute_triggers` calls `.env_clear()` before selectively re-adding `PATH`, `HOME`, and the `AIMX_*` vars. Inline comment explains why.
- [x] New `execute_triggers_clears_parent_env` test sets a sentinel env var on the parent and asserts it does NOT appear in the trigger subshell (while `PATH` is preserved).
- [x] `cargo test`, `cargo clippy`, `cargo fmt -- --check` all clean.

### [S47-3] Validation tightening + TOML-rewrite preservation + stronger rename-failure test
- [x] `validate_mailbox_name` consolidated to a single canonical helper in `src/mailbox.rs`; the duplicate in `src/mailbox_handler.rs` now calls through. Tightened to `[a-z0-9._-]+` (case-folded, no whitespace, no leading/trailing `.`, no `..`). Closes the hole where `"hello world"` made it past validation and produced an invalid `<name>@<domain>` address.
- [x] New unit tests cover `"hello world"`, `"a b"`, `"..foo"`, `""`, `"Alice"`, `"alice+bob"`, `".leading"`, `"trailing."` (all rejected) and `"good-mailbox.1"`, `"catchall"`, `"alice"`, `"a.b_c-1"` (all accepted).
- [x] `write_config_atomic`: chose the document-current-behaviour path (lower-risk for v1). The doc comment now spells out that unknown TOML stanzas and comments are erased on rewrite; `unknown_stanza_is_dropped_on_rewrite` pins the behaviour. `toml_edit` adoption deferred to v2.
- [x] `create_failure_at_disk_write_leaves_handle_and_disk_unchanged` rewritten: the temp write now succeeds and the `rename(2)` fails because the target path is a non-empty directory (forces `EISDIR`/`ENOTEMPTY`). Previous form tripped `File::create` before the temp write started, so the rollback branch was never exercised.
- [x] `cargo test`, `cargo clippy`, `cargo fmt -- --check` all clean.

### [S47-4] Unify ingest + MARK writers under one per-mailbox lock
- [x] New `src/mailbox_locks.rs` owns `MailboxLocks` — a shared per-mailbox `Arc<tokio::sync::Mutex<()>>` map keyed by mailbox name, exposed via the `Arc<Mutex<HashMap<String, Arc<AsyncMutex<()>>>>>` accessor pattern.
- [x] `ingest_email` now takes `&MailboxLocks` and acquires the per-mailbox lock via `blocking_lock()` for its filename-allocation + bundle-write + `.md`-write critical section. Replaces the process-wide `INGEST_WRITE_LOCK`.
- [x] `StateContext` holds `Arc<MailboxLocks>` instead of its own `RwLock` map; `handle_mark` takes the same per-mailbox lock. `MailboxContext`'s handler already routed through `state_ctx.lock_for(...)` — unchanged at the call site.
- [x] `aimx serve` constructs one `MailboxLocks` and threads it to the SMTP server (via `with_mailbox_locks`), `StateContext`, and `MailboxContext` so inbound ingest, MARK-*, and MAILBOX-* all serialize on the same lock per mailbox.
- [x] Module-level comment in `src/state_handler.rs` updated; new full explanation lives in `src/mailbox_locks.rs` covering the lock hierarchy (**outer**: per-mailbox tokio Mutex; **inner**: process-wide `CONFIG_WRITE_LOCK`; always outer → inner).
- [x] New integration test `concurrent_ingest_burst_and_mark_same_mailbox_no_torn_writes`: 6 concurrent SMTP ingests + 2 concurrent MARK-READ calls on a seeded mailbox; verifies every `.md` file has intact `+++ … +++` frontmatter that parses as TOML.
- [x] New integration test `concurrent_mailbox_create_and_ingest_does_not_deadlock`: races `MAILBOX-CREATE` + ingest addressed to the same name under a 20-second watchdog; verifies no deadlock, the message lands consistently (either in the new mailbox or catchall, never lost or torn), and a follow-up message still delivers after the race (daemon remains responsive).
- [x] `cargo test`, `cargo clippy`, `cargo fmt -- --check` all clean.

## Technical Decisions

- **`debug_assert!` over async-ifying `DkimTxtResolver`.** Async-ification would cascade into `run_dkim_startup_check` and every mock resolver in the test suite. The debug-assert documents the contract in one place, fires in test builds, and leaves the zero-cost production path unchanged. If a future caller needs the current-thread flavor we can flip to async then.
- **`tokio::sync::Mutex` (not `RwLock`) for the unified per-mailbox lock.** The spec prescribed `Mutex`, and writes dominate every user on this lock (ingest always writes; MARK always rewrites; MAILBOX-* always rewrites). A reader/writer split would buy nothing and complicate the API surface (`.write().await` vs `.lock().await`).
- **`blocking_lock()` for the ingest call path.** `ingest_email` runs from a sync context (manual stdin or SMTP session's `spawn_blocking` worker). `tokio::sync::Mutex::blocking_lock()` works from a blocking thread and never needs an async context. This avoids making `ingest_email` `async`, which would require refactoring the stdin path and every test (30+ call sites).
- **Lock hierarchy: per-mailbox outer, `CONFIG_WRITE_LOCK` inner.** Inverting would deadlock: two `MAILBOX-CREATE` calls on different names would both acquire the config lock, then race for their per-mailbox locks. The config write is short and bounded, so holding it while a longer ingest critical section waits on the outer lock is also bad (priority inversion).
- **`write_config_atomic`: document-not-fix for v1.** Adopting `toml_edit` needs a Cargo.toml dep + `Config` serialization rewrite + round-trip testing. For v1 (machine-authored `config.toml`, only `aimx setup` / `aimx mailbox *` edit it), the simpler path is to pin the current behaviour with a test and flag it for v2.
- **Rename-failure test uses a non-empty directory as the rename target.** Simplest way to force `rename(2)` to fail after `File::create` succeeds, cross-platform between Linux and macOS (`EISDIR`/`ENOTEMPTY`).

## Deferred Items
- **`toml_edit` adoption** — documented-behaviour path taken for v1; pinning test guards the current behaviour; revisit in v2 alongside `Config::save` which has the same limitation.

## Review Focus Areas
- `src/mailbox_locks.rs` — the new shared-lock type and its documented hierarchy. The soundness argument for moving from "disjoint-file invariant" to "unified lock" lives here.
- `src/ingest.rs` — `ingest_email` signature change ripples through session.rs and ~30 test call sites. Please confirm the `blocking_lock()` placement is correct for all three callers (stdin, SMTP `spawn_blocking`, tests).
- `src/state_handler.rs` module doc — the updated lock-hierarchy explanation. Flag any ambiguity that could mislead a future reader.
- `tests/integration.rs` — the two new concurrency tests plus the DKIM startup tests. The watchdog in the deadlock test is 20s (tests normally complete in <1s); flag if you want that tighter.
- `src/serve.rs` — the `AIMX_TEST_DKIM_RESOLVER_OVERRIDE` test-only hatch. Please confirm the env-var gating is tight enough (it only triggers when the var is set, and the production daemon never sets it).