### PR TITLE
fix: default DKIM selector to aimx (`aimx._domainkey`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ domain = "agent.yourdomain.com"
 data_dir = "/var/lib/aimx"
 
 # DKIM selector name (default: dkim)
-dkim_selector = "dkim"
+dkim_selector = "aimx"
 
 # Verifier service base URL (default: https://check.aimx.email)
 # Used by `aimx portcheck` and `aimx setup`. Set this only if
@@ -324,7 +324,7 @@ Precedence is **CLI flag > config > default** (`https://check.aimx.email`).
 | A | agent.yourdomain.com | Your server IP |
 | MX | agent.yourdomain.com | 10 agent.yourdomain.com. |
 | TXT | agent.yourdomain.com | v=spf1 ip4:YOUR_IP -all |
-| TXT | dkim._domainkey.agent.yourdomain.com | v=DKIM1; k=rsa; p=... |
+| TXT | aimx._domainkey.agent.yourdomain.com | v=DKIM1; k=rsa; p=... |
 | TXT | _dmarc.agent.yourdomain.com | v=DMARC1; p=reject |
 
 Reverse DNS (PTR) is configured at your VPS provider's control panel. Setting a correct PTR record improves deliverability but is the operator's responsibility and is out of scope for `aimx setup`.

--- a/book/configuration.md
+++ b/book/configuration.md
@@ -181,8 +181,8 @@ domain = "agent.yourdomain.com"
 # Data directory (default: /var/lib/aimx)
 data_dir = "/var/lib/aimx"
 
-# DKIM selector name (default: dkim)
-dkim_selector = "dkim"
+# DKIM selector name (default: aimx)
+dkim_selector = "aimx"
 
 # Custom verifier service host (optional)
 # verify_host = "https://verify.yourdomain.com"

--- a/book/setup.md
+++ b/book/setup.md
@@ -126,7 +126,7 @@ After the setup wizard displays the required DNS records, add them at your domai
 | AAAA | `agent.yourdomain.com` | Your server IPv6 (if available) | Domain registrar |
 | MX | `agent.yourdomain.com` | `10 agent.yourdomain.com.` | Domain registrar |
 | TXT | `agent.yourdomain.com` | `v=spf1 ip4:YOUR_IP -all` (or `v=spf1 ip4:YOUR_IP ip6:YOUR_IPV6 -all` with IPv6) | Domain registrar |
-| TXT | `dkim._domainkey.agent.yourdomain.com` | `v=DKIM1; k=rsa; p=...` | Domain registrar |
+| TXT | `aimx._domainkey.agent.yourdomain.com` | `v=DKIM1; k=rsa; p=...` | Domain registrar |
 | TXT | `_dmarc.agent.yourdomain.com` | `v=DMARC1; p=reject` | Domain registrar |
 
 Reverse DNS (PTR) is configured at your VPS provider's control panel and is **not** covered by `aimx setup` — it is out of scope for aimx as of v0.2. A correct PTR record pointing to your domain does improve deliverability; see the VPS provider's documentation for how to set it.
@@ -163,7 +163,7 @@ dig +short TXT agent.yourdomain.com
 # Should include: v=spf1 ip4:YOUR_IP -all (or v=spf1 ip4:YOUR_IP ip6:YOUR_IPV6 -all)
 
 # DKIM record
-dig +short TXT dkim._domainkey.agent.yourdomain.com
+dig +short TXT aimx._domainkey.agent.yourdomain.com
 # Should include: v=DKIM1; k=rsa; p=...
 
 # DMARC record
@@ -211,7 +211,7 @@ aimx send \
 DKIM keys are generated automatically during setup. To manage them independently:
 
 ```bash
-# Generate DKIM keypair (default selector: "dkim")
+# Generate DKIM keypair (default selector: "aimx")
 aimx dkim-keygen
 
 # Force regenerate (overwrites existing keys)

--- a/book/troubleshooting.md
+++ b/book/troubleshooting.md
@@ -92,7 +92,7 @@ The generated OpenRC init script uses `supervise-daemon`, which routes daemon ou
 ### Check DKIM DNS record
 
 ```bash
-dig +short TXT dkim._domainkey.agent.yourdomain.com
+dig +short TXT aimx._domainkey.agent.yourdomain.com
 ```
 
 The output should contain `v=DKIM1; k=rsa; p=...` matching your public key.

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -177,7 +177,7 @@ mod tests {
         Config {
             domain: "test.com".to_string(),
             data_dir: PathBuf::from("/tmp/aimx-test"),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             trust: "none".to_string(),
             trusted_senders: vec![],
             mailboxes: HashMap::new(),

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -113,7 +113,7 @@ pub enum Command {
     /// Generate DKIM keypair for email signing
     DkimKeygen {
         /// DKIM selector name
-        #[arg(long, default_value = "dkim")]
+        #[arg(long, default_value = "aimx")]
         selector: String,
 
         /// Overwrite existing keys

--- a/src/config.rs
+++ b/src/config.rs
@@ -136,7 +136,7 @@ fn default_data_dir() -> PathBuf {
 }
 
 fn default_dkim_selector() -> String {
-    "dkim".to_string()
+    "aimx".to_string()
 }
 
 /// Allowed values for `Config::trust` and per-mailbox `MailboxConfig::trust`.
@@ -514,6 +514,14 @@ printf 'from=%s subject=%s id=%s\n' "$AIMX_FROM" "$AIMX_SUBJECT" "{id}"
     }
 
     #[test]
+    fn default_dkim_selector_is_aimx() {
+        assert_eq!(super::default_dkim_selector(), "aimx");
+        let toml_str = "domain = \"test.com\"\n[mailboxes]\n";
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.dkim_selector, "aimx");
+    }
+
+    #[test]
     fn save_and_load_roundtrip() {
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("config.toml");
@@ -532,7 +540,7 @@ printf 'from=%s subject=%s id=%s\n' "$AIMX_FROM" "$AIMX_SUBJECT" "{id}"
         let config = Config {
             domain: "test.com".to_string(),
             data_dir: tmp.path().to_path_buf(),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             trust: "none".to_string(),
             trusted_senders: vec![],
             mailboxes,
@@ -683,7 +691,7 @@ trusted_senders = []
         let config = Config {
             domain: "test.com".to_string(),
             data_dir: PathBuf::from("/tmp/x"),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             trust: "none".to_string(),
             trusted_senders: vec![],
             mailboxes: HashMap::new(),
@@ -720,7 +728,7 @@ trusted_senders = []
         let config = Config {
             domain: "test.com".to_string(),
             data_dir: PathBuf::from("/tmp/x"),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             trust: "verified".to_string(),
             trusted_senders: vec!["*@company.com".to_string()],
             mailboxes,

--- a/src/dkim.rs
+++ b/src/dkim.rs
@@ -524,13 +524,13 @@ mod tests {
             \r\n\
             Hello world\r\n";
 
-        let signed = sign_message(message, &private_key, "example.com", "dkim").unwrap();
+        let signed = sign_message(message, &private_key, "example.com", "aimx").unwrap();
         let signed_str = String::from_utf8_lossy(&signed);
 
         assert!(signed_str.contains("DKIM-Signature:"));
         assert!(signed_str.contains("a=rsa-sha256"));
         assert!(signed_str.contains("d=example.com"));
-        assert!(signed_str.contains("s=dkim"));
+        assert!(signed_str.contains("s=aimx"));
 
         assert!(signed_str.contains("From: test@example.com"));
     }
@@ -594,7 +594,7 @@ mod tests {
             \r\n\
             Hello world\r\n";
 
-        let signed = sign_message(message, &private_key, "example.com", "dkim").unwrap();
+        let signed = sign_message(message, &private_key, "example.com", "aimx").unwrap();
         let signed_str = String::from_utf8_lossy(&signed);
 
         let dkim_header = signed_str
@@ -653,7 +653,7 @@ mod tests {
             \r\n\
             Hello world\r\n";
 
-        let signed = sign_message(message, &private_key, "example.com", "dkim").unwrap();
+        let signed = sign_message(message, &private_key, "example.com", "aimx").unwrap();
         let signed_str = String::from_utf8_lossy(&signed);
 
         assert!(
@@ -683,7 +683,7 @@ mod tests {
             \r\n\
             Hello world\r\n";
 
-        let signed = sign_message(message, &private_key, "example.com", "dkim").unwrap();
+        let signed = sign_message(message, &private_key, "example.com", "aimx").unwrap();
         let signed_str = String::from_utf8_lossy(&signed);
 
         // Collect the full DKIM-Signature header (may span multiple lines)

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -816,7 +816,7 @@ mod tests {
         Config {
             domain: "test.com".to_string(),
             data_dir: tmp.to_path_buf(),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             trust: "none".to_string(),
             trusted_senders: vec![],
             mailboxes,

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -344,7 +344,7 @@ mod tests {
         Config {
             domain: "test.com".to_string(),
             data_dir: tmp.to_path_buf(),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             trust: "none".to_string(),
             trusted_senders: vec![],
             mailboxes,

--- a/src/mailbox_handler.rs
+++ b/src/mailbox_handler.rs
@@ -296,7 +296,7 @@ mod tests {
         Config {
             domain: "example.com".to_string(),
             data_dir: data_dir.to_path_buf(),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             trust: "none".to_string(),
             trusted_senders: vec![],
             mailboxes,

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -939,7 +939,7 @@ mod tests {
         Config {
             domain: "test.com".to_string(),
             data_dir: tmp.to_path_buf(),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             trust: "none".to_string(),
             trusted_senders: vec![],
             mailboxes,

--- a/src/send_handler.rs
+++ b/src/send_handler.rs
@@ -54,7 +54,7 @@ pub struct RegisteredMailbox {
 pub struct SendContext {
     /// DKIM private key, loaded once at `aimx serve` startup.
     pub dkim_key: Arc<RsaPrivateKey>,
-    /// DKIM selector (`dkim._domainkey.<domain>`).
+    /// DKIM selector (`<selector>._domainkey.<domain>`).
     pub dkim_selector: String,
     /// Live handle to the daemon's `Config`. Read briefly at the top of
     /// `handle_send` to capture the snapshot used for this request.
@@ -613,7 +613,7 @@ mod tests {
         let config = crate::config::Config {
             domain: "example.com".to_string(),
             data_dir: dir.clone(),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             trust: "none".to_string(),
             trusted_senders: vec![],
             mailboxes,
@@ -623,7 +623,7 @@ mod tests {
         let config_handle = ConfigHandle::new(config);
         SendContext {
             dkim_key: Arc::new(key),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             config_handle,
             transport,
             data_dir: dir,

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -119,7 +119,7 @@ pub enum DkimStartupCheck {
     Match,
     /// DNS `p=` differs from the on-disk key — receivers will see DKIM fail.
     Mismatch { dns: String, local: String },
-    /// No `dkim._domainkey.<domain>` TXT record present.
+    /// No `<selector>._domainkey.<domain>` TXT record present.
     NoRecord,
     /// TXT record exists but has no `p=` tag.
     NoPTag,
@@ -1012,7 +1012,7 @@ mod tests {
             let config = crate::config::Config {
                 domain: "test.local".to_string(),
                 data_dir: tmp.path().to_path_buf(),
-                dkim_selector: "dkim".to_string(),
+                dkim_selector: "aimx".to_string(),
                 trust: "none".to_string(),
                 trusted_senders: vec![],
                 mailboxes,
@@ -1202,7 +1202,7 @@ mod tests {
         let resolver = FakeDkimResolver {
             result: Err("simulated NXDOMAIN".into()),
         };
-        match run_dkim_startup_check(&resolver, "example.com", "dkim", tmp.path()) {
+        match run_dkim_startup_check(&resolver, "example.com", "aimx", tmp.path()) {
             DkimStartupCheck::ResolveError(msg) => {
                 assert!(msg.contains("NXDOMAIN"), "got: {msg}");
             }
@@ -1221,7 +1221,7 @@ mod tests {
             result: Ok(vec![record]),
         };
         assert_eq!(
-            run_dkim_startup_check(&resolver, "example.com", "dkim", tmp.path()),
+            run_dkim_startup_check(&resolver, "example.com", "aimx", tmp.path()),
             DkimStartupCheck::Match
         );
     }
@@ -1233,10 +1233,10 @@ mod tests {
         let resolver = FakeDkimResolver {
             result: Ok(vec!["v=DKIM1; k=rsa; p=SOMEOTHERKEY".to_string()]),
         };
-        let outcome = run_dkim_startup_check(&resolver, "example.com", "dkim", tmp.path());
+        let outcome = run_dkim_startup_check(&resolver, "example.com", "aimx", tmp.path());
         assert!(matches!(outcome, DkimStartupCheck::Mismatch { .. }));
         // Smoke: the logging path does not panic on a long base64 payload.
-        log_dkim_startup_check(&outcome, "example.com", "dkim");
+        log_dkim_startup_check(&outcome, "example.com", "aimx");
     }
 
     #[test]
@@ -1247,7 +1247,7 @@ mod tests {
             result: Ok(vec!["v=spf1 -all".to_string()]),
         };
         assert_eq!(
-            run_dkim_startup_check(&resolver, "example.com", "dkim", tmp.path()),
+            run_dkim_startup_check(&resolver, "example.com", "aimx", tmp.path()),
             DkimStartupCheck::NoRecord
         );
     }
@@ -1317,7 +1317,7 @@ mod tests {
         crate::config::Config {
             domain: "example.com".to_string(),
             data_dir: data_dir.to_path_buf(),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             trust: "none".to_string(),
             trusted_senders: vec![],
             mailboxes,
@@ -1337,7 +1337,7 @@ mod tests {
         let transport: Arc<dyn MailTransport + Send + Sync> = Arc::new(NoopTransport);
         Arc::new(crate::send_handler::SendContext {
             dkim_key: Arc::new(key),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             config_handle: handle,
             transport,
             data_dir: data_dir.to_path_buf(),
@@ -1462,7 +1462,7 @@ mod tests {
             let config = crate::config::Config {
                 domain: "example.com".to_string(),
                 data_dir: tmp.path().to_path_buf(),
-                dkim_selector: "dkim".to_string(),
+                dkim_selector: "aimx".to_string(),
                 trust: "none".to_string(),
                 trusted_senders: vec![],
                 mailboxes,
@@ -1473,7 +1473,7 @@ mod tests {
 
             let send_ctx = Arc::new(crate::send_handler::SendContext {
                 dkim_key: Arc::new(key),
-                dkim_selector: "dkim".to_string(),
+                dkim_selector: "aimx".to_string(),
                 config_handle: handle_cfg.clone(),
                 transport,
                 data_dir: tmp.path().to_path_buf(),
@@ -1529,12 +1529,12 @@ mod tests {
             let signed = String::from_utf8_lossy(&signed_bytes);
             assert!(signed.starts_with("DKIM-Signature:"));
             assert!(signed.contains("d=example.com"));
-            assert!(signed.contains("s=dkim"));
+            assert!(signed.contains("s=aimx"));
 
             // Cryptographically verify the DKIM signature using our test
             // public key. We feed the key to `mail-auth` through an
             // in-memory TXT cache so no DNS lookup is performed.
-            verify_dkim_with_pubkey(&signed_bytes, &pub_pem, "example.com", "dkim").await;
+            verify_dkim_with_pubkey(&signed_bytes, &pub_pem, "example.com", "aimx").await;
 
             shutdown_tx.send(true).unwrap();
             let _ = tokio::time::timeout(std::time::Duration::from_secs(5), handle).await;

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1407,10 +1407,10 @@ pub fn run_setup(
     let (dkim_selector, enable_ipv6) = if config_path.exists() {
         match Config::load(&config_path) {
             Ok(c) => (c.dkim_selector, c.enable_ipv6),
-            Err(_) => ("dkim".to_string(), false),
+            Err(_) => ("aimx".to_string(), false),
         }
     } else {
-        ("dkim".to_string(), false)
+        ("aimx".to_string(), false)
     };
 
     // Re-entrant detection: if already configured, skip install/configure steps
@@ -1861,7 +1861,7 @@ mod tests {
             "1.2.3.4",
             None,
             "v=DKIM1; k=rsa; p=ABC123",
-            "dkim",
+            "aimx",
         );
         assert_eq!(records.len(), 5);
 
@@ -1878,7 +1878,7 @@ mod tests {
         assert!(!records[2].value.contains("ip6:"));
 
         assert_eq!(records[3].record_type, "TXT");
-        assert_eq!(records[3].name, "dkim._domainkey.agent.example.com");
+        assert_eq!(records[3].name, "aimx._domainkey.agent.example.com");
         assert!(records[3].value.contains("DKIM1"));
 
         assert_eq!(records[4].record_type, "TXT");
@@ -1895,7 +1895,7 @@ mod tests {
     #[test]
     fn dns_record_formatting() {
         let records =
-            generate_dns_records("test.com", "5.6.7.8", None, "v=DKIM1; k=rsa; p=XYZ", "dkim");
+            generate_dns_records("test.com", "5.6.7.8", None, "v=DKIM1; k=rsa; p=XYZ", "aimx");
         let formatted = format_dns_records(&records);
         assert!(formatted.contains("A"));
         assert!(formatted.contains("MX"));
@@ -1998,11 +1998,11 @@ mod tests {
     fn verify_dkim_pass_no_local_key() {
         let mut net = MockNetworkOps::default();
         net.txt_records.insert(
-            "dkim._domainkey.example.com".into(),
+            "aimx._domainkey.example.com".into(),
             vec!["v=DKIM1; k=rsa; p=ABC123".into()],
         );
         assert_eq!(
-            verify_dkim(&net, "example.com", "dkim", None),
+            verify_dkim(&net, "example.com", "aimx", None),
             DnsVerifyResult::Pass
         );
     }
@@ -2011,11 +2011,11 @@ mod tests {
     fn verify_dkim_pass_with_matching_key() {
         let mut net = MockNetworkOps::default();
         net.txt_records.insert(
-            "dkim._domainkey.example.com".into(),
+            "aimx._domainkey.example.com".into(),
             vec!["v=DKIM1; k=rsa; p=ABC123".into()],
         );
         assert_eq!(
-            verify_dkim(&net, "example.com", "dkim", Some("ABC123")),
+            verify_dkim(&net, "example.com", "aimx", Some("ABC123")),
             DnsVerifyResult::Pass
         );
     }
@@ -2024,10 +2024,10 @@ mod tests {
     fn verify_dkim_fail_mismatched_key() {
         let mut net = MockNetworkOps::default();
         net.txt_records.insert(
-            "dkim._domainkey.example.com".into(),
+            "aimx._domainkey.example.com".into(),
             vec!["v=DKIM1; k=rsa; p=ABC123".into()],
         );
-        match verify_dkim(&net, "example.com", "dkim", Some("WRONG_KEY")) {
+        match verify_dkim(&net, "example.com", "aimx", Some("WRONG_KEY")) {
             DnsVerifyResult::Fail(msg) => {
                 assert!(msg.contains("does not match"), "Got: {msg}")
             }
@@ -2043,11 +2043,11 @@ mod tests {
         let long_key = "MIIBCgKCAQEA011La5tkO7DUxlLEduWsIbrPcK0NAS9SpcW9rftGU2Kx6F0YSPy/54QjZ13AZk6eGM0zJgF3JF9ibX/GiRDVefqCJPhi7lj1kq6xErWxO0ZR7/YslRcoSoAHR/PnO8chRr1DVHEY+5e0cY54z5SLR+lq/xn69zuiHq5AZBpevcfn/ESA3KujF3rXjDT4DM+ydqu92bdLB4MpLMezVoOjNq75RsSQW/ItokH37V4g6OtrV41yYEGvhAawG24j2Kj6RT96cXdOrvRqUb1/IH/a81Is0WH/PoXSLpwarF0Ie1u/+RfUWLj57osAuIsScbzVmzo5Pil+GgAU45UXj91pDwIDAQAB";
         let mut net = MockNetworkOps::default();
         net.txt_records.insert(
-            "dkim._domainkey.example.com".into(),
+            "aimx._domainkey.example.com".into(),
             vec![format!("v=DKIM1; k=rsa; p={long_key}")],
         );
         assert_eq!(
-            verify_dkim(&net, "example.com", "dkim", Some(long_key)),
+            verify_dkim(&net, "example.com", "aimx", Some(long_key)),
             DnsVerifyResult::Pass,
         );
     }
@@ -2055,7 +2055,7 @@ mod tests {
     #[test]
     fn verify_dkim_missing() {
         let net = MockNetworkOps::default();
-        match verify_dkim(&net, "example.com", "dkim", None) {
+        match verify_dkim(&net, "example.com", "aimx", None) {
             DnsVerifyResult::Missing(msg) => assert!(msg.contains("No DKIM")),
             other => panic!("Expected Missing, got {:?}", other),
         }
@@ -2144,7 +2144,7 @@ mod tests {
         net.txt_records
             .insert("example.com".into(), vec!["v=spf1 ip4:1.2.3.4 -all".into()]);
         net.txt_records.insert(
-            "dkim._domainkey.example.com".into(),
+            "aimx._domainkey.example.com".into(),
             vec!["v=DKIM1; k=rsa; p=ABC".into()],
         );
         net.txt_records.insert(
@@ -2152,7 +2152,7 @@ mod tests {
             vec!["v=DMARC1; p=reject".into()],
         );
 
-        let results = verify_all_dns(&net, "example.com", &ip, None, "dkim", None);
+        let results = verify_all_dns(&net, "example.com", &ip, None, "aimx", None);
         assert!(results.iter().all(|(_, r)| *r == DnsVerifyResult::Pass));
     }
 
@@ -2164,7 +2164,7 @@ mod tests {
             .insert("example.com".into(), vec!["10 example.com.".into()]);
         // A record missing, SPF missing, etc.
 
-        let results = verify_all_dns(&net, "example.com", &ip, None, "dkim", None);
+        let results = verify_all_dns(&net, "example.com", &ip, None, "aimx", None);
         let pass_count = results
             .iter()
             .filter(|(_, r)| *r == DnsVerifyResult::Pass)
@@ -2525,7 +2525,7 @@ mod tests {
     fn config_dir_exists_after_finalize() {
         let tmp = TempDir::new().unwrap();
         let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
-        finalize_setup(tmp.path(), "mode.example.com", "dkim", None).unwrap();
+        finalize_setup(tmp.path(), "mode.example.com", "aimx", None).unwrap();
 
         // Config file resolved via AIMX_CONFIG_DIR lives inside tmp.
         let cfg_path = crate::config::config_path();
@@ -2536,7 +2536,7 @@ mod tests {
     fn finalize_creates_data_dir_and_config() {
         let tmp = TempDir::new().unwrap();
         let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
-        finalize_setup(tmp.path(), "test.example.com", "dkim", None).unwrap();
+        finalize_setup(tmp.path(), "test.example.com", "aimx", None).unwrap();
 
         assert!(crate::config::config_path().exists());
         assert!(tmp.path().join("catchall").exists());
@@ -2553,11 +2553,11 @@ mod tests {
     fn finalize_is_idempotent() {
         let tmp = TempDir::new().unwrap();
         let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
-        finalize_setup(tmp.path(), "test.example.com", "dkim", None).unwrap();
+        finalize_setup(tmp.path(), "test.example.com", "aimx", None).unwrap();
 
         let key1 = std::fs::read_to_string(tmp.path().join("dkim/private.key")).unwrap();
 
-        finalize_setup(tmp.path(), "test.example.com", "dkim", None).unwrap();
+        finalize_setup(tmp.path(), "test.example.com", "aimx", None).unwrap();
 
         let key2 = std::fs::read_to_string(tmp.path().join("dkim/private.key")).unwrap();
         assert_eq!(key1, key2);
@@ -2571,12 +2571,12 @@ mod tests {
     fn finalize_preserves_existing_mailboxes() {
         let tmp = TempDir::new().unwrap();
         let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
-        finalize_setup(tmp.path(), "test.example.com", "dkim", None).unwrap();
+        finalize_setup(tmp.path(), "test.example.com", "aimx", None).unwrap();
 
         let config = Config::load_resolved().unwrap();
         mailbox::create_mailbox(&config, "alice").unwrap();
 
-        finalize_setup(tmp.path(), "test.example.com", "dkim", None).unwrap();
+        finalize_setup(tmp.path(), "test.example.com", "aimx", None).unwrap();
 
         let config = Config::load_resolved().unwrap();
         assert!(config.mailboxes.contains_key("alice"));
@@ -2587,9 +2587,9 @@ mod tests {
     fn finalize_updates_domain_if_changed() {
         let tmp = TempDir::new().unwrap();
         let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
-        finalize_setup(tmp.path(), "old.example.com", "dkim", None).unwrap();
+        finalize_setup(tmp.path(), "old.example.com", "aimx", None).unwrap();
 
-        finalize_setup(tmp.path(), "new.example.com", "dkim", None).unwrap();
+        finalize_setup(tmp.path(), "new.example.com", "aimx", None).unwrap();
 
         let config = Config::load_resolved().unwrap();
         assert_eq!(config.domain, "new.example.com");
@@ -2914,7 +2914,7 @@ mod tests {
         finalize_setup(
             tmp.path(),
             "trust.example.com",
-            "dkim",
+            "aimx",
             Some(("verified".to_string(), vec!["*@company.com".to_string()])),
         )
         .unwrap();
@@ -2937,12 +2937,12 @@ mod tests {
         finalize_setup(
             tmp.path(),
             "trust.example.com",
-            "dkim",
+            "aimx",
             Some(("verified".to_string(), vec!["*@company.com".to_string()])),
         )
         .unwrap();
         // Re-entry passes None — the on-disk value must survive regardless.
-        finalize_setup(tmp.path(), "trust.example.com", "dkim", None).unwrap();
+        finalize_setup(tmp.path(), "trust.example.com", "aimx", None).unwrap();
 
         let on_disk = Config::load(&crate::config::config_path()).unwrap();
         assert_eq!(on_disk.trust, "verified");
@@ -2955,7 +2955,7 @@ mod tests {
         // tests), `None` should behave identically to `Some((\"none\", []))`.
         let tmp = tempfile::TempDir::new().unwrap();
         let _guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
-        finalize_setup(tmp.path(), "trust.example.com", "dkim", None).unwrap();
+        finalize_setup(tmp.path(), "trust.example.com", "aimx", None).unwrap();
 
         let on_disk = Config::load(&crate::config::config_path()).unwrap();
         assert_eq!(on_disk.trust, "none");
@@ -3155,7 +3155,7 @@ mod tests {
             "1.2.3.4",
             Some("2001:db8::1"),
             "v=DKIM1; k=rsa; p=ABC123",
-            "dkim",
+            "aimx",
         );
         assert_eq!(records.len(), 6);
 
@@ -3184,7 +3184,7 @@ mod tests {
             "1.2.3.4",
             None,
             "v=DKIM1; k=rsa; p=ABC",
-            "dkim",
+            "aimx",
         );
         assert!(!records.iter().any(|r| r.record_type == "AAAA"));
         let spf = records
@@ -3202,7 +3202,7 @@ mod tests {
             "1.2.3.4",
             Some("2001:db8::1"),
             "v=DKIM1; k=rsa; p=ABC",
-            "dkim",
+            "aimx",
         );
         assert_eq!(records.len(), 6);
         assert!(records.iter().any(|r| r.record_type == "AAAA"));
@@ -3338,7 +3338,7 @@ mod tests {
             vec!["v=spf1 ip4:1.2.3.4 ip6:2001:db8::1 -all".into()],
         );
         net.txt_records.insert(
-            "dkim._domainkey.example.com".into(),
+            "aimx._domainkey.example.com".into(),
             vec!["v=DKIM1; k=rsa; p=ABC".into()],
         );
         net.txt_records.insert(
@@ -3346,7 +3346,7 @@ mod tests {
             vec!["v=DMARC1; p=reject".into()],
         );
 
-        let results = verify_all_dns(&net, "example.com", &ip, Some(&ipv6), "dkim", None);
+        let results = verify_all_dns(&net, "example.com", &ip, Some(&ipv6), "aimx", None);
         assert!(results.iter().all(|(_, r)| *r == DnsVerifyResult::Pass));
         assert!(results.iter().any(|(name, _)| name == "AAAA"));
         assert!(results.iter().any(|(name, _)| name == "SPF (IPv6)"));
@@ -3362,7 +3362,7 @@ mod tests {
         net.txt_records
             .insert("example.com".into(), vec!["v=spf1 ip4:1.2.3.4 -all".into()]);
         net.txt_records.insert(
-            "dkim._domainkey.example.com".into(),
+            "aimx._domainkey.example.com".into(),
             vec!["v=DKIM1; k=rsa; p=ABC".into()],
         );
         net.txt_records.insert(
@@ -3370,7 +3370,7 @@ mod tests {
             vec!["v=DMARC1; p=reject".into()],
         );
 
-        let results = verify_all_dns(&net, "example.com", &ip, None, "dkim", None);
+        let results = verify_all_dns(&net, "example.com", &ip, None, "aimx", None);
         assert!(!results.iter().any(|(name, _)| name == "AAAA"));
         assert!(!results.iter().any(|(name, _)| name == "SPF (IPv6)"));
     }

--- a/src/smtp/tests.rs
+++ b/src/smtp/tests.rs
@@ -77,7 +77,7 @@ fn test_config(data_dir: &std::path::Path) -> Config {
     Config {
         domain: "test.local".to_string(),
         data_dir: data_dir.to_path_buf(),
-        dkim_selector: "dkim".to_string(),
+        dkim_selector: "aimx".to_string(),
         trust: "none".to_string(),
         trusted_senders: vec![],
         mailboxes,
@@ -674,7 +674,7 @@ async fn test_ingest_failure_returns_451() {
     let config = Config {
         domain: "test.local".to_string(),
         data_dir: bad_data_dir,
-        dkim_selector: "dkim".to_string(),
+        dkim_selector: "aimx".to_string(),
         trust: "none".to_string(),
         trusted_senders: vec![],
         mailboxes: HashMap::new(),

--- a/src/state_handler.rs
+++ b/src/state_handler.rs
@@ -273,7 +273,7 @@ mod tests {
         let config = crate::config::Config {
             domain: "example.com".to_string(),
             data_dir: data_dir.to_path_buf(),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             trust: "none".to_string(),
             trusted_senders: vec![],
             mailboxes,

--- a/src/status.rs
+++ b/src/status.rs
@@ -479,7 +479,7 @@ mod tests {
         Config {
             domain: "test.com".to_string(),
             data_dir: data_dir.to_path_buf(),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             trust: "none".to_string(),
             trusted_senders: vec![],
             mailboxes: std::collections::HashMap::new(),
@@ -522,7 +522,7 @@ mod tests {
         let info = StatusInfo {
             domain: "test.example.com".to_string(),
             data_dir: "/var/lib/aimx".to_string(),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             dkim_key_present: true,
             smtp_running: true,
             mailboxes: vec![],
@@ -541,7 +541,7 @@ mod tests {
         let info = StatusInfo {
             domain: "agent.example.com".to_string(),
             data_dir: "/var/lib/aimx".to_string(),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             dkim_key_present: true,
             smtp_running: false,
             mailboxes: vec![
@@ -577,7 +577,7 @@ mod tests {
         let info = StatusInfo {
             domain: "ex.com".to_string(),
             data_dir: "/var/lib/aimx".to_string(),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             dkim_key_present: true,
             smtp_running: true,
             mailboxes: vec![
@@ -657,7 +657,7 @@ mod tests {
         let info = StatusInfo {
             domain: "test.com".to_string(),
             data_dir: "/var/lib/aimx".to_string(),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             dkim_key_present: false,
             smtp_running: false,
             mailboxes: vec![],
@@ -764,7 +764,7 @@ mod tests {
         let config = Config {
             domain: "test.com".to_string(),
             data_dir: data_dir.to_path_buf(),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             trust: "none".to_string(),
             trusted_senders: vec![],
             mailboxes,
@@ -784,7 +784,7 @@ mod tests {
         let info = StatusInfo {
             domain: "test.com".to_string(),
             data_dir: "/var/lib/aimx".to_string(),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             dkim_key_present: true,
             smtp_running: true,
             mailboxes: vec![],
@@ -824,7 +824,7 @@ mod tests {
         let info = StatusInfo {
             domain: "test.com".to_string(),
             data_dir: "/var/lib/aimx".to_string(),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             dkim_key_present: true,
             smtp_running: true,
             mailboxes: vec![],
@@ -859,7 +859,7 @@ mod tests {
         let config = Config {
             domain: "test.com".to_string(),
             data_dir: data_dir.to_path_buf(),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             trust: "none".to_string(),
             trusted_senders: vec![],
             mailboxes,
@@ -895,7 +895,7 @@ mod tests {
             vec!["v=DMARC1; p=reject".into()],
         );
         net.txt_records.insert(
-            format!("dkim._domainkey.{}", config.domain),
+            format!("aimx._domainkey.{}", config.domain),
             vec!["v=DKIM1; k=rsa; p=AAAA".into()],
         );
 
@@ -991,7 +991,7 @@ mod tests {
         let info = gather_status_with_ops(&config, &FakeServiceOps { running: false }, &net);
         let dns = info.dns.expect("DNS section must be present");
 
-        let dkim_name = format!("dkim._domainkey.{}", config.domain);
+        let dkim_name = format!("aimx._domainkey.{}", config.domain);
         let has_dkim_record = dns
             .records
             .iter()
@@ -1044,12 +1044,12 @@ mod tests {
             "1.2.3.4",
             None,
             "v=DKIM1; k=rsa; p=AAAA",
-            "dkim",
+            "aimx",
         );
         let info = StatusInfo {
             domain: "test.com".to_string(),
             data_dir: "/var/lib/aimx".to_string(),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             dkim_key_present: true,
             smtp_running: true,
             mailboxes: vec![],
@@ -1077,7 +1077,7 @@ mod tests {
         let info = StatusInfo {
             domain: "test.com".to_string(),
             data_dir: "/var/lib/aimx".to_string(),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             dkim_key_present: true,
             smtp_running: true,
             mailboxes: vec![],

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -134,7 +134,7 @@ mod tests {
         Config {
             domain: "test.com".to_string(),
             data_dir: PathBuf::from("/tmp/aimx-test"),
-            dkim_selector: "dkim".to_string(),
+            dkim_selector: "aimx".to_string(),
             trust: "none".to_string(),
             trusted_senders: vec![],
             mailboxes: HashMap::new(),


### PR DESCRIPTION
## Summary
Switch the default DKIM selector from `dkim` to `aimx` so fresh setups publish `aimx._domainkey.<domain>` and the signed `DKIM-Signature: s=` tag matches the brand. Pre-launch — no migration / backwards-compat.

## Requirements
- [x] `src/cli.rs` — `aimx dkim-keygen --selector` flag defaults to `"aimx"`.
- [x] `src/config.rs` — `default_dkim_selector()` returns `"aimx"` (serde default when the field is absent from `config.toml`).
- [x] `src/setup.rs` — re-entry fallback uses `"aimx"`.
- [x] Fresh `aimx setup` produces DNS instructions using `aimx._domainkey.<domain>`.
- [x] Tests that reference the default selector or use it as an arbitrary stand-in flipped to `"aimx"` so the full suite exercises the new default.
- [x] User-facing docs updated: `README.md`, `book/setup.md`, `book/configuration.md`, `book/troubleshooting.md`.
- [x] `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test` all pass (782 unit + 64 integration).

## Out of scope
- Renaming `/etc/aimx/dkim/` key directory (path is named after the DKIM tech, not the selector — unchanged).
- Migration / backwards-compat shims (pre-launch).
- Historical `docs/*.md` planning artifacts (`docs/sprint*.md`, `docs/idea.md`, `docs/manual-*.md`) — left as-is.
- `agents/common/references/troubleshooting.md` — uses `default._domainkey` as an illustrative wrong-selector example; unchanged.

## Technical approach
Three source-of-truth default sites flipped: `src/cli.rs:116`, `src/config.rs:139`, `src/setup.rs` re-entry fallback. Tests across `config.rs`, `channel.rs`, `dkim.rs`, `ingest.rs`, `mailbox.rs`, `mailbox_handler.rs`, `mcp.rs`, `send_handler.rs`, `serve.rs`, `setup.rs`, `smtp/tests.rs`, `state_handler.rs`, `status.rs`, `trust.rs` updated so hard-coded `"dkim"` selector fixtures now read `"aimx"`. A new regression test `config::tests::default_dkim_selector_is_aimx` guards against future accidental flips. Frontmatter field names (auth-result keys `dkim`, `spf`, `dmarc`) and the `dkim_dir()` path are unrelated to the selector and left alone.

## Test plan
- [x] Full `cargo test` — **782 unit + 64 integration passing**.
- [x] `cargo fmt --check` — clean.
- [x] `cargo clippy -- -D warnings` — clean.
- [x] New regression test asserts `default_dkim_selector() == "aimx"` and that a config loaded from TOML without the field defaults to `"aimx"`.
- [x] Existing `src/setup.rs` DNS-record test now asserts `aimx._domainkey.agent.example.com` as the canonical check.

## Notes
Operators running manual pre-launch installs should re-run `aimx setup` (or manually flip `dkim_selector` in their `config.toml`) so DKIM signing and published DNS stay in sync. The startup check in `aimx serve` logs a loud warning on mismatch, so any drift is visible.