### PR TITLE
[Sprint 5] MCP tools + agent primer updates

### DIFF
--- a/agents/common/aimx-primer.md
+++ b/agents/common/aimx-primer.md
@@ -10,6 +10,7 @@ For full reference material, see the files in `references/`:
 - `references/mcp-tools.md`: full MCP tool signatures, types, and examples
 - `references/frontmatter.md`: complete frontmatter schema
 - `references/workflows.md`: worked examples for common tasks
+- `references/hooks.md`: creating hooks via MCP (template model, tools, origin)
 - `references/troubleshooting.md`: error codes and recovery steps
 
 At runtime, `/var/lib/aimx/README.md` is the authoritative guide to the data
@@ -32,7 +33,7 @@ directly. The daemon owns those paths.
 
 ## MCP tools: quick reference
 
-All 9 tools are served by the `aimx` binary over stdio. They return strings
+All 13 tools are served by the `aimx` binary over stdio. They return strings
 on success and error strings on failure.
 
 ### Mailbox tools
@@ -58,8 +59,30 @@ on success and error strings on failure.
 - `email_mark_read(mailbox, id, folder?)`: mark a single email as read.
 - `email_mark_unread(mailbox, id, folder?)`: mark a single email as unread.
 
-See `references/mcp-tools.md` for full parameter types, return values, and
-worked examples.
+### Hook tools
+
+Hooks are shell commands the daemon fires on mail events (`on_receive`,
+`after_send`). To keep the world-writable UDS socket safe, MCP cannot
+submit arbitrary shell. Every hook you create references a **template**
+the operator installed during `aimx setup` — you only pick a template and
+fill its declared params.
+
+- `hook_list_templates()`: list templates enabled on this install. Call
+  this first. An empty list means the operator has not enabled any
+  templates — ask them to re-run `sudo aimx setup`.
+- `hook_create(mailbox, event, template, params, name?)`: attach a
+  template hook. The daemon substitutes your `params` into the
+  template's argv and stamps `origin = "mcp"` on the resulting hook.
+- `hook_list(mailbox?)`: list all hooks. Your own hooks (created via
+  MCP) show full details; operator-authored hooks appear with only
+  `{name, mailbox, event, origin}` — their `cmd` / `params` are masked.
+- `hook_delete(name)`: delete a hook. Only works on MCP-origin hooks;
+  the daemon returns `ERR origin-protected` for operator-origin hooks
+  and tells the user to run `sudo aimx hooks delete` on the host.
+
+See `references/hooks.md` for worked examples, the full template model,
+and troubleshooting. See `references/mcp-tools.md` for full parameter
+types and return values across every tool.
 
 ## Storage layout
 
@@ -199,6 +222,48 @@ infinite mail loops between bots. The same applies to mailing list mail
 See `references/workflows.md` for 10+ additional worked examples including
 triage, filtering by list, handling attachments, reply-all, and mark-all-read.
 
