### PR TITLE
feat(cli): rename `aimx verify` to `aimx portcheck`

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ These are NOT a Cargo workspace — they have independent `Cargo.toml` files and
 - `frontmatter.rs` — `InboundFrontmatter` and `OutboundFrontmatter` structs with section-ordered serialization. `compute_thread_id()` derives the 16-hex-char thread root hash. `format_outbound_frontmatter()` for sent copies.
 - `datadir_readme.rs` — baked-in `/var/lib/aimx/README.md` template with version-gated refresh. `write()` (unconditional, called by setup), `refresh_if_outdated()` (called by serve startup).
 - `smtp/` — embedded SMTP server module: `mod.rs` (listener accept loop), `session.rs` (per-connection SMTP state machine: EHLO, MAIL FROM, RCPT TO, DATA, STARTTLS, QUIT, RSET, NOOP), `tls.rs` (STARTTLS upgrade via tokio-rustls), `tests.rs` (unit tests).
-- `verify.rs` — `aimx verify`: checks port 25 connectivity via the verifier service.
+- `portcheck.rs` — `aimx portcheck`: checks port 25 connectivity via the verifier service.
 - `cli.rs` — `clap` CLI surface: the `Cli` parser and `Command` enum enumerating every subcommand and its flags. `main.rs` matches on `Command` to dispatch.
 - `config.rs` — `Config` struct + `ConfigHandle` (`RwLock<Arc<Config>>`) used by the daemon for live hot-swap of mailbox config. `config_path()` and `dkim_dir()` resolve paths and honor `AIMX_CONFIG_DIR` for tests.
 - `mailbox.rs` — `aimx mailbox create | list | delete`: client-side logic. Create/delete try the daemon UDS first (`MAILBOX-CREATE` / `MAILBOX-DELETE`) so inbound routing picks up the change without a restart, and fall back to a direct `config.toml` edit + restart hint when the socket is absent.

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ sudo aimx setup agent.yourdomain.com
 
 # 3. Follow the interactive prompts to add DNS records
 # 4. Verify inbound + outbound port 25 reachability
-sudo aimx verify
+sudo aimx portcheck
 
 # 5. Check status
 aimx status
@@ -100,7 +100,7 @@ sudo aimx setup agent.yourdomain.com
 aimx status
 
 # Check port 25 connectivity (requires root)
-sudo aimx verify
+sudo aimx portcheck
 ```
 
 ### Mailbox management
@@ -219,7 +219,7 @@ data_dir = "/var/lib/aimx"
 dkim_selector = "dkim"
 
 # Verifier service base URL (default: https://check.aimx.email)
-# Used by `aimx verify` and `aimx setup`. Set this only if
+# Used by `aimx portcheck` and `aimx setup`. Set this only if
 # you are self-hosting the verifier service (see `services/verifier/`). aimx appends
 # `/probe` to this base URL internally.
 # verify_host = "https://verify.yourdomain.com"
@@ -377,10 +377,10 @@ To point AIMX at a self-hosted instance, set `verify_host` in `config.toml`:
 verify_host = "https://verify.yourdomain.com"
 ```
 
-Or override it per-invocation with the `--verify-host` flag, which is accepted by `aimx verify` and `aimx setup`:
+Or override it per-invocation with the `--verify-host` flag, which is accepted by `aimx portcheck` and `aimx setup`:
 
 ```bash
-sudo aimx verify --verify-host https://verify.yourdomain.com
+sudo aimx portcheck --verify-host https://verify.yourdomain.com
 ```
 
 Precedence is **CLI flag > config > default** (`https://check.aimx.email`).

