### PR TITLE
feat: add Hermes Agent support to agent-setup

### DIFF
--- a/agents/hermes/README.md
+++ b/agents/hermes/README.md
@@ -1,0 +1,84 @@
+# AIMX skill for Hermes Agent
+
+This directory is the source tree for the Hermes Agent skill that wires
+AIMX into [Hermes Agent](https://hermes-agent.nousresearch.com/) by Nous
+Research. Contents are bundled into the `aimx` binary at compile time
+(via `include_dir!`) and installed by `aimx agent-setup hermes`.
+
+## What gets installed
+
+- `skills/aimx/SKILL.md` — an agent-facing skill dropped into
+  `~/.hermes/skills/aimx/SKILL.md`. Its body is the canonical AIMX
+  primer (`agents/common/aimx-primer.md`); the installer assembles the
+  final `SKILL.md` from a YAML header plus that primer so there is one
+  source of truth.
+- `skills/aimx/references/` — detailed reference docs (MCP tool signatures,
+  frontmatter schema, workflows, troubleshooting) copied from
+  `agents/common/references/`.
+
+Hermes' MCP configuration lives in `~/.hermes/config.yaml` (a YAML file)
+under the top-level `mcp_servers:` key. The installer does **not** mutate
+that file; instead it prints a YAML snippet you paste in, then refresh
+the running agent with the in-app `/reload-mcp` slash command.
+
+## Install
+
+```bash
+aimx agent-setup hermes
+```
+
+Default skill destination: `~/.hermes/skills/aimx/SKILL.md`.
+
+## Activation
+
+After the skill is installed, register AIMX's MCP server by adding the
+following block to `~/.hermes/config.yaml` under the top-level
+`mcp_servers:` key (create the key if it does not yet exist):
+
+```yaml
+mcp_servers:
+  aimx:
+    command: /usr/local/bin/aimx
+    args: [mcp]
+    enabled: true
+```
+
+Save the file, then run `/reload-mcp` inside Hermes to pick up the new
+server without restarting the agent. Hermes will discover the AIMX
+mailbox/email tools automatically.
+
+## Overriding the data directory
+
+If AIMX was set up with a non-default data directory, re-run the
+installer with `--data-dir`:
+
+```bash
+aimx --data-dir /custom/path agent-setup hermes
+```
+
+The printed YAML snippet's `args` array will become
+`[--data-dir, /custom/path, mcp]`.
+
+## Schema reference
+
+Hermes' skill format is documented at
+<https://hermes-agent.nousresearch.com/docs/developer-guide/creating-skills>.
+Skills use YAML frontmatter with `name`, `description`, `version`,
+`author`, `license` (all required) plus an optional `metadata.hermes`
+block declaring tags and required toolsets. The body is agent-facing
+instructions.
+
+Hermes' MCP server configuration lives in `~/.hermes/config.yaml` under
+`mcp_servers.<name>` with `command` + `args` + `enabled` (stdio
+transport). The MCP reference is at
+<https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp/>.
+
+## Design choice: print-snippet activation
+
+Hermes does not currently expose a shell-side CLI for registering
+external MCP servers — `hermes mcp serve` runs Hermes itself as an MCP
+server (the opposite direction), and the canonical registration path per
+the official docs is editing `~/.hermes/config.yaml` directly. AIMX
+follows FR-49: the installer writes the skill to disk and prints the
+exact YAML block you paste into your config, mirroring the Gemini CLI /
+OpenCode integrations rather than the OpenClaw `mcp set` pattern.

--- a/agents/hermes/SKILL.md.header
+++ b/agents/hermes/SKILL.md.header
@@ -1,0 +1,12 @@
+---
+name: aimx
+description: Self-hosted email for AI agents. Send, read, reply to, and manage email via AIMX MCP tools. Invoke when the user asks about sending mail, checking an inbox, replying to a message, or managing mailboxes, or when the conversation references AIMX.
+author: U-Zyn Chua <chua@uzyn.com>
+version: 1.0.0
+license: MIT
+metadata:
+  hermes:
+    tags: [email, communication]
+    requires_toolsets: [terminal]
+---
+

--- a/book/agent-integration.md
+++ b/book/agent-integration.md
@@ -58,11 +58,12 @@ grows as more agents are added.
 | Gemini CLI | `aimx agent-setup gemini` | `~/.gemini/skills/aimx/` | Merge the printed JSON block into `~/.gemini/settings.json`, then restart Gemini CLI. | Single skill file (primer body); references inlined |
 | Goose | `aimx agent-setup goose` | `~/.config/goose/recipes/aimx.yaml` | Run `goose run --recipe aimx`. The recipe bundles its own MCP extension, so no separate config step. | Single YAML blob (primer as `prompt` block scalar); references inlined |
 | OpenClaw | `aimx agent-setup openclaw` | `~/.openclaw/skills/aimx/` | Run the printed `openclaw mcp set aimx '...'` command, then restart the OpenClaw gateway. | Primer as skill + `references/` directory copied as siblings |
+| Hermes | `aimx agent-setup hermes` | `~/.hermes/skills/aimx/` | Paste the printed YAML block under `mcp_servers:` in `~/.hermes/config.yaml`, then run `/reload-mcp` inside Hermes. | Primer as skill + `references/` directory copied as siblings |
 
 ### Progressive disclosure
 
 Every agent receives the same canonical AIMX primer (`agents/common/aimx-primer.md`).
-For agents that support multi-file skill directories (Claude Code, Codex CLI, OpenClaw),
+For agents that support multi-file skill directories (Claude Code, Codex CLI, OpenClaw, Hermes),
 the installer also copies `agents/common/references/` alongside the skill so the agent
 can load detailed reference material on demand without bloating the initial context.
 
@@ -306,6 +307,51 @@ The printed `openclaw mcp set` command's JSON will include
 See [`agents/openclaw/README.md`](https://github.com/uzyn/aimx/tree/main/agents/openclaw)
 for the schema reference.
 
+### Hermes
+
+[Hermes Agent](https://hermes-agent.nousresearch.com/) (by Nous Research)
+loads skills from `~/.hermes/skills/<name>/SKILL.md` (with optional
+`references/` siblings) and reads MCP server definitions from
+`~/.hermes/config.yaml` under the top-level `mcp_servers:` key. There is
+no shell-side CLI for registering external MCP servers in Hermes today
+(`hermes mcp serve` runs Hermes as an MCP server — the opposite
+direction), so AIMX prints a YAML snippet for you to paste into the
+config file, mirroring the Gemini CLI / OpenCode flow.
+
+Install:
+
+```bash
+aimx agent-setup hermes
+```
+
+The installer writes `~/.hermes/skills/aimx/SKILL.md` and the bundled
+`references/` directory, then prints a YAML block like:
+
+```yaml
+mcp_servers:
+  aimx:
+    command: /usr/local/bin/aimx
+    args: [mcp]
+    enabled: true
+```
+
+Add that block to `~/.hermes/config.yaml` under the top-level
+`mcp_servers:` key (create the key if it does not yet exist), save the
+file, then run `/reload-mcp` inside Hermes to pick up the new server
+without restarting.
+
+For a custom data directory:
+
+```bash
+aimx --data-dir /custom/path agent-setup hermes
+```
+
+The printed YAML's `args` line will become
+`args: [--data-dir, /custom/path, mcp]`.
+
+See [`agents/hermes/README.md`](https://github.com/uzyn/aimx/tree/main/agents/hermes)
+for the schema reference.
+
 ## Manual MCP wiring
 
 If your agent is not yet supported, wire AIMX in manually as a plain MCP
@@ -403,3 +449,13 @@ through your own OpenClaw binary:
 Alternatively, hand-edit `~/.openclaw/openclaw.json` and add the
 printed object under `mcpServers.aimx`. The JSON5 format accepts
 comments and trailing commas but vanilla JSON works too.
+
+### Hermes: AIMX tools missing after editing config.yaml
+
+Hermes does not auto-reload MCP servers when `~/.hermes/config.yaml`
+changes — you must run the in-app `/reload-mcp` slash command (or
+restart Hermes) after pasting the snippet. Confirm the snippet sits
+under the top-level `mcp_servers:` key (not nested inside another
+section) and that YAML indentation uses spaces, not tabs. If you have
+no other MCP servers configured, the block can be the entire
+`mcp_servers:` section.

--- a/book/channel-recipes.md
+++ b/book/channel-recipes.md
@@ -31,7 +31,7 @@ Every recipe below assumes the agent binary (`claude`, `codex`, `opencode`, `gem
 | OpenClaw | Yes (`aimx agent-setup openclaw`) | `openclaw agent --message "<prompt>" --deliver --json` | `--deliver` routes the reply back through OpenClaw; `--json` produces a stable, scriptable output envelope | The `agent` subcommand is non-interactive. See [OpenClaw](#openclaw) for a complete recipe. |
 | Aider | No (no MCP server) | `aider --message "<prompt>"` | `--yes-always` | Aider is a code-editing agent; recipes below pattern it as "take email, apply patch, commit." |
 
-All six agents with an `aimx agent-setup <agent>` installer can ALSO be wired as channel triggers — MCP support and channel-trigger support are orthogonal. MCP gives the agent a way to read/send mail on demand; a channel trigger is AIMX pushing an email into the agent when it arrives.
+Every agent with an `aimx agent-setup <agent>` installer can ALSO be wired as channel triggers — MCP support and channel-trigger support are orthogonal. MCP gives the agent a way to read/send mail on demand; a channel trigger is AIMX pushing an email into the agent when it arrives. (Hermes is intentionally not covered by a recipe below yet; it has an installer but no canonical non-interactive CLI story today.)
 
 > **Flag drift warning.** CLI flags for every agent below were verified against each project's current `--help` output and public docs at the time of writing. Agent CLIs evolve fast — always run `<agent> --help` yourself before deploying a recipe to a production mailbox, and check the linked docs for current flag names.
 

--- a/book/getting-started.md
+++ b/book/getting-started.md
@@ -102,7 +102,7 @@ aimx send --from catchall@agent.yourdomain.com \
 Install AIMX into your agent with one command:
 
 ```bash
-aimx agent-setup claude-code    # or codex / opencode / gemini / goose / openclaw
+aimx agent-setup claude-code    # or codex / opencode / gemini / goose / openclaw / hermes
 ```
 
 Run `aimx agent-setup --list` to see every supported agent and its

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -263,8 +263,19 @@ fn hermes_hint(data_dir: Option<&Path>) -> String {
     // library so we avoid a serde_yaml dependency (FR-49 principle: never
     // mutate agent config files; print snippets instead). The args list uses
     // YAML inline-flow syntax so the rendered block stays compact.
+    //
+    // YAML flow sequences treat `,`, `[`, `]`, and `#` as structural, so any
+    // `--data-dir` path containing those characters must be quoted. We route
+    // the path through `serde_json::to_string` to produce a valid YAML
+    // double-quoted scalar (matches how `rewrite_recipe_data_dir` handles the
+    // same problem for Goose recipes).
     let args_inline = match data_dir {
-        Some(dd) => format!("[--data-dir, {}, mcp]", dd.to_string_lossy()),
+        Some(dd) => {
+            let dd_str = dd.to_string_lossy();
+            let quoted =
+                serde_json::to_string(dd_str.as_ref()).unwrap_or_else(|_| format!("\"{dd_str}\""));
+            format!("[--data-dir, {quoted}, mcp]")
+        }
         None => "[mcp]".to_string(),
     };
     format!(
@@ -2350,10 +2361,119 @@ mod tests {
     fn hermes_activation_hint_with_custom_data_dir_rewrites_args() {
         let spec = find_agent("hermes").unwrap();
         let hint = (spec.activation_hint)(Some(Path::new("/custom/aimx-data")));
-        assert!(hint.contains("args: [--data-dir, /custom/aimx-data, mcp]"));
+        // The path is routed through a JSON-string serializer so it is always
+        // emitted as a YAML double-quoted scalar, even for "safe" inputs.
+        assert!(hint.contains("args: [--data-dir, \"/custom/aimx-data\", mcp]"));
         // The other lines remain identical to the default form.
         assert!(hint.contains("command: /usr/local/bin/aimx"));
         assert!(hint.contains("enabled: true"));
+    }
+
+    #[test]
+    fn hermes_activation_hint_escapes_yaml_flow_sensitive_chars_in_data_dir() {
+        // YAML flow sequences treat `,`, `[`, `]`, and `#` as structural.
+        // A `--data-dir` containing any of these MUST be quoted, or the
+        // rendered snippet either fails to parse or silently produces the
+        // wrong argv for Hermes. Regression coverage for the blocker raised
+        // on PR #91.
+        let spec = find_agent("hermes").unwrap();
+
+        // Case 1: path with `[` and `]` (previously produced a YAML parse error).
+        let hint = (spec.activation_hint)(Some(Path::new("/opt/aimx [staging]")));
+        assert!(
+            hint.contains("args: [--data-dir, \"/opt/aimx [staging]\", mcp]"),
+            "bracketed path must be quoted: {hint}"
+        );
+        // Three argv entries separated by commas — not nine.
+        let args_line = hint
+            .lines()
+            .find(|l| l.trim_start().starts_with("args:"))
+            .expect("snippet must contain an args: line");
+        assert_eq!(
+            args_count_in_flow_sequence(args_line),
+            3,
+            "args list must contain exactly 3 entries: {args_line}"
+        );
+
+        // Case 2: path containing `,` (previously split into extra argv entries).
+        let hint = (spec.activation_hint)(Some(Path::new("/path,with,commas")));
+        assert!(
+            hint.contains("args: [--data-dir, \"/path,with,commas\", mcp]"),
+            "comma path must be quoted: {hint}"
+        );
+        let args_line = hint
+            .lines()
+            .find(|l| l.trim_start().starts_with("args:"))
+            .unwrap();
+        assert_eq!(
+            args_count_in_flow_sequence(args_line),
+            3,
+            "args list must contain exactly 3 entries: {args_line}"
+        );
+
+        // Case 3: path containing `#` (previously triggered YAML comment handling).
+        let hint = (spec.activation_hint)(Some(Path::new("/opt/aimx #archive")));
+        assert!(
+            hint.contains("args: [--data-dir, \"/opt/aimx #archive\", mcp]"),
+            "hash path must be quoted: {hint}"
+        );
+
+        // Case 4: path containing `"` and `\` — must be JSON-escaped inside
+        // the double-quoted scalar so the resulting YAML is still valid.
+        let hint = (spec.activation_hint)(Some(Path::new(r#"/opt/a"b\c"#)));
+        assert!(
+            hint.contains(r#"args: [--data-dir, "/opt/a\"b\\c", mcp]"#),
+            "quote/backslash path must be JSON-escaped: {hint}"
+        );
+    }
+
+    // Count items in a YAML flow sequence like `args: [a, b, c]` by splitting
+    // on the commas that live OUTSIDE any double-quoted scalar. This mirrors
+    // what a real YAML parser does on the `args:` line and lets us verify
+    // the argv survives round-trip without pulling in a YAML crate.
+    fn args_count_in_flow_sequence(line: &str) -> usize {
+        let lb = line.find('[').expect("expected `[` in flow sequence");
+        let rb = line.rfind(']').expect("expected `]` in flow sequence");
+        let inner = &line[lb + 1..rb];
+
+        let mut count = 0usize;
+        let mut has_content = false;
+        let mut in_quotes = false;
+        let mut escaped = false;
+        for ch in inner.chars() {
+            if escaped {
+                escaped = false;
+                has_content = true;
+                continue;
+            }
+            if in_quotes {
+                match ch {
+                    '\\' => escaped = true,
+                    '"' => in_quotes = false,
+                    _ => {}
+                }
+                has_content = true;
+                continue;
+            }
+            match ch {
+                '"' => {
+                    in_quotes = true;
+                    has_content = true;
+                }
+                ',' => {
+                    if has_content {
+                        count += 1;
+                    }
+                    has_content = false;
+                }
+                c if c.is_whitespace() => {}
+                _ => has_content = true,
+            }
+        }
+        if has_content {
+            count += 1;
+        }
+        count
     }
 
     #[test]

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -35,7 +35,7 @@ pub struct AgentSpec {
 /// Static registry of supported agents.
 ///
 /// v1 roster: `claude-code`, `codex`, `opencode`, `gemini`, `goose`,
-/// `openclaw` (PRD §6.10 FR-50). Source-tree layout asymmetry is by
+/// `openclaw`, `hermes` (PRD §6.10 FR-50). Source-tree layout asymmetry is by
 /// design; `assemble_plugin_files` walks each source tree relative to its
 /// root and handles all three shapes. Do not "normalize" the layout —
 /// the destination template determines the depth.
@@ -103,6 +103,18 @@ pub fn registry() -> &'static [AgentSpec] {
             // skill-directory package (no flat SKILL.md at the root).
             dest_template: "$HOME/.openclaw/skills/aimx",
             activation_hint: openclaw_hint,
+            progressive_disclosure: true,
+        },
+        AgentSpec {
+            name: "hermes",
+            source_subdir: "hermes",
+            // Hermes Agent (Nous Research) loads skills from
+            // ~/.hermes/skills/<name>/SKILL.md with optional `references/`
+            // siblings. MCP servers live in ~/.hermes/config.yaml under
+            // `mcp_servers:`; there is no shell-side `mcp add` CLI today, so
+            // the activation hint prints a YAML snippet to paste in.
+            dest_template: "$HOME/.hermes/skills/aimx",
+            activation_hint: hermes_hint,
             progressive_disclosure: true,
         },
     ]
@@ -236,6 +248,40 @@ fn goose_hint(_data_dir: Option<&Path>) -> String {
      $GOOSE_RECIPE_GITHUB_REPO; Goose loads recipes from that repo when \
      the variable is set.\n"
         .to_string()
+}
+
+fn hermes_hint(data_dir: Option<&Path>) -> String {
+    // Hermes Agent does NOT expose a shell-side CLI for registering external
+    // MCP servers. `hermes mcp serve` runs Hermes itself as an MCP server
+    // (the opposite direction); the canonical registration path per the
+    // official docs is editing ~/.hermes/config.yaml directly. We print a
+    // YAML snippet to paste under the top-level `mcp_servers:` key, then
+    // the user runs `/reload-mcp` inside Hermes to pick up the new server
+    // without restarting.
+    //
+    // The snippet is hand-rendered as YAML rather than serialized via a YAML
+    // library so we avoid a serde_yaml dependency (FR-49 principle: never
+    // mutate agent config files; print snippets instead). The args list uses
+    // YAML inline-flow syntax so the rendered block stays compact.
+    let args_inline = match data_dir {
+        Some(dd) => format!("[--data-dir, {}, mcp]", dd.to_string_lossy()),
+        None => "[mcp]".to_string(),
+    };
+    format!(
+        "Skill installed at ~/.hermes/skills/aimx/. Add the following block \
+         to the top-level `mcp_servers:` key in ~/.hermes/config.yaml \
+         (create the key if it does not yet exist):\n\
+         \n\
+         \x20\x20mcp_servers:\n\
+         \x20\x20\x20\x20aimx:\n\
+         \x20\x20\x20\x20\x20\x20command: /usr/local/bin/aimx\n\
+         \x20\x20\x20\x20\x20\x20args: {args_inline}\n\
+         \x20\x20\x20\x20\x20\x20enabled: true\n\
+         \n\
+         Then run `/reload-mcp` inside Hermes to pick up the new server \
+         without restarting. (Hermes loads MCP servers from \
+         ~/.hermes/config.yaml; `/reload-mcp` re-reads that file at runtime.)"
+    )
 }
 
 fn openclaw_hint(data_dir: Option<&Path>) -> String {
@@ -1505,7 +1551,7 @@ mod tests {
     }
 
     #[test]
-    fn registry_lists_six_agents_in_canonical_order() {
+    fn registry_lists_seven_agents_in_canonical_order() {
         let names: Vec<&str> = registry().iter().map(|s| s.name).collect();
         assert_eq!(
             names,
@@ -1515,7 +1561,8 @@ mod tests {
                 "opencode",
                 "gemini",
                 "goose",
-                "openclaw"
+                "openclaw",
+                "hermes",
             ]
         );
     }
@@ -2087,6 +2134,7 @@ mod tests {
         assert!(by_name("claude-code").progressive_disclosure);
         assert!(by_name("codex").progressive_disclosure);
         assert!(by_name("openclaw").progressive_disclosure);
+        assert!(by_name("hermes").progressive_disclosure);
 
         assert!(!by_name("opencode").progressive_disclosure);
         assert!(!by_name("gemini").progressive_disclosure);
@@ -2112,7 +2160,14 @@ mod tests {
 
     #[test]
     fn author_metadata_in_all_skill_headers() {
-        for agent in ["claude-code", "codex", "opencode", "gemini", "openclaw"] {
+        for agent in [
+            "claude-code",
+            "codex",
+            "opencode",
+            "gemini",
+            "openclaw",
+            "hermes",
+        ] {
             let header_path = match agent {
                 "claude-code" => "claude-code/skills/aimx/SKILL.md.header",
                 _ => &format!("{agent}/SKILL.md.header"),
@@ -2226,5 +2281,104 @@ mod tests {
         assert!(ref_text.contains("\"true\""));
         assert!(ref_text.contains("\"false\""));
         assert!(ref_text.contains("trusted_senders"));
+    }
+
+    #[test]
+    fn registry_contains_hermes() {
+        let spec = find_agent("hermes").expect("registry must include hermes");
+        assert_eq!(spec.dest_template, "$HOME/.hermes/skills/aimx");
+        assert!(spec.progressive_disclosure);
+    }
+
+    #[test]
+    fn install_hermes_lays_out_expected_files() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        run_with_env(Some("hermes".into()), false, false, false, None, &env).unwrap();
+
+        let dest = tmp.path().join(".hermes/skills/aimx");
+        assert!(dest.join("SKILL.md").exists());
+        assert!(!dest.join("SKILL.md.header").exists());
+        assert!(!dest.join("README.md").exists());
+
+        let skill = std::fs::read_to_string(dest.join("SKILL.md")).unwrap();
+        assert!(
+            skill.starts_with("---\n"),
+            "missing YAML frontmatter: {skill:.200}"
+        );
+        assert!(skill.contains("name: aimx"));
+        assert!(skill.contains("description:"));
+        assert!(skill.contains("license: MIT"));
+        assert!(skill.contains("metadata:"));
+        assert!(skill.contains("hermes:"));
+        assert!(skill.contains("mailbox_create"));
+        assert!(skill.contains("Trust model"));
+    }
+
+    #[test]
+    fn hermes_progressive_disclosure_installs_references() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        run_with_env(Some("hermes".into()), false, false, false, None, &env).unwrap();
+
+        let dest = tmp.path().join(".hermes/skills/aimx");
+        assert!(dest.join("SKILL.md").exists());
+        assert!(dest.join("references/mcp-tools.md").exists());
+        assert!(dest.join("references/frontmatter.md").exists());
+        assert!(dest.join("references/workflows.md").exists());
+        assert!(dest.join("references/troubleshooting.md").exists());
+    }
+
+    #[test]
+    fn hermes_activation_hint_mentions_config_and_reload() {
+        let spec = find_agent("hermes").unwrap();
+        let hint = (spec.activation_hint)(None);
+        assert!(hint.contains("~/.hermes/config.yaml"));
+        assert!(hint.contains("/reload-mcp"));
+        assert!(hint.contains("mcp_servers:"));
+        assert!(hint.contains("aimx:"));
+        assert!(hint.contains("command: /usr/local/bin/aimx"));
+        assert!(hint.contains("args: [mcp]"));
+        assert!(hint.contains("enabled: true"));
+        // Default install must not leak --data-dir into the snippet.
+        assert!(!hint.contains("--data-dir"));
+    }
+
+    #[test]
+    fn hermes_activation_hint_with_custom_data_dir_rewrites_args() {
+        let spec = find_agent("hermes").unwrap();
+        let hint = (spec.activation_hint)(Some(Path::new("/custom/aimx-data")));
+        assert!(hint.contains("args: [--data-dir, /custom/aimx-data, mcp]"));
+        // The other lines remain identical to the default form.
+        assert!(hint.contains("command: /usr/local/bin/aimx"));
+        assert!(hint.contains("enabled: true"));
+    }
+
+    #[test]
+    fn assembled_hermes_skill_is_header_plus_primer_byte_for_byte() {
+        let source = AGENTS_DIR.get_dir("hermes").unwrap();
+        let files = assemble_plugin_files(source, None).unwrap();
+
+        let (_, skill_bytes) = files
+            .iter()
+            .find(|(rel, _)| rel.to_string_lossy() == "SKILL.md")
+            .expect("assembled SKILL.md should be present");
+
+        let header = AGENTS_DIR
+            .get_file("hermes/SKILL.md.header")
+            .unwrap()
+            .contents();
+        let primer = AGENTS_DIR
+            .get_file("common/aimx-primer.md")
+            .unwrap()
+            .contents();
+
+        let mut expected = Vec::with_capacity(header.len() + primer.len());
+        expected.extend_from_slice(header);
+        expected.extend_from_slice(primer);
+
+        assert_eq!(skill_bytes, &expected);
     }
 }


### PR DESCRIPTION
## Summary

Adds Hermes Agent (Nous Research, MIT-licensed CLI agent) as the seventh
supported agent in `aimx agent-setup`, alongside Claude Code, Codex CLI,
OpenCode, Gemini CLI, Goose, and OpenClaw. Hermes' skill model
(`~/.hermes/skills/<name>/SKILL.md` + optional `references/`) and MCP
config (`~/.hermes/config.yaml` under `mcp_servers:`) map cleanly onto
the existing assembly + activation-hint infrastructure — no new helpers
or dependencies needed.

## Requirements

- [x] New `agents/hermes/SKILL.md.header` with YAML frontmatter
  (`name`, `description`, `version`, `author`, `license`, plus a
  `metadata.hermes` block declaring tags + required toolsets).
- [x] New `agents/hermes/README.md` mirroring the OpenClaw README shape.
- [x] New `AgentSpec` entry in `registry()` (`$HOME/.hermes/skills/aimx`,
  `progressive_disclosure: true`).
- [x] New `hermes_hint` activation function that prints the install
  path, a YAML snippet for `~/.hermes/config.yaml` under `mcp_servers:`,
  and the `/reload-mcp` in-app instruction. `--data-dir` rewrites the
  printed args list.
- [x] Six new unit tests: registry membership, install file layout,
  `references/` inclusion, hint mentions config.yaml + `/reload-mcp`,
  `--data-dir` args rewrite, byte-for-byte header+primer assembly.
- [x] Existing matrix tests updated (registry count six → seven,
  author-metadata loop, progressive-disclosure assignments).
- [x] `book/agent-integration.md` updated: new matrix row, per-agent
  section, Hermes troubleshooting note, progressive-disclosure mention.
- [x] `book/getting-started.md` install one-liner extended.
- [x] `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`,
  full `cargo test` suite all green (769 unit + 64 integration tests).

## Out of scope

- Auto-editing `~/.hermes/config.yaml` (FR-49: never mutate agent config
  files; print snippets instead). No `serde_yaml` dependency added.
- A `hermes mcp add`-style printed CLI command — Hermes docs confirm no
  such shell CLI exists today (`hermes mcp serve` runs Hermes itself as
  an MCP server, the opposite direction). Re-evaluate if Hermes adds one
  in a future release.
- Hermes channel-trigger recipe in `book/channel-recipes.md` — defer
  until there's a clear non-interactive CLI story for Hermes.

## Technical approach

Mirrors the OpenClaw integration shape (closest analog: both agents use
`~/<agent>/skills/aimx/` folder layouts with progressive disclosure).
Reuses the existing `assemble_plugin_files_with_disclosure` pipeline —
it concatenates `SKILL.md.header` + `agents/common/aimx-primer.md` and
copies `agents/common/references/` siblings when
`progressive_disclosure: true`. `hermes_hint` is a pure function that
hand-renders the YAML snippet (no env-var interpolation, matches the
goose/openclaw determinism convention) and uses the same arg order as
`rewrite_plugin_args` for `--data-dir` injection
(`[--data-dir, <path>, mcp]`).

Activation strategy uses the print-snippet pattern (mirroring
Gemini/OpenCode) rather than the OpenClaw `mcp set` pattern because
Hermes' official MCP docs confirm there is no canonical shell CLI for
registering external MCP servers today.

## Test plan

- TDD: wrote the six Hermes unit tests, observed they failed, then
  implemented the registry entry + `hermes_hint` to green.
- Full `cargo test` suite green (769 unit + 64 integration tests).
- Manual smoke tests:
  - `cargo run -- agent-setup --list` shows Hermes with the correct
    destination and full activation hint.
  - `cargo run -- agent-setup hermes --print` emits SKILL.md (header +
    primer), four `references/*.md` files, and the activation hint with
    the YAML snippet.
  - `cargo run -- --data-dir /custom/path agent-setup hermes --print`
    rewrites the printed `args` line to
    `[--data-dir, /custom/path, mcp]`.

## Notes

- One mid-task course-correction: research initially suggested printing
  both a YAML snippet and a `hermes mcp add` CLI command, but
  verifying against the official Hermes MCP docs revealed the only
  `hermes mcp` subcommand is `serve` (runs Hermes as an MCP server, not
  for registering external ones). Plan was revised before
  implementation to YAML-snippet-only; this is documented in
  `agents/hermes/README.md` under "Design choice: print-snippet
  activation" so a future contributor can revisit if Hermes ships a
  registration CLI.