+## Creating hooks
+
+Hooks are shell commands that fire when mail arrives (`on_receive`) or is
+sent (`after_send`). They are how you go from "the agent reads mail" to
+"the agent acts on mail automatically."
+
+The safety model: you cannot submit raw shell via MCP. Every hook you
+create must reference a **template** the operator pre-vetted during
+`aimx setup`. A template declares an argv shape plus the parameter
+names you are allowed to fill. Your `hook_create` call supplies values
+for those params, and the daemon substitutes them into the template's
+argv slots — no shell interpretation, no argv splitting, no way to
+escape the value slot.
+
+The four tools work together:
+
+1. **Discover**: call `hook_list_templates` to see what is installed.
+   Each entry names the template, its params, and which events it
+   allows (`on_receive`, `after_send`, or both).
+2. **Create**: call `hook_create` with a mailbox, an event, a template
+   name, and param values. The daemon stamps `origin = "mcp"` on the
+   resulting hook, returns the effective name, and echoes the final
+   substituted argv so you can confirm the wiring.
+3. **Inspect**: call `hook_list` to see what is configured. Your hooks
+   show full details; operator hooks are masked to just name + mailbox
+   + event + origin (the operator's automation logic is private).
+4. **Remove**: call `hook_delete(name)` to remove a hook you created.
+   Operator-origin hooks cannot be deleted via MCP — the daemon returns
+   `ERR origin-protected` pointing at `sudo aimx hooks delete` on the
+   host.
+
+If `hook_list_templates` is empty, no amount of calling `hook_create`
+will help — the operator needs to run `sudo aimx setup` and tick the
+templates they want. Tell the user that, with the exact command. Do not
+guess at template names.
+
+Template hooks fire only on **trusted** inbound mail (`trusted == "true"`
+on the email's frontmatter). If your hook does not fire, check the
+email's `trusted` field first. See `references/hooks.md` for the full
+troubleshooting checklist (template enabled? mailbox exists? event
+allowed? `aimx-hook` user readable?) and several worked example prompts.
+
 ## Trust model
 
 aimx verifies DKIM, SPF, and DMARC on every inbound email. Results are
@@ -322,6 +387,8 @@ email's content (e.g. following a link), consult `trusted`, `dkim`, and
   both inbound and outbound emails.
 - `references/workflows.md`: 10+ worked task recipes (triage, thread
   summarization, attachment handling, filter by list-id, mark all read, etc.).
+- `references/hooks.md`: creating hooks via MCP — the template model,
+  worked example prompts, origin split, and troubleshooting.
 - `references/troubleshooting.md`: UDS protocol error codes, common
   misconfigurations, and recovery steps.
 - `/var/lib/aimx/README.md`: runtime guide to the data directory layout,

--- a/agents/common/references/hooks.md
+++ b/agents/common/references/hooks.md
@@ -1,0 +1,305 @@
+# aimx hooks: creating and managing automations via MCP
+
+Hooks are shell commands the aimx daemon fires on mail events:
+
+- `on_receive`: an inbound email has been ingested. Fires only on
+  **trusted** mail (`trusted == "true"` in frontmatter) unless the
+  operator explicitly opted the hook out of the trust gate — and that
+  opt-out is not settable via MCP.
+- `after_send`: an outbound email has resolved (delivered, deferred,
+  or failed). Fires on every send regardless of trust.
+
+You do not ship arbitrary shell. You pick a **template** the operator
+has pre-vetted and fill its declared parameters. The daemon substitutes
+your values into the template's argv, drops privileges to the
+`aimx-hook` user, and spawns the child with a per-hook timeout. The
+local operator is the only party who can install raw-cmd hooks (via
+`sudo aimx hooks create --cmd "..."` on the host).
+
+## The four MCP hook tools
+
+### `hook_list_templates`
+
+List every hook template enabled on this aimx install. Call this first,
+always, before `hook_create`. The list is empty until the operator has
+ticked templates during `aimx setup` — if it is empty, tell the user to
+run `sudo aimx setup` on the host.
+
+**Parameters:** none.
+
+**Returns:** JSON array. Each entry:
+
+```json
+{
+  "name": "invoke-claude",
+  "description": "Pipe the received/sent email into Claude Code with a custom prompt.",
+  "params": ["prompt"],
+  "allowed_events": ["on_receive", "after_send"]
+}
+```
+
+The `params` array lists every parameter you must bind when calling
+`hook_create`. The `allowed_events` array tells you which events this
+template may be wired to — passing a disallowed event returns an error.
+
+### `hook_create(mailbox, event, template, params, name?)`
+
+Attach a template-bound hook to a mailbox.
+
+**Parameters:**
+
+| Name       | Type              | Required | Description |
+|------------|-------------------|----------|-------------|
+| `mailbox`  | string            | yes      | Mailbox name (e.g. `"alice"`) — must exist |
+| `event`    | string            | yes      | `"on_receive"` or `"after_send"` |
+| `template` | string            | yes      | Template name from `hook_list_templates` |
+| `params`   | object (str→str)  | yes      | Key=value map matching the template's declared params exactly |
+| `name`     | string (optional) | no       | Explicit hook name. When omitted, the daemon derives a 12-hex-char name from `(event, template, sorted params)` |
+
+**Returns:** JSON with the effective name and the final substituted
+argv so you can confirm the wiring in your reply to the user:
+
+```json
+{
+  "effective_name": "mcp_test_hook",
+  "substituted_argv": ["/usr/local/bin/claude", "-p", "You are an assistant"]
+}
+```
+
+**Errors:**
+
+- `Mailbox '…' does not exist.`: create it first with `mailbox_create`.
+- `Unknown template '…'.`: call `hook_list_templates` to see the list.
+- `Template '…' does not permit event '…'.`: pick a different event
+  or a different template.
+- `missing-param: template '…' requires '…'.`: bind every declared
+  param.
+- `unknown-param: template '…' does not declare '…'.`: you sent a key
+  not in the template's `params` list. Remove it.
+- `param-invalid: parameter '…' contains an ASCII control character`
+  or `contains a NUL byte` or `is N bytes (max 8192)`: sanitize your
+  value.
+- `name-conflict: hook name '…' already exists`: pick a different
+  explicit name, or omit `name` to get a derived one.
+
+### `hook_list(mailbox?)`
+
+List hooks visible to MCP across all mailboxes (or a single one).
+
+**Parameters:**
+
+| Name      | Type              | Required | Description |
+|-----------|-------------------|----------|-------------|
+| `mailbox` | string (optional) | no       | Filter to one mailbox |
+
+**Returns:** JSON array. MCP-origin rows (created by you or by a
+CLI `--template` invocation) expose full details:
+
+```json
+{
+  "name": "agent_hook",
+  "mailbox": "alice",
+  "event": "on_receive",
+  "origin": "mcp",
+  "template": "invoke-claude",
+  "params": {"prompt": "You are an assistant"}
+}
+```
+
+Operator-origin rows (raw-cmd hooks the operator wrote on the host)
+are **masked** — only these four fields survive:
+
+```json
+{
+  "name": "daily-report",
+  "mailbox": "alice",
+  "event": "after_send",
+  "origin": "operator"
+}
+```
+
+This lets you see that a slot is taken without inspecting the operator's
+automation. Do not try to work around the masking.
+
+### `hook_delete(name)`
+
+Delete a hook by effective name.
+
+**Parameters:**
+
+| Name   | Type   | Required | Description |
+|--------|--------|----------|-------------|
+| `name` | string | yes      | Effective name from `hook_list` |
+
+**Returns:** confirmation string.
+
+**Errors:**
+
+- `ERR origin-protected: hook '…' was created by the operator —
+  remove via \`sudo aimx hooks delete\` instead`: the target hook is
+  operator-origin. MCP cannot delete it. Tell the user to run
+  `sudo aimx hooks delete <name>` on the host.
+- `hook '…' not found`: no hook with that name exists. Re-list to
+  find the right name.
+- `daemon not running`: the `aimx serve` process is down. Hooks
+  cannot be deleted until it restarts.
+
+Note: the `origin` tag is a *submission channel*, not an authorship
+marker. Any hook that reached the daemon through the UDS (MCP
+`hook_create`, or `aimx hooks create --template` on the host) carries
+`origin = "mcp"` and is deletable via `hook_delete`. Operator-only
+hooks are the ones the operator direct-wrote to `config.toml` via
+`aimx hooks create --cmd "..."`.
+
+## The template model, in detail
+
+A template is one `[[hook_template]]` block the operator installed in
+`/etc/aimx/config.toml` at setup time. It looks like:
+
+```toml
+[[hook_template]]
+name = "invoke-claude"
+description = "Pipe the email into Claude Code with a custom prompt."
+cmd = ["/usr/local/bin/claude", "-p", "{prompt}"]
+params = ["prompt"]
+stdin = "email"
+run_as = "aimx-hook"
+timeout_secs = 60
+allowed_events = ["on_receive", "after_send"]
+```
+
+Key facts for agents:
+
+- `{placeholder}` tokens inside a `cmd` entry are the only places your
+  `params` values land. They never split into new argv entries — if
+  your value contains spaces, quotes, or shell metacharacters, they are
+  passed verbatim into one argv slot.
+- Built-in placeholders `{event}`, `{mailbox}`, `{message_id}`,
+  `{from}`, `{subject}` are populated by the daemon at fire time. You
+  do not bind them; you cannot supply them.
+- `cmd[0]` (the binary path) is never substituted. An operator who
+  trusts a template trusts the exact binary it will exec.
+- `stdin = "email"` pipes the raw Markdown (frontmatter + body) of the
+  email to the hook's child process on stdin. `"email_json"` wraps it
+  in `{frontmatter, body}` JSON. `"none"` closes stdin.
+- `run_as = "aimx-hook"` means the child runs as an unprivileged
+  service user with read-only access to mailbox contents and no access
+  to `/etc/aimx/dkim/` or `/etc/aimx/tls/`.
+- `timeout_secs` is a hard ceiling; SIGTERM at `timeout_secs`, SIGKILL
+  at `+5s`.
+
+## Example: "file + reply" hook on an accounts mailbox
+
+A user says: *"When I get an email from my bank, file it and reply
+with the current balance."*
+
+1. `hook_list_templates()` → verify `invoke-claude` (or your agent's
+   matching `invoke-…` template) is enabled.
+2. `hook_create(mailbox: "accounts", event: "on_receive", template:
+   "invoke-claude", params: {prompt: "You are the accounts agent.
+   Read the email on stdin. If it is from the bank, file it via
+   email_mark_read and reply with email_reply including the current
+   balance from the local ledger. Otherwise mark it read and do
+   nothing."})`
+3. Echo the `substituted_argv` in your reply to the user so they can
+   see exactly what will run.
+4. If the user later says *"undo that"*, call `hook_delete(name:
+   <effective_name>)` with the name the daemon returned in step 2.
+
+## Example: webhook on outbound mail
+
+A user says: *"Ping https://ops.example.com/log every time I send an
+email."*
+
+1. `hook_list_templates()` → verify `webhook` is in the list.
+2. `hook_create(mailbox: "agent", event: "after_send", template:
+   "webhook", params: {url: "https://ops.example.com/log"})`
+3. The template's `stdin = "email_json"` means the remote endpoint
+   receives the full message as JSON. Confirm that matches what the
+   user wants — if they need HTTP Basic auth or a custom header, the
+   `webhook` template does not support it (v1); tell them to ask the
+   operator to write a raw-cmd hook instead.
+
+## Troubleshooting
+
+### "My hook does not fire on inbound mail."
+
+The `on_receive` trust gate is the most common cause. MCP-created
+hooks **always** honor the gate — they fire iff the email's `trusted`
+frontmatter is `"true"`. Check `email_read` output for the target
+email:
+
+- `trusted = "none"`: the mailbox's trust policy is `"none"` (the
+  default). Ask the operator to set `trust = "verified"` and add a
+  `trusted_senders` allowlist in `config.toml`.
+- `trusted = "false"`: the sender did not match the allowlist, or
+  DKIM did not pass. Hooks do not fire on this mail. Ask the user
+  what they want (add sender to allowlist, or accept that this mail
+  is untrusted).
+- `trusted = "true"` but the hook still didn't fire: the daemon
+  logs a structured line per firing. Ask the operator to check
+  `aimx logs` or `journalctl -u aimx`.
+
+### "hook_create returned `Unknown template`."
+
+Call `hook_list_templates` again — the operator may have disabled the
+template, or your template name is misspelled. The list is the
+authoritative source; never assume a template exists from a past
+install.
+
+### "hook_create returned `Mailbox '…' does not exist`."
+
+Call `mailbox_list` to check spelling. `mailbox_create` first if you
+are setting up a new identity.
+
+### "hook_delete returned `origin-protected`."
+
+The target hook was written to `config.toml` by the operator via
+`aimx hooks create --cmd "..."`. Only the operator can remove it:
+`sudo aimx hooks delete <name>` on the host. Tell the user exactly
+that command.
+
+### "I created a hook but `hook_list` does not show the full details."
+
+Check the `origin` field. If it is `"operator"`, the hook was
+hand-written; the details are deliberately masked. Your hooks (via
+`hook_create`) always show full details because they carry
+`origin = "mcp"`.
+
+### "The operator disabled a template I was using."
+
+Existing hooks bound to that template keep firing — the daemon
+resolves the template name at fire time, and a disabled template that
+still exists in `config.toml` remains callable. But new
+`hook_create` calls referencing it will fail with `Unknown template`.
+Ask the operator whether they want the template back, or whether the
+existing hooks should be removed.
+
+### "I can see an operator-origin hook in hook_list, but I'm told to stay away from it."
+
+Correct. You can see operator-origin hooks so you do not create
+duplicates or step on their names, but you cannot inspect, modify, or
+delete them. Treat operator hooks as opaque infrastructure.
+
+### "hook_create worked but the child process exits non-zero every time."
+
+Inspect the operator's logs — the daemon captures up to 64 KiB of
+stderr per hook fire and logs it at the end of the hook-fire
+structured log line. Common causes: the template's `cmd[0]` binary is
+not installed on this machine (template points at `/usr/local/bin/…`
+and the binary lives at `/usr/bin/…`), or the user / recipe path in a
+param value is wrong.
+
+## What you must not do
+
+- **Do not submit raw `cmd` values to `hook_create`.** The tool does
+  not expose a `cmd` parameter. Templates are the only path.
+- **Do not try to bypass masking on operator-origin hooks.** The
+  daemon enforces it server-side.
+- **Do not assume `hook_list_templates` is stable across installs.**
+  Call it every time — the operator may add or remove templates.
+- **Do not `hook_create` every time you reply to a user.** Hooks
+  persist across restarts; create them once and reuse by name.
+- **Do not set `dangerously_support_untrusted = true`.** It is not a
+  valid MCP-side field. Only operators can set it, and only by hand-
+  editing `config.toml`.

--- a/agents/common/references/mcp-tools.md
+++ b/agents/common/references/mcp-tools.md
@@ -293,3 +293,118 @@ Mark a single email as unread (sets `read = false` in frontmatter).
 email_mark_unread(mailbox: "agent", id: "2026-04-15-143022-meeting-notes")
 → "Marked as unread."
 ```
+
+## Hook tools
+
+Hooks fire shell commands on mail events. Agents create hooks by
+referencing pre-vetted **templates**; the template model makes it
+impossible to submit arbitrary shell over the world-writable UDS. See
+`references/hooks.md` for the full model, worked examples, and
+troubleshooting.
+
+### `hook_list_templates`
+
+List hook templates enabled on this install. Call this first — the
+list is empty until the operator has enabled templates during
+`aimx setup`.
+
+**Parameters:** None.
+
+**Returns:** JSON array. Fields per entry: `name`, `description`,
+`params` (string array of declared parameter names), `allowed_events`
+(subset of `["on_receive", "after_send"]`).
+
+**Example:**
+```
+hook_list_templates()
+→ [{"name":"invoke-claude","description":"Pipe email into Claude with a prompt.",
+    "params":["prompt"],"allowed_events":["on_receive","after_send"]}]
+```
+
+---
+
+### `hook_create`
+
+Attach a template-bound hook to a mailbox. The daemon substitutes the
+supplied params into the template's argv, stamps `origin = "mcp"` on
+the resulting hook, and writes it to `config.toml`.
+
+**Parameters:**
+| Name       | Type              | Required | Description |
+|------------|-------------------|----------|-------------|
+| `mailbox`  | string            | yes      | Mailbox name (must exist) |
+| `event`    | string            | yes      | `"on_receive"` or `"after_send"` |
+| `template` | string            | yes      | Template name from `hook_list_templates` |
+| `params`   | object(str→str)   | yes      | Must match template's declared `params` exactly |
+| `name`     | string            | no       | Optional explicit name; derived from `(event, template, sorted params)` when omitted |
+
+**Returns:** JSON `{effective_name, substituted_argv}`.
+
+**Example:**
+```
+hook_create(
+  mailbox: "agent",
+  event: "on_receive",
+  template: "invoke-claude",
+  params: {"prompt": "You are an assistant."}
+)
+→ {"effective_name":"a1b2c3d4e5f6",
+   "substituted_argv":["/usr/local/bin/claude","-p","You are an assistant."]}
+```
+
+**Errors:**
+- Unknown template.
+- Unknown or missing param.
+- Event not allowed by the template.
+- Mailbox not found.
+- Param validation (NUL / control chars / >8 KiB value).
+- Daemon not running.
+
+---
+
+### `hook_list`
+
+List hooks visible to MCP across all mailboxes (or one when `mailbox`
+is set). Operator-origin hooks are **masked** to `{name, mailbox,
+event, origin}`; MCP-origin hooks include `template` and `params`.
+
+**Parameters:**
+| Name      | Type   | Required | Description |
+|-----------|--------|----------|-------------|
+| `mailbox` | string | no       | Filter to one mailbox |
+
+**Returns:** JSON array. See `references/hooks.md` for the exact
+shape of each origin variant.
+
+**Example:**
+```
+hook_list()
+→ [{"name":"daily-report","mailbox":"agent","event":"after_send","origin":"operator"},
+   {"name":"mcp_hook","mailbox":"agent","event":"on_receive","origin":"mcp",
+    "template":"invoke-claude","params":{"prompt":"…"}}]
+```
+
+---
+
+### `hook_delete`
+
+Delete a hook by effective name. Only MCP-origin hooks are deletable
+via this tool; operator-origin hooks refuse with `ERR origin-protected`.
+
+**Parameters:**
+| Name   | Type   | Required | Description |
+|--------|--------|----------|-------------|
+| `name` | string | yes      | Effective name from `hook_list` |
+
+**Returns:** Confirmation string.
+
+**Example:**
+```
+hook_delete(name: "mcp_hook")
+→ "Hook 'mcp_hook' deleted."
+
+hook_delete(name: "daily-report")
+→ Error: "[VALIDATION] origin-protected: hook 'daily-report' was
+   created by the operator — remove via `sudo aimx hooks delete`
+   instead"
+```

--- a/agents/common/references/troubleshooting.md
+++ b/agents/common/references/troubleshooting.md
@@ -141,3 +141,24 @@ attachment files as siblings:
 
 The `id` for this email is `2026-04-15-153300-invoice-march` (the directory
 name), and `email_read` works with this ID normally.
+
+## Hook-related errors
+
+Full coverage lives in `references/hooks.md`. Quick entry points:
+
+- **`hook_list_templates` returned `[]`.** The operator has not
+  enabled any templates. Ask them to run `sudo aimx setup` on the
+  host and tick the templates they want.
+- **`hook_create` returned `Unknown template`.** Re-call
+  `hook_list_templates`; the operator may have disabled it or your
+  spelling is off.
+- **`hook_create` returned `missing-param` / `unknown-param` /
+  `param-invalid`.** The param map must match the template's `params`
+  list exactly, and values cannot contain ASCII control chars or NUL
+  bytes. Sanitize and retry.
+- **`hook_delete` returned `origin-protected`.** The hook is operator-
+  origin; MCP cannot delete it. Tell the user to run
+  `sudo aimx hooks delete <name>` on the host.
+- **My hook does not fire on inbound mail.** Check the target email's
+  `trusted` field via `email_read`. MCP-origin hooks fire only on
+  trusted mail. See `references/hooks.md` for the full trust checklist.

--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -2461,8 +2461,84 @@ mod tests {
         assert!(text.contains("references/mcp-tools.md"));
         assert!(text.contains("references/frontmatter.md"));
         assert!(text.contains("references/workflows.md"));
+        assert!(text.contains("references/hooks.md"));
         assert!(text.contains("references/troubleshooting.md"));
         assert!(text.contains("/var/lib/aimx/README.md"));
+    }
+
+    /// S5-5: every bundled agent (progressive_disclosure or not) picks
+    /// up the primer text, so the "Creating hooks" section must be
+    /// visible from the primer alone. A missing section means the
+    /// primer edit got lost or reverted.
+    #[test]
+    fn primer_contains_creating_hooks_section() {
+        let primer = AGENTS_DIR
+            .get_file("common/aimx-primer.md")
+            .unwrap()
+            .contents();
+        let text = std::str::from_utf8(primer).unwrap();
+        assert!(
+            text.contains("## Creating hooks"),
+            "primer must contain 'Creating hooks' section"
+        );
+        assert!(text.contains("hook_list_templates"), "{text}");
+        assert!(text.contains("hook_create"), "{text}");
+        assert!(text.contains("hook_list"), "{text}");
+        assert!(text.contains("hook_delete"), "{text}");
+        assert!(
+            text.contains("origin = \"mcp\"") || text.contains("origin = \\\"mcp\\\""),
+            "primer must explain the origin tag"
+        );
+    }
+
+    /// S5-5: new reference file must be present in the embedded bundle
+    /// and cover the four new tools end-to-end.
+    #[test]
+    fn hooks_reference_file_bundled_and_comprehensive() {
+        let contents = AGENTS_DIR
+            .get_file("common/references/hooks.md")
+            .expect("references/hooks.md must be embedded")
+            .contents();
+        let text = std::str::from_utf8(contents).unwrap();
+        // Every hook tool documented by name.
+        assert!(text.contains("hook_list_templates"), "{text}");
+        assert!(text.contains("hook_create"), "{text}");
+        assert!(text.contains("hook_list"), "{text}");
+        assert!(text.contains("hook_delete"), "{text}");
+        // Safety / origin model present.
+        assert!(text.contains("template"), "{text}");
+        assert!(text.contains("origin"), "{text}");
+        assert!(
+            text.contains("ERR origin-protected") || text.contains("origin-protected"),
+            "must mention origin-protected"
+        );
+        // Troubleshooting subsection.
+        assert!(text.contains("Troubleshooting"), "{text}");
+    }
+
+    /// S5-5: progressive-disclosure bundles (Claude Code, Codex,
+    /// OpenClaw, Hermes) copy every references/*.md, so the new
+    /// `hooks.md` lands alongside the existing four.
+    #[test]
+    fn progressive_disclosure_bundles_include_hooks_reference() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf());
+
+        run_with_env(Some("claude-code".into()), false, false, false, None, &env).unwrap();
+
+        let refs = tmp
+            .path()
+            .join(".claude/plugins/aimx/skills/aimx/references");
+        assert!(
+            refs.join("hooks.md").exists(),
+            "claude-code bundle must include references/hooks.md"
+        );
+        let installed = std::fs::read_to_string(refs.join("hooks.md")).unwrap();
+        let embedded = AGENTS_DIR
+            .get_file("common/references/hooks.md")
+            .unwrap()
+            .contents();
+        assert_eq!(installed.as_bytes(), embedded);
     }
 
     #[test]

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,6 +1,9 @@
 use crate::cli::SendArgs;
-use crate::config::Config;
+use crate::config::{Config, HookTemplate};
 use crate::frontmatter::InboundFrontmatter;
+use crate::hook::{HookEvent, HookOrigin, derive_template_hook_name, effective_hook_name};
+use crate::hook_client::{self, HookCrudFallback};
+use crate::hook_substitute::{BuiltinContext, substitute_argv};
 use crate::mailbox;
 use crate::send;
 use crate::send_protocol::{
@@ -12,6 +15,7 @@ use rmcp::handler::server::wrapper::Parameters;
 use rmcp::model::{ServerCapabilities, ServerInfo};
 use rmcp::{ServerHandler, ServiceExt, schemars, tool, tool_handler, tool_router};
 use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
@@ -105,6 +109,52 @@ pub struct EmailReplyParams {
     pub id: String,
     #[schemars(description = "Reply body text")]
     pub body: String,
+}
+
+// ---- Hook-template MCP tool params (Sprint 5) -----------------------------
+
+#[derive(Serialize, Deserialize, schemars::JsonSchema)]
+pub struct HookCreateParams {
+    #[schemars(description = "Mailbox to attach the hook to")]
+    pub mailbox: String,
+    #[schemars(description = "Event to fire on: \"on_receive\" or \"after_send\"")]
+    pub event: String,
+    #[schemars(
+        description = "Template name. Call hook_list_templates first to see which \
+                       templates this install has enabled."
+    )]
+    pub template: String,
+    #[schemars(
+        description = "Bound parameter values. Keys must match the template's \
+                       declared params exactly; values are passed verbatim to the \
+                       substituted argv slot (no shell interpretation, no argv \
+                       splitting)."
+    )]
+    pub params: BTreeMap<String, String>,
+    #[schemars(description = "Optional explicit hook name. When omitted, the daemon \
+                       derives a stable 12-hex-char name from (event, template, \
+                       sorted params).")]
+    pub name: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, schemars::JsonSchema)]
+pub struct HookListParams {
+    #[schemars(
+        description = "Optional mailbox filter. When omitted, every mailbox's \
+                       hooks are listed."
+    )]
+    pub mailbox: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, schemars::JsonSchema)]
+pub struct HookDeleteParams {
+    #[schemars(
+        description = "Effective hook name (explicit name or derived 12-hex-char \
+                       digest). The daemon refuses to delete operator-origin \
+                       hooks with `ERR origin-protected` — those can only be \
+                       removed via `sudo aimx hooks delete` on the host."
+    )]
+    pub name: String,
 }
 
 impl AimxMcpServer {
@@ -387,6 +437,300 @@ impl AimxMcpServer {
         };
 
         submit_via_daemon(&args)
+    }
+
+    // ---- Hook-template MCP tools (Sprint 5) -------------------------------
+
+    #[tool(
+        name = "hook_list_templates",
+        description = "List hook templates enabled on this aimx install. Call \
+                       this first before hook_create — an empty list means the \
+                       operator has not enabled any templates (they must re-run \
+                       `sudo aimx setup` and tick them). Returns a JSON array \
+                       of {name, description, params, allowed_events}. Your \
+                       agent can only wire events to templates that appear in \
+                       this list; arbitrary-shell `cmd` hooks are operator-only."
+    )]
+    fn hook_list_templates(&self) -> Result<String, String> {
+        let config = self.load_config()?;
+        let view: Vec<HookTemplateView> = config
+            .hook_templates
+            .iter()
+            .map(HookTemplateView::from_template)
+            .collect();
+        serde_json::to_string(&view).map_err(|e| format!("Failed to serialize hook templates: {e}"))
+    }
+
+    #[tool(
+        name = "hook_create",
+        description = "Attach a template-bound hook to a mailbox. Your agent \
+                       cannot submit arbitrary shell — every hook must \
+                       reference a template registered on this install via \
+                       `aimx setup`. Bind values for each of the template's \
+                       declared params; the daemon refuses unknown params, \
+                       missing params, and param values containing NUL / \
+                       control characters. The daemon stamps `origin = \"mcp\"` \
+                       on the resulting hook so you can delete it later via \
+                       hook_delete. Returns {effective_name, substituted_argv}."
+    )]
+    fn hook_create(
+        &self,
+        Parameters(params): Parameters<HookCreateParams>,
+    ) -> Result<String, String> {
+        let event = parse_event_param(&params.event)?;
+        let config = self.load_config()?;
+
+        // Pre-flight: mailbox + template lookups. We stop here before
+        // hitting the socket so the agent gets a precise error on obvious
+        // typos. The daemon re-validates under its write lock, so this
+        // check is advisory — a race between two agents cannot produce a
+        // stale success.
+        if !config.mailboxes.contains_key(&params.mailbox) {
+            return Err(format!("Mailbox '{}' does not exist.", params.mailbox));
+        }
+        let template = config
+            .hook_templates
+            .iter()
+            .find(|t| t.name == params.template)
+            .ok_or_else(|| {
+                format!(
+                    "Unknown template '{}'. Call hook_list_templates to see \
+                     which templates this install has enabled.",
+                    params.template
+                )
+            })?;
+        if !template.allowed_events.contains(&event) {
+            return Err(format!(
+                "Template '{}' does not permit event '{}' (allowed: {}).",
+                template.name,
+                event.as_str(),
+                template
+                    .allowed_events
+                    .iter()
+                    .map(|e| e.as_str())
+                    .collect::<Vec<_>>()
+                    .join(", ")
+            ));
+        }
+
+        // Surface missing/unknown params with the same wording the daemon
+        // uses so the agent's error path is stable whether we catch here
+        // or the daemon rejects. Done before `substitute_argv` so the
+        // error message mentions the param name rather than a confusing
+        // "unknown placeholder" diagnosis.
+        for required in &template.params {
+            if !params.params.contains_key(required) {
+                return Err(format!(
+                    "missing-param: template '{}' requires '{required}'",
+                    template.name
+                ));
+            }
+        }
+        for supplied in params.params.keys() {
+            if !template.params.iter().any(|p| p == supplied) {
+                return Err(format!(
+                    "unknown-param: template '{}' does not declare '{supplied}' \
+                     (declared: {})",
+                    template.name,
+                    template.params.join(", ")
+                ));
+            }
+        }
+
+        // Compute the effective name + substituted argv client-side so we
+        // can echo them in the response. The UDS verb returns bare OK on
+        // success, so the daemon does not hand back these values — but
+        // they are deterministic functions of the submitted inputs that
+        // the daemon validates against the same logic.
+        let effective = match &params.name {
+            Some(n) => n.clone(),
+            None => derive_template_hook_name(event, &template.name, &params.params),
+        };
+
+        // Populate built-ins with the mailbox + event we know at
+        // submission time; other builtins remain empty and are filled in
+        // at fire time by the daemon. This mirrors
+        // `handle_hook_create`'s pre-flight substitution so the MCP
+        // response surfaces a failure before the daemon rejects it.
+        let builtins = BuiltinContext {
+            event: event.as_str().to_string(),
+            mailbox: params.mailbox.clone(),
+            message_id: String::new(),
+            from: String::new(),
+            subject: String::new(),
+        };
+        let substituted = substitute_argv(&template.cmd, &params.params, &builtins)
+            .map_err(|e| format!("Param validation failed: {e}"))?;
+
+        // Submit via UDS. This is the same verb the CLI's `--template`
+        // path uses, so both submission channels stamp `origin = "mcp"`.
+        match hook_client::submit_hook_template_create_via_daemon(
+            &params.mailbox,
+            event,
+            &template.name,
+            params.params,
+            params.name.as_deref(),
+        ) {
+            Ok(()) => {
+                let payload = HookCreateResponse {
+                    effective_name: effective,
+                    substituted_argv: substituted,
+                };
+                serde_json::to_string(&payload)
+                    .map_err(|e| format!("Failed to serialize response: {e}"))
+            }
+            Err(HookCrudFallback::SocketMissing) => Err(
+                "aimx daemon not running. Start with 'sudo systemctl start aimx' \
+                 (template hooks cannot be installed while the daemon is down)."
+                    .to_string(),
+            ),
+            Err(HookCrudFallback::Daemon(msg)) => Err(msg),
+        }
+    }
+
+    #[tool(
+        name = "hook_list",
+        description = "List hooks visible to MCP across all mailboxes (or one \
+                       when `mailbox` is set). Operator-origin hooks are \
+                       returned with only {name, mailbox, event, origin}: \
+                       their `cmd` / `params` are masked so your agent cannot \
+                       inspect operator automations. MCP-origin hooks — ones \
+                       you created via hook_create or ones the operator \
+                       created via `aimx hooks create --template` — return \
+                       full {name, mailbox, event, template, params, origin} \
+                       so you can tell exactly what you wired up."
+    )]
+    fn hook_list(&self, Parameters(params): Parameters<HookListParams>) -> Result<String, String> {
+        let config = self.load_config()?;
+        let rows = collect_hook_rows(&config, params.mailbox.as_deref());
+        serde_json::to_string(&rows).map_err(|e| format!("Failed to serialize hooks: {e}"))
+    }
+
+    #[tool(
+        name = "hook_delete",
+        description = "Delete a hook by effective name. The daemon refuses \
+                       operator-origin hooks with `ERR origin-protected`; the \
+                       error points at `sudo aimx hooks delete` which the \
+                       operator must run on the host. MCP-origin hooks \
+                       (created via hook_create or `aimx hooks create \
+                       --template`) delete successfully."
+    )]
+    fn hook_delete(
+        &self,
+        Parameters(params): Parameters<HookDeleteParams>,
+    ) -> Result<String, String> {
+        match hook_client::submit_hook_delete_via_daemon(&params.name) {
+            Ok(()) => Ok(format!("Hook '{}' deleted.", params.name)),
+            Err(HookCrudFallback::SocketMissing) => Err(
+                "aimx daemon not running. Start with 'sudo systemctl start aimx' \
+                 (hook deletion requires the daemon)."
+                    .to_string(),
+            ),
+            Err(HookCrudFallback::Daemon(msg)) => Err(msg),
+        }
+    }
+}
+
+// ---- Hook-template MCP tool helpers (Sprint 5) ----------------------------
+
+/// JSON shape returned by `hook_list_templates`. Kept as an explicit
+/// view struct (rather than reusing [`HookTemplate`]) so the wire
+/// format stays stable even if `HookTemplate` grows new internal
+/// fields. Only the four values the agent needs to call `hook_create`
+/// are exposed: `name`, `description`, `params`, `allowed_events`.
+#[derive(Serialize)]
+struct HookTemplateView<'a> {
+    name: &'a str,
+    description: &'a str,
+    params: &'a [String],
+    allowed_events: Vec<&'static str>,
+}
+
+impl<'a> HookTemplateView<'a> {
+    fn from_template(t: &'a HookTemplate) -> Self {
+        Self {
+            name: &t.name,
+            description: &t.description,
+            params: &t.params,
+            allowed_events: t.allowed_events.iter().map(|e| e.as_str()).collect(),
+        }
+    }
+}
+
+/// JSON shape returned by `hook_create` on success.
+#[derive(Serialize)]
+struct HookCreateResponse {
+    effective_name: String,
+    substituted_argv: Vec<String>,
+}
+
+/// One row in the `hook_list` JSON output. Operator-origin hooks are
+/// serialized with only the first four fields; MCP-origin hooks include
+/// the `template` and `params` details. See `collect_hook_rows`.
+#[derive(Serialize)]
+struct HookListRow<'a> {
+    name: String,
+    mailbox: &'a str,
+    event: &'static str,
+    origin: &'static str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    template: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    params: Option<&'a BTreeMap<String, String>>,
+}
+
+/// Gather hooks across mailboxes applying the origin-masking rule from
+/// PRD §6.6 + §11 Q2. MCP-origin hooks surface full details; operator-
+/// origin hooks expose only name + mailbox + event + origin so the
+/// agent knows a slot is taken without inspecting the operator's
+/// automation.
+fn collect_hook_rows<'a>(config: &'a Config, filter: Option<&str>) -> Vec<HookListRow<'a>> {
+    let mut rows: Vec<HookListRow<'a>> = Vec::new();
+    let mut mailbox_names: Vec<&str> = config
+        .mailboxes
+        .keys()
+        .map(String::as_str)
+        .filter(|n| filter.is_none_or(|f| f == *n))
+        .collect();
+    mailbox_names.sort();
+    for name in mailbox_names {
+        let mb = match config.mailboxes.get(name) {
+            Some(m) => m,
+            None => continue,
+        };
+        for hook in &mb.hooks {
+            let effective = effective_hook_name(hook);
+            let row = match hook.origin {
+                HookOrigin::Mcp => HookListRow {
+                    name: effective,
+                    mailbox: name,
+                    event: hook.event.as_str(),
+                    origin: hook.origin.as_str(),
+                    template: hook.template.as_deref(),
+                    params: Some(&hook.params),
+                },
+                HookOrigin::Operator => HookListRow {
+                    name: effective,
+                    mailbox: name,
+                    event: hook.event.as_str(),
+                    origin: hook.origin.as_str(),
+                    template: None,
+                    params: None,
+                },
+            };
+            rows.push(row);
+        }
+    }
+    rows
+}
+
+fn parse_event_param(s: &str) -> Result<HookEvent, String> {
+    match s {
+        "on_receive" => Ok(HookEvent::OnReceive),
+        "after_send" => Ok(HookEvent::AfterSend),
+        other => Err(format!(
+            "Invalid event '{other}': expected 'on_receive' or 'after_send'."
+        )),
     }
 }
 
