### PR TITLE
feat: expose reply_to / references params on MCP email_send

### DIFF
--- a/agents/common/references/mcp-tools.md
+++ b/agents/common/references/mcp-tools.md
@@ -169,8 +169,8 @@ directly to the recipient's MX server.
 | `subject`      | string   | yes      | Email subject |
 | `body`         | string   | yes      | Email body text |
 | `attachments`  | string[] | no       | Absolute file paths to attach |
-| `reply_to`     | string   | no       | Message-ID of the email being replied to. Sets `In-Reply-To`; when `references` is omitted, `References` is built automatically from this value |
-| `references`   | string   | no       | Full `References` header chain (space-separated Message-IDs). Use alongside `reply_to` for reply-all or manually-threaded sends |
+| `reply_to`     | string   | no       | Message-ID of the email being replied to. Sets `In-Reply-To`; when `references` is omitted, `References` is built automatically from this value. Required to enable threading — without `reply_to`, any `references` value is silently ignored and no threading headers are emitted |
+| `references`   | string   | no       | Full `References` header chain (space-separated Message-IDs). **Only applied when `reply_to` is also set** — supplied alone, it is silently ignored |
 
 For simple replies to a single sender, prefer `email_reply` — it reads the
 original email and fills in threading headers and the `Re:` subject

--- a/agents/common/references/mcp-tools.md
+++ b/agents/common/references/mcp-tools.md
@@ -169,6 +169,14 @@ directly to the recipient's MX server.
 | `subject`      | string   | yes      | Email subject |
 | `body`         | string   | yes      | Email body text |
 | `attachments`  | string[] | no       | Absolute file paths to attach |
+| `reply_to`     | string   | no       | Message-ID of the email being replied to. Sets `In-Reply-To`; when `references` is omitted, `References` is built automatically from this value |
+| `references`   | string   | no       | Full `References` header chain (space-separated Message-IDs). Use alongside `reply_to` for reply-all or manually-threaded sends |
+
+For simple replies to a single sender, prefer `email_reply` — it reads the
+original email and fills in threading headers and the `Re:` subject
+automatically. Use `email_send` with `reply_to` / `references` only when
+you need to override the recipient list (e.g. reply-all) or build a
+custom threading chain.
 
 **Returns:** Confirmation with Message-ID.
 
@@ -191,6 +199,24 @@ email_send(
   subject: "Report",
   body: "Please see attached.",
   attachments: ["/tmp/report.csv", "/tmp/chart.png"]
+)
+```
+
+**Example — threaded reply-all:**
+```
+# First, read the original to get recipients and the Message-ID:
+email_read(mailbox: "agent", id: "2025-06-01-001")
+# Frontmatter yields: message_id = "<abc@example.com>",
+#                     references = "<prev@example.com>",
+#                     from / to / cc.
+
+email_send(
+  from_mailbox: "agent",
+  to: "alice@example.com, bob@example.com, carol@example.com",
+  subject: "Re: Status Update",
+  body: "Looping everyone in.",
+  reply_to: "<abc@example.com>",
+  references: "<prev@example.com> <abc@example.com>"
 )
 ```
 

--- a/agents/common/references/workflows.md
+++ b/agents/common/references/workflows.md
@@ -99,26 +99,33 @@ email_send(
 
 ## 5. Reply-all
 
-AIMX's `email_reply` sends to the original sender. To reply to all
-recipients, use `email_send` with explicit addresses:
+AIMX's `email_reply` sends to the original sender only. To reply to all
+recipients, use `email_send` with explicit addresses — and pass
+`reply_to` (and optionally `references`) so the outgoing message stays
+in the same thread:
 
 ```
-# Read the original to get all recipients
+# Read the original to get all recipients and the Message-ID
 email_read(mailbox: "agent", id: "<id>")
-# Parse frontmatter: from, to, cc
+# Parse frontmatter: from, to, cc, message_id, references
 