--- a/book/configuration.md
+++ b/book/configuration.md
@@ -42,7 +42,7 @@ This changes where `config.toml` and the DKIM keypair (`dkim/private.key`, `dkim
 | `domain` | string | *(required)* | The email domain (e.g. `agent.yourdomain.com`) |
 | `data_dir` | string | `/var/lib/aimx` | Directory for storing mailboxes (config and keys live under `/etc/aimx/`) |
 | `dkim_selector` | string | `dkim` | DKIM selector name used in DNS records |
-| `verify_host` | string | `https://check.aimx.email` | Base URL of the verifier service used by `aimx verify` and `aimx setup`. Can be overridden per-invocation with the `--verify-host` flag. |
+| `verify_host` | string | `https://check.aimx.email` | Base URL of the verifier service used by `aimx portcheck` and `aimx setup`. Can be overridden per-invocation with the `--verify-host` flag. |
 | `enable_ipv6` | bool | `false` | Advanced. Opt into IPv6 outbound delivery. See [IPv6 delivery](#ipv6-delivery-advanced). |
 
 ### Mailbox settings
@@ -154,7 +154,7 @@ If your server has a global IPv6 address and you want outbound mail to use it:
 
 See the full DNS records table in [Setup](setup.md#dns-configuration) for formats. Without these DNS updates, messages delivered over IPv6 will fail SPF and may be rejected under your DMARC policy.
 
-**When `enable_ipv6` is unset or `false`:** `aimx setup` ignores IPv6 entirely — no AAAA is advertised, no `ip6:` SPF is generated, and existing AAAA records in DNS are not validated (their presence is harmless). `aimx verify` only probes port 25 connectivity and is unaffected by this flag.
+**When `enable_ipv6` is unset or `false`:** `aimx setup` ignores IPv6 entirely — no AAAA is advertised, no `ip6:` SPF is generated, and existing AAAA records in DNS are not validated (their presence is harmless). `aimx portcheck` only probes port 25 connectivity and is unaffected by this flag.
 
 Leave `enable_ipv6` unset (or `false`) if any of these apply:
 - Your server does not have a global IPv6 address

--- a/book/getting-started.md
+++ b/book/getting-started.md
@@ -82,7 +82,7 @@ After DNS records propagate, verify the setup:
 
 ```bash
 # Check port 25 connectivity (requires root)
-sudo aimx verify
+sudo aimx portcheck
 
 # Check server status and mailbox counts
 aimx status

--- a/book/index.md
+++ b/book/index.md
@@ -46,7 +46,7 @@ sudo cp target/release/aimx /usr/local/bin/
 sudo aimx setup agent.yourdomain.com
 
 # 3. Verify
-sudo aimx verify
+sudo aimx portcheck
 ```
 
 See the full [Getting Started](getting-started.md) guide for details.

--- a/book/setup.md
+++ b/book/setup.md
@@ -46,10 +46,10 @@ aimx --version
 Before running setup, you can verify port 25 connectivity:
 
 ```bash
-sudo aimx verify
+sudo aimx portcheck
 ```
 
-`aimx verify` requires root. When `aimx serve` is running, it performs an outbound EHLO handshake plus an inbound EHLO handshake probe. When nothing is on port 25 (fresh VPS), it spawns a temporary listener and runs checks. If port 25 is occupied by another process, verify tells you to stop it before setup.
+`aimx portcheck` requires root. When `aimx serve` is running, it performs an outbound EHLO handshake plus an inbound EHLO handshake probe. When nothing is on port 25 (fresh VPS), it spawns a temporary listener and runs checks. If port 25 is occupied by another process, portcheck tells you to stop it before setup.
 
 | Check | What it does | Fix if it fails |
 |-------|-------------|-----------------|
@@ -176,7 +176,7 @@ dig +short TXT _dmarc.agent.yourdomain.com
 Run the automated verification:
 
 ```bash
-sudo aimx verify
+sudo aimx portcheck
 ```
 
 This tests outbound port 25 connectivity (via EHLO handshake) and inbound SMTP reachability (via EHLO probe). Requires root.
@@ -295,7 +295,7 @@ If you prefer not to use the public instance:
 
    Or override it per-invocation with `--verify-host`:
    ```
-   sudo aimx verify --verify-host https://verify.yourdomain.com
+   sudo aimx portcheck --verify-host https://verify.yourdomain.com
    ```
 
 The verifier service provides:

--- a/book/troubleshooting.md
+++ b/book/troubleshooting.md
@@ -7,13 +7,13 @@ Diagnostic commands and solutions for common issues.
 ```bash
 # Check port 25 connectivity (outbound + inbound EHLO handshake)
 # Requires root
-sudo aimx verify
+sudo aimx portcheck
 
 # Show server status, configuration, and mailbox counts
 aimx status
 
 # Test against a self-hosted verify service instead of the default
-sudo aimx verify --verify-host https://verify.yourdomain.com
+sudo aimx portcheck --verify-host https://verify.yourdomain.com
 ```
 
 The `--verify-host` flag is also accepted by `aimx setup`, and overrides the `verify_host` value from `config.toml` for the current invocation.
@@ -25,7 +25,7 @@ The `--verify-host` flag is also accepted by `aimx setup`, and overrides the `ve
 | Verify: outbound port 25 blocked | VPS provider blocks SMTP | Switch providers or request unblock (see [compatible providers](getting-started.md#compatible-vps-providers)) |
 | Verify: inbound port 25 not reachable | Firewall or VPS blocks inbound | `sudo ufw allow 25/tcp`, check VPS firewall settings |
 | DNS records not resolving | Propagation delay | Wait (up to 48h), re-check with `dig` (see [verifying DNS](setup.md#verifying-dns-records)) |
-| `sudo aimx verify` times out | DNS not propagated or verify service down | Run again later; check `curl https://check.aimx.email/health` |
+| `sudo aimx portcheck` times out | DNS not propagated or verify service down | Run again later; check `curl https://check.aimx.email/health` |
 | Emails landing in spam | Missing DNS records, bad reverse DNS, or receiver spam filter | Add all [DNS records](setup.md#dns-configuration), configure a PTR record at your VPS provider, use a Gmail filter |
 | `aimx serve` not running | Service crashed or not started | Check status and logs (see below) |
 | Emails not delivered to mailbox | `aimx serve` not running or misconfigured | Check service status with `systemctl status aimx` |
@@ -153,9 +153,9 @@ If permissions are wrong:
 sudo chmod 600 /etc/aimx/dkim/private.key
 ```
 
-## How verify works
+## How portcheck works
 
-`aimx verify` requires root and auto-detects what is listening on port 25:
+`aimx portcheck` requires root and auto-detects what is listening on port 25:
 
 | Scenario | What happens |
 |----------|-------------|
@@ -163,13 +163,13 @@ sudo chmod 600 /etc/aimx/dkim/private.key
 | **Other process on port 25** (Postfix, Exim, etc.) | Fails -- advises to stop the conflicting process |
 | **Nothing on port 25** (fresh VPS) | Spawns temporary SMTP listener, then runs outbound + inbound EHLO checks |
 
-If verify fails with EHLO probe after setup, the issue is likely in the `aimx serve` configuration rather than firewall/port access. Run `sudo systemctl status aimx` to check.
+If portcheck fails with EHLO probe after setup, the issue is likely in the `aimx serve` configuration rather than firewall/port access. Run `sudo systemctl status aimx` to check.
 
 ## Useful commands reference
 
 | Command | Purpose |
 |---------|---------|
-| `sudo aimx verify` | Check port 25 connectivity (requires root) |
+| `sudo aimx portcheck` | Check port 25 connectivity (requires root) |
 | `aimx status` | Show config, mailboxes, and message counts |
 | `aimx mailbox list` | List all mailboxes |
 | `aimx dkim-keygen` | Generate DKIM keypair |

--- a/docs/idea.md
+++ b/docs/idea.md
@@ -384,7 +384,7 @@ aimx mailbox create <n>     Create a new mailbox (via UDS — daemon picks up li
 aimx mailbox list           List all mailboxes
 aimx mailbox delete <n>     Delete a mailbox
 aimx status                 Show server status, mailbox counts, recent activity
-aimx verify                 Check port 25 connectivity via the verifier service
+aimx portcheck              Check port 25 connectivity via the verifier service
 aimx dkim-keygen            Regenerate the DKIM keypair (requires root)
 aimx agent-setup <agent>    Install the aimx plugin/skill into a supported agent
 ```

--- a/docs/manual-setup.md
+++ b/docs/manual-setup.md
@@ -5,7 +5,7 @@ This guide walks through every step needed to launch AIMX, from deploying the ve
 - **Part A** — Deploy the verifier service (done once, before anything else)
 - **Part B** — Set up an AIMX mail server (done per server)
 
-The verifier service must be running before any mail server can complete setup, because `aimx setup` and `aimx verify` both call its HTTP `/probe` endpoint (to test inbound port 25) and connect to its built-in port 25 listener (to test outbound port 25 via EHLO handshake). Both commands use `/probe` (full SMTP EHLO handshake).
+The verifier service must be running before any mail server can complete setup, because `aimx setup` and `aimx portcheck` both call its HTTP `/probe` endpoint (to test inbound port 25) and connect to its built-in port 25 listener (to test outbound port 25 via EHLO handshake). Both commands use `/probe` (full SMTP EHLO handshake).
 
 ---
 
@@ -13,7 +13,7 @@ The verifier service must be running before any mail server can complete setup, 
 
 The aimx-verifier service provides two functions, both exposed from a single binary:
 
-1. **Port probe** (`GET /probe`) — HTTPS endpoint that opens a TCP connection back to the caller's own IP on port 25 and performs a full SMTP EHLO handshake. Used by `aimx setup` and `aimx verify` to confirm a real SMTP server is responding. The probe always targets the caller's IP; there is no way to probe an arbitrary address.
+1. **Port probe** (`GET /probe`) — HTTPS endpoint that opens a TCP connection back to the caller's own IP on port 25 and performs a full SMTP EHLO handshake. Used by `aimx setup` and `aimx portcheck` to confirm a real SMTP server is responding. The probe always targets the caller's IP; there is no way to probe an arbitrary address.
 2. **Port 25 listener** — Built-in TCP listener on `:25` that implements a minimal but correct SMTP exchange: banner → `EHLO`/`HELO` → `250` → `QUIT` → `221 Bye`. Used by `aimx` clients to test that their outbound port 25 is not blocked by their VPS provider via EHLO handshake. This is a plain tokio listener built into the `aimx-verifier` binary — **no MTA is required on the verifier server**.
 
 `/probe` identifies the caller via Caddy's `X-AIMX-Client-IP` header (injected by the canonical `Caddyfile`). Direct exposure of the backend without Caddy is not supported — see the security note in `services/verifier/README.md`.
@@ -151,7 +151,7 @@ The listener implements a minimal but correct SMTP exchange (banner → `EHLO`/`
 
 **Functional `/probe` test:**
 
-The `/probe` endpoint always probes the caller's own IP — there is no `?ip=` parameter. To exercise it end-to-end, run `sudo aimx verify` (which hits `/probe`) from a real mail server with port 25 open. A `PASS` on the "Inbound port 25" line means the verifier service reached back and completed a full EHLO handshake.
+The `/probe` endpoint always probes the caller's own IP — there is no `?ip=` parameter. To exercise it end-to-end, run `sudo aimx portcheck` (which hits `/probe`) from a real mail server with port 25 open. A `PASS` on the "Inbound port 25" line means the verifier service reached back and completed a full EHLO handshake.
 
 A `curl` from the mail server is useful for debugging:
 
@@ -168,10 +168,10 @@ The default verify host is `https://check.aimx.email`. If you deployed your own 
 verify_host = "https://check.yourdomain.com"
 ```
 
-…or per-invocation with the `--verify-host` flag (accepted by `sudo aimx verify` and `sudo aimx setup`):
+…or per-invocation with the `--verify-host` flag (accepted by `sudo aimx portcheck` and `sudo aimx setup`):
 
 ```bash
-sudo aimx verify --verify-host https://check.yourdomain.com
+sudo aimx portcheck --verify-host https://check.yourdomain.com
 sudo aimx setup agent.yourdomain.com --verify-host https://check.yourdomain.com
 ```
 
@@ -246,7 +246,7 @@ sudo iptables -A INPUT -p tcp --dport 25 -j ACCEPT
 Run verify to confirm your server is ready before setup:
 
 ```bash
-sudo aimx verify
+sudo aimx portcheck
 ```
 
 This checks two things:
@@ -261,7 +261,7 @@ Both should show PASS.
 The default verify host is `https://check.aimx.email`. To point at a self-hosted instance instead (see Part A), set `verify_host` in `config.toml` or pass `--verify-host` on the command line:
 
 ```bash
-sudo aimx verify --verify-host https://check.yourdomain.com
+sudo aimx portcheck --verify-host https://check.yourdomain.com
 ```
 
 The same flag is accepted by `aimx setup`, and takes precedence over the config value.
@@ -282,7 +282,7 @@ The setup wizard performs these steps automatically:
 6. Displays the DNS records you need to add (see next step)
 7. After you add the records and press Enter, resolves and validates each one
 
-Setup ends after DNS verification. There is no end-to-end email test — run `sudo aimx verify` later to re-check port 25 connectivity.
+Setup ends after DNS verification. There is no end-to-end email test — run `sudo aimx portcheck` later to re-check port 25 connectivity.
 
 ### B6: DNS Configuration
 
@@ -339,10 +339,10 @@ dig +short TXT _dmarc.agent.yourdomain.com
 **Automated verification:**
 
 ```bash
-sudo aimx verify
+sudo aimx portcheck
 ```
 
-`aimx verify` runs two checks: outbound port 25 (EHLO handshake to the verifier service's built-in TCP listener) and inbound port 25 (via `/probe`, which connects back to your server). It does not send an actual email or wait for an echo reply.
+`aimx portcheck` runs two checks: outbound port 25 (EHLO handshake to the verifier service's built-in TCP listener) and inbound port 25 (via `/probe`, which connects back to your server). It does not send an actual email or wait for an echo reply.
 
 **Check server status:**
 
@@ -457,7 +457,7 @@ The only directory to back up is `/var/lib/aimx/`. It contains everything: confi
 | Verify: outbound port 25 blocked | VPS provider blocks SMTP | Switch providers or request unblock (see compatible providers table) |
 | Verify: inbound port 25 not reachable | Firewall or VPS blocks inbound | `sudo ufw allow 25/tcp`, check VPS firewall settings |
 | DNS records not resolving | Propagation delay | Wait (up to 48h), re-check with `dig` |
-| `sudo aimx verify` shows inbound FAIL | The verifier service's `/probe` endpoint could not reach your port 25 (firewall, VPS block, `aimx serve` down, or DNS `A` record not yet resolving) | `sudo systemctl status aimx`, `sudo ufw status`, `dig +short A agent.yourdomain.com`, check VPS firewall |
+| `sudo aimx portcheck` shows inbound FAIL | The verifier service's `/probe` endpoint could not reach your port 25 (firewall, VPS block, `aimx serve` down, or DNS `A` record not yet resolving) | `sudo systemctl status aimx`, `sudo ufw status`, `dig +short A agent.yourdomain.com`, check VPS firewall |
 | Emails landing in spam | Missing DNS records, bad reverse DNS, or receiver spam filter | Add all DNS records, configure a PTR record at your VPS provider, use a Gmail filter |
 | `aimx serve` not running | Service crashed or misconfigured | `sudo systemctl status aimx` and `journalctl -u aimx -e` |
 | Emails not being delivered to mailbox | Ingest misconfigured | Check config and mailbox setup with `aimx status` |
@@ -465,7 +465,7 @@ The only directory to back up is `/var/lib/aimx/`. It contains everything: confi
 **Useful commands:**
 
 ```bash
-sudo aimx verify            # Re-run port 25 checks
+sudo aimx portcheck            # Re-run port 25 checks
 aimx status                 # Show config, mailboxes, and message counts
 sudo systemctl status aimx  # Check aimx serve service status
 journalctl -u aimx -e       # View aimx serve logs

--- a/docs/manual-test.md
+++ b/docs/manual-test.md
@@ -57,14 +57,14 @@ sudo systemctl status aimx --no-pager
 sudo ss -tlnp sport :25          # aimx listening on :25
 ls -la /run/aimx/send.sock       # UDS present, mode 0666
 sudo aimx status                 # summary output
-sudo aimx verify                 # port 25 reachability probe
+sudo aimx portcheck              # port 25 reachability probe
 ```
 
 **Acceptance criteria.**
 - `systemctl status aimx` → `active (running)`.
 - `ss` shows aimx on `:25`.
 - `/run/aimx/send.sock` exists with mode `srw-rw-rw-`.
-- `aimx verify` reports port 25 reachable.
+- `aimx portcheck` reports port 25 reachable.
 - `/etc/aimx/config.toml` exists and contains your domain.
 - `/etc/aimx/dkim/private.key` is `0600 root:root`.
 - `/var/lib/aimx/README.md` was generated.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -148,7 +148,7 @@ All routes expose sensitive communications to third parties, which is absurd whe
   The frontmatter field is `trusted` (distinct from the mailbox config field `trust`) to reflect that the value is the result of the evaluation, not the policy itself. `trusted == "true"` is equivalent to "this email passed the trigger gate for this mailbox," so the channel manager's gating logic (FR-35/36/37) can be expressed as `if mailbox.trust == "verified" then require trusted == "true"`.
 
 ### 6.8 Verifier Service
-- FR-38: Hosted verifier service at `check.aimx.email` exposing an HTTP `/probe` endpoint that identifies the caller via a Caddy-injected `X-AIMX-Client-IP` header and performs a full SMTP EHLO handshake against the caller's IP on port 25 (used by `aimx setup` and `aimx verify` to confirm `aimx serve` is responding after setup). The endpoint applies a target guard that rejects loopback, unspecified, link-local, and RFC 1918 / RFC 4193 ranges so the service cannot be used as a port-scanner proxy. `/probe` (EHLO handshake) is the single endpoint.
+- FR-38: Hosted verifier service at `check.aimx.email` exposing an HTTP `/probe` endpoint that identifies the caller via a Caddy-injected `X-AIMX-Client-IP` header and performs a full SMTP EHLO handshake against the caller's IP on port 25 (used by `aimx setup` and `aimx portcheck` to confirm `aimx serve` is responding after setup). The endpoint applies a target guard that rejects loopback, unspecified, link-local, and RFC 1918 / RFC 4193 ranges so the service cannot be used as a port-scanner proxy. `/probe` (EHLO handshake) is the single endpoint.
 - FR-39: ~~Hosted email endpoint at `verify@aimx.email` that receives test email and sends reply.~~ _Removed: email echo eliminated to avoid backscatter risk and MTA dependency on the verify server. DKIM/SPF verification is handled by DNS record checks during setup instead._
 - FR-39b: Port 25 listener on the verifier service that accepts SMTP connections (responds to EHLO), allowing `aimx` clients to test outbound port 25 connectivity via EHLO handshake. _Note: outbound check now performs EHLO handshake directly from the client, not via `/reach`._
 - FR-40: Verifier service is open source and self-hostable. No MTA required on the verifier server.
@@ -175,14 +175,14 @@ All routes expose sensitive communications to third parties, which is absurd whe
 ### 6.9 CLI Commands
 - FR-41: `aimx setup [domain]` — interactive setup wizard. When domain is omitted, prompt interactively for domain and confirm DNS access.
 - FR-41b: ~~Pre-seed OpenSMTPD debconf answers.~~ _Removed: OpenSMTPD replaced by embedded SMTP server. Setup now generates a systemd/OpenRC service file for `aimx serve`._
-- FR-42: ~~`aimx preflight` — run port 25 reachability checks (outbound and inbound) without installing.~~ _Removed: preflight functionality merged into `aimx verify`._
+- FR-42: ~~`aimx preflight` — run port 25 reachability checks (outbound and inbound) without installing.~~ _Removed: preflight functionality merged into `aimx portcheck`._
 - FR-42b: `aimx serve` — start the embedded SMTP listener daemon. Options: `--bind` (default `0.0.0.0:25`), `--tls-cert`, `--tls-key`. Runs until SIGTERM/SIGINT.
 - FR-43: `aimx ingest <rcpt>` — delivery command for manual/pipe usage (reads raw email from stdin). Also called in-process by `aimx serve`.
 - FR-44: `aimx send` — compose, sign, and send email.
 - FR-45: `aimx mcp` — start MCP server in stdio mode.
 - FR-46: `aimx mailbox create|list|delete <name>` — mailbox management.
 - FR-47: `aimx status` — show server status, mailbox counts, recent activity.
-- FR-48: `aimx verify` — check port 25 connectivity. Requires root. If `aimx serve` is running: outbound EHLO + inbound EHLO probe. If port 25 is free: spawn temp SMTP listener and run checks. If port 25 is occupied by another process: report process name and exit.
+- FR-48: `aimx portcheck` — check port 25 connectivity. Requires root. If `aimx serve` is running: outbound EHLO + inbound EHLO probe. If port 25 is free: spawn temp SMTP listener and run checks. If port 25 is occupied by another process: report process name and exit.
 - FR-48b: `aimx agent-setup <agent> [--list] [--force] [--print]` — install per-agent plugin/skill/recipe (see §6.10). Runs as the current user.
 
 ## 7. Non-Functional Requirements
@@ -309,7 +309,7 @@ All routes expose sensitive communications to third parties, which is absurd whe
 | M5: Inbound Trust | Gate triggers on sender verification | DKIM/SPF verification during ingest, per-mailbox trust policy, trusted_senders allowlist |
 | M6: Setup Wizard | One-command setup | `aimx setup`, preflight checks, service file generation, DNS guidance, verification |
 | M7: Verifier Service | Hosted verification endpoint | `check.aimx.email` probe + reach endpoints, self-hostable |
-| M8: Polish | CLI completeness and docs | `aimx status`, `aimx verify`, README, usage docs |
+| M8: Polish | CLI completeness and docs | `aimx status`, `aimx portcheck`, README, usage docs |
 | M9: Embedded SMTP | Replace OpenSMTPD with built-in SMTP | `aimx serve` daemon, hand-rolled tokio SMTP receiver, lettre outbound, systemd/OpenRC service |
 
 ## 10. Risks and Mitigations

--- a/services/verifier/README.md
+++ b/services/verifier/README.md
@@ -2,7 +2,7 @@
 
 Verification service for [AIMX](https://github.com/uzyn/aimx). Provides an HTTP endpoint plus a built-in port 25 listener:
 
-1. **`/probe`** — full SMTP EHLO handshake back to the caller's IP on port 25. Used by `aimx setup` and `aimx verify` to confirm a real SMTP server is responding.
+1. **`/probe`** — full SMTP EHLO handshake back to the caller's IP on port 25. Used by `aimx setup` and `aimx portcheck` to confirm a real SMTP server is responding.
 2. **Port 25 listener** — built-in TCP listener on port 25 that implements a minimal but correct SMTP exchange (banner → EHLO/HELO → 250 → QUIT → 221 Bye), allowing `aimx` clients to test outbound port 25 reachability via EHLO handshake.
 
 No MTA is required on the verifier server.
@@ -34,7 +34,7 @@ BIND_ADDR=0.0.0.0:8080 SMTP_BIND_ADDR=0.0.0.0:2525 ./target/release/aimx-verifie
 Health check. Returns `{"status": "ok", "service": "aimx-verifier"}`.
 
 #### `GET /probe`
-Connects back to the caller's IP on port 25 and performs a full SMTP EHLO handshake. Returns `reachable: true` only if a real SMTP server responds with a valid `220` banner, accepts `EHLO`, and replies `250`. Used by `aimx setup` and `aimx verify`, both of which run after OpenSMTPD is installed and should validate that a real SMTP responder is live.
+Connects back to the caller's IP on port 25 and performs a full SMTP EHLO handshake. Returns `reachable: true` only if a real SMTP server responds with a valid `220` banner, accepts `EHLO`, and replies `250`. Used by `aimx setup` and `aimx portcheck`, both of which run after OpenSMTPD is installed and should validate that a real SMTP responder is live.
 
 Response: `{"reachable": true, "ip": "1.2.3.4"}`
 
@@ -88,7 +88,7 @@ To self-host (replacing `check.aimx.email`):
 
    You can also override it per-invocation:
    ```
-   aimx verify --verify-host https://check.yourdomain.com
+   aimx portcheck --verify-host https://check.yourdomain.com
    ```
 
 No MTA, no email sending, no DNS records beyond the A record are needed on the verifier server — it only needs:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -86,7 +86,7 @@ pub enum Command {
     },
 
     /// Check port 25 connectivity (outbound, inbound)
-    Verify {
+    Portcheck {
         /// Override the verify service host (e.g. https://verify.example.com)
         #[arg(long)]
         verify_host: Option<String>,

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod mailbox_locks;
 mod mcp;
 mod mx;
 mod platform;
+mod portcheck;
 mod send;
 mod send_handler;
 mod send_protocol;
@@ -25,7 +26,6 @@ mod term;
 mod transport;
 mod trust;
 mod uninstall;
-mod verify;
 
 use clap::Parser;
 use cli::{Cli, Command};
@@ -54,8 +54,8 @@ fn dispatch(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
             let sys = setup::RealSystemOps;
             uninstall::run(yes, &sys)
         }
-        // Verify does not read config for storage — only `verify_host`.
-        Command::Verify { verify_host } => verify::run(verify_host.as_deref()),
+        // Portcheck does not read config for storage — only `verify_host`.
+        Command::Portcheck { verify_host } => portcheck::run(verify_host.as_deref()),
         // MCP server reloads config on each tool call; pass the override through.
         Command::Mcp => {
             let rt = tokio::runtime::Runtime::new()
@@ -105,7 +105,7 @@ fn dispatch_with_config(
         Command::Status => status::run(config),
         Command::Setup { .. }
         | Command::Uninstall { .. }
-        | Command::Verify { .. }
+        | Command::Portcheck { .. }
         | Command::Mcp
         | Command::Send(_)
         | Command::AgentSetup { .. } => unreachable!("handled by dispatch"),
@@ -117,6 +117,6 @@ fn build_network_ops(
 ) -> Result<setup::RealNetworkOps, Box<dyn std::error::Error>> {
     let config = config::Config::load_resolved().ok();
     let host =
-        verify::resolve_verify_host(cli_override, config.as_ref(), setup::DEFAULT_VERIFY_HOST);
+        portcheck::resolve_verify_host(cli_override, config.as_ref(), setup::DEFAULT_VERIFY_HOST);
     setup::RealNetworkOps::from_verify_host(host)
 }

--- a/src/portcheck.rs
+++ b/src/portcheck.rs
@@ -3,15 +3,15 @@ use crate::setup::{self, DEFAULT_VERIFY_HOST, NetworkOps, Port25Status, SystemOp
 use crate::term;
 
 pub fn run(verify_host: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
-    run_verify(verify_host, &setup::RealSystemOps)
+    run_portcheck(verify_host, &setup::RealSystemOps)
 }
 
-pub(crate) fn run_verify(
+pub(crate) fn run_portcheck(
     verify_host: Option<&str>,
     sys: &dyn SystemOps,
 ) -> Result<(), Box<dyn std::error::Error>> {
     if !sys.check_root() {
-        return Err("`aimx verify` requires root. Run with: sudo aimx verify".into());
+        return Err("`aimx portcheck` requires root. Run with: sudo aimx portcheck".into());
     }
 
     let config = Config::load_resolved().ok();
@@ -30,7 +30,7 @@ pub(crate) fn run_verify(
 
 /// Bind a minimal SMTP listener on `0.0.0.0:25` for the duration of `f`,
 /// then tear it down. Used by the preflight probe during `aimx setup`
-/// (before aimx.service is installed) and by `aimx verify` (when nothing
+/// (before aimx.service is installed) and by `aimx portcheck` (when nothing
 /// is holding the port). The listener speaks just enough SMTP — 220 banner,
 /// EHLO/HELO, QUIT — for the remote `/probe` endpoint to confirm the port
 /// is reachable.
@@ -151,7 +151,7 @@ pub fn run_with_net(
 ) -> Result<(), Box<dyn std::error::Error>> {
     println!(
         "{}\n",
-        term::header("AIMX verify - Port 25 connectivity check")
+        term::header("AIMX portcheck - Port 25 connectivity check")
     );
 
     let mut all_pass = true;
@@ -198,7 +198,7 @@ pub fn run_with_net(
 
         Port25Status::OtherProcess(name) => Err(format!(
             "Port 25 is occupied by `{name}`.\n\
-             Stop or uninstall the process and run `sudo aimx verify` again to check."
+             Stop or uninstall the process and run `sudo aimx portcheck` again to check."
         )
         .into()),
     }
@@ -314,9 +314,9 @@ mod tests {
     }
 
     #[test]
-    fn verify_requires_root() {
+    fn portcheck_requires_root() {
         let sys = MockSystemOps { is_root: false };
-        let result = run_verify(Some("https://check.example.com"), &sys);
+        let result = run_portcheck(Some("https://check.example.com"), &sys);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -328,7 +328,7 @@ mod tests {
     // --- aimx running tests ---
 
     #[test]
-    fn verify_aimx_all_pass() {
+    fn portcheck_aimx_all_pass() {
         let net = MockNetworkOps::default();
         assert!(run_with_net(&net, &Port25Status::Aimx).is_ok());
         assert!(
@@ -338,7 +338,7 @@ mod tests {
     }
 
     #[test]
-    fn verify_aimx_outbound_fail() {
+    fn portcheck_aimx_outbound_fail() {
         let net = MockNetworkOps {
             outbound: false,
             ..Default::default()
@@ -347,7 +347,7 @@ mod tests {
     }
 
     #[test]
-    fn verify_aimx_inbound_ehlo_fail() {
+    fn portcheck_aimx_inbound_ehlo_fail() {
         let net = MockNetworkOps {
             inbound: false,
             ..Default::default()
@@ -358,7 +358,7 @@ mod tests {
     // --- OtherProcess tests ---
 
     #[test]
-    fn verify_other_process_fails_with_name() {
+    fn portcheck_other_process_fails_with_name() {
         let net = MockNetworkOps::default();
         let err = run_with_net(&net, &Port25Status::OtherProcess("postfix".into()))
             .unwrap_err()
@@ -373,7 +373,7 @@ mod tests {
     // --- Free (temp server) tests ---
 
     #[test]
-    fn verify_free_all_pass() {
+    fn portcheck_free_all_pass() {
         let net = MockNetworkOps::default();
         assert!(run_with_net(&net, &Port25Status::Free).is_ok());
         assert!(
@@ -383,7 +383,7 @@ mod tests {
     }
 
     #[test]
-    fn verify_free_inbound_fail() {
+    fn portcheck_free_inbound_fail() {
         let net = MockNetworkOps {
             inbound: false,
             ..Default::default()

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -46,14 +46,14 @@ pub trait SystemOps {
         &self,
         f: &mut dyn FnMut() -> Result<(), Box<dyn std::error::Error>>,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        crate::verify::with_temp_smtp_listener(f)
+        crate::portcheck::with_temp_smtp_listener(f)
     }
 }
 
 pub trait NetworkOps {
     fn check_outbound_port25(&self) -> Result<bool, Box<dyn std::error::Error>>;
     /// Full SMTP EHLO handshake via `{verify_host}/probe`.
-    /// Used by `aimx setup` (post-install) and `aimx verify`.
+    /// Used by `aimx setup` (post-install) and `aimx portcheck`.
     fn check_inbound_port25(&self) -> Result<bool, Box<dyn std::error::Error>>;
     /// Return the server's IPv4 and IPv6 addresses in a single call.
     ///

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -148,7 +148,7 @@ fn help_shows_subcommands() {
         .stdout(predicate::str::contains("setup"))
         .stdout(predicate::str::contains("status"))
         .stdout(predicate::str::contains("serve"))
-        .stdout(predicate::str::contains("verify"))
+        .stdout(predicate::str::contains("portcheck"))
         .stdout(predicate::str::contains("dkim-keygen"));
 }
 
@@ -1392,13 +1392,13 @@ fn status_help_works() {
 }
 
 #[test]
-fn verify_help_works() {
+fn portcheck_help_works() {
     Command::cargo_bin("aimx")
         .unwrap()
-        .args(["verify", "--help"])
+        .args(["portcheck", "--help"])
         .assert()
         .success()
-        .stdout(predicate::str::contains("verify"));
+        .stdout(predicate::str::contains("port 25"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Rename the port-25 connectivity subcommand from `aimx verify` to `aimx portcheck` so the name reflects what the command does.
- The external verifier service (`services/verifier/`) and the `verify_host` config field keep their names — only the CLI command and its in-repo module change.
- Updates `src/verify.rs` → `src/portcheck.rs` (module, `Command` variant, test names, error/header strings) plus CLI docs and all user-facing documentation (README, CLAUDE.md, book/, services/verifier/README.md, docs/prd.md, docs/manual-{setup,test}.md, docs/idea.md). Historical sprint files are left untouched.

## Test plan
- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` (740 unit + 63 integration, all green)
- [x] `services/verifier` — `cargo clippy --all-targets -- -D warnings` clean
- [x] `aimx --help` shows `portcheck`; `aimx portcheck --help` works