@@ -1407,7 +1751,8 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let server = AimxMcpServer::new(Some(tmp.path().to_path_buf()));
         let tools = server.tool_router.list_all();
-        assert_eq!(tools.len(), 9);
+        // 9 mail/mailbox tools + 4 hook tools (Sprint 5).
+        assert_eq!(tools.len(), 13);
     }
 
     #[test]
@@ -1426,6 +1771,12 @@ mod tests {
         assert!(names.contains(&"email_mark_unread"));
         assert!(names.contains(&"email_send"));
         assert!(names.contains(&"email_reply"));
+
+        // Sprint 5 additions.
+        assert!(names.contains(&"hook_list_templates"));
+        assert!(names.contains(&"hook_create"));
+        assert!(names.contains(&"hook_list"));
+        assert!(names.contains(&"hook_delete"));
     }
 
     #[test]
@@ -1638,5 +1989,307 @@ mod tests {
         assert!(args.reply_to.is_none());
         assert!(args.references.is_none());
         assert!(args.attachments.is_empty());
+    }
+
+    // ---- Sprint 5 hook-template tool helpers -----------------------------
+
+    use crate::config::{HookTemplate, HookTemplateStdin};
+    use crate::hook::Hook;
+
+    fn sample_template(name: &str, params: Vec<&str>, events: Vec<HookEvent>) -> HookTemplate {
+        HookTemplate {
+            name: name.to_string(),
+            description: format!("test template {name}"),
+            cmd: {
+                let mut argv = vec!["/usr/bin/true".to_string()];
+                for p in &params {
+                    argv.push(format!("{{{p}}}"));
+                }
+                argv
+            },
+            params: params.into_iter().map(String::from).collect(),
+            stdin: HookTemplateStdin::Email,
+            run_as: "aimx-hook".to_string(),
+            timeout_secs: 60,
+            allowed_events: events,
+        }
+    }
+
+    #[test]
+    fn hook_template_view_serializes_expected_shape() {
+        let tmpl = sample_template(
+            "invoke-claude",
+            vec!["prompt"],
+            vec![HookEvent::OnReceive, HookEvent::AfterSend],
+        );
+        let view = HookTemplateView::from_template(&tmpl);
+        let json = serde_json::to_value(&view).unwrap();
+        assert_eq!(json["name"], "invoke-claude");
+        assert_eq!(json["description"], "test template invoke-claude");
+        assert_eq!(json["params"][0], "prompt");
+        let events: Vec<&str> = json["allowed_events"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|v| v.as_str().unwrap())
+            .collect();
+        assert_eq!(events, vec!["on_receive", "after_send"]);
+    }
+
+    #[test]
+    fn hook_template_view_empty_config_serializes_empty_array() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let view: Vec<HookTemplateView> = config
+            .hook_templates
+            .iter()
+            .map(HookTemplateView::from_template)
+            .collect();
+        let json = serde_json::to_string(&view).unwrap();
+        assert_eq!(json, "[]");
+    }
+
+    #[test]
+    fn hook_template_view_golden_three_templates() {
+        // Regression guard against accidental shape drift: serialized
+        // JSON must carry exactly the four fields the agent uses to
+        // pick a template — name, description, params, allowed_events.
+        let tmpls = [
+            sample_template("invoke-claude", vec!["prompt"], vec![HookEvent::OnReceive]),
+            sample_template(
+                "webhook",
+                vec!["url"],
+                vec![HookEvent::OnReceive, HookEvent::AfterSend],
+            ),
+            sample_template("notify", vec![], vec![HookEvent::AfterSend]),
+        ];
+        let view: Vec<HookTemplateView> =
+            tmpls.iter().map(HookTemplateView::from_template).collect();
+        let json: serde_json::Value = serde_json::to_value(&view).unwrap();
+        assert_eq!(json.as_array().unwrap().len(), 3);
+        // First entry: single param + one allowed event.
+        assert_eq!(json[0]["name"], "invoke-claude");
+        assert_eq!(json[0]["params"][0], "prompt");
+        assert_eq!(json[0]["allowed_events"][0], "on_receive");
+        // Third entry: empty params array must still serialize as [].
+        assert_eq!(json[2]["name"], "notify");
+        assert_eq!(json[2]["params"].as_array().unwrap().len(), 0);
+        assert_eq!(json[2]["allowed_events"][0], "after_send");
+        // Unexpected fields must not appear.
+        assert!(json[0].get("cmd").is_none());
+        assert!(json[0].get("run_as").is_none());
+        assert!(json[0].get("timeout_secs").is_none());
+        assert!(json[0].get("stdin").is_none());
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn insert_hook(
+        config: &mut Config,
+        mailbox: &str,
+        name: Option<&str>,
+        event: HookEvent,
+        origin: HookOrigin,
+        template: Option<&str>,
+        params: &[(&str, &str)],
+        cmd: &str,
+    ) {
+        let hook = Hook {
+            name: name.map(String::from),
+            event,
+            r#type: "cmd".into(),
+            cmd: cmd.to_string(),
+            dangerously_support_untrusted: false,
+            origin,
+            template: template.map(String::from),
+            params: params
+                .iter()
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect(),
+            run_as: None,
+        };
+        config.mailboxes.get_mut(mailbox).unwrap().hooks.push(hook);
+    }
+
+    #[test]
+    fn collect_hook_rows_masks_operator_origin_and_reveals_mcp_origin() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = test_config(tmp.path());
+        // Operator-origin raw-cmd hook: only name/mailbox/event/origin
+        // must survive the mask; `cmd` / `template` / `params` never
+        // leak to the agent.
+        insert_hook(
+            &mut config,
+            "alice",
+            Some("op_hook"),
+            HookEvent::OnReceive,
+            HookOrigin::Operator,
+            None,
+            &[],
+            "curl secret.example.com",
+        );
+        // MCP-origin template hook: template + params surface.
+        insert_hook(
+            &mut config,
+            "alice",
+            Some("agent_hook"),
+            HookEvent::OnReceive,
+            HookOrigin::Mcp,
+            Some("invoke-claude"),
+            &[("prompt", "hello")],
+            "",
+        );
+
+        let rows = collect_hook_rows(&config, None);
+        let json = serde_json::to_value(&rows).unwrap();
+        let rows_arr = json.as_array().unwrap();
+        assert_eq!(rows_arr.len(), 2);
+
+        let op = rows_arr
+            .iter()
+            .find(|r| r["name"] == "op_hook")
+            .expect("operator hook row");
+        assert_eq!(op["origin"], "operator");
+        assert_eq!(op["mailbox"], "alice");
+        assert_eq!(op["event"], "on_receive");
+        assert!(
+            op.get("template").is_none(),
+            "template must be masked: {op}"
+        );
+        assert!(op.get("params").is_none(), "params must be masked: {op}");
+        // And certainly no cmd.
+        assert!(op.get("cmd").is_none());
+
+        let mcp = rows_arr
+            .iter()
+            .find(|r| r["name"] == "agent_hook")
+            .expect("mcp hook row");
+        assert_eq!(mcp["origin"], "mcp");
+        assert_eq!(mcp["template"], "invoke-claude");
+        assert_eq!(mcp["params"]["prompt"], "hello");
+    }
+
+    #[test]
+    fn collect_hook_rows_filter_by_mailbox() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = test_config(tmp.path());
+        insert_hook(
+            &mut config,
+            "alice",
+            Some("alice_hook"),
+            HookEvent::OnReceive,
+            HookOrigin::Mcp,
+            Some("invoke-claude"),
+            &[("prompt", "a")],
+            "",
+        );
+        insert_hook(
+            &mut config,
+            "catchall",
+            Some("catchall_hook"),
+            HookEvent::OnReceive,
+            HookOrigin::Mcp,
+            Some("invoke-claude"),
+            &[("prompt", "b")],
+            "",
+        );
+        let rows = collect_hook_rows(&config, Some("alice"));
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].name, "alice_hook");
+    }
+
+    #[test]
+    fn collect_hook_rows_uses_effective_name_when_explicit_absent() {
+        let tmp = TempDir::new().unwrap();
+        let mut config = test_config(tmp.path());
+        let mut params = BTreeMap::new();
+        params.insert("prompt".to_string(), "hi".to_string());
+        insert_hook(
+            &mut config,
+            "alice",
+            None, // anonymous — name is derived
+            HookEvent::OnReceive,
+            HookOrigin::Mcp,
+            Some("invoke-claude"),
+            &[("prompt", "hi")],
+            "",
+        );
+        let rows = collect_hook_rows(&config, None);
+        assert_eq!(rows.len(), 1);
+        let expected = derive_template_hook_name(HookEvent::OnReceive, "invoke-claude", &params);
+        assert_eq!(rows[0].name, expected);
+    }
+
+    #[test]
+    fn parse_event_param_accepts_valid() {
+        assert_eq!(
+            parse_event_param("on_receive").unwrap(),
+            HookEvent::OnReceive
+        );
+        assert_eq!(
+            parse_event_param("after_send").unwrap(),
+            HookEvent::AfterSend
+        );
+    }
+
+    #[test]
+    fn parse_event_param_rejects_unknown() {
+        let err = parse_event_param("reboot").unwrap_err();
+        assert!(err.contains("Invalid event"));
+        assert!(err.contains("reboot"));
+    }
+
+    #[test]
+    fn hook_create_params_deserialize_minimal() {
+        let json = r#"{
+            "mailbox": "alice",
+            "event": "on_receive",
+            "template": "invoke-claude",
+            "params": {"prompt": "hello"}
+        }"#;
+        let p: HookCreateParams = serde_json::from_str(json).unwrap();
+        assert_eq!(p.mailbox, "alice");
+        assert_eq!(p.event, "on_receive");
+        assert_eq!(p.template, "invoke-claude");
+        assert_eq!(p.params.get("prompt").unwrap(), "hello");
+        assert!(p.name.is_none());
+    }
+
+    #[test]
+    fn hook_create_params_deserialize_with_name() {
+        let json = r#"{
+            "mailbox": "alice",
+            "event": "after_send",
+            "template": "webhook",
+            "params": {"url": "https://example.com"},
+            "name": "my_hook"
+        }"#;
+        let p: HookCreateParams = serde_json::from_str(json).unwrap();
+        assert_eq!(p.name.as_deref(), Some("my_hook"));
+    }
+
+    #[test]
+    fn hook_list_params_defaults_to_no_filter() {
+        let json = r#"{}"#;
+        let p: HookListParams = serde_json::from_str(json).unwrap();
+        assert!(p.mailbox.is_none());
+    }
+
+    #[test]
+    fn hook_delete_params_requires_name() {
+        let json = r#"{"name": "foo"}"#;
+        let p: HookDeleteParams = serde_json::from_str(json).unwrap();
+        assert_eq!(p.name, "foo");
+    }
+
+    #[test]
+    fn hook_create_response_serializes_fields() {
+        let resp = HookCreateResponse {
+            effective_name: "abc123".to_string(),
+            substituted_argv: vec!["/bin/echo".to_string(), "hi".to_string()],
+        };
+        let json: serde_json::Value = serde_json::to_value(&resp).unwrap();
+        assert_eq!(json["effective_name"], "abc123");
+        assert_eq!(json["substituted_argv"][0], "/bin/echo");
+        assert_eq!(json["substituted_argv"][1], "hi");
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -630,7 +630,8 @@ fn mcp_list_tools() {
 
     let resp = client.list_tools();
     let tools = resp["result"]["tools"].as_array().unwrap();
-    assert_eq!(tools.len(), 9);
+    // 9 mail/mailbox tools + 4 hook tools (Sprint 5).
+    assert_eq!(tools.len(), 13);
 
     let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
     assert!(names.contains(&"mailbox_create"));
@@ -642,6 +643,10 @@ fn mcp_list_tools() {
     assert!(names.contains(&"email_mark_unread"));
     assert!(names.contains(&"email_send"));
     assert!(names.contains(&"email_reply"));
+    assert!(names.contains(&"hook_list_templates"));
+    assert!(names.contains(&"hook_create"));
+    assert!(names.contains(&"hook_list"));
+    assert!(names.contains(&"hook_delete"));
 
     client.shutdown();
 }
@@ -4299,4 +4304,378 @@ fn hooks_create_anonymous_prints_derived_name_via_daemon() {
     );
 
     stop_serve(daemon);
+}
+
+// ---------------------------------------------------------------------
+// Sprint 5: MCP hook tools (hook_list_templates, hook_create, hook_list,
+// hook_delete)
+// ---------------------------------------------------------------------
+
+/// Like `setup_test_env`, but also registers a single `invoke-claude`
+/// template so the Sprint 5 MCP tool tests have something to bind to.
+fn setup_test_env_with_template(tmp: &Path) -> String {
+    let config_content = format!(
+        "domain = \"agent.example.com\"\ndata_dir = \"{}\"\n\n\
+         [[hook_template]]\n\
+         name = \"invoke-claude\"\n\
+         description = \"Test invoke-claude template\"\n\
+         cmd = [\"/usr/bin/true\", \"{{prompt}}\"]\n\
+         params = [\"prompt\"]\n\
+         stdin = \"email\"\n\
+         run_as = \"aimx-hook\"\n\
+         timeout_secs = 60\n\
+         allowed_events = [\"on_receive\", \"after_send\"]\n\n\
+         [mailboxes.catchall]\n\
+         address = \"*@agent.example.com\"\n\n\
+         [mailboxes.alice]\n\
+         address = \"alice@agent.example.com\"\n",
+        tmp.display()
+    );
+    std::fs::create_dir_all(tmp.join("inbox").join("catchall")).unwrap();
+    std::fs::create_dir_all(tmp.join("inbox").join("alice")).unwrap();
+    std::fs::create_dir_all(tmp.join("sent").join("alice")).unwrap();
+    let config_path = tmp.join("config.toml");
+    std::fs::write(&config_path, &config_content).unwrap();
+    install_cached_dkim_keys(tmp);
+    config_path.to_string_lossy().to_string()
+}
+
+/// S5-1: `hook_list_templates` with zero templates returns `[]`.
+#[test]
+fn mcp_hook_list_templates_empty_returns_empty_array() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    let resp = client.call_tool("hook_list_templates", serde_json::json!({}));
+    let text = get_tool_text(&resp);
+    assert_eq!(text, "[]", "empty config must return []: {text}");
+
+    client.shutdown();
+}
+
+/// S5-1: with one template registered, `hook_list_templates` returns
+/// the PRD-specified shape.
+#[test]
+fn mcp_hook_list_templates_returns_registered_template() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env_with_template(tmp.path());
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    let resp = client.call_tool("hook_list_templates", serde_json::json!({}));
+    let text = get_tool_text(&resp);
+    let json: serde_json::Value = serde_json::from_str(&text).unwrap();
+    let arr = json.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["name"], "invoke-claude");
+    assert_eq!(arr[0]["description"], "Test invoke-claude template");
+    assert_eq!(arr[0]["params"][0], "prompt");
+    let events: Vec<&str> = arr[0]["allowed_events"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(events.contains(&"on_receive"));
+    assert!(events.contains(&"after_send"));
+    // Internals must not leak.
+    assert!(arr[0].get("cmd").is_none());
+    assert!(arr[0].get("run_as").is_none());
+    assert!(arr[0].get("timeout_secs").is_none());
+
+    client.shutdown();
+}
+
+/// S5-2: `hook_create` without a running daemon returns a precise
+/// socket-missing error rather than panicking.
+#[test]
+fn mcp_hook_create_without_daemon_reports_missing_socket() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env_with_template(tmp.path());
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    let resp = client.call_tool(
+        "hook_create",
+        serde_json::json!({
+            "mailbox": "alice",
+            "event": "on_receive",
+            "template": "invoke-claude",
+            "params": {"prompt": "hi"}
+        }),
+    );
+    assert!(
+        is_tool_error(&resp),
+        "expected error when daemon missing: {resp}"
+    );
+    let text = get_tool_text(&resp);
+    assert!(
+        text.contains("daemon not running"),
+        "expected socket-missing message: {text}"
+    );
+
+    client.shutdown();
+}
+
+/// S5-2: full round-trip against a live daemon. `hook_create` submits
+/// via UDS, the daemon stamps `origin = "mcp"` in `config.toml`, and
+/// the tool response includes the effective name + substituted argv.
+#[test]
+fn mcp_hook_create_end_to_end_against_daemon() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env_with_template(tmp.path());
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    let resp = client.call_tool(
+        "hook_create",
+        serde_json::json!({
+            "mailbox": "alice",
+            "event": "on_receive",
+            "template": "invoke-claude",
+            "params": {"prompt": "You are an assistant"},
+            "name": "mcp_test_hook"
+        }),
+    );
+    assert!(!is_tool_error(&resp), "expected success, got {resp}");
+    let text = get_tool_text(&resp);
+    let json: serde_json::Value = serde_json::from_str(&text).expect(&text);
+    assert_eq!(json["effective_name"], "mcp_test_hook");
+    assert_eq!(json["substituted_argv"][0], "/usr/bin/true");
+    assert_eq!(json["substituted_argv"][1], "You are an assistant");
+
+    // config.toml must now carry the hook with origin = "mcp".
+    let content = std::fs::read_to_string(tmp.path().join("config.toml")).unwrap();
+    assert!(content.contains("name = \"mcp_test_hook\""), "{content}");
+    assert!(content.contains("origin = \"mcp\""), "{content}");
+    assert!(
+        content.contains("template = \"invoke-claude\""),
+        "{content}"
+    );
+
+    client.shutdown();
+    stop_serve(daemon);
+}
+
+/// S5-2: the daemon's `unknown-template` error surfaces verbatim.
+#[test]
+fn mcp_hook_create_unknown_template_returns_error() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env_with_template(tmp.path());
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    let resp = client.call_tool(
+        "hook_create",
+        serde_json::json!({
+            "mailbox": "alice",
+            "event": "on_receive",
+            "template": "does-not-exist",
+            "params": {}
+        }),
+    );
+    assert!(is_tool_error(&resp));
+    let text = get_tool_text(&resp);
+    assert!(text.contains("Unknown template"), "{text}");
+    assert!(text.contains("hook_list_templates"), "{text}");
+
+    client.shutdown();
+}
+
+/// S5-2: missing required params fail at the pre-flight substitution
+/// check on the MCP side (daemon-side re-validates).
+#[test]
+fn mcp_hook_create_missing_param_returns_error() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env_with_template(tmp.path());
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    let resp = client.call_tool(
+        "hook_create",
+        serde_json::json!({
+            "mailbox": "alice",
+            "event": "on_receive",
+            "template": "invoke-claude",
+            "params": {}
+        }),
+    );
+    assert!(is_tool_error(&resp), "expected error: {resp}");
+    let text = get_tool_text(&resp);
+    // The daemon returns `missing-param: ...`; MCP surfaces verbatim.
+    assert!(text.contains("missing-param"), "{text}");
+
+    client.shutdown();
+    stop_serve(daemon);
+}
+
+/// S5-3: `hook_list` emits an empty array when no hooks are configured.
+#[test]
+fn mcp_hook_list_empty_returns_empty_array() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env_with_template(tmp.path());
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    let resp = client.call_tool("hook_list", serde_json::json!({}));
+    let text = get_tool_text(&resp);
+    assert_eq!(text, "[]", "{text}");
+
+    client.shutdown();
+}
+
+/// S5-3: origin-masking is enforced end-to-end. Operator-origin hooks
+/// written to `config.toml` expose only name/mailbox/event/origin;
+/// MCP-origin hooks (created via the daemon in this test) expose the
+/// template + params too.
+#[test]
+fn mcp_hook_list_masks_operator_origin() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env_with_template(tmp.path());
+
+    // Append an operator-origin hook to the config before spinning up.
+    let config_path = tmp.path().join("config.toml");
+    let existing = std::fs::read_to_string(&config_path).unwrap();
+    let extra = "\n[[mailboxes.alice.hooks]]\nname = \"op_hook\"\n\
+                 event = \"on_receive\"\ncmd = \"echo operator-secret\"\n\
+                 origin = \"operator\"\n";
+    std::fs::write(&config_path, format!("{existing}{extra}")).unwrap();
+
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    // Create an MCP-origin hook alongside the operator one.
+    let resp = client.call_tool(
+        "hook_create",
+        serde_json::json!({
+            "mailbox": "alice",
+            "event": "on_receive",
+            "template": "invoke-claude",
+            "params": {"prompt": "agent secret"},
+            "name": "mcp_hook"
+        }),
+    );
+    assert!(!is_tool_error(&resp), "{resp}");
+
+    // Now query hook_list.
+    let resp = client.call_tool("hook_list", serde_json::json!({}));
+    let text = get_tool_text(&resp);
+    let json: serde_json::Value = serde_json::from_str(&text).expect(&text);
+    let rows = json.as_array().unwrap();
+    assert_eq!(rows.len(), 2);
+
+    let op = rows.iter().find(|r| r["name"] == "op_hook").unwrap();
+    assert_eq!(op["origin"], "operator");
+    assert_eq!(op["mailbox"], "alice");
+    // Masking: the operator's cmd / template / params must not appear
+    // in the MCP-facing row.
+    assert!(op.get("template").is_none(), "{op}");
+    assert!(op.get("params").is_none(), "{op}");
+    assert!(op.get("cmd").is_none(), "{op}");
+    // And operator's command text must not appear anywhere in the
+    // serialized payload.
+    assert!(
+        !text.contains("operator-secret"),
+        "operator cmd leaked via hook_list: {text}"
+    );
+
+    let mcp = rows.iter().find(|r| r["name"] == "mcp_hook").unwrap();
+    assert_eq!(mcp["origin"], "mcp");
+    assert_eq!(mcp["template"], "invoke-claude");
+    assert_eq!(mcp["params"]["prompt"], "agent secret");
+
+    client.shutdown();
+    stop_serve(daemon);
+}
+
+/// S5-4: `hook_delete` on an MCP-origin hook succeeds; on an operator-
+/// origin hook the daemon's `origin-protected` message surfaces verbatim.
+#[test]
+fn mcp_hook_delete_respects_origin_protection() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env_with_template(tmp.path());
+
+    // Plant an operator-origin hook on disk before starting the daemon.
+    let config_path = tmp.path().join("config.toml");
+    let existing = std::fs::read_to_string(&config_path).unwrap();
+    let extra = "\n[[mailboxes.alice.hooks]]\nname = \"op_hook\"\n\
+                 event = \"on_receive\"\ncmd = \"echo operator\"\n\
+                 origin = \"operator\"\n";
+    std::fs::write(&config_path, format!("{existing}{extra}")).unwrap();
+
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    // Create an MCP-origin hook to delete.
+    let resp = client.call_tool(
+        "hook_create",
+        serde_json::json!({
+            "mailbox": "alice",
+            "event": "on_receive",
+            "template": "invoke-claude",
+            "params": {"prompt": "hi"},
+            "name": "mcp_hook"
+        }),
+    );
+    assert!(!is_tool_error(&resp), "{resp}");
+
+    // Delete MCP-origin hook: success.
+    let resp = client.call_tool("hook_delete", serde_json::json!({"name": "mcp_hook"}));
+    assert!(!is_tool_error(&resp), "{resp}");
+    let text = get_tool_text(&resp);
+    assert!(text.contains("deleted"), "{text}");
+
+    // Delete operator-origin hook: daemon returns origin-protected.
+    let resp = client.call_tool("hook_delete", serde_json::json!({"name": "op_hook"}));
+    assert!(is_tool_error(&resp), "{resp}");
+    let text = get_tool_text(&resp);
+    assert!(text.contains("origin-protected"), "{text}");
+    assert!(text.contains("sudo aimx hooks delete"), "{text}");
+
+    // The operator hook must still be present on disk.
+    let content = std::fs::read_to_string(&config_path).unwrap();
+    assert!(
+        content.contains("name = \"op_hook\""),
+        "operator hook must survive protected-delete attempt: {content}"
+    );
+
+    client.shutdown();
+    stop_serve(daemon);
+}
+
+/// S5-4: `hook_delete` without a running daemon returns a precise
+/// socket-missing error.
+#[test]
+fn mcp_hook_delete_without_daemon_reports_missing_socket() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env_with_template(tmp.path());
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    let resp = client.call_tool("hook_delete", serde_json::json!({"name": "anything"}));
+    assert!(is_tool_error(&resp));
+    let text = get_tool_text(&resp);
+    assert!(text.contains("daemon not running"), "{text}");
+
+    client.shutdown();
 }


