### PR TITLE
[Sprint 51] hooks CLI + UDS hot-swap + mailboxes show

### DIFF
--- a/book/hooks.md
+++ b/book/hooks.md
@@ -52,6 +52,66 @@ cmd = 'echo "New email from $AIMX_FROM: $AIMX_SUBJECT" >> /tmp/email.log'
 
 Multiple hooks can be defined per mailbox; each is evaluated independently.
 
+## Managing hooks via CLI
+
+Use `aimx hooks` (alias: `aimx hook`) to manage hooks without hand-editing `config.toml`. All three sub-subcommands route through the daemon's UDS socket first so newly-created or -deleted hooks take effect on the very next event — **no restart required** while `aimx serve` is running. If the daemon is stopped, the CLI falls back to editing `config.toml` directly and prints a restart hint.
+
+### List hooks
+
+```bash
+aimx hooks list                  # all mailboxes
+aimx hooks list --mailbox support # single mailbox
+```
+
+Prints a table (`ID`, `MAILBOX`, `EVENT`, `CMD`, `FILTERS`). The `CMD` column is truncated to 60 chars with a `…` suffix when longer.
+
+### Create a hook
+
+`create` is flag-based (not interactive) and auto-generates the 12-char hook id. The id is printed on success.
+
+```bash
+# on_receive: fire a webhook for urgent-subject mail from Gmail senders
+aimx hooks create \
+  --mailbox support \
+  --event on_receive \
+  --cmd 'curl -fsS -X POST https://hooks.example.com/notify -d "$AIMX_SUBJECT"' \
+  --from '*@gmail.com' \
+  --subject urgent
+
+# after_send: log successful deliveries to clients
+aimx hooks create \
+  --mailbox alice \
+  --event after_send \
+  --cmd 'printf "%s -> %s: %s\n" "$AIMX_FROM" "$AIMX_TO" "$AIMX_SEND_STATUS" >> /var/log/aimx-outbound.log' \
+  --to '*@client.com'
+
+# on_receive: fire on untrusted mail too (verbose flag is intentional)
+aimx hooks create \
+  --mailbox catchall \
+  --event on_receive \
+  --cmd 'logger -t aimx "inbound from $AIMX_FROM"' \
+  --dangerously-support-untrusted
+```
+
+Flag validation matches the on-load validator:
+
+| Flag | Event constraint |
+|------|------------------|
+| `--from <glob>` | only valid on `--event on_receive` |
+| `--to <glob>` | only valid on `--event after_send` |
+| `--has-attachment` | only valid on `--event on_receive` (outbound submissions via UDS are text-only in v0.2) |
+| `--dangerously-support-untrusted` | only valid on `--event on_receive` |
+| `--subject <sub>` | both events |
+
+### Delete a hook
+
+```bash
+aimx hooks delete aaaabbbbcccc        # interactive prompt
+aimx hooks delete aaaabbbbcccc --yes  # scripted
+```
+
+The prompt shows the hook's `id`, `mailbox`, `event`, and `cmd` (truncated to 60 chars) before asking `[y/N]`. There is no `update` verb — delete the old hook and create a new one if you want to tweak filters.
+
 ## Hook context: env vars and placeholders
 
 User-controlled header fields are delivered to the hook shell as **env vars**; aimx-controlled fields are substituted into the command string as `{...}` placeholders.

--- a/book/mailboxes.md
+++ b/book/mailboxes.md
@@ -58,6 +58,33 @@ aimx mailboxes list
 
 Shows all mailboxes with their addresses and message counts (total and unread).
 