-# Compose with all original recipients
+# Compose with all original recipients, preserving threading
 email_send(
   from_mailbox: "agent",
   to: "<original-from>, <original-to>, <original-cc>",
   subject: "Re: <original-subject>",
-  body: "<reply-body>"
+  body: "<reply-body>",
+  reply_to: "<original-message-id>",
+  references: "<original-references> <original-message-id>"
 )
 ```
 
-Note: when using `email_send` for reply-all, you must manually set the
-subject with `Re:` prefix. Threading headers (`In-Reply-To`, `References`)
-are only set automatically by `email_reply`.
+Notes:
+- `subject` still needs the `Re:` prefix added manually — `email_send`
+  never rewrites the subject.
+- If you only pass `reply_to`, AIMX builds a minimal `References` chain
+  from it automatically. Pass `references` when you need to preserve the
+  full thread history (typical for reply-all on a long thread).
 
 ## 6. Filter by list-id
 

--- a/book/mcp.md
+++ b/book/mcp.md
@@ -112,8 +112,12 @@ Compose and send an email with DKIM signing.
 | `subject` | string | yes | Email subject |
 | `body` | string | yes | Email body text |
 | `attachments` | array of strings | no | File paths to attach |
+| `reply_to` | string | no | Message-ID of the email being replied to. Sets the `In-Reply-To` header and (when `references` is omitted) builds the `References` chain automatically |
+| `references` | string | no | Full `References` header chain (space-separated Message-IDs). Typically used alongside `reply_to` for reply-all or manually threaded sends |
 
 The MCP server composes the RFC 5322 message and submits it to `aimx serve` over the local `/run/aimx/send.sock` UDS. `aimx serve` DKIM-signs the message and delivers it directly to the recipient's MX server via SMTP.
+
+For replies to a single sender, prefer `email_reply` — it handles threading headers and the `Re:` subject prefix automatically. Use `email_send` with `reply_to` / `references` only when you need to override the recipient list (e.g. reply-all) or build a custom threading chain.
 
 ---
 

--- a/book/mcp.md
+++ b/book/mcp.md
@@ -112,8 +112,8 @@ Compose and send an email with DKIM signing.
 | `subject` | string | yes | Email subject |
 | `body` | string | yes | Email body text |
 | `attachments` | array of strings | no | File paths to attach |
-| `reply_to` | string | no | Message-ID of the email being replied to. Sets the `In-Reply-To` header and (when `references` is omitted) builds the `References` chain automatically |
-| `references` | string | no | Full `References` header chain (space-separated Message-IDs). Typically used alongside `reply_to` for reply-all or manually threaded sends |
+| `reply_to` | string | no | Message-ID of the email being replied to. Sets the `In-Reply-To` header and (when `references` is omitted) builds the `References` chain automatically. Required to enable threading — without `reply_to`, any `references` value is silently ignored and no threading headers are emitted |
+| `references` | string | no | Full `References` header chain (space-separated Message-IDs). **Only applied when `reply_to` is also set** — supplied alone, it is silently ignored |
 
 The MCP server composes the RFC 5322 message and submits it to `aimx serve` over the local `/run/aimx/send.sock` UDS. `aimx serve` DKIM-signs the message and delivers it directly to the recipient's MX server via SMTP.
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -86,12 +86,13 @@ pub struct EmailSendParams {
     pub attachments: Option<Vec<String>>,
     #[schemars(
         description = "Message-ID of the email being replied to (sets In-Reply-To header for threading). \
+                       Required to enable threading: without reply_to, the references field is silently ignored and no threading headers are emitted. \
                        When set, References is built automatically unless overridden by the references field."
     )]
     pub reply_to: Option<String>,
     #[schemars(
         description = "Full References header chain (space-separated Message-IDs) for threading. \
-                       Typically used alongside reply_to for reply-all or manually threaded sends."
+                       Only applied when reply_to is also set — supplied alone, it is silently ignored."
     )]
     pub references: Option<String>,
 }
@@ -317,15 +318,7 @@ impl AimxMcpServer {
             ));
         }
 
-        let args = SendArgs {
-            from: from_address.clone(),
-            to: params.to,
-            subject: params.subject,
-            body: params.body,
-            reply_to: params.reply_to,
-            references: params.references,
-            attachments: params.attachments.unwrap_or_default(),
-        };
+        let args = build_send_args(params, from_address);
 
         submit_via_daemon(&args)
     }
@@ -394,6 +387,22 @@ impl AimxMcpServer {
         };
 
         submit_via_daemon(&args)
+    }
+}
+
+/// Build `SendArgs` from `EmailSendParams` and the resolved sender
+/// address. Pure and side-effect-free so it can be unit-tested without
+/// the daemon; keeps the `params.reply_to` / `params.references`
+/// forwarding explicit (see the deserialization tests below).
+fn build_send_args(params: EmailSendParams, from_address: &str) -> SendArgs {
+    SendArgs {
+        from: from_address.to_string(),
+        to: params.to,
+        subject: params.subject,
+        body: params.body,
+        reply_to: params.reply_to,
+        references: params.references,
+        attachments: params.attachments.unwrap_or_default(),
     }
 }
 
@@ -1583,5 +1592,50 @@ mod tests {
             params.references.as_deref(),
             Some("<first@example.com> <second@example.com> <third@example.com>")
         );
+    }
+
+    // ----- build_send_args forwards threading params ------------------
+
+    #[test]
+    fn build_send_args_forwards_reply_to_and_references() {
+        // Guards against regression that would re-introduce hardcoded
+        // `None`s on the SendArgs construction inside `email_send`.
+        let params = EmailSendParams {
+            from_mailbox: "agent".to_string(),
+            to: "alice@example.com".to_string(),
+            subject: "Re: Hello".to_string(),
+            body: "Thanks.".to_string(),
+            attachments: None,
+            reply_to: Some("<third@example.com>".to_string()),
+            references: Some(
+                "<first@example.com> <second@example.com> <third@example.com>".to_string(),
+            ),
+        };
+        let args = build_send_args(params, "agent@example.com");
+        assert_eq!(args.from, "agent@example.com");
+        assert_eq!(args.to, "alice@example.com");
+        assert_eq!(args.reply_to.as_deref(), Some("<third@example.com>"));
+        assert_eq!(
+            args.references.as_deref(),
+            Some("<first@example.com> <second@example.com> <third@example.com>")
+        );
+        assert!(args.attachments.is_empty());
+    }
+
+    #[test]
+    fn build_send_args_defaults_threading_to_none() {
+        let params = EmailSendParams {
+            from_mailbox: "agent".to_string(),
+            to: "alice@example.com".to_string(),
+            subject: "Hello".to_string(),
+            body: "Hi.".to_string(),
+            attachments: None,
+            reply_to: None,
+            references: None,
+        };
+        let args = build_send_args(params, "agent@example.com");
+        assert!(args.reply_to.is_none());
+        assert!(args.references.is_none());
+        assert!(args.attachments.is_empty());
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -84,6 +84,16 @@ pub struct EmailSendParams {
     pub body: String,
     #[schemars(description = "File paths to attach")]
     pub attachments: Option<Vec<String>>,
+    #[schemars(
+        description = "Message-ID of the email being replied to (sets In-Reply-To header for threading). \
+                       When set, References is built automatically unless overridden by the references field."
+    )]
+    pub reply_to: Option<String>,
+    #[schemars(
+        description = "Full References header chain (space-separated Message-IDs) for threading. \
+                       Typically used alongside reply_to for reply-all or manually threaded sends."
+    )]
+    pub references: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, schemars::JsonSchema)]
@@ -312,8 +322,8 @@ impl AimxMcpServer {
             to: params.to,
             subject: params.subject,
             body: params.body,
-            reply_to: None,
-            references: None,
+            reply_to: params.reply_to,
+            references: params.references,
             attachments: params.attachments.unwrap_or_default(),
         };
 
@@ -1518,6 +1528,60 @@ mod tests {
         assert!(
             hint.contains("aimx mailboxes delete --force orders"),
             "{hint}"
+        );
+    }
+
+    // ----- email_send threading params --------------------------------
+
+    #[test]
+    fn email_send_params_deserialize_without_threading_fields() {
+        // Existing callers that omit reply_to/references still parse and
+        // default both to None — backward compatibility guarantee.
+        let json = r#"{
+            "from_mailbox": "agent",
+            "to": "alice@example.com",
+            "subject": "Hello",
+            "body": "Hi."
+        }"#;
+        let params: EmailSendParams = serde_json::from_str(json).unwrap();
+        assert_eq!(params.from_mailbox, "agent");
+        assert_eq!(params.to, "alice@example.com");
+        assert_eq!(params.subject, "Hello");
+        assert_eq!(params.body, "Hi.");
+        assert!(params.attachments.is_none());
+        assert!(params.reply_to.is_none());
+        assert!(params.references.is_none());
+    }
+
+    #[test]
+    fn email_send_params_deserialize_with_reply_to() {
+        let json = r#"{
+            "from_mailbox": "agent",
+            "to": "alice@example.com",
+            "subject": "Re: Hello",
+            "body": "Thanks.",
+            "reply_to": "<original@example.com>"
+        }"#;
+        let params: EmailSendParams = serde_json::from_str(json).unwrap();
+        assert_eq!(params.reply_to.as_deref(), Some("<original@example.com>"));
+        assert!(params.references.is_none());
+    }
+
+    #[test]
+    fn email_send_params_deserialize_with_reply_to_and_references() {
+        let json = r#"{
+            "from_mailbox": "agent",
+            "to": "alice@example.com",
+            "subject": "Re: Hello",
+            "body": "Thanks.",
+            "reply_to": "<third@example.com>",
+            "references": "<first@example.com> <second@example.com> <third@example.com>"
+        }"#;
+        let params: EmailSendParams = serde_json::from_str(json).unwrap();
+        assert_eq!(params.reply_to.as_deref(), Some("<third@example.com>"));
+        assert_eq!(
+            params.references.as_deref(),
+            Some("<first@example.com> <second@example.com> <third@example.com>")
         );
     }
 }


### PR DESCRIPTION
## Summary
The MCP `email_send` tool hardcoded `reply_to: None` / `references: None` when building `SendArgs`, so agents using it could not produce correctly threaded outbound. The `aimx send` CLI and `send::compose_message` already supported both fields; this PR exposes them on the MCP surface so reply-all and manually-threaded sends work without falling back to `email_reply` (which always sends to the original sender only).

## Requirements
- [x] `EmailSendParams` gains optional `reply_to` and `references` fields with `schemars` descriptions matching the CLI intent (`reply_to` = parent Message-ID → `In-Reply-To`; `references` = full chain).
- [x] `email_send` handler passes the fields through to `SendArgs` unchanged — `send::compose_message` already sanitizes and normalizes.
- [x] Both fields default to `None`; existing callers are unaffected.
- [x] When `reply_to` is supplied, the composed message carries `In-Reply-To` / `References` headers. When `references` is also supplied, that chain is used verbatim. (Behavior provided by `compose_message`, covered by existing `src/send.rs` tests.)
- [x] New unit tests in `src/mcp.rs::tests` cover JSON deserialization with and without the new fields; the existing `mcp_server_has_correct_tool_count` assertion (still 9) is preserved.

## Out of scope
- Changing `email_reply` behavior.
- Adding an RFC 5322 `Reply-To:` *mailbox* header param (semantically different from the existing `reply_to` = parent Message-ID naming used by the CLI). Would be a separate param if pursued later.
- Any wire-protocol change — `SendRequest` carries only the composed body; threading headers are baked in by `compose_message`.
- Daemon-level integration tests — unit-level param-plumbing coverage is enough since `compose_message`'s behavior is already covered in `src/send.rs::tests`.

## Technical approach
Minimal surface-level addition in `src/mcp.rs`:

- `EmailSendParams`: two new `Option<String>` fields (`reply_to`, `references`) with `#[schemars(description = ...)]` annotations.
- `email_send` handler: replace the two hardcoded `None`s in the `SendArgs` construction with `params.reply_to` / `params.references`.

No changes to `send.rs`, `send_protocol.rs`, `send_handler.rs`, or any other module — plumbing is purely inside `mcp.rs`.

Docs updated in the same PR:
- `book/mcp.md` — add both params to the `email_send` table, plus a note on when to prefer `email_reply`.
- `agents/common/references/mcp-tools.md` — extend the param table and add a threaded reply-all example.
- `agents/common/references/workflows.md` — fix the reply-all note (previously claimed threading headers were only settable by `email_reply`).

## Test plan
- [x] 3 new deserialization tests in `src/mcp.rs::tests`:
  - `email_send_params_deserialize_without_threading_fields` (backward-compat guarantee)
  - `email_send_params_deserialize_with_reply_to`
  - `email_send_params_deserialize_with_reply_to_and_references`
- [x] Existing `mcp_server_has_correct_tool_count` still passes (9 tools, no additions/removals).
- [x] Full suite: `cargo test` — 863 unit + 85 integration, all green.
- [x] `cargo clippy --all-targets -- -D warnings` — clean.
- [x] `cargo fmt -- --check` — clean.

## Notes
Reviewer may want to double-check the description wording on the two new `schemars(description = ...)` annotations — they're surfaced verbatim to MCP clients and are the agent-facing docs for the params.