### PR DESCRIPTION
## Sprint Goal
Expose the hook-templates model through four new MCP tools and refresh the agent-facing primer so every bundled agent knows how to use them.

## Stories Implemented

### [S5-1] MCP `hook_list_templates` tool
- [x] `#[tool(name = "hook_list_templates", ...)]` method on `AimxMcpServer`
- [x] Returns serialized JSON array; no params struct needed
- [x] Empty-config case returns `[]`
- [x] Unit tests for empty + populated + golden shape
- [x] `cargo test` / `clippy` / `fmt` clean

### [S5-2] MCP `hook_create` tool
- [x] `HookCreateParams` struct `{mailbox, event, template, params, name?}` with `#[schemars(description = ...)]`
- [x] Submits via `hook_client::submit_hook_template_create_via_daemon`; surfaces daemon errors verbatim
- [x] Pre-flights missing/unknown params and substitution errors client-side with the same wording the daemon uses, so the agent gets the clearest possible error
- [x] Returns `{effective_name, substituted_argv}` on success (computed client-side — the UDS verb itself returns bare `AIMX/1 OK`, so we mirror the deterministic derivation the daemon performs)
- [x] Tool description spells out the safety model ("your agent cannot submit arbitrary shell — every hook must reference a template")
- [x] Integration test spins up a live daemon, submits `hook_create`, verifies `origin = "mcp"` landed in `config.toml`
- [x] `cargo test` / `clippy` / `fmt` clean

