### PR TITLE
feat(uninstall): add `aimx uninstall` command

### DIFF
--- a/book/setup.md
+++ b/book/setup.md
@@ -106,6 +106,16 @@ At the DNS verification step, you can:
 - Press **Enter** to re-check DNS records (useful when you've just updated DNS in another tab)
 - Press **q** to finish and verify later with `sudo aimx setup <domain>`
 
+### Uninstalling
+
+To reverse `aimx setup`, stop the daemon and remove its init-system service file:
+
+```bash
+sudo aimx uninstall
+```
+
+Pass `--yes` to skip the confirmation prompt. Uninstall is intentionally non-destructive: it leaves your config (`/etc/aimx/`) and mailbox data (`/var/lib/aimx/`) in place so a subsequent `aimx setup` reuses them. If you also want to wipe those, remove them manually with `rm -rf`.
+
 ## DNS configuration
 
 After the setup wizard displays the required DNS records, add them at your domain registrar:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -60,6 +60,13 @@ pub enum Command {
         verify_host: Option<String>,
     },
 
+    /// Uninstall the aimx daemon service (config and data are retained)
+    Uninstall {
+        /// Skip the confirmation prompt
+        #[arg(long)]
+        yes: bool,
+    },
+
     /// Show server status, mailbox counts, and configuration
     Status,
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -63,7 +63,7 @@ pub enum Command {
     /// Uninstall the aimx daemon service (config and data are retained)
     Uninstall {
         /// Skip the confirmation prompt
-        #[arg(long)]
+        #[arg(short = 'y', long)]
         yes: bool,
     },
 
@@ -170,7 +170,7 @@ pub enum MailboxCommand {
         name: String,
 
         /// Skip confirmation prompt
-        #[arg(long)]
+        #[arg(short = 'y', long)]
         yes: bool,
     },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod status;
 mod term;
 mod transport;
 mod trust;
+mod uninstall;
 mod verify;
 
 use clap::Parser;
@@ -47,6 +48,11 @@ fn dispatch(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             let sys = setup::RealSystemOps;
             let net = build_network_ops(verify_host.as_deref())?;
             setup::run_setup(domain.as_deref(), cli.data_dir.as_deref(), &sys, &net)
+        }
+        // Uninstall also runs pre-config: config may be missing or unreadable.
+        Command::Uninstall { yes } => {
+            let sys = setup::RealSystemOps;
+            uninstall::run(yes, &sys)
         }
         // Verify does not read config for storage — only `verify_host`.
         Command::Verify { verify_host } => verify::run(verify_host.as_deref()),
@@ -98,6 +104,7 @@ fn dispatch_with_config(
         ),
         Command::Status => status::run(config),
         Command::Setup { .. }
+        | Command::Uninstall { .. }
         | Command::Verify { .. }
         | Command::Mcp
         | Command::Send(_)

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -28,6 +28,11 @@ pub trait SystemOps {
     fn check_root(&self) -> bool;
     fn check_port25_occupancy(&self) -> Result<Port25Status, Box<dyn std::error::Error>>;
     fn install_service_file(&self, data_dir: &Path) -> Result<(), Box<dyn std::error::Error>>;
+    /// Stop + disable the `aimx` service and remove its init-system service
+    /// file. Service-control commands are best-effort (service may already be
+    /// stopped); file removal is the authoritative step. Returns an error when
+    /// the init system is unsupported.
+    fn uninstall_service_file(&self) -> Result<(), Box<dyn std::error::Error>>;
     /// Poll `127.0.0.1:25` until a TCP connection succeeds or the timeout
     /// elapses. Returns `true` if the port became reachable, `false` on timeout.
     fn wait_for_service_ready(&self) -> bool;
@@ -201,6 +206,49 @@ impl SystemOps for RealSystemOps {
             InitSystem::Unknown => {
                 return Err("Could not detect init system (systemd or OpenRC). \
                      Start aimx serve manually."
+                    .into());
+            }
+        }
+        Ok(())
+    }
+
+    fn uninstall_service_file(&self) -> Result<(), Box<dyn std::error::Error>> {
+        use crate::serve::service::{InitSystem, detect_init_system};
+
+        match detect_init_system() {
+            InitSystem::Systemd => {
+                let _ = std::process::Command::new("systemctl")
+                    .args(["stop", "aimx"])
+                    .status();
+                let _ = std::process::Command::new("systemctl")
+                    .args(["disable", "aimx"])
+                    .status();
+                let unit_path = Path::new("/etc/systemd/system/aimx.service");
+                if unit_path.exists() {
+                    std::fs::remove_file(unit_path)?;
+                }
+                let _ = std::process::Command::new("systemctl")
+                    .args(["daemon-reload"])
+                    .status();
+                let _ = std::process::Command::new("systemctl")
+                    .args(["reset-failed", "aimx"])
+                    .status();
+            }
+            InitSystem::OpenRC => {
+                let _ = std::process::Command::new("rc-service")
+                    .args(["aimx", "stop"])
+                    .status();
+                let _ = std::process::Command::new("rc-update")
+                    .args(["del", "aimx", "default"])
+                    .status();
+                let script_path = Path::new("/etc/init.d/aimx");
+                if script_path.exists() {
+                    std::fs::remove_file(script_path)?;
+                }
+            }
+            InitSystem::Unknown => {
+                return Err("Could not detect init system (systemd or OpenRC). \
+                     Remove /etc/systemd/system/aimx.service or /etc/init.d/aimx manually."
                     .into());
             }
         }
@@ -1589,6 +1637,10 @@ mod tests {
         }
         fn install_service_file(&self, _data_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
             *self.service_file_installed.borrow_mut() = true;
+            Ok(())
+        }
+        fn uninstall_service_file(&self) -> Result<(), Box<dyn std::error::Error>> {
+            *self.service_file_installed.borrow_mut() = false;
             Ok(())
         }
         fn wait_for_service_ready(&self) -> bool {

--- a/src/status.rs
+++ b/src/status.rs
@@ -317,6 +317,9 @@ mod tests {
         fn install_service_file(&self, _data_dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
             unreachable!("gather_status must not touch install_service_file")
         }
+        fn uninstall_service_file(&self) -> Result<(), Box<dyn std::error::Error>> {
+            unreachable!("gather_status must not touch uninstall_service_file")
+        }
         fn wait_for_service_ready(&self) -> bool {
             unreachable!("gather_status must not touch wait_for_service_ready")
         }

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -1,0 +1,157 @@
+use crate::setup::SystemOps;
+use crate::term;
+use std::io::{self, BufRead, Write};
+
+pub fn run(yes: bool, sys: &dyn SystemOps) -> Result<(), Box<dyn std::error::Error>> {
+    if !sys.check_root() {
+        return Err("`aimx uninstall` requires root. Run with: sudo aimx uninstall".into());
+    }
+
+    let config_dir = crate::config::config_dir();
+    let data_dir = resolve_data_dir_for_display();
+
+    println!("\n{}", term::header("[UNINSTALL]"));
+    println!("This will stop the aimx daemon and remove its service file.");
+    println!(
+        "Config ({}) and mailbox data ({}) will be kept.",
+        config_dir.display(),
+        data_dir
+    );
+
+    if !yes {
+        let stdin = io::stdin();
+        let mut reader = stdin.lock();
+        confirm(&mut reader, "Proceed with uninstall? (y/N) ")?;
+    }
+
+    sys.uninstall_service_file()?;
+
+    println!("\n{}\n", term::success_banner("Uninstall complete."));
+    println!(
+        "To wipe config and data manually: sudo rm -rf {} {}",
+        config_dir.display(),
+        data_dir
+    );
+    Ok(())
+}
+
+fn resolve_data_dir_for_display() -> String {
+    crate::config::Config::load_resolved()
+        .map(|c| c.data_dir.display().to_string())
+        .unwrap_or_else(|_| "/var/lib/aimx".to_string())
+}
+
+pub fn confirm(reader: &mut dyn BufRead, prompt: &str) -> Result<(), Box<dyn std::error::Error>> {
+    print!("{prompt}");
+    io::stdout().flush()?;
+    let mut line = String::new();
+    reader.read_line(&mut line)?;
+    if !line.trim().eq_ignore_ascii_case("y") {
+        return Err("Uninstall cancelled.".into());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::setup::Port25Status;
+    use std::cell::RefCell;
+    use std::path::{Path, PathBuf};
+
+    struct MockSys {
+        is_root: bool,
+        uninstall_calls: RefCell<u32>,
+    }
+
+    impl MockSys {
+        fn new(is_root: bool) -> Self {
+            Self {
+                is_root,
+                uninstall_calls: RefCell::new(0),
+            }
+        }
+    }
+
+    impl SystemOps for MockSys {
+        fn write_file(&self, _p: &Path, _c: &str) -> Result<(), Box<dyn std::error::Error>> {
+            Ok(())
+        }
+        fn file_exists(&self, _p: &Path) -> bool {
+            false
+        }
+        fn restart_service(&self, _s: &str) -> Result<(), Box<dyn std::error::Error>> {
+            Ok(())
+        }
+        fn is_service_running(&self, _s: &str) -> bool {
+            false
+        }
+        fn generate_tls_cert(
+            &self,
+            _cert_dir: &Path,
+            _domain: &str,
+        ) -> Result<(), Box<dyn std::error::Error>> {
+            Ok(())
+        }
+        fn get_aimx_binary_path(&self) -> Result<PathBuf, Box<dyn std::error::Error>> {
+            Ok(PathBuf::from("/usr/local/bin/aimx"))
+        }
+        fn check_root(&self) -> bool {
+            self.is_root
+        }
+        fn check_port25_occupancy(&self) -> Result<Port25Status, Box<dyn std::error::Error>> {
+            Ok(Port25Status::Free)
+        }
+        fn install_service_file(&self, _d: &Path) -> Result<(), Box<dyn std::error::Error>> {
+            Ok(())
+        }
+        fn uninstall_service_file(&self) -> Result<(), Box<dyn std::error::Error>> {
+            *self.uninstall_calls.borrow_mut() += 1;
+            Ok(())
+        }
+        fn wait_for_service_ready(&self) -> bool {
+            true
+        }
+    }
+
+    #[test]
+    fn non_root_invocation_is_rejected() {
+        let sys = MockSys::new(false);
+        let err = run(true, &sys).unwrap_err();
+        assert!(err.to_string().contains("requires root"));
+        assert_eq!(*sys.uninstall_calls.borrow(), 0);
+    }
+
+    #[test]
+    fn yes_flag_skips_prompt_and_uninstalls() {
+        let sys = MockSys::new(true);
+        run(true, &sys).expect("uninstall should succeed");
+        assert_eq!(*sys.uninstall_calls.borrow(), 1);
+    }
+
+    #[test]
+    fn confirm_accepts_y() {
+        let mut input = b"y\n" as &[u8];
+        confirm(&mut input, "? ").expect("y should be accepted");
+    }
+
+    #[test]
+    fn confirm_accepts_uppercase_y() {
+        let mut input = b"Y\n" as &[u8];
+        confirm(&mut input, "? ").expect("Y should be accepted");
+    }
+
+    #[test]
+    fn confirm_rejects_no() {
+        let mut input = b"n\n" as &[u8];
+        let err = confirm(&mut input, "? ").unwrap_err();
+        assert!(err.to_string().contains("cancelled"));
+    }
+
+    #[test]
+    fn confirm_rejects_empty() {
+        let mut input = b"\n" as &[u8];
+        let err = confirm(&mut input, "? ").unwrap_err();
+        assert!(err.to_string().contains("cancelled"));
+    }
+}

--- a/src/verify.rs
+++ b/src/verify.rs
@@ -299,6 +299,9 @@ mod tests {
         ) -> Result<(), Box<dyn std::error::Error>> {
             Ok(())
         }
+        fn uninstall_service_file(&self) -> Result<(), Box<dyn std::error::Error>> {
+            Ok(())
+        }
         fn wait_for_service_ready(&self) -> bool {
             true
         }


### PR DESCRIPTION
## Summary

- Adds `aimx uninstall` — reverses `aimx setup` by stopping the daemon and removing its init-system service file (`/etc/systemd/system/aimx.service` on systemd, `/etc/init.d/aimx` on OpenRC).
- Requires root, matching `aimx setup`. Pass `--yes` to skip the confirmation prompt.
- **Non-destructive by design:** config (`/etc/aimx/`) and mailbox data (`/var/lib/aimx/`) are retained, so a subsequent `aimx setup` reuses them. Prints a hint with the `rm -rf` command if the operator wants to wipe those too.

## Implementation notes

- New `uninstall` module mirroring the `SystemOps`-trait pattern used by `setup`.
- `SystemOps::uninstall_service_file()` added; `RealSystemOps` handles systemd and OpenRC paths (service-control calls are best-effort; file removal is authoritative). Mocks in `setup.rs`, `status.rs`, and `verify.rs` updated for trait expansion.
- 6 new unit tests cover the root gate, `--yes` bypassing the prompt, and `confirm` accepting/rejecting inputs.
- `book/setup.md` gains a short "Uninstalling" subsection.

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` — 743 tests pass (6 new `uninstall::tests::*`)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `aimx uninstall --help` renders expected text
- [x] Non-root `aimx uninstall` exits 1 with the expected error
- [ ] Manual systemd VM: setup → `systemctl is-active aimx` shows `active` → `sudo aimx uninstall --yes` → service stopped, unit file gone, `/etc/aimx` + `/var/lib/aimx` intact → reinstall succeeds
- [ ] Manual OpenRC (Alpine) parity check: `/etc/init.d/aimx` removed, `rc-update show` clean