### PR TITLE
feat(setup): default DNS-ownership prompt to Yes

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1421,12 +1421,17 @@ pub fn prompt_domain(reader: &mut dyn BufRead) -> Result<String, Box<dyn std::er
 
     print!(
         "You will need to add MX, SPF, and DKIM DNS records for this domain.\n\
-         Do you control this domain and have access to its DNS settings? (y/N) "
+         Do you control this domain and have access to its DNS settings? (Y/n) "
     );
     io::stdout().flush()?;
     let mut confirm = String::new();
     reader.read_line(&mut confirm)?;
-    if !confirm.trim().eq_ignore_ascii_case("y") {
+    if confirm
+        .trim()
+        .chars()
+        .next()
+        .is_some_and(|c| c == 'n' || c == 'N')
+    {
         return Err("Setup cancelled. You need DNS access to proceed.".into());
     }
 
@@ -3153,6 +3158,26 @@ mod tests {
     #[test]
     fn prompt_domain_exits_on_declined_confirmation() {
         let input = b"agent.example.com\nn\n";
+        let mut reader = io::Cursor::new(input);
+        let result = prompt_domain(&mut reader);
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("cancelled"),
+            "should indicate cancellation"
+        );
+    }
+
+    #[test]
+    fn prompt_domain_accepts_empty_confirmation_as_yes() {
+        let input = b"agent.example.com\n\n";
+        let mut reader = io::Cursor::new(input);
+        let domain = prompt_domain(&mut reader).expect("empty confirmation should default to yes");
+        assert_eq!(domain, "agent.example.com");
+    }
+
+    #[test]
+    fn prompt_domain_exits_on_uppercase_n() {
+        let input = b"agent.example.com\nN\n";
         let mut reader = io::Cursor::new(input);
         let result = prompt_domain(&mut reader);
         assert!(result.is_err());


### PR DESCRIPTION
## Summary
After the user has entered a domain during `aimx setup`, the follow-up "Do you control this domain and have access to its DNS settings?" is a go/no-go gate on the happy path — declining is the exceptional answer. Flip the default from N to Y so pressing Enter proceeds.

## Requirements
- [x] DNS-ownership prompt text changes from `(y/N)` to `(Y/n)`.
- [x] Empty input (bare Enter) is treated as **yes** and setup proceeds.
- [x] Any input starting with `n` or `N` (case-insensitive) is treated as **no** and setup is cancelled with the existing error message.
- [x] Explicit `y` / `Y` / `yes` continues to be treated as **yes** (unchanged happy path).
- [x] No other `y/N` prompts modified.

## Out of scope
- Flipping destructive confirmations (`aimx hooks delete`, `aimx mailboxes delete`, `aimx mailboxes delete --force`, `aimx agent-setup` overwrite, `aimx uninstall`). Convention across Unix tooling is default-No on destructive prompts; each already has `--yes` / `--force` for scripted use.
- `docs/sprint.2.md:642` — historical sprint doc, marked `[x]` done. Per `CLAUDE.md`, `[DONE]` sprint entries are not modified.
- `book/` docs do not quote the DNS-ownership prompt text, so no doc updates were needed.

## Technical approach
Single edit site: `prompt_domain()` in `src/setup.rs`.

- Prompt text: `(y/N) ` → `(Y/n) `.
- Decline logic: from `!input.eq_ignore_ascii_case("y")` (which rejected empty and anything non-y) to an explicit "first char is n/N" check, so empty input falls through to the accept path.

No changes to callers — `run_setup()` already handles the `Err` returned on decline.

## Test plan
- [x] Existing `prompt_domain_accepts_valid_domain_with_confirmation` (explicit `y`) — passes.
- [x] Existing `prompt_domain_exits_on_declined_confirmation` (explicit `n`) — passes.
- [x] New `prompt_domain_accepts_empty_confirmation_as_yes` — bare Enter now returns `Ok`.
- [x] New `prompt_domain_exits_on_uppercase_n` — uppercase `N` still declines.
- [x] Full `cargo test` (6 unit + 85 integration) — green.
- [x] `cargo clippy -- -D warnings` — clean.
- [x] `cargo fmt -- --check` — clean.

## Notes
During the audit, five other `y/N` prompts were found and intentionally **not** flipped (all destructive): hooks delete, mailbox delete (non-force + `--force`), agent-setup overwrite, uninstall. Reviewer: please confirm you agree destructive prompts should stay default-No.