### [S5-3] MCP `hook_list` tool with origin-masked output
- [x] `HookListParams { mailbox: Option<String> }`
- [x] Operator-origin rows: `{name, mailbox, event, origin: "operator"}` only
- [x] MCP-origin rows: `{name, mailbox, event, template, params, origin: "mcp"}`
- [x] Tool description explains the origin split
- [x] Integration test plants an operator-origin hook on disk, creates an MCP-origin hook via the daemon, asserts both masking rules (including that operator command text never leaks into the serialized payload)
- [x] `cargo test` / `clippy` / `fmt` clean

### [S5-4] MCP `hook_delete` tool
- [x] `HookDeleteParams { name: String }`; thin wrapper over `submit_hook_delete_via_daemon`
- [x] Daemon error bodies surface verbatim; tool description shows the `ERR origin-protected` case
- [x] Integration test: succeeds on MCP-origin hook; refuses operator-origin with `origin-protected` pointing at `sudo aimx hooks delete`
- [x] `cargo test` / `clippy` / `fmt` clean

### [S5-5] Update agent primer + references with "Creating hooks" section
- [x] `agents/common/aimx-primer.md` gains a Hook tools quick-reference in the MCP tools list, a new "Creating hooks" section explaining the template model and the four-tool workflow, and updated Further Reading / reference cross-links
- [x] New `agents/common/references/hooks.md`: full tool signatures, the template schema, worked example prompts ("file + reply", "webhook on outbound"), the origin split, a troubleshooting subsection (trust gate / unknown template / origin-protected / non-zero exit)
- [x] Updated `agents/common/references/mcp-tools.md` with entries for all four new tools
- [x] Updated `agents/common/references/troubleshooting.md` with a Hook-related errors section that cross-links to `hooks.md`
- [x] `include_dir!` automatically bundles `references/hooks.md` into every progressive-disclosure agent (Claude Code, Codex, OpenClaw, Hermes); non-progressive bundles (Gemini, Goose, OpenCode) pick up the primer text
- [x] New unit tests guard the primer `## Creating hooks` section, the bundled reference file's completeness, and that progressive-disclosure bundles copy `hooks.md`
- [x] `cargo test` / `clippy` / `fmt` clean

