### PR TITLE
docs(hook-templates): add PRD for MCP-driven hook templates

### DIFF
--- a/docs/hook-templates-prd.md
+++ b/docs/hook-templates-prd.md
@@ -1,0 +1,373 @@
+# Hook Templates — Product Requirements Document
+
+## 1. Overview
+
+Hook templates let AI agents configure their own inbound/outbound mail automations through MCP, safely. The operator registers a small set of pre-vetted command shapes (e.g. "invoke Claude with prompt X", "POST to URL Y") once at setup time; agents then pick a template and fill declared parameters via the MCP `hook_create` tool. Raw-command hooks remain available to the operator via CLI, but they can never reach the daemon over a world-writable Unix socket.
+
+This PRD also covers three supporting changes that together form the security story: a dedicated unprivileged service user (`aimx-hook`) that hooks drop privileges to before `exec`, a rename of the runtime socket from `send.sock` to `aimx.sock`, and tighter scoping of the existing `HOOK-CREATE` UDS verb.
+
+**Tagline:** Chat with your agent to wire up mail automations, without handing it a shell.
+
+## 2. Problem Statement
+
+Today an operator who wants an agent to react to mail has two paths, both bad:
+
+1. **Hand-edit `/etc/aimx/config.toml`** — add a `[[mailboxes.accounts.hooks.on_receive]]` block with a `cmd = "..."` field and restart the daemon. Works, but it's friction for a non-trivial command and breaks the "chat with your agent" UX that aimx is meant to deliver.
+2. **Expose raw `HOOK-CREATE` over the world-writable UDS** — convenient for MCP, but any local user could then instruct the root-owned daemon to execute arbitrary shell as root on every inbound email. The DKIM-key isolation that protects `SEND` does not protect hooks; hooks are the attack surface.
+
+The impact today: operators either avoid hooks (the most differentiated aimx feature) or accept an unsafe posture. The feature that was supposed to be the headline of agent-native mail is friction to set up and scary to expose.
+
+**Who experiences this:** Agent operators who want self-configuring agents (personal productivity use cases — "file mail into the right folder", "reply with current system state", "route receipts to an accounting agent"), plus framework developers who want to ship agent bundles that assume MCP-level hook control.
+
+**Impact of not solving:** Hooks remain operator-only, set up by hand. The "chat with your AI to wire things up" promise regresses. Alternatively, someone ships MCP hook-create with no authorization story and opens aimx installs to local privilege escalation.
+
+## 3. Goals and Success Metrics
+
+| Goal | Metric | Target |
+|------|--------|--------|
+| Agents can self-configure hooks via MCP | MCP `hook_create` works without operator intervention after one-time template install | Setting up a "file + reply" hook requires 0 `sudo` calls once templates are installed |
+| No local privilege escalation via UDS | Hooks submitted over `aimx.sock` cannot invoke arbitrary binaries | MCP `hook_create` rejects any non-template payload; penetration review finds no bypass |
+| Hook execution is sandboxed | Hook processes run as `aimx-hook`, not root | `ps -ef` during hook exec shows `aimx-hook` UID; attempts to read `/etc/aimx/dkim/private.key` fail with EACCES |
+| Operator keeps full power | Raw-cmd hooks via CLI continue to work | `aimx hooks create --mailbox x --event on_receive --cmd "..."` still creates an arbitrary-command hook (after `sudo`) |
+| Zero-migration rollout | Pre-launch, no backward compat | Config schema changes land in one release; no `v1 → v2` shim needed |
+
+## 4. User Personas
+
+### Agent Operator (primary, root)
+- **Description:** Root user on the aimx box. Runs `aimx setup` once, configures domains + DKIM, decides which agents are trusted to self-configure.
+- **Needs:** Control over which templates exist. Visibility into what hooks the agent has created on their behalf. Ability to create raw-cmd hooks when templates don't fit.
+- **Context:** SSH'd in as root (or via `sudo`). Interacts with aimx via `aimx setup`, `aimx hooks …`, and hand-edits to `/etc/aimx/config.toml` when needed.
+
+### AI Agent (secondary, non-root)
+- **Description:** Claude Code / Codex / Goose / etc., running as the operator's unprivileged user, talking to `aimx mcp` over stdio.
+- **Needs:** Discover what templates are available. Create hooks wired to those templates. List and delete hooks it owns.
+- **Context:** The agent is triggered by a natural-language instruction ("when I get an email from my bank, file it and reply with my balance"). It must be able to wire that up end-to-end without the operator opening a second terminal.
+
+### Agent Framework Developer (tertiary)
+- **Description:** Builder shipping an agent plugin/skill that relies on aimx hooks.
+- **Needs:** Predictable template names (`invoke-claude`, `webhook`) on any aimx install. Stable parameter schemas.
+- **Context:** Writing `SKILL.md` or plugin manifests that instruct the agent to call `hook_create` with specific params.
+
+## 5. User Stories
+
+### P0 — Must Have
+
+- As an **operator**, I want `aimx setup` to ask me (checkboxes) which hook templates to install so that only templates I want are registered.
+- As an **operator**, I want the daemon to execute hook commands as a dedicated unprivileged user (`aimx-hook`) so that a buggy or malicious hook cannot read my DKIM key, rewrite `config.toml`, or touch other mailboxes.
+- As an **operator**, I want `aimx hooks create --cmd "..."` to keep working so that I can still register arbitrary commands when no template fits.
+- As an **agent**, I want a `hook_list_templates` MCP tool so that I can discover what templates are available on this install.
+- As an **agent**, I want a `hook_create` MCP tool that accepts `(mailbox, event, template, params)` so that I can wire up an automation without operator intervention.
+- As an **agent**, I want `hook_create` to refuse any payload containing a raw `cmd` field so that a prompt-injection attack cannot smuggle arbitrary shell past the template boundary.
+- As an **agent**, I want `hook_list` and `hook_delete` MCP tools so that I can introspect and clean up the hooks I have created.
+- As an **operator**, I want `aimx agent-setup <agent>` to print a one-line `sudo aimx hooks template-enable <name>` hint for any template that maps to the agent I just installed so that I know exactly how to complete the wiring.
+
+### P1 — Should Have
+
+- As an **operator**, I want `aimx hooks templates` (and `aimx hooks template-list`) CLI commands so that I can inspect which templates are registered without opening `config.toml`.
+- As an **operator**, I want hook processes to have a default `timeout_secs` so that a hanging hook never starves the daemon's event loop.
+- As an **operator**, I want the daemon to log a single-line structured record for every hook fire (template or raw-cmd, exit code, duration, stderr tail) so that I can debug without `strace`.
+- As an **agent**, I want `hook_delete` to be restricted to hooks whose `origin = "mcp"` so that I cannot (accidentally or adversarially) nuke operator-authored hooks.
+- As an **operator on a systemd box**, I want hook processes spawned via `systemd-run --uid=aimx-hook --property=ProtectSystem=strict --property=PrivateNetwork=... --property=MemoryMax=...` so that I get OS-level sandboxing for free.
+
+### P2 — Nice to Have
+
+- As an **operator**, I want `aimx hooks template-enable <name>` / `template-disable <name>` CLI commands so that I can toggle templates without hand-editing `config.toml`.
+- As an **operator**, I want per-template `allowed_mailboxes` so that I can restrict a sensitive template (e.g. `webhook`) to specific mailboxes only.
+- As an **operator**, I want a dry-run mode (`aimx hooks test <name>`) that fires a template with a synthetic email so that I can verify wiring before going live.
+
+## 6. Functional Requirements
+
+### 6.1 Template schema (`config.toml`)
+
+Each template is a `[[hook_template]]` block in `/etc/aimx/config.toml`. The schema:
+
+```toml
+[[hook_template]]
+name = "invoke-claude"                    # unique across templates; [a-z0-9-]+
+description = "Pipe the received/sent email into Claude Code with a custom prompt."
+cmd = ["/usr/local/bin/claude", "-p", "{prompt}"]
+params = ["prompt"]                        # list of placeholder names that may appear in `cmd`
+stdin = "email"                            # "email" | "email_json" | "none"
+run_as = "aimx-hook"                       # fixed in v1; kept as a field for future flexibility
+timeout_secs = 60                          # default 60, max 600
+allowed_events = ["on_receive", "after_send"]  # optional; defaults to both
+```
+
+Substitution rules:
+
+1. `{name}` placeholders are replaced **inside argv string values only** — never in `cmd[0]` (the binary path) and never as standalone argv entries (no parameter may introduce new argv entries via whitespace).
+2. Every placeholder used in `cmd` must appear in `params`. Every `params` entry must be referenced by at least one placeholder. Validation fails loudly on mismatch.
+3. `{event}`, `{mailbox}`, `{message_id}`, `{from}`, `{subject}` are **built-in placeholders** populated by the daemon at fire time; they do not need to be declared in `params`.
+4. User-supplied param values are passed verbatim to the substituted argv entry. No shell, no `sh -c`, no string splitting. Placeholder substitution happens **after** the argv is parsed, so quotes and spaces in values cannot escape the value slot.
+5. Values are UTF-8 strings. Binary/NUL is rejected.
+
+### 6.2 Default templates (shipped in the binary, installed via `aimx setup` checkboxes)
+
+| Template | Agents | `cmd` shape | `stdin` |
+|----------|--------|-------------|---------|
+| `invoke-claude` | claude-code | `["/usr/local/bin/claude", "-p", "{prompt}"]` | `email` |
+| `invoke-codex` | codex | `["/usr/local/bin/codex", "-p", "{prompt}"]` | `email` |
+| `invoke-opencode` | opencode | `["/usr/local/bin/opencode", "run", "{prompt}"]` | `email` |
+| `invoke-gemini` | gemini | `["/usr/local/bin/gemini", "-p", "{prompt}"]` | `email` |
+| `invoke-goose` | goose | `["/usr/local/bin/goose", "run", "--recipe", "{recipe}"]` | `email` |
+| `invoke-openclaw` | openclaw | `["/usr/local/bin/openclaw", "run", "{prompt}"]` | `email` |
+| `invoke-hermes` | hermes | `["/usr/local/bin/hermes", "run", "{prompt}"]` | `email` |
+| `webhook` | generic | `["/usr/bin/curl", "-sS", "-X", "POST", "-H", "Content-Type: application/json", "--data-binary", "@-", "{url}"]` | `email_json` |
+
+Exact binary paths and argv shapes are finalized during implementation by confirming each agent's current CLI surface.
+
+The binary embeds all template definitions via `include_dir!` or equivalent, so `aimx setup` can write them without a separate asset download.
+
+### 6.3 `aimx setup` interactive install
+
+During `aimx setup`, after DKIM and systemd-unit writing, present a checkbox list:
+
+```
+[Hook Templates]
+Hook templates let your agents create their own on_receive / after_send
+automations via MCP, safely. Each template is a pre-vetted command shape;
+agents can only fill declared parameters. Hook commands run as the
+unprivileged 'aimx-hook' user, never as root.
+
+Which templates should I enable? (space to toggle, enter to confirm)
+ [x] invoke-claude     Pipe email into Claude Code with a prompt
+ [ ] invoke-codex      Pipe email into Codex CLI with a prompt
+ [ ] invoke-opencode   Pipe email into OpenCode with a prompt
+ [ ] invoke-gemini     Pipe email into Gemini CLI with a prompt
+ [ ] invoke-goose      Pipe email into a Goose recipe
+ [ ] invoke-openclaw   Pipe email into OpenClaw with a prompt
+ [ ] invoke-hermes     Pipe email into Hermes with a prompt
+ [x] webhook           POST the email as JSON to a URL
+```
+
+Defaults: none checked (conservative). Operator explicitly opts in. Re-running `aimx setup` offers the same menu with current selections pre-ticked.
+
+`aimx setup` also creates the `aimx-hook` system user if it does not exist:
+
+```
+useradd --system --no-create-home --shell /usr/sbin/nologin aimx-hook
+```
+
+(OpenRC boxes use the equivalent `adduser` flags; both paths are idempotent.)
+
+### 6.4 `aimx agent-setup <agent>` template hint
+
+`aimx agent-setup` stays a per-user command (refuses root, writes only to `$HOME`). It does **not** touch `config.toml` directly. It gains a new post-install hint: when the installed agent maps to a known template, print the exact command to activate it:
+
+```
+✓ Installed claude-code plugin to /Users/alice/.claude/plugins/aimx
+
+To let Claude Code create its own hooks via MCP, enable the matching template
+as root:
+
+    sudo aimx hooks template-enable invoke-claude
+
+(Already enabled if you ticked it during `aimx setup`.)
+```
+
+The hint is always printed; `agent-setup` does not try to detect whether the template is already enabled (that would require reading root-owned `/etc/aimx/config.toml`).
+
+### 6.5 UDS protocol and socket rename
+
+**Socket rename:** `/run/aimx/send.sock` → `/run/aimx/aimx.sock` (still mode `0666`, still owned `root:root`, still managed by systemd `RuntimeDirectory=aimx` or OpenRC `checkpath`). This is a breaking change on the wire; acceptable because aimx is pre-launch. All occurrences updated atomically in one release.
+
+**`HOOK-CREATE` verb** (tightened):
+
+```
+AIMX/1 HOOK-CREATE\n
+Mailbox: accounts\n
+Event: on_receive\n
+Template: invoke-claude\n
+Name: accounts-auto-reply            (optional)
+Content-Length: 137\n
+\n
+{"prompt": "You are the accounts agent. Read the email on stdin, file it into the right folder, and draft a reply with the current balance."}
+```
+
+The body is JSON with keys matching the template's declared `params`. The daemon:
+
+1. Rejects any request whose body contains a `cmd`, `run_as`, `dangerously_support_untrusted`, `timeout_secs`, or `stdin` field. These are template properties, not hook properties.
+2. Rejects any request that omits `Template:` or names an unknown / disabled template.
+3. Rejects any `params` key not declared by the template; rejects missing required params.
+4. Tags the resulting hook with `origin = "mcp"` when written to `config.toml`.
+
+**Raw-cmd hook creation** stays in the CLI via `aimx hooks create --cmd "..."`. It does **not** use the UDS: it writes `config.toml` directly (requires `sudo`) and sends SIGHUP to the running `aimx serve` process for hot-reload. If `aimx serve` is not running, it writes the file and prints a restart hint.
+
+Hooks written to `config.toml` carry an `origin` field:
+- `origin = "operator"` — authored by root via CLI or hand-edit (default when field is absent)
+- `origin = "mcp"` — created by MCP over `aimx.sock`
+
+**`HOOK-DELETE` verb** (tightened): MCP may delete a hook only if its `origin = "mcp"`. Operator-origin hooks can only be removed via CLI (`sudo aimx hooks delete <name>` or `config.toml` edit). The daemon returns `ERR origin-protected` for cross-origin delete attempts on `aimx.sock`.
+
+**Other verbs unchanged:** `SEND`, `MARK-READ`, `MARK-UNREAD`, `MAILBOX-CREATE`, `MAILBOX-DELETE` all continue to work on `aimx.sock` with existing semantics.
+
+### 6.6 MCP tool surface
+
+New `aimx mcp` tools:
+
+1. **`hook_list_templates`** — returns the list of enabled templates. Each entry: `{ name, description, params, allowed_events }`. No auth, no arguments.
+2. **`hook_create(mailbox, event, template, params, name?)`** — thin wrapper around the UDS `HOOK-CREATE` verb. Returns the effective hook name and the substituted argv (for confirmation in the agent's UI).
+3. **`hook_list(mailbox?)`** — returns hooks visible to MCP: `{ name, mailbox, event, template, params, origin }`. Both operator- and MCP-origin hooks appear in the list so the agent can see the full picture, but `origin` distinguishes them.
+4. **`hook_delete(name)`** — thin wrapper around the UDS `HOOK-DELETE` verb. Returns the daemon's error verbatim on `origin-protected` rejection.
+
+Existing 9 MCP tools (`mailbox_*`, `email_*`) are unchanged.
+
+### 6.7 Hook execution flow (daemon-side)
+
+When an event fires for a hook with `origin = "mcp"` or any hook with `run_as = "aimx-hook"`:
+
+1. Daemon resolves the template, substitutes placeholders into argv, and builds the final `Command`.
+2. Daemon spawns the command:
+   - **systemd box** (detected by `sd_notify` or `/run/systemd/system` presence): `systemd-run --uid=aimx-hook --gid=aimx-hook --property=ProtectSystem=strict --property=PrivateDevices=yes --property=NoNewPrivileges=yes --property=MemoryMax=256M --property=RuntimeMaxSec={timeout_secs} --collect --pipe -- <argv>`.
+   - **OpenRC / fallback**: `posix_spawn` / `fork+exec` with manual `setgid(aimx-hook)` + `setuid(aimx-hook)` before `exec`. Wrap in a per-hook timeout (`SIGTERM` at `timeout_secs`, `SIGKILL` at `timeout_secs + 5`).
+3. `stdin` policy per template:
+   - `email` — pipe the raw `.md` (frontmatter + body) that ingest wrote.
+   - `email_json` — pipe a JSON object `{ "frontmatter": {...}, "body": "..." }`.
+   - `none` — close stdin immediately.
+4. Capture stdout and stderr; truncate at 64 KiB each. Log one structured line at hook completion with `template`, `mailbox`, `event`, `hook_name`, `exit_code`, `duration_ms`, `stderr_tail`.
+5. Non-zero exit is logged but does not stop delivery / ingest. After-send hooks with non-zero exit do not retry the send.
+
+Raw-cmd hooks (no template) follow the same exec flow, with `cmd` from the hook itself and `run_as` defaulting to `aimx-hook`. An operator who really wants a raw-cmd hook to run as root can set `run_as = "root"` in `config.toml`; this is intentionally only possible by editing the file as root, not via CLI flag or UDS.
+
+### 6.8 Trust interaction
+
+Template hooks inherit the existing `on_receive` trust gate (`hook.should_fire_on_receive`). `dangerously_support_untrusted` is **not** an MCP-settable field — it can only be set on operator-origin hooks in `config.toml`. MCP-origin hooks always fire only on trusted inbound mail. Rationale: if the agent could opt itself into firing on untrusted mail, the template sandbox is the only thing standing between a spoofed email and `aimx-hook`-level shell.
+
+## 7. Non-Functional Requirements
+
+### 7.1 Security
+
+- **Injection resistance:** placeholder values cannot introduce new argv entries, cannot escape the value slot, cannot appear in `cmd[0]`. No shell interpreter is invoked.
+- **Privilege separation:** hook processes run as `aimx-hook` UID. `aimx-hook` has no login shell, no home directory, no group membership beyond its own. `aimx-hook` has read access to `/var/lib/aimx/<folder>/<mailbox>/` (via group `aimx-hook` on those directories) so stdin-piped content is legitimate; it has **no** access to `/etc/aimx/dkim/`, `/etc/aimx/tls/`, or any other mailbox's private data.
+- **Socket perms:** `/run/aimx/aimx.sock` stays `0666` (any local user can submit mail — preserved from today). The authorization boundary is the verb surface, not the socket: MCP cannot reach raw-cmd hooks because no verb accepts them.
+- **Resource caps:** default `timeout_secs = 60`, default `MemoryMax = 256M` (on systemd). Operator can tighten per template.
+- **Audit trail:** every hook fire logs template name, mailbox, event, exit code, duration. `origin` field in `config.toml` lets the operator quickly audit which hooks the agent added.
+
+### 7.2 Reliability
+
+- Placeholder validation happens at **config load**, not at hook fire. A malformed template fails daemon startup (or config reload), not the first inbound email.
+- `systemd-run` failure falls back to direct `fork+exec` with the same privilege-drop logic; the hook still fires, just without systemd's sandboxing.
+- Hook timeout is enforced even if the template forgets to set one (daemon applies the 60s default).
+
+### 7.3 Observability
+
+- `aimx doctor` gains a "Hook templates" section listing enabled templates and per-template fire counts over the last 24 hours (read from service logs).
+- `aimx logs` surfaces the structured hook-fire log line unchanged.
+
+### 7.4 Compatibility
+
+- Pre-launch: no migration path. Operators on pre-release builds must re-run `aimx setup` after upgrading to the release that ships this change; existing raw-cmd hooks remain valid and continue to work.
+- No external API changes outside the UDS rename and new `HOOK-CREATE` fields; MCP clients that don't use the new tools are unaffected.
+
+## 8. Technical Considerations
+
+### 8.1 Affected modules
+
+| Module | Change |
+|--------|--------|
+| `src/config.rs` | Add `HookTemplate` struct, `hook_templates: Vec<HookTemplate>` field on `Config`. Validate `params` ↔ placeholder consistency at load time. Add `origin` field to `Hook`. |
+| `src/hook.rs` | Extend `Hook` with optional `template: Option<String>` and `params: BTreeMap<String, String>`. Build final argv from template + params at fire time. |
+| `src/hook_handler.rs` | Tighten `HOOK-CREATE` body parsing: reject raw `cmd`, require `Template:`, validate params. Tag `origin = "mcp"`. Add `HOOK-DELETE` origin check. |
+| `src/send_protocol.rs` | Update `HOOK-CREATE` `Request` variant to carry `template + params` instead of raw `cmd`. |
+| `src/hook_client.rs` | CLI-side helpers: `submit_template_hook_create`. Raw-cmd CLI path bypasses UDS (writes `config.toml` + SIGHUP). |
+| `src/hooks.rs` | `aimx hooks create` splits: with `--template`, goes through UDS; with `--cmd`, writes `config.toml` directly (requires root) and signals daemon. Add `aimx hooks templates` subcommand. |
+| `src/cli.rs` | New subcommands: `hooks templates`, `hooks template-enable <name>`, `hooks template-disable <name>`. `hooks create` grows `--template` and `--param KEY=VAL` flags. |
+| `src/mcp.rs` | New tools: `hook_list_templates`, `hook_create`, `hook_list`, `hook_delete`. |
+| `src/setup.rs` | New "Hook Templates" checkbox section in `run_setup`. Creates `aimx-hook` system user. Embeds default template definitions. |
+| `src/agent_setup.rs` | Post-install hint prints the `sudo aimx hooks template-enable <name>` line per installed agent. |
+| `src/serve.rs` | Socket rename: `send.sock` → `aimx.sock`. Hook executor grows systemd-run path and `setuid` fallback. SIGHUP handler for config reload (for raw-cmd hook hot-reload). |
+| `src/platform.rs` | Helper: `spawn_sandboxed(argv, stdin, run_as, timeout)` — picks `systemd-run` vs. `fork+exec` based on platform detection. |
+
+### 8.2 systemd unit changes
+
+The unit file at `/etc/systemd/system/aimx.service` needs two additions:
+
+- `ExecStartPre=/usr/sbin/useradd --system --no-create-home --shell /usr/sbin/nologin aimx-hook` (or equivalent idempotent creation — probably better done in `aimx setup` so the unit stays simple).
+- Ensure `RuntimeDirectory=aimx` remains (socket rename doesn't change the dir).
+
+`aimx-hook` needs group-read on `/var/lib/aimx/` so `stdin = "email"` can succeed. Plan: `aimx setup` creates the `aimx-hook` user, then `chown root:aimx-hook /var/lib/aimx/{inbox,sent}` + `chmod g+rX` recursively.
+
+### 8.3 MCP skill / primer updates
+
+`agents/common/aimx-primer.md` and `agents/common/references/*.md` need a new section: "Creating hooks." It should document the four new tools, the template-first discipline ("call `hook_list_templates` first, never assume a template exists"), and example params for each built-in template.
+
+### 8.4 Book documentation updates
+
+Once shipped, these `book/` chapters need revisions (exact wording out of scope for this PRD, but we should know the hit list):
+
+- `book/hooks.md` — new first section explaining the template model; raw-cmd hooks move below templates with a "power user" framing.
+- `book/hook-recipes.md` — every recipe rewritten around templates where possible; raw-cmd recipes clearly labeled.
+- `book/mcp.md` — new tool entries for `hook_list_templates`, `hook_create`, `hook_list`, `hook_delete`.
+- `book/setup.md` — new "Hook Templates" checkbox section in the `aimx setup` walkthrough. `aimx-hook` user creation mentioned.
+- `book/agent-integration.md` — per-agent section gains the `sudo aimx hooks template-enable` step.
+- `book/configuration.md` — new `[[hook_template]]` schema reference; socket rename note.
+- `book/cli.md` — `aimx hooks create` gains `--template` / `--param`; new `aimx hooks templates` / `template-enable` / `template-disable` subcommands; socket path changes.
+- `book/troubleshooting.md` — common errors: `aimx-hook` user missing, template disabled, param validation failure, sandbox denied access.
+- `book/faq.md` — new Q: "Why can my agent create hooks but not arbitrary shell commands?" (explains the template model).
+
+## 9. Scope and Milestones
+
+### In Scope (v1)
+
+- `[[hook_template]]` schema + load-time validation.
+- Default templates embedded in the binary (listed in §6.2).
+- `aimx setup` interactive checkbox install; creation of `aimx-hook` user.
+- Socket rename `send.sock` → `aimx.sock`.
+- UDS `HOOK-CREATE` tightened to template-only; body carries `template + params`.
+- UDS `HOOK-DELETE` tightened with `origin` check.
+- CLI `aimx hooks create --template ... --param k=v`, plus preserved `--cmd` path (via `config.toml` edit + SIGHUP).
+- CLI `aimx hooks templates` (list enabled templates).
+- MCP `hook_list_templates`, `hook_create`, `hook_list`, `hook_delete`.
+- Daemon hook executor with systemd-run sandbox on systemd; `setuid` fallback on OpenRC.
+- Structured hook-fire log line.
+- `aimx agent-setup` post-install template-enable hint.
+- Trust gate: MCP-origin hooks always trusted-only (no `dangerously_support_untrusted` via MCP).
+- Agent-facing primer / reference docs updated in `agents/common/`.
+
+### Out of Scope (future consideration)
+
+- `admin.sock` (root-only socket). Not needed for this feature; can be added later if other privileged verbs appear.
+- `aimx hooks template-enable / template-disable` CLI commands (P2). For v1, operators enable templates only during `aimx setup`; toggling later = hand-edit `config.toml` + SIGHUP.
+- Per-template `allowed_mailboxes` restriction.
+- Dry-run / test mode (`aimx hooks test <name>`).
+- Per-user / multi-tenant hook isolation. Single-operator stance stands; multi-user Unix explicitly out of scope.
+- Custom operator-authored templates (i.e. operator writes their own `[[hook_template]]` block). v1 only ships the built-in templates; operator-authored templates are mechanically supported (the schema accepts them) but not documented as a supported path until we've hardened validation.
+- `email_json` stdin format stabilization — v1 treats it as a best-effort JSON dump of the frontmatter; breaking changes allowed post-v1 if the format proves wrong.
+
+### Milestones
+
+| Milestone | Description | Key Deliverables |
+|-----------|-------------|------------------|
+| M1 — Schema & validation | `HookTemplate` struct, load-time validation, placeholder substitution | `src/config.rs` + `src/hook.rs` changes; unit tests for substitution edge cases (whitespace injection, placeholder in `cmd[0]`, unknown params) |
+| M2 — Sandboxed executor | `spawn_sandboxed` helper; systemd-run path; `setuid` fallback; timeout enforcement; structured log | `src/platform.rs`; integration test on a systemd-less environment via `AIMX_TEST_*` env toggles |
+| M3 — UDS & CLI wiring | Socket rename; `HOOK-CREATE` body schema change; `HOOK-DELETE` origin check; CLI `--template` flag; `config.toml` SIGHUP path for raw-cmd | End-to-end test: MCP creates hook → inbound email fires hook → logs show `aimx-hook` UID |
+| M4 — Setup & agent-setup integration | Checkbox UI in `aimx setup`; `aimx-hook` user creation; `aimx agent-setup` post-install hint | Fresh-install integration test validates the full flow |
+| M5 — MCP tools | `hook_list_templates`, `hook_create`, `hook_list`, `hook_delete`; skill / primer updates | MCP integration test against a live `aimx mcp` process |
+| M6 — Docs | `book/` chapters revised per §8.4 | Docs land in the same release as the code |
+
+## 10. Risks and Mitigations
+
+| Risk | Likelihood | Impact | Mitigation |
+|------|-----------|--------|------------|
+| Placeholder substitution has an injection bug (value escapes its slot, introduces new argv entry) | Medium | Critical (local RCE as `aimx-hook`) | No shell invocation anywhere; argv is parsed before substitution; substitution only fills string slots; fuzz test with whitespace, quotes, NUL, `$(...)`, backticks, `;`, newlines. |
+| `systemd-run` is not available (non-systemd box) and the `setuid` fallback is weaker than expected | Medium | High | Document the reduced guarantee; require `aimx-hook` user regardless of init system; apply `RLIMIT_NOFILE`, `RLIMIT_CPU`, `setrlimit` manually in the fork path; add a `chroot`-like fallback later if needed. |
+| Operator doesn't know about the `sudo aimx hooks template-enable` step and agent's `hook_create` keeps failing | High | Low (UX only) | `agent-setup` post-install hint; MCP `hook_list_templates` returns empty list with a helpful message; daemon rejection of unknown template includes "run `sudo aimx hooks template-enable <name>`" in the error body. |
+| Binary path in a template drifts (user has Claude at `/usr/bin/claude`, not `/usr/local/bin/claude`) | High | Medium (template silently fails) | Ship templates with the canonical distribution path; let operator override via `config.toml`; `aimx doctor` warns if a template's `cmd[0]` is not executable. |
+| Agent creates many hooks via MCP and fills `config.toml` with noise | Medium | Low | `hook_list` surfaces all MCP-origin hooks; `hook_delete` works per-hook; future enhancement: rate-limit `HOOK-CREATE` per UDS connection. |
+| `aimx-hook` user cannot read `/var/lib/aimx/` (setup fails to chown) | Medium | High (hooks can't see email stdin) | `aimx setup` explicitly chowns and chmods; `aimx doctor` verifies `aimx-hook` read access and surfaces a specific error if missing. |
+| Socket rename breaks an already-deployed pre-launch install | Low (pre-launch) | Low | Release notes call out the rename; `aimx doctor` detects the old socket name and prints the migration command. |
+| Operator edits `config.toml` while daemon is live and SIGHUP races with an in-flight `MAILBOX-CREATE` | Low | Medium | Existing per-mailbox lock hierarchy in `src/mailbox_locks.rs` already serializes config writes; SIGHUP reload uses the same path. |
+
+## 11. Open Questions
+
+1. **Operator-authored templates — supported or explicitly not?** Technically the schema accepts any `[[hook_template]]` block, so nothing stops an operator from writing their own. Question: do we document this path in `book/configuration.md` for v1, or intentionally leave it undocumented until validation is hardened? Leaning "undocumented in v1, supported in v1.1."
+2. **`hook_list` visibility — should MCP see operator-origin hooks at all?** Arguments for: the agent has a clearer picture of the mailbox's behavior. Arguments against: information leakage (operator may have hooks the agent shouldn't know about). Leaning "show name + mailbox + event + origin, but not `cmd` for operator-origin hooks" — enough for the agent to not step on operator hooks, not enough to inspect them.
+3. **`invoke-goose` stdin format**: goose recipes take YAML input, not raw email. Does the `email` stdin mode work, or do we need a `goose`-specific `stdin = "email_yaml"` encoding? Needs a real recipe test.
+4. **Webhook template authentication**: should the `webhook` template support a header-params slot (e.g. `Authorization: Bearer {token}`)? The concern is that `{token}` in an HTTP header value is a fine substitution slot, but if we don't ship it, operators will reach for raw-cmd hooks just to do webhooks with auth.
+5. **`aimx-hook` user on shared hosts**: what if the UID is already taken? Setup should probe with `id aimx-hook` first and skip `useradd` if the user exists; unclear whether we should fail loudly or silently if the existing user has a login shell.
+6. **Hot-reload semantics for template changes**: if the operator enables a template via `sudo aimx hooks template-enable`, do we hot-reload the daemon, or require a restart? Hot-reload is user-friendlier; restart is simpler to reason about. Leaning hot-reload via the existing `ConfigHandle` swap.
+7. **Do we need a separate `hook_disable(name)` MCP tool?** Or is `hook_delete` sufficient? If an agent wants to "pause" a hook while debugging, deleting and re-creating is stateful (loses the name). Probably defer to v1.1 unless a clear use case shows up.
+
+---
+
+*Status: draft — pending operator review.*

--- a/docs/hook-templates-sprint.md
+++ b/docs/hook-templates-sprint.md
@@ -1,0 +1,426 @@
+# AIMX — Hook Templates Sprint Plan
+
+**Sprint cadence:** 2.5 days per sprint
+**Team:** Solo developer with heavy AI augmentation (Claude Code)
+**Total sprints:** 6
+**Timeline:** ~15 calendar days (Days 1–15 of the hook-templates track, independent of the core aimx sprint clock)
+**v1 Scope:** Everything in [`hook-templates-prd.md`](hook-templates-prd.md) §9 "In Scope (v1)". Pre-launch feature — no migration path. Sprint 1 front-loads mechanical breaking changes (socket rename, schema, service user). Sprint 2 rewrites the hook executor onto an argv + sandbox + timeout base. Sprint 3 locks down the UDS verb surface so MCP physically cannot submit raw-cmd hooks. Sprint 4 ships the 8 default templates behind an interactive `aimx setup` checkbox and adds the `aimx agent-setup` hint. Sprint 5 adds the four new MCP tools and refreshes the agent-facing primer. Sprint 6 closes with end-to-end integration tests, placeholder-substitution fuzz tests, book docs, and `aimx doctor` extensions.
+
+**Source PRD:** [`hook-templates-prd.md`](hook-templates-prd.md) — every story traces back to a requirement section there. When acceptance criteria reference `§X.Y`, they mean sections of that PRD.
+
+---
+
+## Sprint 1 — Foundation: schema, socket rename, service user (Days 1–2.5) [NOT STARTED]
+
+**Goal:** Land all low-risk mechanical changes (socket rename, config schema additions, service user creation) so every downstream sprint builds on a clean base.
+
+**Dependencies:** None — this is the foundation sprint for the hook-templates track.
+
+#### S1-1: Rename runtime socket `send.sock` → `aimx.sock`
+
+**Context:** The UDS at `/run/aimx/send.sock` is named after the first verb it carried (`SEND`) but now handles mailbox CRUD, mark-read, and hook CRUD too. PRD §6.5 calls for renaming to `/run/aimx/aimx.sock` to match the `/run/<service>/<service>.sock` convention used by containerd, podman, and Docker. Mechanically this is a one-word change at the `SEND_SOCKET_NAME` constant (`src/serve.rs` around line 246), but it propagates to all client call sites (`src/hook_client.rs`, `src/mailbox.rs`, `src/hooks.rs`, `src/state_handler.rs`, `src/send.rs`) and every test that references the path literally (`src/serve.rs` tests at ~1457, 1474, 1563, 1616, 1744; `tests/integration.rs` wherever UDS fixtures appear). Pre-launch, so no compatibility shim is needed — the rename is atomic across one release.
+
+**Priority:** P0
+
+- [ ] `SEND_SOCKET_NAME` constant in `src/serve.rs` renamed to `AIMX_SOCKET_NAME` with value `"aimx.sock"`; `send_socket_path()` renamed to `aimx_socket_path()` (or equivalent) and updated accordingly
+- [ ] All client call sites (`hook_client.rs`, `mailbox.rs`, `hooks.rs`, `state_handler.rs`, `send.rs`) resolve the new path via the shared helper — no literal `send.sock` strings remain in non-test code
+- [ ] All test fixtures, snapshot paths, and test helpers updated to use the new name; `grep -r "send.sock" src/ tests/` returns no hits except in historical comments (if any) that explicitly call out the rename
+- [ ] Systemd unit generator (`src/setup.rs`) and OpenRC template (same) still declare `RuntimeDirectory=aimx` — the directory name does not change, only the socket filename inside it
+- [ ] Release notes / `CHANGELOG.md` (if present) note the rename as a breaking change for pre-launch testers; `aimx doctor` surfaces a helpful error if it sees `send.sock` but not `aimx.sock`
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S1-2: Add `[[hook_template]]` schema with load-time validation
+
+**Context:** PRD §6.1 defines the template block: `name`, `description`, `cmd` (argv array), `params`, `stdin`, `run_as`, `timeout_secs`, `allowed_events`. The schema lands in `src/config.rs` alongside the existing `Config` / `MailboxConfig` / `Hook` structs. Validation is non-trivial: every `{placeholder}` in `cmd` must appear in `params`, every `params` entry must appear in at least one `cmd` string value, no placeholder may live in `cmd[0]` (the binary path), and substitution values must not be able to split into new argv entries. Validation runs at `Config::load()` — a malformed template fails daemon startup, not the first hook fire. Built-in placeholders (`{event}`, `{mailbox}`, `{message_id}`, `{from}`, `{subject}`) are recognized without being declared in `params`.
+
+**Priority:** P0
+
+- [ ] New `HookTemplate` struct in `src/config.rs` with `#[derive(Deserialize, Serialize, Clone, Debug)]` and fields matching PRD §6.1 exactly; field defaults applied via `#[serde(default = "...")]` where appropriate (e.g. `timeout_secs` defaults to 60, `run_as` defaults to `"aimx-hook"`, `allowed_events` defaults to both events)
+- [ ] `Config` struct gains `#[serde(default)] hook_templates: Vec<HookTemplate>`
+- [ ] New `validate_hook_templates(&[HookTemplate]) -> Result<(), ConfigError>` function called from `Config::load()` after TOML parse; returns `Err` on: duplicate template `name`, unknown placeholder in `cmd` not in `params + builtins`, declared-but-unused `params` entry, placeholder in `cmd[0]`, empty `cmd` array, `timeout_secs > 600` or `< 1`, `run_as` value other than `"aimx-hook"` or `"root"`
+- [ ] Unit tests cover each rejection path with a minimal failing TOML input, plus a golden "valid template" round-trip test
+- [ ] A TOML fixture file in `tests/fixtures/` demonstrating a valid multi-template config is round-tripped through `Config::load → Config::save` without diff
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S1-3: Extend `Hook` struct with `origin` + `template` + `params`
+
+**Context:** PRD §6.5 introduces the `origin = "operator" | "mcp"` tag that gates UDS `HOOK-DELETE` and drives the MCP visibility rules in §6.6. Template-bound hooks also need to record which template they reference (`template: Option<String>`) and the bound parameter values (`params: BTreeMap<String, String>`), so the hook fire path can re-substitute at runtime (the config can be reloaded with an updated template; hooks should pick up the change). Raw-cmd hooks keep `template = None` and continue to use the existing `cmd` field. Pre-launch, so the struct layout can change freely; absent `origin` in existing TOML defaults to `Operator` via `#[serde(default)]`.
+
+**Priority:** P0
+
+- [ ] New `HookOrigin` enum (`Operator`, `Mcp`) with `#[serde(rename_all = "lowercase")]` in `src/hook.rs`; `Operator` is the `Default::default()` value
+- [ ] `Hook` struct gains `#[serde(default)] origin: HookOrigin`, `#[serde(default)] template: Option<String>`, `#[serde(default)] params: BTreeMap<String, String>`
+- [ ] Mutual-exclusion validation: if `template` is `Some`, `cmd` must be absent / empty; if `template` is `None`, `cmd` must be non-empty. Enforced in `Config::load` alongside existing hook validation
+- [ ] `Hook::is_template_bound(&self) -> bool` convenience method; `Hook::resolve_argv(&self, &[HookTemplate], &Builtins) -> Result<Vec<String>>` returns the final argv (template substitution for template hooks, `["/bin/sh", "-c", cmd]` for raw-cmd hooks)
+- [ ] Unit tests cover: operator-origin hook with raw cmd round-trips; MCP-origin hook with template + params round-trips; mutually-exclusive (`cmd` + `template`) fails validation; missing template reference fails validation
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S1-4: Create `aimx-hook` system user in `aimx setup`
+
+**Context:** PRD §6.3 and §8.2 require a dedicated `aimx-hook` unprivileged user that hooks drop privileges to before `exec`. `aimx setup` already handles root-only bootstrap (writing `/etc/aimx/`, installing the systemd/OpenRC unit, generating DKIM keys); user creation fits in the same phase. The creation must be idempotent (re-running setup on an already-installed box must not fail), and the user must be usable as both UID and GID target (we create a matching primary group). After user creation, `/var/lib/aimx/inbox` and `/var/lib/aimx/sent` are chowned `root:aimx-hook` and chmod'd `g+rX` recursively so `stdin = "email"` can read piped email content at hook fire time.
+
+**Priority:** P0
+
+- [ ] `src/setup.rs` gains an `ensure_hook_user(&dyn SystemOps) -> Result<()>` function that runs `useradd --system --no-create-home --shell /usr/sbin/nologin aimx-hook` (or the platform equivalent via `SystemOps`), gracefully no-ops if `id aimx-hook` already resolves, and creates a matching `aimx-hook` system group
+- [ ] `run_setup` calls `ensure_hook_user` after config + DKIM setup and before systemd unit install, so the unit file can reference the user if needed
+- [ ] `chown_datadir_for_hook_user(&Path, &dyn SystemOps)` helper chowns `<datadir>/inbox` and `<datadir>/sent` to `root:aimx-hook` and chmods `g+rX` recursively; called from `run_setup` after mailbox directories exist
+- [ ] `MockSystemOps` in the test module records user-creation and chown attempts so unit tests can assert `aimx setup` triggers them in the right order; integration test on a live Linux box is manual (CI does not root-create users)
+- [ ] Colorized `[User]` section in setup output reports `aimx-hook created` / `aimx-hook already present`, matching the existing `[DNS]` / `[MCP]` style
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+---
+
+## Sprint 2 — Sandboxed hook executor (Days 2.5–5) [NOT STARTED]
+
+**Goal:** Replace today's `sh -c` executor with an argv-based, privilege-dropping, timeout-enforced sandboxed runner. This is the highest-risk sprint in the track — the current `Command::new("sh").arg("-c")` call at `src/hook.rs:309` is tightly coupled and every downstream sprint depends on a working new executor.
+
+**Dependencies:** Sprint 1 (service user must exist; `Hook` struct must carry `template` + `params`).
+
+#### S2-1: Placeholder substitution with argv-safety guarantees
+
+**Context:** PRD §6.1 requires substitution rules that are injection-resistant by construction: `{placeholder}` values fill string slots inside argv entries, never introduce new argv entries, never appear in `cmd[0]`, and never carry whitespace, NUL, or unprintable control chars (newlines and tabs allowed, quoted values are fine as-is since there's no shell). The substitution function is pure — no I/O, no locks — so it can be unit-tested with aggressive fuzz inputs. A new module `src/hook_substitute.rs` keeps this self-contained and testable in isolation.
+
+**Priority:** P0
+
+- [ ] New `src/hook_substitute.rs` module exposing `pub fn substitute_argv(template_cmd: &[String], params: &BTreeMap<String, String>, builtins: &BuiltinContext) -> Result<Vec<String>, SubstitutionError>`
+- [ ] `BuiltinContext { event, mailbox, message_id, from, subject }` populated by the caller at fire time; missing builtins are substituted as empty strings (PRD: builtins are always available but may be empty when irrelevant)
+- [ ] `SubstitutionError` variants: `UnknownPlaceholder`, `ParamContainsWhitespace`, `ParamContainsNul`, `ParamContainsControl`, `ParamTooLong` (>8 KiB per value), `PlaceholderInBinaryPath`
+- [ ] Substitution happens after argv parse: placeholder appears anywhere inside a string slot → replace in-place; a placeholder occupying the entire slot still produces exactly one argv entry
+- [ ] Unit tests cover: happy path with multiple params; unknown placeholder rejection; whitespace rejection (space, tab, newline); NUL rejection; control-char rejection; long-value rejection; placeholder in `cmd[0]` rejection; placeholders only referenced via builtins; param declared but never used (caught at config load, not substitution)
+- [ ] Fuzz test (`cargo test --release`) iterates 10_000 random inputs containing shell metacharacters (`;`, `$(...)`, backticks, `|`, `&&`, `>`, newlines) and asserts `substituted.len() == template.len()` — substitution never expands argv count
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S2-2: `spawn_sandboxed` platform helper (systemd-run + setuid fallback)
+
+**Context:** PRD §6.7 defines the execution flow. On systemd boxes (`/run/systemd/system` exists — reuse `detect_init_system()` at `src/serve.rs:782`), spawn hooks via `systemd-run --uid=aimx-hook --gid=aimx-hook --property=ProtectSystem=strict --property=PrivateDevices=yes --property=NoNewPrivileges=yes --property=MemoryMax=256M --property=RuntimeMaxSec={N} --collect --pipe -- <argv>`. On OpenRC / unknown, `fork()` + in-child `setgid(aimx_hook_gid)` + `setuid(aimx_hook_uid)` + `execvp(argv[0], argv)`, wrapped in a parent-side wait-with-timeout loop. The helper returns `(exit_code, stdout_tail, stderr_tail, duration)` so the caller can log uniformly regardless of sandbox path.
+
+**Priority:** P0
+
+- [ ] New `src/platform.rs::spawn_sandboxed(argv: &[String], stdin: SandboxStdin, run_as: &str, timeout: Duration) -> Result<SandboxOutcome, SandboxError>` function
+- [ ] `SandboxStdin` enum: `Email(Vec<u8>)`, `EmailJson(Vec<u8>)`, `None`; written to the child's stdin and closed before timeout starts (no hook blocks on stdin read mid-run)
+- [ ] Systemd path detected via `detect_init_system()`; shells out to `systemd-run` with the exact `--property=...` set from PRD §6.7; captures stdout + stderr via `--pipe` and parses them from the `systemd-run` output stream
+- [ ] Fallback path uses `nix::unistd::{fork, setgid, setuid, execvp}` (or equivalent via `std::os::unix::process::CommandExt::uid/gid`) and a parent-side `select!` / `tokio::time::timeout` on the child's wait; SIGTERM at `timeout`, SIGKILL at `timeout + 5s`
+- [ ] `SandboxOutcome { exit_code: i32, stdout_tail: Vec<u8>, stderr_tail: Vec<u8>, duration: Duration, sandbox: "systemd-run" | "setuid" }` truncates stdout and stderr at 64 KiB each
+- [ ] `SandboxError` variants: `UserNotFound` (aimx-hook UID lookup failed), `SpawnFailed(io::Error)`, `SystemdRunFailed(String)`, `TimedOut`, `Killed(i32)` — all carry enough detail for the caller to log meaningfully
+- [ ] Unit tests use a fake binary in a tempdir (e.g. a tiny shell script that prints, sleeps, or exits with a chosen code) to verify exit code propagation, stdout/stderr capture, truncation at 64 KiB, and timeout behavior (a 2-second sleep with a 500ms timeout must be SIGKILLed); `setuid` path tests are skipped as non-root (CI) but run when `cargo test` is invoked as root
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S2-3: Structured hook-fire log with new fields
+
+**Context:** The current log line at `src/hook.rs` around line 343 emits `hook_name`, `event`, `mailbox`, `email_id`, `exit_code`, `duration_ms`. PRD §7.3 asks for three new fields: `template` (template name or `-` for raw-cmd), `run_as` (usually `aimx-hook`; `root` only for explicitly-opted raw-cmd hooks), and `stderr_tail` (last 64 KiB of stderr, for quick debugging without `strace`). The log line stays one structured record — consumers like `aimx doctor` parse it via `journalctl -u aimx --output=json`.
+
+**Priority:** P0
+
+- [ ] Log line in `src/hook.rs` extended with `template = ?`, `run_as = ?`, `stderr_tail = ?` fields via `tracing::info!` structured kv syntax
+- [ ] `stderr_tail` is JSON-escaped so multi-line output doesn't break structured parsing; empty stderr is represented as `""`, not `null`
+- [ ] `aimx logs` (which pipes through `journalctl`) does not need changes — structured fields just flow through
+- [ ] Unit test for the log-line formatter verifies each field appears with the expected key and type, including edge cases (empty stderr, very long stderr truncated at 64 KiB, template=None becomes `-`)
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S2-4: Wire sandboxed executor into on_receive + after_send
+
+**Context:** The existing `run_and_log` at `src/hook.rs:300` is called from `src/ingest.rs:262` for `on_receive` and `src/send_handler.rs:350` for `after_send`. Both call sites stay the same — only `run_and_log` changes internally: for template hooks it calls `Hook::resolve_argv` then `spawn_sandboxed`; for raw-cmd hooks it passes `["/bin/sh", "-c", cmd]` to `spawn_sandboxed` with `run_as = "aimx-hook"` by default (or `"root"` if the operator explicitly set `run_as = "root"` in the hook block). The key invariant: **no hook ever spawns as root unless the operator set `run_as = "root"` in `config.toml`**, and that field is not settable via UDS.
+
+**Priority:** P0
+
+- [ ] `run_and_log` refactored to: (a) resolve argv via `Hook::resolve_argv`, (b) build the `BuiltinContext` from the ingest/send event, (c) prepare stdin per `template.stdin` (or `"email"` default for raw-cmd), (d) call `spawn_sandboxed` with the hook's `run_as` (defaults to `"aimx-hook"`)
+- [ ] Raw-cmd hooks with `run_as = "root"` in `config.toml` still work — `spawn_sandboxed` accepts `"root"` and maps it to the current process user (no setuid)
+- [ ] Integration test spawns a raw-cmd hook that writes its effective UID to a tempfile; assertion verifies UID matches `aimx-hook` (skipped on non-root CI)
+- [ ] Env vars passed to hooks (`AIMX_MAILBOX`, `AIMX_EVENT`, `AIMX_MESSAGE_ID`, etc. — currently set in `src/hook.rs`) continue to work; check they propagate through `systemd-run --setenv=KEY=VAL` on the systemd path
+- [ ] Removed dead code from the old `Command::new("sh").arg("-c")` path; no fallbacks, no compat shim
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+---
+
+## Sprint 3 — UDS protocol + CLI wiring + SIGHUP reload (Days 5–7.5) [NOT STARTED]
+
+**Goal:** Lock down the UDS verb surface so MCP physically cannot submit raw-cmd hooks, and wire the operator's CLI path to write `config.toml` directly with a SIGHUP-based hot-reload.
+
+**Dependencies:** Sprint 1 (schema); Sprint 2 (executor must handle both template and raw-cmd hooks uniformly).
+
+#### S3-1: Tighten UDS `HOOK-CREATE` to template-only
+
+**Context:** PRD §6.5 specifies that `HOOK-CREATE` body changes from TOML-encoded `Hook` to JSON `{ template, params, name? }`. The daemon rejects any body containing `cmd`, `run_as`, `dangerously_support_untrusted`, `timeout_secs`, or `stdin` — these are template properties, not hook properties. Unknown template names produce an `ERR unknown-template` with a hint pointing the caller at `aimx hooks templates` and `sudo aimx hooks template-enable <name>` (the latter is deferred to v2 per PRD §9, but the hint still reads naturally). The daemon stamps `origin = "mcp"` on every hook it creates via this verb.
+
+**Priority:** P0
+
+- [ ] `src/send_protocol.rs::Request::HookCreate` variant changes: body is now `HookTemplateCreateBody { template: String, params: BTreeMap<String, String>, name: Option<String> }` parsed via `serde_json`
+- [ ] Parser rejects bodies containing the forbidden fields (`cmd`, `run_as`, `dangerously_support_untrusted`, `timeout_secs`, `stdin`) — this is enforced at the JSON schema level so error messages are precise
+- [ ] `src/hook_handler.rs::handle_hook_create` validates: mailbox exists, template exists and is enabled, event is in `template.allowed_events`, all declared `params` are present and pass substitution validation, resulting hook name is unique within the mailbox
+- [ ] Daemon stamps `origin = Mcp` on the constructed `Hook` before writing to config
+- [ ] Error responses carry specific reasons: `ERR unknown-template`, `ERR missing-param: KEY`, `ERR event-not-allowed`, `ERR mailbox-not-found`, `ERR name-conflict` — all human-readable and actionable
+- [ ] Unit tests cover each rejection path with a minimal request fixture
+- [ ] Integration test: submit a valid `HOOK-CREATE` → verify hook appears in `config.toml` with `origin = "mcp"`; submit a body with `cmd = "..."` → verify rejection
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S3-2: Tighten UDS `HOOK-DELETE` with origin check
+
+**Context:** PRD §6.5 requires `HOOK-DELETE` on the UDS socket to refuse deletion of operator-origin hooks (`origin = "operator"`). An MCP client can remove hooks it created but cannot interfere with the operator's hand-rolled hooks. Operator deletes go through the CLI (`sudo aimx hooks delete`), which writes `config.toml` directly.
+
+**Priority:** P0
+
+- [ ] `src/hook_handler.rs::handle_hook_delete` looks up the target hook by name across all mailboxes, checks `hook.origin`, and returns `ERR origin-protected: hook was created by the operator — remove via \`sudo aimx hooks delete\` instead` if `origin == Operator`
+- [ ] Successful delete still swaps `ConfigHandle` via the existing atomic path; the response is `AIMX/1 OK` unchanged
+- [ ] Unit test covers operator-protected rejection, successful MCP-origin delete, and unknown-name case
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S3-3: CLI `aimx hooks create --template` + `--param`
+
+**Context:** PRD §6.6 exposes template-based creation via MCP, but operators also want to create template hooks from the CLI (e.g. for scripting). `aimx hooks create` grows two new flags: `--template NAME` (mutually exclusive with `--cmd`) and `--param KEY=VAL` (repeatable). When `--template` is set the CLI uses the UDS path (same verb MCP uses, producing `origin = "mcp"` — or we add a `--origin operator` override; PRD is silent, default to `operator` for CLI-origin template hooks since the operator is invoking it). When `--cmd` is set the CLI takes the raw-cmd path (§S3-4). When neither is set, the CLI prints a helpful error.
+
+**Priority:** P0
+
+- [ ] `src/cli.rs::HookCreateArgs` gains `#[arg(long, conflicts_with = "cmd")] template: Option<String>` and `#[arg(long = "param", value_name = "KEY=VAL")] params: Vec<String>`; `cmd` field becomes optional and `ArgGroup` enforces exactly-one-of (`--template`, `--cmd`)
+- [ ] When `--template` is used, `src/hooks.rs::create` parses the `Vec<String>` into `BTreeMap<String, String>`, validates locally against the loaded config's templates (fast-fail on missing template / unknown params), then submits via a new `hook_client::submit_hook_template_create_via_daemon`
+- [ ] CLI-origin template hooks get `origin = "operator"` in `config.toml` so the operator retains control and MCP cannot later delete them; this is visible via `aimx hooks list` (existing command) showing the `origin` column
+- [ ] Error UX: `aimx hooks create --template invoke-claude --param prompt="..."` succeeds; `aimx hooks create --template invoke-claude` (missing required param) fails with a pointer to `aimx hooks templates` for param names
+- [ ] Unit + integration tests cover the happy path and the param-parse failure path
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S3-4: Raw-cmd CLI path writes `config.toml` directly (no UDS)
+
+**Context:** Raw-cmd hooks must not be submittable over UDS (PRD §6.5). Today `aimx hooks create --cmd "..."` goes through the UDS `HOOK-CREATE` verb with TOML body; in §S3-1 that verb stops accepting `cmd`. The CLI raw-cmd path is therefore rerouted to write `config.toml` directly via the existing atomic-write helper in `src/config.rs`, then SIGHUP the running `aimx serve` so the in-memory `ConfigHandle` swaps to the new config. If no daemon is running, the file write succeeds and the CLI prints a "restart daemon when convenient" hint.
+
+**Priority:** P0
+
+- [ ] `aimx hooks create --cmd "..."` requires root (returns `ERR requires-root: run with sudo` otherwise); the existing `check_root()` helper in `src/setup.rs` (or equivalent) is reused
+- [ ] When root, the CLI calls a new `hooks::write_raw_cmd_hook_to_config(&config_path, hook)` helper that reads `config.toml`, appends the new hook to the target mailbox's `hooks` vec, and writes back via atomic temp-then-rename (same pattern used by `mailbox_handler.rs`)
+- [ ] After the write, the CLI sends SIGHUP to `aimx serve` if it is running (PID discovered via `/run/aimx/aimx.pid` if present, otherwise `pgrep -x aimx | head -1` fallback); if no daemon is running the CLI prints "config updated — restart aimx when convenient"
+- [ ] `hooks create --cmd` does NOT go through UDS even when the daemon is reachable — the separation is absolute
+- [ ] Unit test verifies the direct-write + SIGHUP path; integration test (root-gated) verifies a live daemon picks up the new hook within 2 seconds of the SIGHUP
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S3-5: SIGHUP handler in `aimx serve`
+
+**Context:** The daemon must hot-reload `config.toml` on SIGHUP so the CLI's raw-cmd path (§S3-4) and operators who hand-edit `config.toml` don't need to restart the service. Reuses the existing `ConfigHandle::store()` atomic swap at `src/config.rs` around line 426. The handler runs inside the existing tokio signal loop in `src/serve.rs` alongside the SIGTERM / SIGINT handlers. On validation failure the daemon keeps the old config and logs a warning — failing-open to the running config is safer than crashing.
+
+**Priority:** P0
+
+- [ ] `src/serve.rs` signal loop adds a SIGHUP branch that calls a new `reload_config(&ConfigHandle) -> Result<ReloadSummary, ReloadError>` function
+- [ ] `reload_config` re-reads `config.toml`, runs the full validation chain (hook templates, per-hook origin/template mutual exclusion, trust config), atomically swaps `ConfigHandle` on success, and logs `"config reloaded: M mailboxes, H hooks, T templates"` at info level
+- [ ] On validation error, `reload_config` logs at warn level with the specific error and **does not** swap the handle — the running daemon keeps operating on the last known-good config
+- [ ] Integration test sends SIGHUP to a live test daemon with a modified `config.toml` and asserts the daemon's in-memory config reflects the change within 2 seconds (polled via an MCP `mailbox_list` tool call)
+- [ ] Integration test sends SIGHUP with a malformed `config.toml` and asserts the daemon continues running on the old config (MCP `mailbox_list` still succeeds)
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+---
+
+## Sprint 4 — Default templates + interactive setup + agent-setup hint (Days 7.5–10) [NOT STARTED]
+
+**Goal:** Ship the 8 default templates inside the binary, surface them behind an interactive `aimx setup` checkbox, and make `aimx agent-setup` print the matching template-enable hint for each agent.
+
+**Dependencies:** Sprint 1 (schema, service user); Sprint 3 (template hooks are actually creatable — otherwise the setup checkbox would install templates that are useless).
+
+#### S4-1: Embed 8 default templates in the binary
+
+**Context:** PRD §6.2 lists the eight default templates (`invoke-claude`, `invoke-codex`, `invoke-opencode`, `invoke-gemini`, `invoke-goose`, `invoke-openclaw`, `invoke-hermes`, `webhook`). They ship inside the `aimx` binary so `aimx setup` can write them without a separate asset download. A `hook-templates/defaults.toml` file at the repo root, embedded via `include_str!`, keeps them reviewable as plain TOML. Exact binary paths and argv follow PRD §6.2 verbatim; paths are confirmed by running the target agent's `--version` on a reference Linux install during implementation (one commit may adjust a path that drifted since PRD authoring).
+
+**Priority:** P0
+
+- [ ] New `hook-templates/defaults.toml` at the repo root contains eight `[[hook_template]]` blocks matching PRD §6.2; each has `name`, `description`, `cmd`, `params`, `stdin`, `run_as = "aimx-hook"`, `timeout_secs = 60`, `allowed_events = ["on_receive", "after_send"]`
+- [ ] `src/setup.rs` (or a new `src/hook_templates_defaults.rs`) uses `include_str!("../hook-templates/defaults.toml")` to bake the TOML into the binary; a `default_templates() -> Vec<HookTemplate>` helper parses and returns it at runtime
+- [ ] Parser failure on the embedded TOML panics the binary at startup (compile-time validation via a unit test ensures the embedded file is always valid before merge)
+- [ ] Unit test enumerates each default template by name and asserts the `cmd[0]` path, `params` list, and `stdin` mode match PRD §6.2 — a forcing function against accidental drift
+- [ ] `invoke-goose` is flagged with an open question in the implementation notes (PRD §11 Q3): does `stdin = "email"` work for Goose recipes, or do we need a `email_yaml` encoding? Sprint 4 ships with `stdin = "email"`; if manual testing reveals breakage, a follow-up story is added to the v2 backlog
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S4-2: Interactive checkbox UI in `aimx setup`
+
+**Context:** PRD §6.3 specifies the checkbox flow: after DKIM and systemd-unit setup, present a multi-select list of the eight default templates with all boxes unchecked by default. Re-running `aimx setup` pre-ticks currently-enabled templates. The existing setup UI is hand-rolled prompts; adding `dialoguer` gives us `MultiSelect` with minimal code. `dialoguer` is a mature crate (Rust ecosystem standard for this) and adds no async complexity.
+
+**Priority:** P0
+
+- [ ] `dialoguer = "0.11"` (or latest stable) added to `Cargo.toml` with the `fuzzy-select` feature for the `MultiSelect` widget; license check (MIT) documented in `CLAUDE.md` if the repo tracks dep licenses
+- [ ] `src/setup.rs::run_setup` grows a new `configure_hook_templates(&Config, &dyn SystemOps) -> Result<Vec<String>>` phase called after DKIM setup, before systemd unit install
+- [ ] The prompt prints the PRD §6.3 copy verbatim (one-line title, three-line explanation, then the checkbox list); defaults are "none checked" on a fresh install, "currently-enabled" on a re-run
+- [ ] Selected templates are appended to `config.toml` via the same atomic-write helper used elsewhere; unselected but previously-enabled templates are removed (re-running setup is idempotent in both directions)
+- [ ] The prompt is skippable with `--non-interactive` or when stdin is not a TTY (CI, piped setup); in that case no templates are installed and a warning is logged
+- [ ] `MockSystemOps` in the test module simulates a TTY with a scripted selection so unit tests cover both the fresh and re-run cases
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S4-3: `aimx hooks templates` CLI subcommand
+
+**Context:** PRD §9 "In Scope (v1)" includes `aimx hooks templates` to list enabled templates (the enable/disable subcommands are deferred to v2). The subcommand reads `config.toml` directly (no UDS round-trip needed for a read-only query), matching the pattern used by `aimx hooks list`. Output is a compact table with `NAME`, `DESCRIPTION`, `PARAMS`, `EVENTS` columns, using the existing `term::header` / `term::highlight` color helpers.
+
+**Priority:** P0
+
+- [ ] `src/cli.rs::HookCommand` enum gains a `Templates` variant (no args)
+- [ ] `src/hooks.rs::run` dispatches the new variant to a `list_templates(&Config) -> Result<()>` function that prints the table
+- [ ] Output format matches `aimx hooks list`: 4-column aligned table with colored headers, truncated descriptions past 60 chars
+- [ ] Empty-config output: "No hook templates enabled. Run `sudo aimx setup` and tick the templates you need."
+- [ ] Unit test asserts the table renders correctly for a config with 0, 1, and 8 templates
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S4-4: `aimx agent-setup` post-install template-enable hint
+
+**Context:** PRD §6.4 adds a per-agent hint after `aimx agent-setup` completes: "To let <AGENT> create its own hooks via MCP, enable the matching template as root: `sudo aimx hooks template-enable invoke-<agent>`". The hint is printed unconditionally (agent-setup runs as the user and can't read root-owned `config.toml` to know if the template is already enabled). A static table in `src/agent_setup.rs` maps `agent.name → template.name` for the six agents that have a matching invoke- template; `openclaw`, `gemini`, `goose`, `hermes` each have their own invoke-template; `webhook` has no agent mapping (it's generic).
+
+**Priority:** P1
+
+- [ ] `src/agent_setup.rs::AgentSpec` gains an optional `matching_template: Option<&'static str>` field; populated as `Some("invoke-claude")` for the `claude-code` spec, `Some("invoke-codex")` for `codex`, etc.
+- [ ] Post-install output in `install_plugin` appends a "Hook Templates" section when `matching_template` is `Some`, using the exact PRD §6.4 copy with the correct template name substituted
+- [ ] Hint notes that the `template-enable` CLI is v2 (not in this track) — until then, operators tick the template during `aimx setup` or hand-edit `config.toml`; the hint updates in the v2 sprint that ships `template-enable`
+- [ ] Unit tests verify the hint appears for every `AgentSpec` with `matching_template = Some(...)` and is absent for any spec with `matching_template = None`
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+---
+
+## Sprint 5 — MCP tools + agent primer updates (Days 10–12.5) [NOT STARTED]
+
+**Goal:** Expose templates through MCP with four new tools, and update the agent-facing primer so every bundled agent knows how to use them.
+
+**Dependencies:** Sprint 3 (UDS verbs must be tightened); Sprint 4 (templates must be installable so MCP has something to list).
+
+#### S5-1: MCP `hook_list_templates` tool
+
+**Context:** PRD §6.6. No parameters. Reads the current config (via `Config::load_resolved_with_data_dir`) and returns a JSON array of templates with `name`, `description`, `params` (list of required param names), and `allowed_events`. The agent calls this first, before `hook_create`, to discover what it can wire up.
+
+**Priority:** P0
+
+- [ ] `src/mcp.rs` gains a `#[tool(name = "hook_list_templates", description = "List hook templates available on this install for use with hook_create")]` method on `AimxMcpServer`
+- [ ] Return type is `Result<String, String>` — serialized JSON array; no params struct needed
+- [ ] Empty-config case returns `[]` (valid JSON) with a companion explanation in the tool description: "empty means no templates are enabled; the operator must install them via aimx setup"
+- [ ] Unit test calls the tool against a `Config` with 0 and 3 templates and asserts the serialized JSON matches a golden fixture
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S5-2: MCP `hook_create` tool
+
+**Context:** PRD §6.6. Takes `{mailbox, event, template, params, name?}`. Calls a new helper in `src/hook_client.rs` that submits the tightened UDS `HOOK-CREATE` verb. Returns the effective hook name (derived by the daemon if `name` was omitted) plus the substituted argv, so the agent's UI can echo "I created a hook on `accounts` that runs `/usr/local/bin/claude -p 'You are the accounts agent...'`" for confirmation.
+
+**Priority:** P0
+
+- [ ] New `HookCreateParams` struct with fields `mailbox: String`, `event: String` (`"on_receive"` or `"after_send"`), `template: String`, `params: BTreeMap<String, String>`, `name: Option<String>`; each annotated with `#[schemars(description = "...")]` for MCP schema generation
+- [ ] `#[tool(name = "hook_create", description = "...")]` method wraps the UDS submit, surfaces daemon errors verbatim, and returns `{effective_name, substituted_argv}` on success
+- [ ] Tool description highlights the safety model: "Your agent cannot submit arbitrary shell — every hook must reference a template listed by hook_list_templates; the operator installs templates during aimx setup"
+- [ ] Integration test spins up a live daemon with one template configured, submits `hook_create` via the MCP transport, verifies the hook appears in `config.toml` with `origin = "mcp"`
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S5-3: MCP `hook_list` tool with origin-masked output
+
+**Context:** PRD §6.6 + §11 Q2. The agent sees all hooks (operator- and MCP-origin) so it has a full picture of the mailbox, but for operator-origin hooks only the `{name, mailbox, event, origin}` are exposed — `cmd` / `params` are masked. This prevents information leakage of operator-authored automation logic to the agent while still letting the agent avoid creating duplicate hooks.
+
+**Priority:** P0
+
+- [ ] `HookListParams { mailbox: Option<String> }` (filter optional)
+- [ ] Tool method reads `Config` directly (no UDS) and returns a JSON array; for each hook, the fields are conditional on `origin`: MCP-origin hooks include `{name, mailbox, event, template, params, origin: "mcp"}`; operator-origin hooks include `{name, mailbox, event, origin: "operator"}` only
+- [ ] Tool description explains the origin split so the agent understands why operator-origin hook contents are hidden
+- [ ] Unit test against a config with mixed operator- and MCP-origin hooks asserts the JSON output matches the masking rule exactly
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S5-4: MCP `hook_delete` tool
+
+**Context:** PRD §6.6. Thin wrapper over the tightened UDS `HOOK-DELETE` verb from §S3-2. Takes `{name}`. Surfaces `ERR origin-protected` verbatim when the target hook is operator-origin, so the agent can tell the user "I can't delete that hook — the operator created it and would need to remove it via `sudo aimx hooks delete`".
+
+**Priority:** P0
+
+- [ ] `HookDeleteParams { name: String }`; tool method submits UDS `HOOK-DELETE` via existing `submit_hook_delete_via_daemon` helper
+- [ ] Daemon error bodies surface verbatim to the MCP response; the tool description includes an example of `ERR origin-protected` so the agent understands the model
+- [ ] Integration test: submit `hook_delete` against an MCP-origin hook (succeeds) and an operator-origin hook (fails with the expected error)
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S5-5: Update agent primer + references with "Creating hooks" section
+
+**Context:** PRD §8.3. `agents/common/aimx-primer.md` and `agents/common/references/` are the agent-facing docs embedded into every bundle via `include_dir!` at `src/agent_setup.rs:12`. Adding a new "Creating hooks" section to the primer — plus a new reference file `agents/common/references/hooks.md` covering the four tools, the template model, and example agent prompts — propagates to all agents automatically on the next `cargo build`.
+
+**Priority:** P0
+
+- [ ] `agents/common/aimx-primer.md` gains a "Creating hooks" section (after the existing MCP tool summary) explaining: hooks react to inbound/outbound mail; agents create hooks via the four new tools; the template model prevents arbitrary-shell abuse; always call `hook_list_templates` first
+- [ ] New `agents/common/references/hooks.md` file with: full tool signatures, example agent prompts ("file mail from this sender + reply with system status"), the `origin` split explanation, the `ERR origin-protected` case, a troubleshooting subsection ("why does my hook not fire?" → check trust, template enabled, `aimx-hook` user exists)
+- [ ] `agent-setup` bundle for each agent with `progressive_disclosure = true` (Claude Code, Codex, OpenClaw) picks up the new reference file automatically via `include_dir!`; bundles without progressive disclosure (Goose, Gemini, OpenCode) get only the primer updates — verify no build failures in the `assemble_plugin_files` paths
+- [ ] Unit test on the bundled primer asserts the "Creating hooks" section is present for every agent (catches accidental deletion)
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+---
+
+## Sprint 6 — Integration tests + book docs + doctor (Days 12.5–15) [NOT STARTED]
+
+**Goal:** Close out the track with end-to-end integration tests, placeholder-substitution fuzz coverage, book chapter updates, and `aimx doctor` visibility for operators.
+
+**Dependencies:** Sprints 1–5 (the feature is functional; this sprint is validation + documentation + operator visibility).
+
+#### S6-1: End-to-end integration test (MCP → hook fire → sandbox verify)
+
+**Context:** PRD §7 + §9 require test coverage for the full flow. The test spins up `aimx serve` in a tempdir, installs the `webhook` template into `config.toml`, connects an MCP client (in-process rmcp), calls `hook_list_templates` → `hook_create` with a fake webhook URL, ingests a fixture `.eml`, and asserts: (a) the hook fires, (b) the substituted argv matches expectations, (c) the subprocess ran as `aimx-hook` (verified via a log-line inspection since the test likely runs non-root on CI — full UID verification is root-gated).
+
+**Priority:** P0
+
+- [ ] New integration test `tests/integration.rs::hook_templates_end_to_end` that runs in a `tempdir` with `AIMX_DATA_DIR` override
+- [ ] Test fixture: a one-template `config.toml` with `webhook` enabled, a single mailbox, and trust configured so on_receive fires on unsigned fixture mail
+- [ ] Test spawns a tiny mock-curl binary (shell script in a tempdir, added to PATH) that records its argv and stdin to a file; `webhook` template's `cmd[0]` is pointed at the mock
+- [ ] Assertion: after ingest, the mock-curl argv file contains the expected URL, and the stdin file contains JSON with the expected frontmatter fields
+- [ ] Assertion: the hook-fire log line (captured via a test log subscriber) shows `run_as = "aimx-hook"` (even if the subprocess actually ran as the test user due to non-root, the log should reflect what the daemon attempted)
+- [ ] Root-gated assertion (skipped when non-root): subprocess UID really is `aimx-hook` (verified by the mock-curl writing `id -u` to its output file)
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S6-2: Placeholder substitution fuzz test
+
+**Context:** PRD §10 risk table flags placeholder injection as the critical-severity risk. Sprint 2's unit tests cover the intentional edge cases; this sprint adds a property-based fuzz test that hammers the substitution function with 10K+ random inputs containing shell metacharacters, control chars, and long strings, asserting the core invariant: **no input produces more argv entries than the template declared**.
+
+**Priority:** P0
+
+- [ ] New test file `tests/hook_substitute_fuzz.rs` (or inside `src/hook_substitute.rs::tests`) using `proptest` or a simple hand-rolled loop
+- [ ] Input generator produces params containing: empty strings, 8 KiB strings, `;`, `$(foo)`, backticks, pipes, ampersands, redirection chars, newlines, tabs, NUL bytes, high-bit Unicode, surrogate pairs
+- [ ] For each input: call `substitute_argv` against a fixture 3-entry template; assert either (a) success with `substituted.len() == 3` OR (b) deterministic rejection via `SubstitutionError`
+- [ ] 10_000 iterations per run; the test runs in `--release` mode in CI to keep wallclock reasonable
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S6-3: Update book chapters for hook templates
+
+**Context:** PRD §8.4 lists nine book chapters that need revisions. This story is large but mechanical — each chapter gets a focused edit matching the PRD's documentation scope. Book is built via `mdbook` (per `book/` dir structure); changes ship in the same release as the code.
+
+**Priority:** P0
+
+- [ ] `book/hooks.md` — rewritten opening to lead with templates; raw-cmd section retitled "Power-user hooks" and moved below the template section; explains the `origin` split and which flows use UDS vs. direct config edit
+- [ ] `book/hook-recipes.md` — every recipe rewritten in template form; "Operator-only recipes" subsection preserves raw-cmd examples (e.g. complex shell pipelines that no template covers)
+- [ ] `book/mcp.md` — four new tool entries for `hook_list_templates`, `hook_create`, `hook_list`, `hook_delete` with request/response examples
+- [ ] `book/setup.md` — new "Hook Templates" subsection showing the interactive checkbox, explaining the `aimx-hook` user creation, noting re-run idempotence
+- [ ] `book/agent-integration.md` — per-agent section gains the `sudo aimx hooks template-enable <name>` note (cross-referencing v2 caveat) and links to `mcp.md`
+- [ ] `book/configuration.md` — new `[[hook_template]]` schema reference table; socket path updated from `/run/aimx/send.sock` to `/run/aimx/aimx.sock`
+- [ ] `book/cli.md` — `aimx hooks create` documents `--template NAME` and `--param KEY=VAL`; new `aimx hooks templates` subcommand; socket path updated
+- [ ] `book/troubleshooting.md` — new entries: "aimx-hook user missing", "template not found", "param validation failure", "sandbox denied reading stdin", "SIGHUP reload failed"
+- [ ] `book/faq.md` — new Q/A: "Why can my agent create hooks but not run arbitrary commands?" explaining the template safety model in 3–4 paragraphs
+- [ ] Book builds without warnings; any internal links updated; `mdbook build` clean
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+#### S6-4: `aimx doctor` extensions for hook templates
+
+**Context:** PRD §7.3 asks `aimx doctor` to surface enabled templates with fire counts and warn on missing binaries. This gives the operator a single place to verify "is my template setup actually working" without reading `config.toml` + `journalctl` separately. Fire counts are parsed from the last 24h of structured log lines (`journalctl -u aimx --since="24 hours ago" --output=json` on systemd; log-file scan on OpenRC).
+
+**Priority:** P1
+
+- [ ] `src/doctor.rs` gains a "Hook templates" section that lists every enabled template with: name, description (truncated), `cmd[0]` existence check (warn if not executable), 24h fire count, 24h failure count
+- [ ] Section also verifies the `aimx-hook` user exists (UID lookup), reports UID/GID, and checks read access to `<datadir>/inbox` and `<datadir>/sent` (warn if missing)
+- [ ] Fire-count parser tolerates journalctl unavailability (OpenRC) by falling back to a log-file scan; if neither is available, count shows `-` instead of failing the whole report
+- [ ] Unit tests with fixture log lines verify the count parser handles malformed, truncated, and mixed-origin log lines without panicking
+- [ ] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean
+
+---
+
+## Summary table
+
+| Sprint | Days | Focus | Key Output |
+|--------|------|-------|------------|
+| 1 | 1–2.5 | Foundation | Socket renamed, schema lands, `aimx-hook` user created |
+| 2 | 2.5–5 | Sandboxed executor | argv + systemd-run/setuid + timeout runner replaces `sh -c` |
+| 3 | 5–7.5 | UDS + CLI + SIGHUP | `HOOK-CREATE` template-only, raw-cmd via config write, hot-reload works |
+| 4 | 7.5–10 | Templates + setup | 8 defaults embedded, interactive checkbox, `agent-setup` hint |
+| 5 | 10–12.5 | MCP tools + primer | Four MCP tools live, `agents/common/` updated |
+| 6 | 12.5–15 | Tests + docs + doctor | E2E + fuzz tests green, 9 book chapters updated, `aimx doctor` surfaces templates |
+
+## Deferred to v2
+
+Taken directly from [`hook-templates-prd.md`](hook-templates-prd.md) §9 "Out of Scope (future consideration)":
+
+| Feature | Rationale |
+|---------|-----------|
+| `admin.sock` (root-only UDS) | Not needed for hook templates — the template-only `HOOK-CREATE` verb provides the authorization boundary. Add if other privileged verbs appear later (DKIM rotate, TLS cert swap, etc.) |
+| `aimx hooks template-enable` / `template-disable` CLI | v1 requires re-running `aimx setup` to toggle templates; dedicated CLI commands would be friendlier but aren't required for the core flow |
+| Per-template `allowed_mailboxes` restriction | Useful for locking a sensitive template (e.g. `webhook` with prod secrets) to one mailbox; waiting for a real operator request before shipping |
+| Dry-run / test mode (`aimx hooks test <name>`) | Would fire a template against a synthetic email without delivering it. Nice DX but not required for the launch |
+| Per-user / multi-tenant hook isolation | aimx is single-operator by stance; multi-user Unix is explicitly out of scope |
+| Operator-authored custom templates (documented path) | The schema already accepts them; v1 leaves this undocumented until validation is hardened against hostile operator input (unlikely attack surface, but belt-and-braces) |
+| `email_json` stdin format stabilization | v1 treats it as best-effort frontmatter JSON; breaking changes allowed until a real consumer emerges |
+
+---
+
+*Status: plan drafted. No code changes yet — implementation begins at S1-1 on approval.*


### PR DESCRIPTION
## Summary

Adds `docs/hook-templates-prd.md` — a PRD for the hook-templates feature that lets AI agents configure their own `on_receive` / `after_send` hooks through MCP without exposing arbitrary shell. The PRD documents:

- **Template model** — operator registers `[[hook_template]]` blocks (pre-vetted argv + declared params); agents pick a template and fill params via MCP. No raw `cmd` ever reaches the UDS.
- **Socket rename** — `/run/aimx/send.sock` → `/run/aimx/aimx.sock` (pre-launch, no migration).
- **Raw-cmd hooks stay operator-only** — routed through CLI + `config.toml` edit + SIGHUP, never over UDS. MCP physically can't submit them.
- **Privilege separation** — hooks run as a dedicated `aimx-hook` system user created by `aimx setup`; `systemd-run --uid=aimx-hook --property=ProtectSystem=strict …` on systemd, `setuid` fallback on OpenRC.
- **4 new MCP tools** — `hook_list_templates`, `hook_create`, `hook_list`, `hook_delete`. `origin = "mcp" | "operator"` tag protects operator hooks from MCP deletion.
- **Default templates** — `invoke-{claude,codex,opencode,gemini,goose,openclaw,hermes}` + generic `webhook`, embedded in the binary, installed via interactive checkboxes in `aimx setup`.
- **6-milestone plan**, risk table, open questions, and a `book/` chapter hit list for docs follow-up.

No code changes; docs-only.

## Test plan

- [ ] Review PRD for scope alignment — especially §6.2 (default templates), §6.5 (UDS semantics), §6.7 (executor sandbox flags)
- [ ] Confirm open questions in §11 before any implementation sprint is planned
- [ ] When implementation starts, convert PRD into `docs/hook-templates-sprint.md` via scrum-planner
