### PR TITLE
fix(smtp): reject RCPT TO for unrelated domains

### DIFF
--- a/book/mailboxes.md
+++ b/book/mailboxes.md
@@ -32,10 +32,14 @@ as a sibling file when attachments are present.
 
 When an email arrives, aimx matches the local part of the recipient address (the part before `@`) against mailbox names in the config. If a mailbox with that exact name exists, the email is delivered there. Otherwise it falls through to the `catchall` mailbox.
 
+RCPT TO addresses whose domain is not the configured `domain` (case-insensitive exact match) are rejected at SMTP time with `550 5.7.1 relay not permitted` and never reach storage. aimx is not an open relay: `catchall` only covers unrecognized local parts *at your configured domain*, not unrelated domains or subdomains.
+
 For example, with mailboxes `support` and `catchall` configured:
 - `support@agent.yourdomain.com` -> delivered to the `support` mailbox
 - `billing@agent.yourdomain.com` -> delivered to the `catchall` mailbox (no `billing` mailbox exists)
 - `anything@agent.yourdomain.com` -> delivered to the `catchall` mailbox
+- `anything@some-other-domain.com` -> rejected at RCPT TO with `550 5.7.1 relay not permitted`
+- `anything@sub.agent.yourdomain.com` -> rejected at RCPT TO with `550 5.7.1 relay not permitted`
 
 ## Managing mailboxes
 

--- a/src/smtp/session.rs
+++ b/src/smtp/session.rs
@@ -373,6 +373,14 @@ impl SmtpSession {
         if addr.is_empty() {
             return "501 Syntax: RCPT TO:<address>\r\n".to_string();
         }
+        let configured_domain = self.params.config_handle.load().domain.clone();
+        if !recipient_domain_matches(&addr, &configured_domain) {
+            eprintln!(
+                "[{}] RCPT rejected (relay): recipient={} configured_domain={}",
+                self.params.peer_addr, addr, configured_domain
+            );
+            return "550 5.7.1 relay not permitted\r\n".to_string();
+        }
         session_state.forward_paths.push(addr);
         session_state.state = State::RcptTo;
         "250 OK\r\n".to_string()
@@ -649,6 +657,16 @@ fn extract_angle_addr(s: &str) -> String {
     s.to_string()
 }
 
+fn recipient_domain_matches(addr: &str, configured_domain: &str) -> bool {
+    let Some((_, domain)) = addr.rsplit_once('@') else {
+        return false;
+    };
+    if domain.is_empty() {
+        return false;
+    }
+    domain.eq_ignore_ascii_case(configured_domain)
+}
+
 #[cfg(test)]
 mod unit_tests {
     use super::*;
@@ -682,5 +700,53 @@ mod unit_tests {
         );
         assert_eq!(extract_angle_addr("<>"), "");
         assert_eq!(extract_angle_addr("user@example.com"), "user@example.com");
+    }
+
+    #[test]
+    fn recipient_domain_matches_exact() {
+        assert!(recipient_domain_matches("alice@test.local", "test.local"));
+    }
+
+    #[test]
+    fn recipient_domain_matches_case_insensitive() {
+        assert!(recipient_domain_matches("alice@TEST.LOCAL", "test.local"));
+        assert!(recipient_domain_matches("ALICE@test.local", "test.local"));
+        assert!(recipient_domain_matches("alice@test.local", "TEST.LOCAL"));
+    }
+
+    #[test]
+    fn recipient_domain_matches_rejects_different_domain() {
+        assert!(!recipient_domain_matches("alice@other.com", "test.local"));
+    }
+
+    #[test]
+    fn recipient_domain_matches_rejects_subdomain() {
+        assert!(!recipient_domain_matches(
+            "alice@sub.test.local",
+            "test.local"
+        ));
+    }
+
+    #[test]
+    fn recipient_domain_matches_rejects_parent_domain() {
+        assert!(!recipient_domain_matches("alice@local", "test.local"));
+    }
+
+    #[test]
+    fn recipient_domain_matches_rejects_missing_at() {
+        assert!(!recipient_domain_matches("alice", "test.local"));
+    }
+
+    #[test]
+    fn recipient_domain_matches_rejects_empty_domain() {
+        assert!(!recipient_domain_matches("alice@", "test.local"));
+    }
+
+    #[test]
+    fn recipient_domain_matches_quoted_local_part() {
+        assert!(recipient_domain_matches(
+            "\"weird@name\"@test.local",
+            "test.local"
+        ));
     }
 }

--- a/src/smtp/tests.rs
+++ b/src/smtp/tests.rs
@@ -390,6 +390,154 @@ async fn test_double_mail_from() {
     assert!(resp.starts_with("503"));
 }
 