## Technical Decisions

- **Client-side computation of `effective_name` and `substituted_argv`.** The tightened UDS `HOOK-CREATE` verb returns bare `AIMX/1 OK` on success. Rather than extending the wire protocol to echo these back, the MCP tool computes them the same way the daemon does (`derive_template_hook_name` for the name, `substitute_argv` for the argv). Both are pure deterministic functions of inputs the caller already supplied, so the two views cannot drift.
- **Pre-flight validation on the MCP side before UDS submission.** Missing-param / unknown-param / event-not-allowed / unknown-mailbox / unknown-template checks run client-side first, using the exact same error wording the daemon uses (`missing-param: ...`, `unknown-param: ...`). This gives the agent the clearest possible error without a UDS round-trip, while the daemon still re-validates under its write lock so the check is advisory, not load-bearing.
- **Origin masking enforced by construction, not by filtering.** `HookListRow` is a struct where `template` / `params` are `Option`s that only get populated for MCP-origin rows. `#[serde(skip_serializing_if = "Option::is_none")]` means the masked fields are never emitted at all, so an integration test that greps the serialized payload for operator command text confirms nothing leaks.
- **Reference file naming / placement.** `agents/common/references/hooks.md` slots cleanly into the existing four-file references set, so no `include_dir!` / bundle-assembly changes are needed — it is picked up automatically on the next build.