+### Inspect a single mailbox
+
+```bash
+aimx mailboxes show support
+```
+
+Prints the mailbox's address, effective trust policy, full `trusted_senders` list, configured hooks grouped by event (`on_receive` / `after_send` — each entry shows the hook id, `cmd` truncated to 60 chars with a `…` suffix when longer, filters in compact form, and the `dangerously_support_untrusted=true` flag where set), and inbox + sent + unread message counts. Example output:
+
+```text
+Mailbox: support
+  Address: support@agent.yourdomain.com
+  Trust:   verified
+  Trusted senders:
+    - *@company.com
+    - boss@example.com
+
+Hooks
+  on_receive
+    - aaaabbbbcccc  cmd: curl -fsS https://hooks.example.com/notify   [from=*@gmail.com subject=urgent]
+  after_send
+    - ddddeeeeffff  cmd: /usr/local/bin/notify "$AIMX_TO"             [to=*@client.com]
+
+Messages
+  inbox: 12 (3 unread)
+  sent:  5
+```
+
 ### Delete a mailbox
 
 ```bash

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -47,6 +47,10 @@ pub enum Command {
     #[command(subcommand, alias = "mailbox")]
     Mailboxes(MailboxCommand),
 
+    /// Manage hooks
+    #[command(subcommand, alias = "hook")]
+    Hooks(HookCommand),
+
     /// Start MCP server in stdio mode
     Mcp,
 
@@ -181,6 +185,12 @@ pub enum MailboxCommand {
     /// List all mailboxes
     List,
 
+    /// Show trust, hooks, and message counts for a single mailbox
+    Show {
+        /// Mailbox name to inspect
+        name: String,
+    },
+
     /// Delete a mailbox
     Delete {
         /// Mailbox name to delete
@@ -198,4 +208,64 @@ pub enum MailboxCommand {
         #[arg(long)]
         force: bool,
     },
+}
+
+#[derive(Subcommand, Clone)]
+pub enum HookCommand {
+    /// List hooks (optionally filtered by mailbox)
+    List {
+        /// Filter hooks by owning mailbox
+        #[arg(long)]
+        mailbox: Option<String>,
+    },
+
+    /// Create a new hook on a mailbox (auto-generates the hook id)
+    Create(HookCreateArgs),
+
+    /// Delete a hook by id
+    Delete {
+        /// 12-char alphanumeric hook id
+        id: String,
+
+        /// Skip confirmation prompt
+        #[arg(short = 'y', long)]
+        yes: bool,
+    },
+}
+
+#[derive(clap::Args, Clone)]
+pub struct HookCreateArgs {
+    /// Owning mailbox (local part) — must already exist in config
+    #[arg(long)]
+    pub mailbox: String,
+
+    /// Event that triggers the hook
+    #[arg(long, value_parser = ["on_receive", "after_send"])]
+    pub event: String,
+
+    /// Shell command executed via `sh -c` when the hook fires
+    #[arg(long)]
+    pub cmd: String,
+
+    /// Sender-address glob filter (only valid on `on_receive`)
+    #[arg(long)]
+    pub from: Option<String>,
+
+    /// Recipient-address glob filter (only valid on `after_send`)
+    #[arg(long)]
+    pub to: Option<String>,
+
+    /// Subject substring filter (case-insensitive, both events)
+    #[arg(long)]
+    pub subject: Option<String>,
+
+    /// Require the email to have at least one attachment (only valid on
+    /// `on_receive`). Outbound submissions via UDS are text-only in v0.2.
+    #[arg(long)]
+    pub has_attachment: bool,
+
+    /// Opt into firing this hook on non-trusted inbound email. Deliberately
+    /// verbose so operators think twice. Only valid on `on_receive`.
+    #[arg(long)]
+    pub dangerously_support_untrusted: bool,
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -182,7 +182,7 @@ fn reject_legacy_on_receive_schema(toml_text: &str) -> Result<(), Box<dyn std::e
     Ok(())
 }
 
-fn validate_hooks(config: &Config) -> Result<(), String> {
+pub(crate) fn validate_hooks(config: &Config) -> Result<(), String> {
     // Globally-unique ID map: id -> owning mailbox.
     let mut seen: HashMap<String, String> = HashMap::new();
 

--- a/src/hook_client.rs
+++ b/src/hook_client.rs
@@ -1,0 +1,148 @@
+//! Client-side UDS helpers for `aimx hooks create` / `aimx hooks delete`.
+//!
+//! Mirrors the `mailbox_crud` submission path in [`crate::mcp`]: try the
+//! daemon UDS first so `Arc<Config>` hot-swaps and the new hook fires on
+//! the next event, and surface socket-missing errors distinctly so the
+//! caller can fall back to a direct `config.toml` edit + restart hint.
+
+use crate::hook::Hook;
+use crate::mcp::{MarkOutcome, is_socket_missing, parse_ack_response};
+use crate::send_protocol::{self, HookCreateRequest, HookDeleteRequest};
+
+/// Outcome of a hook CRUD submission that didn't succeed via UDS. Tracks
+/// socket-missing distinctly from daemon-side errors so the CLI can
+/// decide whether to fall back to a direct on-disk edit.
+pub(crate) enum HookCrudFallback {
+    /// Socket not present / not connectable (daemon stopped, socket
+    /// cleaned up, first-time setup). Callers fall back to direct edit.
+    SocketMissing,
+    /// Daemon connected and answered but reported an error (validation,
+    /// NOTFOUND, IO, ...). Caller should surface this verbatim.
+    Daemon(String),
+}
+
+/// Submit a `HOOK-CREATE` request over UDS. The hook stanza is serialized
+/// to TOML and shipped as the body; the daemon validates + appends +
+/// hot-swaps the in-memory `Arc<Config>` atomically.
+pub(crate) fn submit_hook_create_via_daemon(
+    mailbox: &str,
+    hook: &Hook,
+) -> Result<(), HookCrudFallback> {
+    let hook_toml = match toml::to_string_pretty(hook) {
+        Ok(s) => s.into_bytes(),
+        Err(e) => {
+            return Err(HookCrudFallback::Daemon(format!(
+                "failed to serialize hook: {e}"
+            )));
+        }
+    };
+    let request = HookCreateRequest {
+        mailbox: mailbox.to_string(),
+        hook_toml,
+    };
+    let socket = crate::serve::send_socket_path();
+
+    let rt = tokio::runtime::Handle::try_current();
+    let io_result: Result<MarkOutcome, std::io::Error> = match rt {
+        Ok(handle) => tokio::task::block_in_place(|| {
+            handle.block_on(submit_hook_create_request(&socket, &request))
+        }),
+        Err(_) => {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| {
+                    HookCrudFallback::Daemon(format!("Failed to create tokio runtime: {e}"))
+                })?;
+            rt.block_on(submit_hook_create_request(&socket, &request))
+        }
+    };
+
+    map_io_outcome(io_result, &socket)
+}
+
+/// Submit a `HOOK-DELETE` request over UDS.
+pub(crate) fn submit_hook_delete_via_daemon(id: &str) -> Result<(), HookCrudFallback> {
+    let request = HookDeleteRequest { id: id.to_string() };
+    let socket = crate::serve::send_socket_path();
+
+    let rt = tokio::runtime::Handle::try_current();
+    let io_result: Result<MarkOutcome, std::io::Error> = match rt {
+        Ok(handle) => tokio::task::block_in_place(|| {
+            handle.block_on(submit_hook_delete_request(&socket, &request))
+        }),
+        Err(_) => {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| {
+                    HookCrudFallback::Daemon(format!("Failed to create tokio runtime: {e}"))
+                })?;
+            rt.block_on(submit_hook_delete_request(&socket, &request))
+        }
+    };
+
+    map_io_outcome(io_result, &socket)
+}
+
+fn map_io_outcome(
+    io_result: Result<MarkOutcome, std::io::Error>,
+    socket: &std::path::Path,
+) -> Result<(), HookCrudFallback> {
+    match io_result {
+        Ok(MarkOutcome::Ok) => Ok(()),
+        Ok(MarkOutcome::Err { code, reason }) => Err(HookCrudFallback::Daemon(format!(
+            "[{}] {reason}",
+            code.as_str()
+        ))),
+        Ok(MarkOutcome::Malformed(reason)) => Err(HookCrudFallback::Daemon(format!(
+            "Malformed response from aimx daemon: {reason}"
+        ))),
+        Err(e) => {
+            if is_socket_missing(&e) {
+                Err(HookCrudFallback::SocketMissing)
+            } else {
+                Err(HookCrudFallback::Daemon(format!(
+                    "Failed to connect to aimx daemon at {}: {e}",
+                    socket.display()
+                )))
+            }
+        }
+    }
+}
+
+async fn submit_hook_create_request(
+    socket_path: &std::path::Path,
+    request: &HookCreateRequest,
+) -> Result<MarkOutcome, std::io::Error> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let stream = tokio::net::UnixStream::connect(socket_path).await?;
+    let (mut reader, mut writer) = stream.into_split();
+
+    send_protocol::write_hook_create_request(&mut writer, request).await?;
+    writer.shutdown().await.ok();
+
+    let mut buf = Vec::with_capacity(128);
+    reader.read_to_end(&mut buf).await?;
+
+    Ok(parse_ack_response(&buf))
+}
+
+async fn submit_hook_delete_request(
+    socket_path: &std::path::Path,
+    request: &HookDeleteRequest,
+) -> Result<MarkOutcome, std::io::Error> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let stream = tokio::net::UnixStream::connect(socket_path).await?;
+    let (mut reader, mut writer) = stream.into_split();
+
+    send_protocol::write_hook_delete_request(&mut writer, request).await?;
+    writer.shutdown().await.ok();
+
+    let mut buf = Vec::with_capacity(128);
+    reader.read_to_end(&mut buf).await?;
+
+    Ok(parse_ack_response(&buf))
+}

--- a/src/hook_handler.rs
+++ b/src/hook_handler.rs
@@ -1,0 +1,562 @@
+//! Daemon-side handlers for the `HOOK-CREATE` and `HOOK-DELETE` verbs of
+//! the `AIMX/1` UDS protocol.
+//!
+//! `aimx hooks create` / `hooks delete` route through the daemon over UDS
+//! so the in-memory `Config` is hot-swapped under a `RwLock<Arc<Config>>`
+//! whenever `config.toml` on disk changes. Newly-created hooks fire on
+//! the very next ingest / after-send event — no restart required.
+//!
+//! Correctness model is symmetric to [`crate::mailbox_handler`]:
+//!
+//! 1. Validate the submitted hook (well-formed id, event-specific filter
+//!    rules, non-empty cmd, supported type, trust gate only on
+//!    `on_receive`).
+//! 2. Load the current `Config` snapshot through the shared
+//!    `ConfigHandle`. Re-derive the new snapshot in memory, either
+//!    appending the new hook to the addressed mailbox's `hooks` array
+//!    (CREATE) or removing the hook with the matching `id` across all
+//!    mailboxes (DELETE).
+//! 3. Write atomically via `write_config_atomic` (write-temp-then-rename
+//!    — shared with `mailbox_handler`).
+//! 4. After the rename succeeds, swap the in-memory `Config` via
+//!    `ConfigHandle::store`.
+//!
+//! Locking follows the same outer-per-mailbox / inner-`CONFIG_WRITE_LOCK`
+//! hierarchy as the MAILBOX-CRUD path (see [`crate::mailbox_locks`]).
+
+use crate::config::{Config, validate_hooks};
+use crate::hook::{Hook, HookEvent, is_valid_hook_id};
+use crate::mailbox_handler::{CONFIG_WRITE_LOCK, MailboxContext, write_config_atomic};
+use crate::send_protocol::{AckResponse, ErrCode, HookCreateRequest, HookDeleteRequest};
+use crate::state_handler::StateContext;
+
+/// Handle an `AIMX/1 HOOK-CREATE` request. Takes the per-mailbox write
+/// lock for the addressed mailbox (outer) plus `CONFIG_WRITE_LOCK`
+/// (inner) while the config rewrite + handle swap runs.
+pub async fn handle_hook_create(
+    state_ctx: &StateContext,
+    mb_ctx: &MailboxContext,
+    req: &HookCreateRequest,
+) -> AckResponse {
+    let hook = match decode_hook_body(&req.hook_toml) {
+        Ok(h) => h,
+        Err(e) => {
+            return AckResponse::Err {
+                code: ErrCode::Validation,
+                reason: e,
+            };
+        }
+    };
+
+    if let Err(reason) = validate_submitted_hook(&hook) {
+        return AckResponse::Err {
+            code: ErrCode::Validation,
+            reason,
+        };
+    }
+
+    let lock = state_ctx.lock_for(&req.mailbox);
+    let _guard = lock.lock().await;
+
+    let _config_guard = CONFIG_WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let current = mb_ctx.config_handle.load();
+
+    if !current.mailboxes.contains_key(&req.mailbox) {
+        return AckResponse::Err {
+            code: ErrCode::Mailbox,
+            reason: format!("mailbox '{}' does not exist", req.mailbox),
+        };
+    }
+
+    // Duplicate id across any mailbox is rejected (hook ids are globally
+    // unique — same invariant `validate_hooks` enforces on load).
+    for (mb_name, mb) in &current.mailboxes {
+        for existing in &mb.hooks {
+            if existing.id == hook.id {
+                return AckResponse::Err {
+                    code: ErrCode::Validation,
+                    reason: format!(
+                        "hook id '{}' already exists on mailbox '{mb_name}'",
+                        hook.id
+                    ),
+                };
+            }
+        }
+    }
+
+    let mut new_config: Config = (*current).clone();
+    if let Some(mb) = new_config.mailboxes.get_mut(&req.mailbox) {
+        mb.hooks.push(hook);
+    }
+
+    // Re-run the full load-time validator so the daemon refuses to write
+    // a config that would fail on next start — catches any cross-hook
+    // invariant we forgot to check above.
+    if let Err(reason) = validate_hooks(&new_config) {
+        return AckResponse::Err {
+            code: ErrCode::Validation,
+            reason,
+        };
+    }
+
+    if let Err(e) = write_config_atomic(&mb_ctx.config_path, &new_config) {
+        return AckResponse::Err {
+            code: ErrCode::Io,
+            reason: format!("failed to write {}: {e}", mb_ctx.config_path.display()),
+        };
+    }
+
+    mb_ctx.config_handle.store(new_config);
+    AckResponse::Ok
+}
+
+/// Handle an `AIMX/1 HOOK-DELETE` request. Locates the hook by id across
+/// every configured mailbox. Takes the per-mailbox lock for the owning
+/// mailbox once it has been resolved, plus the global `CONFIG_WRITE_LOCK`.
+pub async fn handle_hook_delete(
+    state_ctx: &StateContext,
+    mb_ctx: &MailboxContext,
+    req: &HookDeleteRequest,
+) -> AckResponse {
+    if !is_valid_hook_id(&req.id) {
+        return AckResponse::Err {
+            code: ErrCode::Validation,
+            reason: format!(
+                "invalid hook id '{}': must be 12 chars, [a-z0-9] only",
+                req.id
+            ),
+        };
+    }
+
+    // Resolve owning mailbox from a snapshot. If somebody mutates the
+    // config between this lookup and our write, the outer lock still
+    // serializes us on that mailbox's tree; the inner `CONFIG_WRITE_LOCK`
+    // serializes the rewrite across all names.
+    let current = mb_ctx.config_handle.load();
+    let owner = current.mailboxes.iter().find_map(|(name, mb)| {
+        mb.hooks
+            .iter()
+            .any(|h| h.id == req.id)
+            .then(|| name.clone())
+    });
+    let owner = match owner {
+        Some(n) => n,
+        None => {
+            return AckResponse::Err {
+                code: ErrCode::NotFound,
+                reason: format!("hook id '{}' not found", req.id),
+            };
+        }
+    };
+
+    let lock = state_ctx.lock_for(&owner);
+    let _guard = lock.lock().await;
+
+    let _config_guard = CONFIG_WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    // Re-resolve under the lock: owner may have changed if somebody
+    // reconfigured between our snapshot above and acquiring the lock.
+    let current = mb_ctx.config_handle.load();
+    let mut new_config: Config = (*current).clone();
+    let mut removed = false;
+    for mb in new_config.mailboxes.values_mut() {
+        let before = mb.hooks.len();
+        mb.hooks.retain(|h| h.id != req.id);
+        if mb.hooks.len() != before {
+            removed = true;
+            break;
+        }
+    }
+    if !removed {
+        return AckResponse::Err {
+            code: ErrCode::NotFound,
+            reason: format!("hook id '{}' not found", req.id),
+        };
+    }
+
+    if let Err(e) = write_config_atomic(&mb_ctx.config_path, &new_config) {
+        return AckResponse::Err {
+            code: ErrCode::Io,
+            reason: format!("failed to write {}: {e}", mb_ctx.config_path.display()),
+        };
+    }
+
+    mb_ctx.config_handle.store(new_config);
+    AckResponse::Ok
+}
+
+fn decode_hook_body(bytes: &[u8]) -> Result<Hook, String> {
+    let s = std::str::from_utf8(bytes).map_err(|e| format!("hook body is not valid UTF-8: {e}"))?;
+    toml::from_str::<Hook>(s).map_err(|e| format!("malformed hook TOML: {e}"))
+}
+
+/// Pre-disk validation of a submitted hook stanza. Mirrors the per-hook
+/// checks [`validate_hooks`] applies on load so the daemon returns the
+/// same errors the operator would see from a hand-edited file.
+fn validate_submitted_hook(hook: &Hook) -> Result<(), String> {
+    if !is_valid_hook_id(&hook.id) {
+        return Err(format!(
+            "invalid hook id '{}': must be 12 chars, [a-z0-9] only",
+            hook.id
+        ));
+    }
+    if hook.cmd.trim().is_empty() {
+        return Err("hook has empty `cmd`".into());
+    }
+    if hook.r#type != "cmd" {
+        return Err(format!(
+            "hook has unsupported type '{}': only `cmd` is supported",
+            hook.r#type
+        ));
+    }
+    match hook.event {
+        HookEvent::OnReceive => {
+            if hook.to.is_some() {
+                return Err("`to` filter is only valid on `after_send` hooks".into());
+            }
+        }
+        HookEvent::AfterSend => {
+            if hook.from.is_some() {
+                return Err("`from` filter is only valid on `on_receive` hooks".into());
+            }
+            if hook.has_attachment.is_some() {
+                return Err(
+                    "`has_attachment` filter is only valid on `on_receive` hooks (outbound \
+                     submissions via UDS are text-only in v0.2)"
+                        .into(),
+                );
+            }
+            if hook.dangerously_support_untrusted {
+                return Err(
+                    "`dangerously_support_untrusted = true` only applies to `on_receive` hooks"
+                        .into(),
+                );
+            }
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{ConfigHandle, MailboxConfig};
+    use crate::hook::Hook;
+    use std::collections::HashMap;
+    use std::path::Path;
+    use tempfile::TempDir;
+
+    fn base_config(data_dir: &Path) -> Config {
+        let mut mailboxes = HashMap::new();
+        mailboxes.insert(
+            "catchall".to_string(),
+            MailboxConfig {
+                address: "*@example.com".to_string(),
+                hooks: vec![],
+                trust: None,
+                trusted_senders: None,
+            },
+        );
+        mailboxes.insert(
+            "alice".to_string(),
+            MailboxConfig {
+                address: "alice@example.com".to_string(),
+                hooks: vec![],
+                trust: None,
+                trusted_senders: None,
+            },
+        );
+        Config {
+            domain: "example.com".to_string(),
+            data_dir: data_dir.to_path_buf(),
+            dkim_selector: "aimx".to_string(),
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            mailboxes,
+            verify_host: None,
+            enable_ipv6: false,
+        }
+    }
+
+    fn contexts(tmp: &TempDir) -> (StateContext, MailboxContext) {
+        let config = base_config(tmp.path());
+        let handle = ConfigHandle::new(config);
+        let state_ctx = StateContext::new(tmp.path().to_path_buf(), handle.clone());
+        let config_path = tmp.path().join("config.toml");
+        write_config_atomic(&config_path, &handle.load()).unwrap();
+        let mb_ctx = MailboxContext::new(config_path, handle);
+        (state_ctx, mb_ctx)
+    }
+
+    fn hook_toml(hook: &Hook) -> Vec<u8> {
+        toml::to_string_pretty(hook).unwrap().into_bytes()
+    }
+
+    fn sample_hook(id: &str) -> Hook {
+        Hook {
+            id: id.to_string(),
+            event: HookEvent::OnReceive,
+            r#type: "cmd".into(),
+            cmd: "echo hi".into(),
+            from: None,
+            to: None,
+            subject: None,
+            has_attachment: None,
+            dangerously_support_untrusted: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_create_appends_and_swaps_handle() {
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+
+        let hook = Hook {
+            from: Some("*@example.com".into()),
+            ..sample_hook("aaaabbbbcccc")
+        };
+        let req = HookCreateRequest {
+            mailbox: "alice".into(),
+            hook_toml: hook_toml(&hook),
+        };
+        match handle_hook_create(&state_ctx, &mb_ctx, &req).await {
+            AckResponse::Ok => {}
+            other => panic!("expected Ok, got {other:?}"),
+        }
+
+        let live = mb_ctx.config_handle.load();
+        assert_eq!(live.mailboxes["alice"].hooks.len(), 1);
+        assert_eq!(live.mailboxes["alice"].hooks[0].id, "aaaabbbbcccc");
+
+        let reloaded = Config::load(&mb_ctx.config_path).unwrap();
+        assert_eq!(reloaded.mailboxes["alice"].hooks.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn hook_create_rejects_unknown_mailbox() {
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+
+        let req = HookCreateRequest {
+            mailbox: "ghost".into(),
+            hook_toml: hook_toml(&sample_hook("aaaabbbbcccc")),
+        };
+        match handle_hook_create(&state_ctx, &mb_ctx, &req).await {
+            AckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Mailbox);
+                assert!(reason.contains("ghost"), "{reason}");
+            }
+            other => panic!("expected Err(MAILBOX), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_create_rejects_bad_event_filter_combo() {
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+
+        let hook = Hook {
+            event: HookEvent::AfterSend,
+            from: Some("*@example.com".into()),
+            ..sample_hook("aaaabbbbcccc")
+        };
+        let req = HookCreateRequest {
+            mailbox: "alice".into(),
+            hook_toml: hook_toml(&hook),
+        };
+        match handle_hook_create(&state_ctx, &mb_ctx, &req).await {
+            AckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Validation);
+                assert!(reason.contains("from"), "{reason}");
+            }
+            other => panic!("expected Err(VALIDATION), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_create_rejects_dangerous_on_after_send() {
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+
+        let hook = Hook {
+            event: HookEvent::AfterSend,
+            dangerously_support_untrusted: true,
+            ..sample_hook("aaaabbbbcccc")
+        };
+        let req = HookCreateRequest {
+            mailbox: "alice".into(),
+            hook_toml: hook_toml(&hook),
+        };
+        match handle_hook_create(&state_ctx, &mb_ctx, &req).await {
+            AckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Validation);
+                assert!(reason.contains("dangerously_support_untrusted"), "{reason}");
+            }
+            other => panic!("expected Err(VALIDATION), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_create_rejects_bad_id() {
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+
+        let hook = sample_hook("TOO-SHORT");
+        let req = HookCreateRequest {
+            mailbox: "alice".into(),
+            hook_toml: hook_toml(&hook),
+        };
+        match handle_hook_create(&state_ctx, &mb_ctx, &req).await {
+            AckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Validation);
+                assert!(reason.contains("invalid hook id"), "{reason}");
+            }
+            other => panic!("expected Err(VALIDATION), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_create_rejects_duplicate_id() {
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+
+        let hook = sample_hook("aaaabbbbcccc");
+        let req = HookCreateRequest {
+            mailbox: "alice".into(),
+            hook_toml: hook_toml(&hook),
+        };
+        assert!(matches!(
+            handle_hook_create(&state_ctx, &mb_ctx, &req).await,
+            AckResponse::Ok
+        ));
+
+        let req2 = HookCreateRequest {
+            mailbox: "catchall".into(),
+            hook_toml: hook_toml(&hook),
+        };
+        match handle_hook_create(&state_ctx, &mb_ctx, &req2).await {
+            AckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Validation);
+                assert!(reason.contains("already exists"), "{reason}");
+            }
+            other => panic!("expected Err(VALIDATION), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_create_rejects_malformed_toml() {
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+
+        let req = HookCreateRequest {
+            mailbox: "alice".into(),
+            hook_toml: b"not toml at all".to_vec(),
+        };
+        match handle_hook_create(&state_ctx, &mb_ctx, &req).await {
+            AckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Validation);
+                assert!(
+                    reason.to_lowercase().contains("toml")
+                        || reason.to_lowercase().contains("expected"),
+                    "{reason}"
+                );
+            }
+            other => panic!("expected Err(VALIDATION), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_delete_removes_and_swaps_handle() {
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+
+        let hook = sample_hook("aaaabbbbcccc");
+        let create = HookCreateRequest {
+            mailbox: "alice".into(),
+            hook_toml: hook_toml(&hook),
+        };
+        assert!(matches!(
+            handle_hook_create(&state_ctx, &mb_ctx, &create).await,
+            AckResponse::Ok
+        ));
+
+        let del = HookDeleteRequest {
+            id: "aaaabbbbcccc".into(),
+        };
+        assert!(matches!(
+            handle_hook_delete(&state_ctx, &mb_ctx, &del).await,
+            AckResponse::Ok
+        ));
+
+        let live = mb_ctx.config_handle.load();
+        assert!(live.mailboxes["alice"].hooks.is_empty());
+        let reloaded = Config::load(&mb_ctx.config_path).unwrap();
+        assert!(reloaded.mailboxes["alice"].hooks.is_empty());
+    }
+
+    #[tokio::test]
+    async fn hook_delete_unknown_id_returns_notfound() {
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+        let del = HookDeleteRequest {
+            id: "aaaabbbbcccc".into(),
+        };
+        match handle_hook_delete(&state_ctx, &mb_ctx, &del).await {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::NotFound),
+            other => panic!("expected Err(NOTFOUND), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_delete_invalid_id_rejected() {
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+        let del = HookDeleteRequest { id: "BOGUS".into() };
+        match handle_hook_delete(&state_ctx, &mb_ctx, &del).await {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Validation),
+            other => panic!("expected Err(VALIDATION), got {other:?}"),
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_create_different_mailboxes_both_survive() {
+        // Mirrors the `MAILBOX-CREATE` lost-update regression test: two
+        // concurrent `HOOK-CREATE` on different mailboxes must both land
+        // in the final config. Without `CONFIG_WRITE_LOCK`, two threads
+        // would each clone the snapshot, append their hook to disjoint
+        // names, and write-temp-then-rename — clobbering one stanza.
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+        let state_ctx = std::sync::Arc::new(state_ctx);
+        let mb_ctx = std::sync::Arc::new(mb_ctx);
+
+        let mut handles = Vec::new();
+        let names = ["alice", "catchall"];
+        let ids = ["aaaabbbbcccc", "ddddeeeeffff"];
+        for (mbox, id) in names.iter().zip(ids.iter()) {
+            let s = state_ctx.clone();
+            let m = mb_ctx.clone();
+            let mbox = mbox.to_string();
+            let id = id.to_string();
+            handles.push(tokio::spawn(async move {
+                let req = HookCreateRequest {
+                    mailbox: mbox.clone(),
+                    hook_toml: hook_toml(&sample_hook(&id)),
+                };
+                handle_hook_create(&s, &m, &req).await
+            }));
+        }
+        for h in handles {
+            assert!(matches!(h.await.unwrap(), AckResponse::Ok));
+        }
+
+        let reloaded = Config::load(&mb_ctx.config_path).unwrap();
+        assert_eq!(reloaded.mailboxes["alice"].hooks.len(), 1);
+        assert_eq!(reloaded.mailboxes["catchall"].hooks.len(), 1);
+    }
+}

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -1,0 +1,538 @@
+//! `aimx hooks list | create | delete` CLI.
+//!
+//! `hook` (singular) is kept as a clap alias on the subcommand for muscle
+//! memory. All three sub-subcommands route UDS-first so the daemon can
+//! hot-swap its in-memory `Arc<Config>` (S51-3); on socket-missing the
+//! CLI falls back to a direct `config.toml` edit + the Sprint 44 restart
+//! hint. `create` is flag-based and auto-generates the 12-char hook id.
+//! `delete <id>` shows the hook's mailbox / event / cmd and prompts
+//! `[y/N]` unless `--yes`.
+
+use std::io::{self, Write};
+
+use crate::cli::{HookCommand, HookCreateArgs};
+use crate::config::{Config, validate_hooks};
+use crate::hook::{Hook, HookEvent, generate_hook_id};
+use crate::hook_client::{
+    HookCrudFallback, submit_hook_create_via_daemon, submit_hook_delete_via_daemon,
+};
+use crate::term;
+
+pub fn run(cmd: HookCommand, config: Config) -> Result<(), Box<dyn std::error::Error>> {
+    match cmd {
+        HookCommand::List { mailbox } => list(&config, mailbox.as_deref()),
+        HookCommand::Create(args) => create(&config, args),
+        HookCommand::Delete { id, yes } => delete(&config, &id, yes),
+    }
+}
+
+fn list(config: &Config, filter_mailbox: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(name) = filter_mailbox
+        && !config.mailboxes.contains_key(name)
+    {
+        return Err(format!("Mailbox '{name}' does not exist").into());
+    }
+
+    let mut rows = gather_rows(config, filter_mailbox);
+    rows.sort_by(|a, b| {
+        a.mailbox
+            .cmp(&b.mailbox)
+            .then_with(|| a.event.cmp(b.event))
+            .then_with(|| a.id.cmp(&b.id))
+    });
+
+    if rows.is_empty() {
+        println!("No hooks configured.");
+        return Ok(());
+    }
+
+    println!(
+        "{} {} {} {} {}",
+        term::header("ID          "),
+        term::header("MAILBOX             "),
+        term::header("EVENT       "),
+        term::header("CMD                                                          "),
+        term::header("FILTERS"),
+    );
+    for row in rows {
+        println!(
+            "{}  {:<20.20} {:<11} {:<60} {}",
+            term::highlight(&row.id),
+            row.mailbox,
+            row.event,
+            truncate_with_ellipsis(&row.cmd, 60),
+            row.filters,
+        );
+    }
+    Ok(())
+}
+
+fn create(config: &Config, args: HookCreateArgs) -> Result<(), Box<dyn std::error::Error>> {
+    if !config.mailboxes.contains_key(&args.mailbox) {
+        return Err(format!("Mailbox '{}' does not exist", args.mailbox).into());
+    }
+
+    validate_flag_combinations(&args)?;
+
+    let event = parse_event(&args.event)?;
+    let id = generate_unique_hook_id(config);
+    let hook = Hook {
+        id: id.clone(),
+        event,
+        r#type: "cmd".to_string(),
+        cmd: args.cmd,
+        from: args.from,
+        to: args.to,
+        subject: args.subject,
+        has_attachment: if args.has_attachment {
+            Some(true)
+        } else {
+            None
+        },
+        dangerously_support_untrusted: args.dangerously_support_untrusted,
+    };
+
+    match submit_hook_create_via_daemon(&args.mailbox, &hook) {
+        Ok(()) => {
+            println!(
+                "{} {}",
+                term::success("Hook created:"),
+                term::highlight(&id)
+            );
+            Ok(())
+        }
+        Err(HookCrudFallback::SocketMissing) => {
+            apply_create_direct(config, &args.mailbox, hook)?;
+            println!(
+                "{} {}",
+                term::success("Hook created:"),
+                term::highlight(&id)
+            );
+            print_restart_hint();
+            Ok(())
+        }
+        Err(HookCrudFallback::Daemon(msg)) => Err(msg.into()),
+    }
+}
+
+fn delete(config: &Config, id: &str, yes: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let (mailbox, hook) = match find_hook(config, id) {
+        Some(pair) => pair,
+        None => return Err(format!("Hook id '{id}' not found").into()),
+    };
+
+    if !yes {
+        println!("{}", term::warn("About to delete hook:"));
+        println!("  {}   {}", term::header("id:     "), term::highlight(id));
+        println!("  {}   {}", term::header("mailbox:"), mailbox);
+        println!("  {}   {}", term::header("event:  "), hook.event);
+        println!(
+            "  {}   {}",
+            term::header("cmd:    "),
+            truncate_with_ellipsis(&hook.cmd, 60)
+        );
+        print!("Continue? [y/N] ");
+        io::stdout().flush()?;
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        if !input.trim().eq_ignore_ascii_case("y") {
+            println!("Cancelled.");
+            return Ok(());
+        }
+    }
+
+    match submit_hook_delete_via_daemon(id) {
+        Ok(()) => {
+            println!("{} {}", term::success("Hook deleted:"), term::highlight(id));
+            Ok(())
+        }
+        Err(HookCrudFallback::SocketMissing) => {
+            apply_delete_direct(config, id)?;
+            println!("{} {}", term::success("Hook deleted:"), term::highlight(id));
+            print_restart_hint();
+            Ok(())
+        }
+        Err(HookCrudFallback::Daemon(msg)) => Err(msg.into()),
+    }
+}
+
+/// Public-for-test helper: validate event × filter flag combinations
+/// against the same rules [`crate::config::validate_hooks`] enforces on
+/// load. Returns `Ok(())` when the combo is legal.
+pub(crate) fn validate_flag_combinations(
+    args: &HookCreateArgs,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let event = parse_event(&args.event)?;
+    match event {
+        HookEvent::OnReceive => {
+            if args.to.is_some() {
+                return Err("--to is only valid on --event after_send (inbound hooks \
+                     filter on --from)"
+                    .into());
+            }
+        }
+        HookEvent::AfterSend => {
+            if args.from.is_some() {
+                return Err(
+                    "--from is only valid on --event on_receive (outbound hooks \
+                     filter on --to)"
+                        .into(),
+                );
+            }
+            if args.has_attachment {
+                return Err("--has-attachment is only valid on --event on_receive \
+                     (outbound submissions via UDS are text-only in v0.2)"
+                    .into());
+            }
+            if args.dangerously_support_untrusted {
+                return Err("--dangerously-support-untrusted is only valid on --event \
+                     on_receive"
+                    .into());
+            }
+        }
+    }
+    if args.cmd.trim().is_empty() {
+        return Err("--cmd must not be empty".into());
+    }
+    Ok(())
+}
+
+fn parse_event(s: &str) -> Result<HookEvent, Box<dyn std::error::Error>> {
+    match s {
+        "on_receive" => Ok(HookEvent::OnReceive),
+        "after_send" => Ok(HookEvent::AfterSend),
+        other => Err(format!("invalid event '{other}': expected on_receive or after_send").into()),
+    }
+}
+
+fn generate_unique_hook_id(config: &Config) -> String {
+    loop {
+        let candidate = generate_hook_id();
+        if !config
+            .mailboxes
+            .values()
+            .any(|mb| mb.hooks.iter().any(|h| h.id == candidate))
+        {
+            return candidate;
+        }
+    }
+}
+
+fn apply_create_direct(
+    config: &Config,
+    mailbox: &str,
+    hook: Hook,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut new_config = config.clone();
+    if !new_config.mailboxes.contains_key(mailbox) {
+        return Err(format!("Mailbox '{mailbox}' does not exist").into());
+    }
+    if let Some(mb) = new_config.mailboxes.get_mut(mailbox) {
+        mb.hooks.push(hook);
+    }
+    validate_hooks(&new_config).map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+    new_config.save(&crate::config::config_path())?;
+    Ok(())
+}
+
+fn apply_delete_direct(config: &Config, id: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let mut new_config = config.clone();
+    let mut removed = false;
+    for mb in new_config.mailboxes.values_mut() {
+        let before = mb.hooks.len();
+        mb.hooks.retain(|h| h.id != id);
+        if mb.hooks.len() != before {
+            removed = true;
+            break;
+        }
+    }
+    if !removed {
+        return Err(format!("Hook id '{id}' not found").into());
+    }
+    new_config.save(&crate::config::config_path())?;
+    Ok(())
+}
+
+fn find_hook<'a>(config: &'a Config, id: &str) -> Option<(String, &'a Hook)> {
+    for (name, mb) in &config.mailboxes {
+        for h in &mb.hooks {
+            if h.id == id {
+                return Some((name.clone(), h));
+            }
+        }
+    }
+    None
+}
+
+fn print_restart_hint() {
+    let init = crate::serve::service::detect_init_system();
+    for line in crate::mailbox::restart_hint_lines(&init) {
+        println!("{line}");
+    }
+}
+
+#[derive(Debug)]
+struct Row {
+    id: String,
+    mailbox: String,
+    event: &'static str,
+    cmd: String,
+    filters: String,
+}
+
+fn gather_rows(config: &Config, filter_mailbox: Option<&str>) -> Vec<Row> {
+    let mut rows = Vec::new();
+    for (name, mb) in &config.mailboxes {
+        if let Some(f) = filter_mailbox
+            && f != name
+        {
+            continue;
+        }
+        for h in &mb.hooks {
+            rows.push(Row {
+                id: h.id.clone(),
+                mailbox: name.clone(),
+                event: match h.event {
+                    HookEvent::OnReceive => "on_receive",
+                    HookEvent::AfterSend => "after_send",
+                },
+                cmd: h.cmd.clone(),
+                filters: compact_filters(h),
+            });
+        }
+    }
+    rows
+}
+
+/// Build a compact one-line representation of the filter set for list
+/// output and `mailboxes show`. Empty when no filters are set.
+pub(crate) fn compact_filters(hook: &Hook) -> String {
+    let mut parts = Vec::new();
+    if let Some(p) = hook.from.as_deref() {
+        parts.push(format!("from={p}"));
+    }
+    if let Some(p) = hook.to.as_deref() {
+        parts.push(format!("to={p}"));
+    }
+    if let Some(p) = hook.subject.as_deref() {
+        parts.push(format!("subject={p}"));
+    }
+    if let Some(b) = hook.has_attachment {
+        parts.push(format!("has_attachment={b}"));
+    }
+    if hook.dangerously_support_untrusted {
+        parts.push("dangerously_support_untrusted=true".into());
+    }
+    parts.join(" ")
+}
+
+/// Truncate `s` to `max` *chars* (not bytes), appending `…` on overflow.
+/// Deliberately uses the single-codepoint ellipsis so columnar layouts
+/// stay aligned.
+pub(crate) fn truncate_with_ellipsis(s: &str, max: usize) -> String {
+    let count = s.chars().count();
+    if count <= max {
+        return s.to_string();
+    }
+    let head: String = s.chars().take(max.saturating_sub(1)).collect();
+    format!("{head}…")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::MailboxConfig;
+    use std::collections::HashMap;
+    use std::path::PathBuf;
+
+    fn base_config() -> Config {
+        let mut mailboxes = HashMap::new();
+        mailboxes.insert(
+            "catchall".to_string(),
+            MailboxConfig {
+                address: "*@test.com".to_string(),
+                hooks: vec![],
+                trust: None,
+                trusted_senders: None,
+            },
+        );
+        mailboxes.insert(
+            "alice".to_string(),
+            MailboxConfig {
+                address: "alice@test.com".to_string(),
+                hooks: vec![],
+                trust: None,
+                trusted_senders: None,
+            },
+        );
+        Config {
+            domain: "test.com".to_string(),
+            data_dir: PathBuf::from("/tmp"),
+            dkim_selector: "aimx".to_string(),
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            mailboxes,
+            verify_host: None,
+            enable_ipv6: false,
+        }
+    }
+
+    fn base_args(event: &str) -> HookCreateArgs {
+        HookCreateArgs {
+            mailbox: "alice".into(),
+            event: event.into(),
+            cmd: "echo hi".into(),
+            from: None,
+            to: None,
+            subject: None,
+            has_attachment: false,
+            dangerously_support_untrusted: false,
+        }
+    }
+
+    #[test]
+    fn validate_rejects_to_on_on_receive() {
+        let args = HookCreateArgs {
+            to: Some("*@example.com".into()),
+            ..base_args("on_receive")
+        };
+        let err = validate_flag_combinations(&args).unwrap_err().to_string();
+        assert!(err.contains("--to"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_from_on_after_send() {
+        let args = HookCreateArgs {
+            from: Some("*@example.com".into()),
+            ..base_args("after_send")
+        };
+        let err = validate_flag_combinations(&args).unwrap_err().to_string();
+        assert!(err.contains("--from"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_has_attachment_on_after_send() {
+        let args = HookCreateArgs {
+            has_attachment: true,
+            ..base_args("after_send")
+        };
+        let err = validate_flag_combinations(&args).unwrap_err().to_string();
+        assert!(err.contains("--has-attachment"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_dangerous_on_after_send() {
+        let args = HookCreateArgs {
+            dangerously_support_untrusted: true,
+            ..base_args("after_send")
+        };
+        let err = validate_flag_combinations(&args).unwrap_err().to_string();
+        assert!(err.contains("--dangerously-support-untrusted"), "{err}");
+    }
+
+    #[test]
+    fn validate_rejects_empty_cmd() {
+        let args = HookCreateArgs {
+            cmd: "   ".into(),
+            ..base_args("on_receive")
+        };
+        let err = validate_flag_combinations(&args).unwrap_err().to_string();
+        assert!(err.contains("--cmd"), "{err}");
+    }
+
+    #[test]
+    fn validate_accepts_on_receive_with_from_subject_has_attachment() {
+        let args = HookCreateArgs {
+            from: Some("*@gmail.com".into()),
+            subject: Some("urgent".into()),
+            has_attachment: true,
+            dangerously_support_untrusted: true,
+            ..base_args("on_receive")
+        };
+        validate_flag_combinations(&args).unwrap();
+    }
+
+    #[test]
+    fn validate_accepts_after_send_with_to_subject() {
+        let args = HookCreateArgs {
+            to: Some("*@client.com".into()),
+            subject: Some("receipt".into()),
+            ..base_args("after_send")
+        };
+        validate_flag_combinations(&args).unwrap();
+    }
+
+    #[test]
+    fn truncate_short_string_unchanged() {
+        assert_eq!(truncate_with_ellipsis("hi", 60), "hi");
+    }
+
+    #[test]
+    fn truncate_long_string_appends_ellipsis() {
+        let long = "x".repeat(100);
+        let out = truncate_with_ellipsis(&long, 60);
+        assert_eq!(out.chars().count(), 60);
+        assert!(out.ends_with('…'));
+    }
+
+    #[test]
+    fn generate_unique_hook_id_avoids_existing() {
+        // Seed config with every-possible-prefix IDs won't help; instead,
+        // check that the generator at least returns a well-formed ID
+        // distinct from any present in config. The odds of collision
+        // across two random 12-char draws are ~1 in 36^12 — the loop will
+        // terminate practically every time.
+        let mut cfg = base_config();
+        cfg.mailboxes.get_mut("alice").unwrap().hooks.push(Hook {
+            id: "aaaabbbbcccc".into(),
+            event: HookEvent::OnReceive,
+            r#type: "cmd".into(),
+            cmd: "x".into(),
+            from: None,
+            to: None,
+            subject: None,
+            has_attachment: None,
+            dangerously_support_untrusted: false,
+        });
+        let id = generate_unique_hook_id(&cfg);
+        assert_ne!(id, "aaaabbbbcccc");
+        assert_eq!(id.chars().count(), 12);
+    }
+
+    #[test]
+    fn compact_filters_emits_stable_order() {
+        let hook = Hook {
+            id: "aaaabbbbcccc".into(),
+            event: HookEvent::OnReceive,
+            r#type: "cmd".into(),
+            cmd: "x".into(),
+            from: Some("*@gmail.com".into()),
+            to: None,
+            subject: Some("urgent".into()),
+            has_attachment: Some(true),
+            dangerously_support_untrusted: true,
+        };
+        let out = compact_filters(&hook);
+        assert_eq!(
+            out,
+            "from=*@gmail.com subject=urgent has_attachment=true \
+             dangerously_support_untrusted=true"
+        );
+    }
+
+    #[test]
+    fn compact_filters_empty_when_nothing_set() {
+        let hook = Hook {
+            id: "aaaabbbbcccc".into(),
+            event: HookEvent::OnReceive,
+            r#type: "cmd".into(),
+            cmd: "x".into(),
+            from: None,
+            to: None,
+            subject: None,
+            has_attachment: None,
+            dangerously_support_untrusted: false,
+        };
+        assert_eq!(compact_filters(&hook), "");
+    }
+}

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -8,6 +8,7 @@ pub fn run(cmd: MailboxCommand, config: Config) -> Result<(), Box<dyn std::error
     match cmd {
         MailboxCommand::Create { name } => create(&config, &name),
         MailboxCommand::List => list(&config),
+        MailboxCommand::Show { name } => show(&config, &name),
         MailboxCommand::Delete { name, yes, force } => delete(&config, &name, yes, force),
     }
 }
@@ -253,6 +254,160 @@ fn list(config: &Config) -> Result<(), Box<dyn std::error::Error>> {
     }
 
     Ok(())
+}
+
+/// Build the formatted lines emitted by `aimx mailboxes show <name>`.
+/// Pure function — no stdout access — so tests can assert on exact
+/// content without capturing process output. The terminal-color helpers
+/// already strip ANSI when `NO_COLOR` is set or stdout is not a TTY.
+pub(crate) fn build_show_lines(
+    config: &Config,
+    name: &str,
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let mb = config
+        .mailboxes
+        .get(name)
+        .ok_or_else(|| -> Box<dyn std::error::Error> {
+            format!("Mailbox '{name}' does not exist").into()
+        })?;
+
+    let inbox_dir = config.inbox_dir(name);
+    let sent_dir = config.sent_dir(name);
+    let (inbox_total, inbox_unread) = count_with_unread(&inbox_dir);
+    let (sent_total, _sent_unread) = count_with_unread(&sent_dir);
+
+    let effective_trust = mb.effective_trust(config);
+    let effective_senders = mb.effective_trusted_senders(config);
+
+    let mut lines: Vec<String> = Vec::new();
+    lines.push(format!(
+        "{} {}",
+        term::header("Mailbox:"),
+        term::highlight(name)
+    ));
+    lines.push(format!("  {} {}", term::header("Address:"), mb.address));
+    lines.push(format!(
+        "  {} {}",
+        term::header("Trust:  "),
+        term::info(effective_trust)
+    ));
+
+    if effective_senders.is_empty() {
+        lines.push(format!(
+            "  {} {}",
+            term::header("Trusted senders:"),
+            term::dim("(none)")
+        ));
+    } else {
+        lines.push(format!("  {}", term::header("Trusted senders:")));
+        for s in effective_senders {
+            lines.push(format!("    - {s}"));
+        }
+    }
+
+    lines.push(String::new());
+    lines.push(term::header("Hooks").to_string());
+    let on_receive: Vec<_> = mb.on_receive_hooks().collect();
+    let after_send: Vec<_> = mb.after_send_hooks().collect();
+    if on_receive.is_empty() && after_send.is_empty() {
+        lines.push(format!("  {}", term::dim("(none)")));
+    } else {
+        push_event_group(&mut lines, "on_receive", &on_receive);
+        push_event_group(&mut lines, "after_send", &after_send);
+    }
+
+    lines.push(String::new());
+    lines.push(term::header("Messages").to_string());
+    lines.push(format!(
+        "  {} {} ({} unread)",
+        term::header("inbox:"),
+        inbox_total,
+        inbox_unread
+    ));
+    lines.push(format!("  {} {}", term::header("sent: "), sent_total));
+
+    Ok(lines)
+}
+
+fn push_event_group(lines: &mut Vec<String>, event: &str, hooks: &[&crate::hook::Hook]) {
+    if hooks.is_empty() {
+        return;
+    }
+    lines.push(format!("  {}", term::header(event)));
+    for h in hooks {
+        let cmd = crate::hooks::truncate_with_ellipsis(&h.cmd, 60);
+        let filters = crate::hooks::compact_filters(h);
+        let filter_suffix = if filters.is_empty() {
+            String::new()
+        } else {
+            format!("   [{filters}]")
+        };
+        lines.push(format!(
+            "    - {}  cmd: {}{}",
+            term::highlight(&h.id),
+            cmd,
+            filter_suffix
+        ));
+    }
+}
+
+fn show(config: &Config, name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let lines = build_show_lines(config, name)?;
+    for line in lines {
+        println!("{line}");
+    }
+    Ok(())
+}
+
+/// Count messages in a mailbox folder and also return the number of
+/// unread inbox entries. Mirrors `doctor::count_messages`; duplicated
+/// here so the show command does not depend on the doctor module's
+/// internal layout (and because the doctor's helper is private).
+fn count_with_unread(dir: &Path) -> (usize, usize) {
+    use crate::frontmatter::InboundFrontmatter;
+
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return (0, 0),
+    };
+
+    let mut total = 0usize;
+    let mut unread = 0usize;
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        let md_path = if path.is_dir() {
+            let stem = match path.file_name().and_then(|f| f.to_str()) {
+                Some(s) => s.to_string(),
+                None => continue,
+            };
+            let candidate = path.join(format!("{stem}.md"));
+            if !candidate.exists() {
+                continue;
+            }
+            candidate
+        } else if path.extension().is_some_and(|ext| ext == "md") {
+            path
+        } else {
+            continue;
+        };
+
+        total += 1;
+        let content = match std::fs::read_to_string(&md_path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let parts: Vec<&str> = content.splitn(3, "+++").collect();
+        if parts.len() < 3 {
+            continue;
+        }
+        let toml_str = parts[1].trim();
+        if let Ok(meta) = toml::from_str::<InboundFrontmatter>(toml_str)
+            && !meta.read
+        {
+            unread += 1;
+        }
+    }
+    (total, unread)
 }
 
 fn delete(
@@ -832,5 +987,182 @@ mod tests {
         // not error; treat missing directory as already-empty.
         let tmp = TempDir::new().unwrap();
         super::wipe_mailbox_contents(&tmp.path().join("does-not-exist")).unwrap();
+    }
+
+    // ----- S51-1 mailboxes show ----------------------------------------
+
+    fn show_test_config(tmp: &Path) -> Config {
+        let mut mailboxes = HashMap::new();
+        mailboxes.insert(
+            "catchall".to_string(),
+            MailboxConfig {
+                address: "*@test.com".to_string(),
+                hooks: vec![],
+                trust: None,
+                trusted_senders: None,
+            },
+        );
+        mailboxes.insert(
+            "support".to_string(),
+            MailboxConfig {
+                address: "support@test.com".to_string(),
+                hooks: vec![
+                    crate::hook::Hook {
+                        id: "aaaabbbbcccc".into(),
+                        event: crate::hook::HookEvent::OnReceive,
+                        r#type: "cmd".into(),
+                        cmd: "echo $AIMX_FROM >> /tmp/log".into(),
+                        from: Some("*@gmail.com".into()),
+                        to: None,
+                        subject: Some("urgent".into()),
+                        has_attachment: None,
+                        dangerously_support_untrusted: true,
+                    },
+                    crate::hook::Hook {
+                        id: "ddddeeeeffff".into(),
+                        event: crate::hook::HookEvent::AfterSend,
+                        r#type: "cmd".into(),
+                        cmd: "curl https://webhook.example.com/notify".into(),
+                        from: None,
+                        to: Some("*@client.com".into()),
+                        subject: None,
+                        has_attachment: None,
+                        dangerously_support_untrusted: false,
+                    },
+                ],
+                trust: Some("verified".into()),
+                trusted_senders: Some(vec!["*@company.com".into(), "boss@example.com".into()]),
+            },
+        );
+        Config {
+            domain: "test.com".to_string(),
+            data_dir: tmp.to_path_buf(),
+            dkim_selector: "aimx".to_string(),
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            mailboxes,
+            verify_host: None,
+            enable_ipv6: false,
+        }
+    }
+
+    #[test]
+    fn show_unknown_mailbox_errors() {
+        let tmp = TempDir::new().unwrap();
+        let config = show_test_config(tmp.path());
+        let err = super::build_show_lines(&config, "ghost").unwrap_err();
+        assert!(err.to_string().contains("does not exist"));
+    }
+
+    #[test]
+    fn show_renders_trust_senders_hooks_and_counts() {
+        let tmp = TempDir::new().unwrap();
+        let config = show_test_config(tmp.path());
+
+        // Drop a couple of inbox entries (one unread, one read) so the
+        // counts assertion has content.
+        let inbox = tmp.path().join("inbox").join("support");
+        std::fs::create_dir_all(&inbox).unwrap();
+        let frontmatter = |read: bool| -> String {
+            format!(
+                "+++\nid = \"2025-06-01-001\"\n\
+                 message_id = \"<m@x>\"\n\
+                 thread_id = \"0123456789abcdef\"\n\
+                 from = \"s@x\"\n\
+                 to = \"support@test.com\"\n\
+                 delivered_to = \"support@test.com\"\n\
+                 subject = \"hi\"\n\
+                 date = \"2025-06-01T00:00:00Z\"\n\
+                 received_at = \"2025-06-01T00:00:01Z\"\n\
+                 size_bytes = 10\n\
+                 dkim = \"none\"\n\
+                 spf = \"none\"\n\
+                 dmarc = \"none\"\n\
+                 trusted = \"none\"\n\
+                 mailbox = \"support\"\n\
+                 read = {read}\n\
+                 +++\n\nbody\n"
+            )
+        };
+        std::fs::write(inbox.join("2025-06-01-001.md"), frontmatter(false)).unwrap();
+        std::fs::write(inbox.join("2025-06-02-001.md"), frontmatter(true)).unwrap();
+
+        let lines = super::build_show_lines(&config, "support").unwrap();
+        let joined = strip_ansi(&lines.join("\n"));
+
+        assert!(joined.contains("support@test.com"), "{joined}");
+        // Effective trust is the per-mailbox override.
+        assert!(joined.contains("verified"), "{joined}");
+        // Both trusted-sender entries appear verbatim.
+        assert!(joined.contains("*@company.com"), "{joined}");
+        assert!(joined.contains("boss@example.com"), "{joined}");
+        // Both hook ids appear.
+        assert!(joined.contains("aaaabbbbcccc"), "{joined}");
+        assert!(joined.contains("ddddeeeeffff"), "{joined}");
+        // Each event has its section header.
+        assert!(joined.contains("on_receive"), "{joined}");
+        assert!(joined.contains("after_send"), "{joined}");
+        // Filters are surfaced compactly.
+        assert!(joined.contains("from=*@gmail.com"), "{joined}");
+        assert!(joined.contains("to=*@client.com"), "{joined}");
+        assert!(joined.contains("subject=urgent"), "{joined}");
+        assert!(
+            joined.contains("dangerously_support_untrusted=true"),
+            "{joined}"
+        );
+        // Inbox count + unread + sent count all present.
+        assert!(
+            joined.contains("inbox:") && joined.contains("2"),
+            "{joined}"
+        );
+        assert!(joined.contains("1 unread"), "{joined}");
+        assert!(joined.contains("sent:"), "{joined}");
+    }
+
+    #[test]
+    fn show_renders_empty_hooks_and_senders_as_none_placeholder() {
+        let tmp = TempDir::new().unwrap();
+        let config = show_test_config(tmp.path());
+        let lines = super::build_show_lines(&config, "catchall").unwrap();
+        let joined = strip_ansi(&lines.join("\n"));
+        assert!(joined.contains("*@test.com"));
+        assert!(
+            joined.contains("(none)"),
+            "expected (none) placeholder: {joined}"
+        );
+    }
+
+    #[test]
+    fn show_truncates_long_cmd_with_ellipsis() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = show_test_config(tmp.path());
+        let long_cmd = "x".repeat(120);
+        config
+            .mailboxes
+            .get_mut("support")
+            .unwrap()
+            .hooks
+            .push(crate::hook::Hook {
+                id: "bbbbccccdddd".into(),
+                event: crate::hook::HookEvent::OnReceive,
+                r#type: "cmd".into(),
+                cmd: long_cmd.clone(),
+                from: None,
+                to: None,
+                subject: None,
+                has_attachment: None,
+                dangerously_support_untrusted: false,
+            });
+        let lines = super::build_show_lines(&config, "support").unwrap();
+        let joined = strip_ansi(&lines.join("\n"));
+        assert!(
+            joined.contains("…"),
+            "expected ellipsis truncation marker: {joined}"
+        );
+        // The full 120-char cmd must NOT appear verbatim.
+        assert!(
+            !joined.contains(long_cmd.as_str()),
+            "overlong cmd should be truncated"
+        );
     }
 }

--- a/src/mailbox_handler.rs
+++ b/src/mailbox_handler.rs
@@ -50,7 +50,7 @@ use crate::state_handler::StateContext;
 /// `MAILBOX-CREATE`/`DELETE` requests on different mailbox names cannot
 /// clobber each other. Held only for the duration of the critical
 /// section (not across the full request lifetime).
-static CONFIG_WRITE_LOCK: Mutex<()> = Mutex::new(());
+pub(crate) static CONFIG_WRITE_LOCK: Mutex<()> = Mutex::new(());
 
 /// Shared context for MAILBOX-CREATE / MAILBOX-DELETE. Kept separate from
 /// `StateContext` so the state-lock map is not accidentally bypassed (the

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,9 @@ mod dkim;
 mod doctor;
 mod frontmatter;
 mod hook;
+mod hook_client;
+mod hook_handler;
+mod hooks;
 mod ingest;
 mod logs;
 mod mailbox;
@@ -101,6 +104,7 @@ fn dispatch_with_config(
     match cmd {
         Command::Ingest { rcpt } => ingest::run(&rcpt, config),
         Command::Mailboxes(cmd) => mailbox::run(cmd, config),
+        Command::Hooks(cmd) => hooks::run(cmd, config),
         Command::DkimKeygen { selector, force } => {
             dkim::run_keygen(&config::dkim_dir(), &config.domain, &selector, force)
         }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -494,7 +494,7 @@ fn submit_mark_via_daemon(
 }
 
 #[derive(Debug)]
-enum MarkOutcome {
+pub(crate) enum MarkOutcome {
     Ok,
     Err { code: ErrCode, reason: String },
     Malformed(String),
@@ -583,7 +583,7 @@ async fn submit_mailbox_crud_request(
 /// `true` when the I/O error indicates the daemon socket is not reachable
 /// (not present, connection refused, permission denied). Callers use this
 /// to decide whether to fall back to a direct on-disk edit.
-fn is_socket_missing(e: &std::io::Error) -> bool {
+pub(crate) fn is_socket_missing(e: &std::io::Error) -> bool {
     matches!(
         e.kind(),
         std::io::ErrorKind::NotFound
@@ -610,7 +610,7 @@ async fn submit_mark_request(
     Ok(parse_ack_response(&buf))
 }
 
-fn parse_ack_response(buf: &[u8]) -> MarkOutcome {
+pub(crate) fn parse_ack_response(buf: &[u8]) -> MarkOutcome {
     let text = match std::str::from_utf8(buf) {
         Ok(s) => s,
         Err(_) => return MarkOutcome::Malformed("response is not UTF-8".to_string()),

--- a/src/send_protocol.rs
+++ b/src/send_protocol.rs
@@ -30,6 +30,19 @@
 //!   Content-Length: 0\n
 //!   \n
 //!
+//! Client → Server (HOOK-CREATE):
+//!   AIMX/1 HOOK-CREATE\n
+//!   Mailbox: <mailbox-name>\n
+//!   Content-Length: <n>\n
+//!   \n
+//!   <n bytes of TOML encoding one Hook stanza>
+//!
+//! Client → Server (HOOK-DELETE):
+//!   AIMX/1 HOOK-DELETE\n
+//!   Hook-Id: <id>\n
+//!   Content-Length: 0\n
+//!   \n
+//!
 //! Server → Client:
 //!   AIMX/1 OK [<message-id>]\n
 //! or
@@ -57,6 +70,12 @@
 //!   restart for inbound routing to pick up the change. Error codes
 //!   reuse the existing set plus `VALIDATION` (name validation failures)
 //!   and `NONEMPTY` (delete refused because the mailbox still holds files).
+//! - `HOOK-CREATE` / `HOOK-DELETE` follow the same hot-swap pattern for
+//!   hook CRUD. `HOOK-CREATE` carries a TOML-encoded `Hook` stanza plus a
+//!   `Mailbox:` header picking the owning mailbox; `HOOK-DELETE` carries
+//!   a `Hook-Id:` header and empty body (the daemon locates the hook by
+//!   id across all mailboxes). Error codes reuse `VALIDATION`,
+//!   `MAILBOX`, `NOTFOUND`, and `IO`.
 
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
@@ -122,12 +141,35 @@ pub struct MailboxCrudRequest {
     pub create: bool,
 }
 
+/// Decoded `AIMX/1 HOOK-CREATE` request. Carries the owning mailbox name
+/// as a header and a TOML-encoded `Hook` stanza as the body. The daemon
+/// decodes the body into a `crate::hook::Hook` and appends it to the
+/// addressed mailbox's `hooks` array.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookCreateRequest {
+    pub mailbox: String,
+    /// TOML body encoding one [`crate::hook::Hook`] stanza. Kept as raw
+    /// bytes at the codec layer so the codec can stay free of the hook
+    /// struct itself — the daemon handler decodes.
+    pub hook_toml: Vec<u8>,
+}
+
+/// Decoded `AIMX/1 HOOK-DELETE` request. Locates the hook by globally-
+/// unique 12-char id across every configured mailbox; there is no
+/// `Mailbox:` header on delete.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HookDeleteRequest {
+    pub id: String,
+}
+
 /// One decoded `AIMX/1` request, tagged by verb.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Request {
     Send(SendRequest),
     Mark(MarkRequest),
     MailboxCrud(MailboxCrudRequest),
+    HookCreate(HookCreateRequest),
+    HookDelete(HookDeleteRequest),
 }
 
 /// Error codes reported on the wire in `AIMX/1 ERR <code> <reason>`.
@@ -277,6 +319,12 @@ where
         "MAILBOX-DELETE" => parse_mailbox_crud_headers(reader, false)
             .await
             .map(Request::MailboxCrud),
+        "HOOK-CREATE" => parse_hook_create_headers_and_body(reader, max_body)
+            .await
+            .map(Request::HookCreate),
+        "HOOK-DELETE" => parse_hook_delete_headers(reader)
+            .await
+            .map(Request::HookDelete),
         other => Err(ParseError::UnknownVerb(other.to_string())),
     }
 }
@@ -299,6 +347,9 @@ where
         )),
         Request::MailboxCrud(_) => Err(ParseError::Malformed(
             "expected SEND verb, got MAILBOX-*".to_string(),
+        )),
+        Request::HookCreate(_) | Request::HookDelete(_) => Err(ParseError::Malformed(
+            "expected SEND verb, got HOOK-*".to_string(),
         )),
     }
 }
@@ -543,6 +594,152 @@ where
     Ok(MailboxCrudRequest { name, create })
 }
 
+async fn parse_hook_create_headers_and_body<R>(
+    reader: &mut R,
+    max_body: usize,
+) -> Result<HookCreateRequest, ParseError>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut mailbox: Option<String> = None;
+    let mut content_length: Option<usize> = None;
+
+    loop {
+        let line = read_line(reader)
+            .await?
+            .ok_or_else(|| ParseError::Malformed("unexpected EOF in headers".into()))?;
+        let line = line.trim_end_matches('\r');
+        if line.is_empty() {
+            break;
+        }
+
+        let (n, v) = line
+            .split_once(':')
+            .ok_or_else(|| ParseError::Malformed(format!("invalid header line: {line:?}")))?;
+
+        if !n.is_ascii() {
+            return Err(ParseError::Malformed(format!(
+                "non-ascii header name: {n:?}"
+            )));
+        }
+        let name_norm = n.trim().to_ascii_lowercase();
+        let value = v.trim().to_string();
+
+        match name_norm.as_str() {
+            "mailbox" => {
+                if mailbox.is_some() {
+                    return Err(ParseError::Malformed("duplicate Mailbox header".into()));
+                }
+                if value.is_empty() {
+                    return Err(ParseError::Malformed("empty Mailbox value".into()));
+                }
+                mailbox = Some(value);
+            }
+            "content-length" => {
+                if content_length.is_some() {
+                    return Err(ParseError::Malformed(
+                        "duplicate Content-Length header".into(),
+                    ));
+                }
+                let n: usize = value.parse().map_err(|_| {
+                    ParseError::Malformed(format!("non-integer Content-Length: {value:?}"))
+                })?;
+                if n > max_body {
+                    return Err(ParseError::Malformed(format!(
+                        "Content-Length {n} exceeds cap {max_body}"
+                    )));
+                }
+                content_length = Some(n);
+            }
+            _ => {
+                // Unknown headers are ignored.
+            }
+        }
+    }
+
+    let mailbox =
+        mailbox.ok_or_else(|| ParseError::Malformed("missing required header: Mailbox".into()))?;
+    let content_length = content_length
+        .ok_or_else(|| ParseError::Malformed("missing required header: Content-Length".into()))?;
+
+    let mut hook_toml = vec![0u8; content_length];
+    reader.read_exact(&mut hook_toml).await.map_err(|e| {
+        if e.kind() == std::io::ErrorKind::UnexpectedEof {
+            ParseError::Malformed(format!("body truncated: expected {content_length} bytes"))
+        } else {
+            ParseError::Io(e.to_string())
+        }
+    })?;
+
+    Ok(HookCreateRequest { mailbox, hook_toml })
+}
+
+async fn parse_hook_delete_headers<R>(reader: &mut R) -> Result<HookDeleteRequest, ParseError>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut id: Option<String> = None;
+    let mut content_length: Option<usize> = None;
+
+    loop {
+        let line = read_line(reader)
+            .await?
+            .ok_or_else(|| ParseError::Malformed("unexpected EOF in headers".into()))?;
+        let line = line.trim_end_matches('\r');
+        if line.is_empty() {
+            break;
+        }
+
+        let (n, v) = line
+            .split_once(':')
+            .ok_or_else(|| ParseError::Malformed(format!("invalid header line: {line:?}")))?;
+
+        if !n.is_ascii() {
+            return Err(ParseError::Malformed(format!(
+                "non-ascii header name: {n:?}"
+            )));
+        }
+        let name_norm = n.trim().to_ascii_lowercase();
+        let value = v.trim().to_string();
+
+        match name_norm.as_str() {
+            "hook-id" => {
+                if id.is_some() {
+                    return Err(ParseError::Malformed("duplicate Hook-Id header".into()));
+                }
+                if value.is_empty() {
+                    return Err(ParseError::Malformed("empty Hook-Id value".into()));
+                }
+                id = Some(value);
+            }
+            "content-length" => {
+                if content_length.is_some() {
+                    return Err(ParseError::Malformed(
+                        "duplicate Content-Length header".into(),
+                    ));
+                }
+                let n: usize = value.parse().map_err(|_| {
+                    ParseError::Malformed(format!("non-integer Content-Length: {value:?}"))
+                })?;
+                if n != 0 {
+                    return Err(ParseError::Malformed(format!(
+                        "HOOK-DELETE must have Content-Length: 0, got {n}"
+                    )));
+                }
+                content_length = Some(n);
+            }
+            _ => {
+                // Unknown headers are ignored.
+            }
+        }
+    }
+
+    let id = id.ok_or_else(|| ParseError::Malformed("missing required header: Hook-Id".into()))?;
+    let _ = content_length;
+
+    Ok(HookDeleteRequest { id })
+}
+
 /// Read a single `\n`-terminated line from `reader`, returning it without the
 /// trailing `\n`. Returns `Ok(None)` when the stream ends cleanly before any
 /// byte arrives. Enforces [`MAX_HEADER_LINE`] to bound memory on garbage
@@ -686,6 +883,43 @@ where
     let header = format!(
         "AIMX/1 {verb}\nName: {}\nContent-Length: 0\n\n",
         sanitize_inline(&request.name),
+    );
+    writer.write_all(header.as_bytes()).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Write an `AIMX/1 HOOK-CREATE` request frame. The body is an opaque
+/// blob of TOML bytes — the codec does not parse it.
+pub async fn write_hook_create_request<W>(
+    writer: &mut W,
+    request: &HookCreateRequest,
+) -> Result<(), std::io::Error>
+where
+    W: AsyncWrite + Unpin,
+{
+    let header = format!(
+        "AIMX/1 HOOK-CREATE\nMailbox: {}\nContent-Length: {}\n\n",
+        sanitize_inline(&request.mailbox),
+        request.hook_toml.len(),
+    );
+    writer.write_all(header.as_bytes()).await?;
+    writer.write_all(&request.hook_toml).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Write an `AIMX/1 HOOK-DELETE` request frame. Empty body.
+pub async fn write_hook_delete_request<W>(
+    writer: &mut W,
+    request: &HookDeleteRequest,
+) -> Result<(), std::io::Error>
+where
+    W: AsyncWrite + Unpin,
+{
+    let header = format!(
+        "AIMX/1 HOOK-DELETE\nHook-Id: {}\nContent-Length: 0\n\n",
+        sanitize_inline(&request.id),
     );
     writer.write_all(header.as_bytes()).await?;
     writer.flush().await?;
@@ -1262,6 +1496,215 @@ mod tests {
                 String::from_utf8_lossy(verb),
                 String::from_utf8_lossy(&buf)
             );
+        }
+    }
+
+    // ----- HOOK-CREATE / HOOK-DELETE verbs ---------------------------
+
+    #[tokio::test]
+    async fn parses_hook_create_request() {
+        let body = b"id = \"abc123def456\"\nevent = \"on_receive\"\ncmd = \"echo hi\"\n";
+        let header = format!(
+            "AIMX/1 HOOK-CREATE\nMailbox: alice\nContent-Length: {}\n\n",
+            body.len()
+        );
+        let mut input = header.into_bytes();
+        input.extend_from_slice(body);
+        match parse_any_from_bytes(&input).await.unwrap() {
+            Request::HookCreate(r) => {
+                assert_eq!(r.mailbox, "alice");
+                assert_eq!(r.hook_toml, body.to_vec());
+            }
+            other => panic!("expected HookCreate, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_create_missing_mailbox_is_malformed() {
+        let input = b"AIMX/1 HOOK-CREATE\nContent-Length: 0\n\n";
+        let err = parse_any_from_bytes(input).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("Mailbox"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_create_empty_mailbox_is_malformed() {
+        let input = b"AIMX/1 HOOK-CREATE\nMailbox: \nContent-Length: 0\n\n";
+        let err = parse_any_from_bytes(input).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("empty Mailbox"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_create_missing_content_length_is_malformed() {
+        let input = b"AIMX/1 HOOK-CREATE\nMailbox: alice\n\n";
+        let err = parse_any_from_bytes(input).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("Content-Length"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_create_truncated_body_is_malformed() {
+        let input = b"AIMX/1 HOOK-CREATE\nMailbox: alice\nContent-Length: 10\n\nabc";
+        let err = parse_any_from_bytes(input).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("truncated"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_create_oversized_body_is_malformed() {
+        let input = b"AIMX/1 HOOK-CREATE\nMailbox: alice\nContent-Length: 999999999999\n\n";
+        let err = parse_any_from_bytes(input).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("exceeds cap"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn parses_hook_delete_request() {
+        let input = b"AIMX/1 HOOK-DELETE\nHook-Id: abc123def456\nContent-Length: 0\n\n";
+        match parse_any_from_bytes(input).await.unwrap() {
+            Request::HookDelete(r) => assert_eq!(r.id, "abc123def456"),
+            other => panic!("expected HookDelete, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_delete_missing_id_is_malformed() {
+        let input = b"AIMX/1 HOOK-DELETE\nContent-Length: 0\n\n";
+        let err = parse_any_from_bytes(input).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("Hook-Id"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_delete_empty_id_is_malformed() {
+        let input = b"AIMX/1 HOOK-DELETE\nHook-Id: \nContent-Length: 0\n\n";
+        let err = parse_any_from_bytes(input).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("empty Hook-Id"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_delete_without_content_length_accepted() {
+        let input = b"AIMX/1 HOOK-DELETE\nHook-Id: abc123def456\n\n";
+        match parse_any_from_bytes(input).await.unwrap() {
+            Request::HookDelete(r) => assert_eq!(r.id, "abc123def456"),
+            other => panic!("expected HookDelete, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_delete_nonzero_content_length_is_malformed() {
+        let input = b"AIMX/1 HOOK-DELETE\nHook-Id: abc123def456\nContent-Length: 5\n\nhello";
+        let err = parse_any_from_bytes(input).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("Content-Length: 0"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_create_header_names_case_insensitive() {
+        let body = b"id = \"abc123def456\"\n";
+        let header = format!(
+            "AIMX/1 HOOK-CREATE\nmailbox: alice\ncontent-length: {}\n\n",
+            body.len()
+        );
+        let mut input = header.into_bytes();
+        input.extend_from_slice(body);
+        match parse_any_from_bytes(&input).await.unwrap() {
+            Request::HookCreate(r) => assert_eq!(r.mailbox, "alice"),
+            other => panic!("expected HookCreate, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_create_duplicate_mailbox_is_malformed() {
+        let input = b"AIMX/1 HOOK-CREATE\nMailbox: alice\nMailbox: bob\nContent-Length: 0\n\n";
+        let err = parse_any_from_bytes(input).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("duplicate Mailbox"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_create_roundtrip() {
+        let req = HookCreateRequest {
+            mailbox: "alice".to_string(),
+            hook_toml: b"id = \"abc123def456\"\n".to_vec(),
+        };
+        let (mut client, mut server) = duplex(1024);
+        let w = {
+            let req = req.clone();
+            tokio::spawn(async move {
+                write_hook_create_request(&mut client, &req).await.unwrap();
+            })
+        };
+        let parsed = parse_request(&mut server).await.unwrap();
+        w.await.unwrap();
+        match parsed {
+            Request::HookCreate(r) => {
+                assert_eq!(r.mailbox, "alice");
+                assert_eq!(r.hook_toml, req.hook_toml);
+            }
+            other => panic!("expected HookCreate, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_delete_roundtrip() {
+        let req = HookDeleteRequest {
+            id: "abc123def456".to_string(),
+        };
+        let (mut client, mut server) = duplex(1024);
+        let w = {
+            let req = req.clone();
+            tokio::spawn(async move {
+                write_hook_delete_request(&mut client, &req).await.unwrap();
+            })
+        };
+        let parsed = parse_request(&mut server).await.unwrap();
+        w.await.unwrap();
+        match parsed {
+            Request::HookDelete(r) => assert_eq!(r.id, req.id),
+            other => panic!("expected HookDelete, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn hook_create_binary_safe_body_roundtrip() {
+        let body: Vec<u8> = (0u8..=255).collect();
+        let req = HookCreateRequest {
+            mailbox: "alice".to_string(),
+            hook_toml: body.clone(),
+        };
+        let (mut client, mut server) = duplex(4096);
+        let w = {
+            let req = req.clone();
+            tokio::spawn(async move {
+                write_hook_create_request(&mut client, &req).await.unwrap();
+            })
+        };
+        let parsed = parse_request(&mut server).await.unwrap();
+        w.await.unwrap();
+        match parsed {
+            Request::HookCreate(r) => assert_eq!(r.hook_toml, body),
+            other => panic!("expected HookCreate, got {other:?}"),
         }
     }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -603,6 +603,18 @@ async fn handle_uds_connection_with_timeout(
                 ),
                 false,
             ),
+            Ok(Ok(Request::HookCreate(req))) => (
+                Reply::Ack(
+                    crate::hook_handler::handle_hook_create(&state_ctx, &mb_ctx, &req).await,
+                ),
+                false,
+            ),
+            Ok(Ok(Request::HookDelete(req))) => (
+                Reply::Ack(
+                    crate::hook_handler::handle_hook_delete(&state_ctx, &mb_ctx, &req).await,
+                ),
+                false,
+            ),
             Ok(Err(ParseError::ClosedBeforeRequest)) => {
                 return;
             }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3858,3 +3858,360 @@ fn concurrent_mailbox_create_and_ingest_does_not_deadlock() {
 
     stop_serve(daemon);
 }
+
+// ---------------------------------------------------------------------
+// Sprint 51 — `aimx mailboxes show` + `aimx hooks` CLI
+// ---------------------------------------------------------------------
+
+/// S51-1: `aimx mailboxes show <name>` surfaces trust, senders, hooks,
+/// and counts for a configured mailbox. Verify the happy path and the
+/// singular `mailbox show` alias.
+#[test]
+fn mailboxes_show_prints_trust_senders_hooks_and_counts() {
+    let tmp = TempDir::new().unwrap();
+    let config_content = format!(
+        r#"domain = "agent.example.com"
+data_dir = "{}"
+trust = "none"
+
+[mailboxes.catchall]
+address = "*@agent.example.com"
+
+[mailboxes.support]
+address = "support@agent.example.com"
+trust = "verified"
+trusted_senders = ["*@company.com", "boss@example.com"]
+
+[[mailboxes.support.hooks]]
+id = "aaaabbbbcccc"
+event = "on_receive"
+cmd = "echo inbound"
+from = "*@gmail.com"
+subject = "urgent"
+
+[[mailboxes.support.hooks]]
+id = "ddddeeeeffff"
+event = "after_send"
+cmd = "echo outbound"
+to = "*@client.com"
+"#,
+        tmp.path().display()
+    );
+    std::fs::create_dir_all(tmp.path().join("inbox").join("support")).unwrap();
+    std::fs::create_dir_all(tmp.path().join("sent").join("support")).unwrap();
+    std::fs::write(tmp.path().join("config.toml"), &config_content).unwrap();
+    install_cached_dkim_keys(tmp.path());
+
+    let plural = aimx_cmd(tmp.path())
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .args(["mailboxes", "show", "support"])
+        .assert()
+        .success();
+    let out = String::from_utf8_lossy(&plural.get_output().stdout).to_string();
+
+    for expected in [
+        "support@agent.example.com",
+        "verified",
+        "*@company.com",
+        "boss@example.com",
+        "aaaabbbbcccc",
+        "ddddeeeeffff",
+        "on_receive",
+        "after_send",
+        "from=*@gmail.com",
+        "to=*@client.com",
+        "subject=urgent",
+        "inbox:",
+        "sent:",
+    ] {
+        assert!(
+            out.contains(expected),
+            "missing {expected:?} in output: {out}"
+        );
+    }
+
+    // Singular alias must work too.
+    aimx_cmd(tmp.path())
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .args(["mailbox", "show", "support"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn mailboxes_show_unknown_mailbox_errors() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let assert = aimx_cmd(tmp.path())
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .args(["mailboxes", "show", "ghost"])
+        .assert()
+        .failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+    assert!(
+        stderr.contains("does not exist"),
+        "expected 'does not exist' error, got: {stderr}"
+    );
+}
+
+/// Build an `aimx` Command pre-wired with both `AIMX_CONFIG_DIR` and
+/// `AIMX_RUNTIME_DIR` pointed at the test's tempdir. Using a per-test
+/// runtime dir isolates the UDS socket path so the CLI falls back to the
+/// direct-edit path even when a real `aimx serve` is running on the host
+/// (e.g. on developer machines or CI boxes where the daemon is
+/// installed). Without this isolation, `aimx hooks create` would hit the
+/// host daemon's `/run/aimx/send.sock` and fail with `PROTOCOL unknown
+/// verb` when the host daemon is on an older build.
+fn aimx_cmd_isolated(tmp: &Path) -> Command {
+    let runtime = tmp.join("run");
+    std::fs::create_dir_all(&runtime).ok();
+    let mut cmd = Command::cargo_bin("aimx").unwrap();
+    cmd.env("AIMX_CONFIG_DIR", tmp);
+    cmd.env("AIMX_RUNTIME_DIR", &runtime);
+    cmd
+}
+
+/// S51-2: `aimx hooks create` + `aimx hooks list` roundtrip.
+/// Daemon is not running (AIMX_RUNTIME_DIR points at an empty dir), so
+/// the CLI falls back to direct config.toml edit and prints a restart
+/// hint — that path covers the full flag validation and the on-disk
+/// write.
+#[test]
+fn hooks_create_and_list_roundtrip_direct_edit() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+
+    let create = aimx_cmd_isolated(tmp.path())
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .args([
+            "hooks",
+            "create",
+            "--mailbox",
+            "alice",
+            "--event",
+            "on_receive",
+            "--cmd",
+            "echo hi",
+            "--from",
+            "*@example.com",
+        ])
+        .assert()
+        .success();
+    let create_out = String::from_utf8_lossy(&create.get_output().stdout).to_string();
+    assert!(
+        create_out.contains("Hook created"),
+        "create output: {create_out}"
+    );
+    // A restart hint is expected on the socket-missing fallback path.
+    assert!(
+        create_out.contains("restart") || create_out.contains("Hint"),
+        "expected restart hint on socket-missing fallback: {create_out}"
+    );
+
+    let list = aimx_cmd_isolated(tmp.path())
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .args(["hooks", "list"])
+        .assert()
+        .success();
+    let list_out = String::from_utf8_lossy(&list.get_output().stdout).to_string();
+    assert!(list_out.contains("alice"), "list output: {list_out}");
+    assert!(list_out.contains("on_receive"), "list output: {list_out}");
+    assert!(
+        list_out.contains("from=*@example.com"),
+        "list output: {list_out}"
+    );
+}
+
+#[test]
+fn hooks_alias_works() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    aimx_cmd_isolated(tmp.path())
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .args(["hook", "list"])
+        .assert()
+        .success();
+}
+
+#[test]
+fn hooks_create_rejects_invalid_flag_combo() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+
+    let assert = aimx_cmd_isolated(tmp.path())
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .args([
+            "hooks",
+            "create",
+            "--mailbox",
+            "alice",
+            "--event",
+            "on_receive",
+            "--cmd",
+            "echo hi",
+            "--to",
+            "*@example.com",
+        ])
+        .assert()
+        .failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+    assert!(stderr.contains("--to"), "expected --to error: {stderr}");
+}
+
+#[test]
+fn hooks_create_rejects_unknown_event_at_parse_time() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+
+    let assert = aimx_cmd_isolated(tmp.path())
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .args([
+            "hooks",
+            "create",
+            "--mailbox",
+            "alice",
+            "--event",
+            "nope",
+            "--cmd",
+            "echo hi",
+        ])
+        .assert()
+        .failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+    assert!(
+        stderr.contains("nope") || stderr.contains("invalid value"),
+        "expected clap value-parse error: {stderr}"
+    );
+}
+
+#[test]
+fn hooks_delete_prompts_and_removes_via_direct_edit() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+
+    let create = aimx_cmd_isolated(tmp.path())
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .args([
+            "hooks",
+            "create",
+            "--mailbox",
+            "alice",
+            "--event",
+            "on_receive",
+            "--cmd",
+            "echo hi",
+        ])
+        .assert()
+        .success();
+    let create_out = String::from_utf8_lossy(&create.get_output().stdout).to_string();
+    // Parse the created id out of the on-disk config.toml (the simplest
+    // robust path — we know it's the only hook registered).
+    let config_toml = std::fs::read_to_string(tmp.path().join("config.toml")).unwrap();
+    let config_parsed: toml::Value = toml::from_str(&config_toml).unwrap();
+    let id = config_parsed
+        .get("mailboxes")
+        .and_then(|m| m.get("alice"))
+        .and_then(|a| a.get("hooks"))
+        .and_then(|h| h.as_array())
+        .and_then(|arr| arr.first())
+        .and_then(|h| h.get("id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or_else(|| panic!("could not extract hook id; create out was: {create_out}"))
+        .to_string();
+    assert_eq!(id.chars().count(), 12, "hook id should be 12 chars: {id}");
+
+    aimx_cmd_isolated(tmp.path())
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .args(["hooks", "delete", &id, "--yes"])
+        .assert()
+        .success();
+
+    let list = aimx_cmd_isolated(tmp.path())
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .args(["hooks", "list"])
+        .assert()
+        .success();
+    let out = String::from_utf8_lossy(&list.get_output().stdout).to_string();
+    assert!(!out.contains(&id), "hook id should be gone: {out}");
+}
+
+#[test]
+fn hooks_delete_unknown_id_errors() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let assert = aimx_cmd_isolated(tmp.path())
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .args(["hooks", "delete", "aaaabbbbcccc", "--yes"])
+        .assert()
+        .failure();
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+    assert!(stderr.contains("not found"), "stderr: {stderr}");
+}
+
+// ---------------------------------------------------------------------
+// S51-3 — UDS HOOK-CREATE / HOOK-DELETE end-to-end
+// ---------------------------------------------------------------------
+
+/// S51-3: spin up `aimx serve`, issue `aimx hooks create`, confirm the
+/// daemon hot-swaps its in-memory config by immediately listing the
+/// new hook (which reads on-disk config.toml). Also exercises the
+/// success path: no restart hint is printed when the UDS submission
+/// succeeds.
+#[test]
+fn hooks_create_via_daemon_hot_swaps_config() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+
+    let runtime = tmp.path().join("run");
+    let create = Command::cargo_bin("aimx")
+        .unwrap()
+        .env("AIMX_CONFIG_DIR", tmp.path())
+        .env("AIMX_RUNTIME_DIR", &runtime)
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .args([
+            "hooks",
+            "create",
+            "--mailbox",
+            "alice",
+            "--event",
+            "on_receive",
+            "--cmd",
+            "echo via-daemon",
+        ])
+        .assert()
+        .success();
+    let create_out = String::from_utf8_lossy(&create.get_output().stdout).to_string();
+    assert!(
+        create_out.contains("Hook created"),
+        "create output: {create_out}"
+    );
+    // No restart hint on the daemon-success path.
+    assert!(
+        !create_out.contains("Hint:"),
+        "daemon-success should not print restart hint: {create_out}"
+    );
+
+    // On-disk config.toml should contain the new hook (daemon rewrote it).
+    let content = std::fs::read_to_string(tmp.path().join("config.toml")).unwrap();
+    assert!(
+        content.contains("echo via-daemon"),
+        "config.toml should contain new hook: {content}"
+    );
+
+    stop_serve(daemon);
+}