+// --- Relay rejection: RCPT TO for domains other than config.domain ---
+
+#[tokio::test]
+async fn test_rcpt_rejects_unrelated_domain() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    client.send_and_read("EHLO client.example.com").await;
+    client.send_and_read("MAIL FROM:<sender@example.com>").await;
+
+    let resp = client.send_and_read("RCPT TO:<user@evil.example>").await;
+    assert!(
+        resp.starts_with("550 5.7.1"),
+        "Expected 550 5.7.1 for relay reject: {resp}"
+    );
+
+    let resp = client.send_and_read("DATA").await;
+    assert!(
+        resp.starts_with("503"),
+        "Expected 503 when no RCPT accepted: {resp}"
+    );
+
+    client.send_and_read("QUIT").await;
+
+    let catchall_dir = inbox(tmp.path(), "catchall");
+    let md_files = collect_md_files(&catchall_dir);
+    assert_eq!(
+        md_files.len(),
+        0,
+        "No file should land in catchall for rejected RCPT"
+    );
+}
+
+#[tokio::test]
+async fn test_rcpt_rejects_subdomain() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    client.send_and_read("EHLO client.example.com").await;
+    client.send_and_read("MAIL FROM:<sender@example.com>").await;
+
+    let resp = client.send_and_read("RCPT TO:<user@sub.test.local>").await;
+    assert!(
+        resp.starts_with("550 5.7.1"),
+        "Expected 550 5.7.1 for subdomain reject: {resp}"
+    );
+
+    client.send_and_read("QUIT").await;
+
+    let catchall_dir = inbox(tmp.path(), "catchall");
+    let md_files = collect_md_files(&catchall_dir);
+    assert_eq!(md_files.len(), 0);
+}
+
+#[tokio::test]
+async fn test_rcpt_rejects_missing_at() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    client.send_and_read("EHLO client.example.com").await;
+    client.send_and_read("MAIL FROM:<sender@example.com>").await;
+
+    let resp = client.send_and_read("RCPT TO:<alice>").await;
+    assert!(
+        resp.starts_with("550 5.7.1"),
+        "Expected 550 5.7.1 for missing-@ reject: {resp}"
+    );
+
+    client.send_and_read("QUIT").await;
+}
+
+#[tokio::test]
+async fn test_rcpt_mixed_valid_invalid() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    client.send_and_read("EHLO client.example.com").await;
+    client.send_and_read("MAIL FROM:<sender@example.com>").await;
+
+    let resp = client.send_and_read("RCPT TO:<alice@test.local>").await;
+    assert!(resp.starts_with("250"), "Expected 250 for alice: {resp}");
+
+    let resp = client.send_and_read("RCPT TO:<mallory@evil.example>").await;
+    assert!(
+        resp.starts_with("550 5.7.1"),
+        "Expected 550 5.7.1 for evil.example: {resp}"
+    );
+
+    let resp = client.send_and_read("DATA").await;
+    assert!(
+        resp.starts_with("354"),
+        "Expected 354 (one accepted RCPT is enough): {resp}"
+    );
+
+    client.send(test_email()).await;
+    let resp = client.send_and_read(".").await;
+    assert!(resp.starts_with("250"), "Expected 250 on DATA end: {resp}");
+
+    client.send_and_read("QUIT").await;
+
+    let alice_mds = collect_md_files(&inbox(tmp.path(), "alice"));
+    let catchall_mds = collect_md_files(&inbox(tmp.path(), "catchall"));
+    assert_eq!(alice_mds.len(), 1, "alice should have one message");
+    assert_eq!(catchall_mds.len(), 0, "catchall should have nothing");
+}
+
+#[tokio::test]
+async fn test_rcpt_accepts_case_insensitive_domain() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    client.send_and_read("EHLO client.example.com").await;
+    client.send_and_read("MAIL FROM:<sender@example.com>").await;
+
+    let resp = client.send_and_read("RCPT TO:<alice@TEST.LOCAL>").await;
+    assert!(
+        resp.starts_with("250"),
+        "Expected 250 for case-insensitive domain: {resp}"
+    );
+
+    let resp = client.send_and_read("DATA").await;
+    assert!(resp.starts_with("354"), "Expected 354: {resp}");
+
+    client.send(test_email()).await;
+    let resp = client.send_and_read(".").await;
+    assert!(resp.starts_with("250"), "Expected 250: {resp}");
+
+    client.send_and_read("QUIT").await;
+
+    let alice_mds = collect_md_files(&inbox(tmp.path(), "alice"));
+    assert_eq!(alice_mds.len(), 1);
+}
+
 // --- S19.1: Size limit tests ---
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Close the open-relay-adjacent ingestion vector by rejecting SMTP `RCPT TO` recipients whose domain is not `config.domain`. Previously, any address at `RCPT TO` was accepted and fell through to `catchall` for unknown local parts — so `anything@totally-unrelated-domain.com` was happily stored in `inbox/catchall/`. Now, if the recipient's domain is not the configured domain (case-insensitive, exact match), the server replies `550 5.7.1 relay not permitted` and does not enqueue the recipient.