## Deferred Items

- **`origin` semantics documentation pass.** The Sprint 3 backlog note flagged that `origin` is a submission-channel marker, not an authorship marker (CLI `--template` hooks also carry `origin = "mcp"`). The `hook_delete` tool description calls this out; a broader PRD §6.5 / §6.6 / §11 Q2 rewrite is deferred to a follow-up doc pass per the sprint plan.

## Review Focus Areas

- `src/mcp.rs` — the four new tools plus the `HookTemplateView` / `HookListRow` / `HookCreateResponse` view structs and `collect_hook_rows`. Look for: (a) any accidental leak of operator-origin fields, (b) whether the client-side pre-flight is faithful to `src/hook_handler.rs::handle_hook_create`.
- `agents/common/references/hooks.md` — new agent-facing documentation. Verify the worked examples are self-contained and the troubleshooting subsection maps to actual error strings.
- `tests/integration.rs` — the 10 new `mcp_hook_*` tests. `mcp_hook_list_masks_operator_origin` is the canonical leak test; `mcp_hook_delete_respects_origin_protection` is the canonical authz test. Both plant an operator-origin hook on disk and exercise the full daemon path.

## Test Run

- `cargo test` → 997 unit + 94 integration tests passing (0 failures, 3 ignored = pre-existing)
- `cargo clippy --all-targets -- -D warnings` clean
- `cargo fmt -- --check` clean
- Verifier service (`services/verifier/`) → 43 tests passing; clippy + fmt clean