### PR DESCRIPTION
## Sprint Goal
Land the user-facing hooks surface on top of Sprint 50's foundation — `aimx mailboxes show <name>` for per-mailbox deep-dive, `aimx hooks list | create | delete` for flag-based hook CRUD, and UDS `HOOK-CREATE` / `HOOK-DELETE` verbs so the daemon hot-swaps `Arc<Config>` and newly-created hooks fire on the very next event without `systemctl restart aimx`.

## Stories Implemented

### [S51-1] `aimx mailboxes show <name>` CLI
- [x] `src/cli.rs`: `Mailboxes` subcommand gains a `show { name }` variant
- [x] `src/mailbox.rs show`: pretty-prints via `src/term.rs` semantic colors (auto-strip on NO_COLOR / non-TTY)
- [x] Fixture-based integration test: trust + 2 trusted_senders + on_receive hook + after_send hook → asserts every line present
- [x] `aimx mailbox show <name>` works via the clap alias
- [x] `book/mailboxes.md` documents `show` with an example
- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean

### [S51-2] `aimx hooks list | create | delete` CLI (flag-based)
- [x] `src/cli.rs`: new `Hooks` subcommand with `#[clap(alias = "hook")]`; sub-subcommands `list`, `create`, `delete`
- [x] `hooks list [--mailbox <name>]`: table with id, mailbox, event, truncated cmd, filters
- [x] `hooks create --mailbox N --event E --cmd C [--from G] [--to G] [--subject S] [--has-attachment] [--dangerously-support-untrusted]`: validates mailbox exists, validates event × filter combos, auto-generates 12-char hook id via `hook::generate_hook_id()`, prints the new id on success
- [x] `hooks delete <id> [--yes]`: shows `id | mailbox | event | cmd` and prompts `[y/N]` unless `--yes`; `aimx hook delete <id>` works via alias
- [x] All three dispatch UDS first (S51-3); fall back to direct `config.toml` edit + Sprint 44 restart hint on socket-missing
- [x] Integration tests: create + list roundtrip, delete via direct-edit, invalid flag combos + unknown events rejected at parse time
- [x] `book/hooks.md` covers the CLI with copy-paste examples per event type
- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean

### [S51-3] UDS `HOOK-CREATE` / `HOOK-DELETE` verbs (daemon hot-swap)
- [x] `src/send_protocol.rs`: `HOOK-CREATE` + `HOOK-DELETE` verb parsers + writers; `HOOK-CREATE` carries the hook config as a TOML body + `Mailbox:` header, `HOOK-DELETE` carries the id in a `Hook-Id:` header
- [x] `src/hook_handler.rs`: `handle_hook_create` validates, appends, atomic rewrite + `ConfigHandle::store`; `handle_hook_delete` locates by id, removes, atomic write + swap; both re-run `validate_hooks()` before write so any drift from the loader surfaces immediately
- [x] Per-mailbox lock (`MailboxLocks`) taken around the operation; `CONFIG_WRITE_LOCK` under it — preserves the S47-4 / Sprint 46 lock hierarchy
- [x] `src/hook_client.rs`: tries UDS first; on `ENOENT` / `ECONNREFUSED` / `EACCES` falls back to direct `config.toml` edit + Sprint 44 restart hint
- [x] Integration test: daemon running → `aimx hooks create` → rewrites config.toml via UDS without restart (`hooks_create_via_daemon_hot_swaps_config`)
- [x] Integration test: daemon stopped → `aimx hooks create` falls back to direct edit + restart hint in stdout (`hooks_create_and_list_roundtrip_direct_edit`)
- [x] Unit test: concurrent `HOOK-CREATE` on two different mailboxes succeed without stanza loss (`concurrent_create_different_mailboxes_both_survive`, tokio `multi_thread` 4 workers)
- [x] `book/hooks.md` documents the live-update semantics (no restart required when daemon is running)
- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean

## Technical Decisions

- **Global hook-id uniqueness enforced at both UDS-handler and CLI layers.** `handle_hook_create` walks every mailbox's hooks looking for a duplicate id and rejects with `ERR VALIDATION`; `generate_unique_hook_id` in the CLI loops the generator until it draws an unused id. The generator uses OsRng, so collisions are ~1 in 36^12 — practically the loop runs once — but the explicit check is cheap insurance and keeps the invariant symmetric with `validate_hooks` on config load.
- **`HOOK-DELETE` does not take a `Mailbox:` header.** The hook id is already globally unique, so forcing the client to know the owning mailbox would just be ceremony. The daemon resolves owner from its in-memory snapshot, takes that mailbox's lock, and re-resolves under the lock before writing (handles the theoretical case where some other path re-homes the hook id between our snapshot and the write — though there is no such path today).
- **`CONFIG_WRITE_LOCK` and `write_config_atomic` promoted to `pub(crate)`** so `hook_handler.rs` reuses the exact same critical section as `mailbox_handler.rs`. The alternative — a separate hook-specific lock — would have created a rename-race between concurrent `MAILBOX-CREATE alice` + `HOOK-CREATE <aaaabbbbcccc> on bob` because both rewrite `config.toml`.
- **Reused `MarkOutcome` + `parse_ack_response` + `is_socket_missing`** from `mcp.rs` rather than cloning. These are promoted to `pub(crate)`; the hook client re-uses them verbatim.
- **Hook body on the wire is TOML, not a structured header set.** Keeps the codec free of the `Hook` struct (stays a pure framing layer) and keeps the schema extensible — future hook fields land by adding keys to the TOML body, no wire-format bump.
- **Integration tests isolate `AIMX_RUNTIME_DIR` per test** via a new `aimx_cmd_isolated` helper. Without this, CLI tests on a dev machine with a running `aimx serve` would accidentally talk to the host daemon's `/run/aimx/send.sock` and hit a `PROTOCOL unknown verb` from an older build. The isolated runtime dir forces the CLI onto the direct-edit fallback path, which is what the socket-missing tests are trying to exercise anyway.

## Deferred Items

None — all three stories' acceptance criteria are satisfied in this PR.

## Review Focus Areas

- **`src/hook_handler.rs`** — lock hierarchy (outer `MailboxLocks` → inner `CONFIG_WRITE_LOCK`) and the re-resolve-under-the-lock pattern in `handle_hook_delete`. Concurrent-create regression test at the bottom of the module's `tests`.
- **`src/send_protocol.rs`** — framing for the two new verbs. `HOOK-CREATE` reuses the body-with-Content-Length pattern from SEND; `HOOK-DELETE` reuses the bodyless-with-Content-Length-0 pattern from MARK and MAILBOX-*. Round-trip + binary-safe body tests cover the happy path; header-name + duplicate + missing-header + truncated-body tests cover the unhappy paths.
- **`src/hooks.rs` CLI validation matrix** — every event × filter combination the loader rejects is rejected at parse time too (tests in the `tests` module), so operators get a clean error before the network round-trip.
- **`src/mailbox.rs build_show_lines`** — pure function returning `Vec<String>` so tests can assert on exact content; `show()` just prints them. Same pattern as `restart_hint_lines`.