## Requirements

- [x] RCPT TO with a recipient whose domain matches `config.domain` case-insensitively is accepted with the existing `250 OK`.
- [x] RCPT TO with a recipient whose domain does not exactly match `config.domain` (including unrelated domains and any subdomain) is rejected with `550 5.7.1 relay not permitted\r\n` and not added to `session_state.forward_paths`.
- [x] RCPT TO with an address that has no `@` is rejected with the same `550 5.7.1 relay not permitted\r\n`.
- [x] Empty-angle-addr `RCPT TO:<>` continues to return `501 Syntax: RCPT TO:<address>` (existing behavior, unchanged).
- [x] Multi-recipient transactions: a rejected recipient does not block subsequent RCPT TOs, and a transaction with at least one accepted recipient still proceeds to DATA.
- [x] A session whose only RCPT TOs were all rejected continues to refuse DATA with `503 Send RCPT TO first` (state never advances to RcptTo).
- [x] Rejected RCPT TO is logged to stderr with peer address, attempted recipient, and configured domain.
- [x] Existing SMTP integration tests and `tests/integration.rs` pass unchanged.
- [x] `book/mailboxes.md` explicitly documents that RCPT TO for other domains is rejected at SMTP time.

## Out of scope

- Submission-port (587/465) authentication — aimx has no submission port; outbound goes through the UDS signing boundary.
- SPF / DKIM / DMARC policy — those still gate hook firing, not storage.
- Accepting subdomains of `config.domain` — deliberately rejected (one-domain-per-instance layout).
- Configurable reject-code or per-operator allowlists of extra domains.
- Changes to `resolve_mailbox()` / `extract_local_part()` — the domain check runs earlier, at RCPT TO.
- Rate-limiting, blocklists, greylisting.
- IDN normalization beyond ASCII lowercasing — `config.domain` is stored as a plain string and compared case-insensitively.

## Technical approach

- Added `recipient_domain_matches(addr, configured_domain)` helper in `src/smtp/session.rs`. Uses `rsplit_once('@')` so quoted local parts split on the final `@`, and `eq_ignore_ascii_case` per RFC 5321 §2.3.11. Returns `false` for addresses with no `@` or an empty domain part.
- Wired into `SmtpSession::handle_rcpt_to` immediately after `extract_angle_addr` returns a non-empty address and before `session_state.forward_paths.push`. Uses `self.params.config_handle.load().domain` so hot-swapped configs (MAILBOX-* between EHLO and DATA) would be honoured.
- Rejection path: `eprintln!` the peer / recipient / configured_domain, return `550 5.7.1 relay not permitted\r\n`. State is untouched so subsequent RCPT TOs still work and DATA with zero accepted recipients still 503s (via the existing `handle_data_precheck`).
- Doc update in `book/mailboxes.md` under "Routing logic" — added an explicit sentence plus two example bullets for the reject cases (other domain, subdomain).

## Test plan

Unit tests added in `src/smtp/session.rs::unit_tests` (all pass):
- `recipient_domain_matches_exact`
- `recipient_domain_matches_case_insensitive`
- `recipient_domain_matches_rejects_different_domain`
- `recipient_domain_matches_rejects_subdomain`
- `recipient_domain_matches_rejects_parent_domain`
- `recipient_domain_matches_rejects_missing_at`
- `recipient_domain_matches_rejects_empty_domain`
- `recipient_domain_matches_quoted_local_part`

SMTP integration tests added in `src/smtp/tests.rs` (all pass):
- `test_rcpt_rejects_unrelated_domain` — `user@evil.example` rejected with `550 5.7.1`; DATA returns 503; no file in `inbox/catchall/`.
- `test_rcpt_rejects_subdomain` — `user@sub.test.local` rejected.
- `test_rcpt_rejects_missing_at` — `<alice>` rejected with `550 5.7.1` (policy reject, not 501).
- `test_rcpt_mixed_valid_invalid` — alice accepted, mallory@evil.example rejected, DATA proceeds; one `.md` in `inbox/alice/`, zero in `inbox/catchall/`.
- `test_rcpt_accepts_case_insensitive_domain` — `alice@TEST.LOCAL` accepted; file lands in `inbox/alice/`.

Results:
- `cargo fmt -- --check`: clean.
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo test`: 1026 unit/bin tests pass; 95 integration tests pass (one pre-existing flake unrelated to this change — `after_send_hook_fires_with_delivered_status` intermittently times out waiting for a UDS socket under heavy parallel load; passes in isolation and on a second run).

## Notes

- The check runs against `config_handle.load().domain` per RCPT TO, so any future hot-swap that changes `domain` mid-session would be honoured on the next RCPT line.
- No new dependencies; logic is pure ASCII case-insensitive string compare.
