### PR TITLE
feat(ingest): add tracing logs for trust eval and hook dispatch

### DIFF
--- a/src/hook.rs
+++ b/src/hook.rs
@@ -398,9 +398,29 @@ pub fn should_fire_on_receive(hook: &Hook, email_trusted: TrustedValue) -> bool 
 /// propagate.
 pub fn execute_on_receive(config: &Config, mailbox_config: &MailboxConfig, ctx: &OnReceiveContext) {
     let email_trusted = parse_trusted(&ctx.metadata.trusted);
+    let mailbox_name = &ctx.metadata.mailbox;
 
-    for hook in mailbox_config.on_receive_hooks() {
+    let hooks: Vec<&Hook> = mailbox_config.on_receive_hooks().collect();
+    if hooks.is_empty() {
+        tracing::info!(
+            target: "aimx::hook",
+            "No hooks found for event=on_receive mailbox={mailbox}",
+            mailbox = mailbox_name,
+        );
+        return;
+    }
+
+    for hook in hooks {
         if !should_fire_on_receive(hook, email_trusted) {
+            let hook_name = effective_hook_name(hook);
+            tracing::info!(
+                target: "aimx::hook",
+                "hook_name={hook_name} event=on_receive mailbox={mailbox} skipped: trusted={trusted} dangerously_support_untrusted={dangerous}",
+                hook_name = hook_name,
+                mailbox = mailbox_name,
+                trusted = email_trusted.as_str(),
+                dangerous = hook.dangerously_support_untrusted,
+            );
             continue;
         }
 
@@ -443,7 +463,17 @@ pub fn execute_on_receive(config: &Config, mailbox_config: &MailboxConfig, ctx: 
 /// The daemon awaits subprocess completion for predictable timing, but exit
 /// codes are discarded (hooks cannot affect delivery).
 pub fn execute_after_send(config: &Config, mailbox_config: &MailboxConfig, ctx: &AfterSendContext) {
-    for hook in mailbox_config.after_send_hooks() {
+    let hooks: Vec<&Hook> = mailbox_config.after_send_hooks().collect();
+    if hooks.is_empty() {
+        tracing::info!(
+            target: "aimx::hook",
+            "No hooks found for event=after_send mailbox={mailbox}",
+            mailbox = ctx.mailbox,
+        );
+        return;
+    }
+
+    for hook in hooks {
         let hook_name = effective_hook_name(hook);
         let send_status = ctx.send_status.as_str();
 
@@ -560,6 +590,21 @@ fn run_and_log(
         .map(|t| t.stdin)
         .unwrap_or(HookTemplateStdin::Email);
     let stdin_payload = build_stdin(stdin_mode, stdin_source);
+
+    let pre_fire_template_tag = hook
+        .template
+        .as_deref()
+        .map(|s| s.to_string())
+        .unwrap_or_else(|| "-".to_string());
+    tracing::info!(
+        target: "aimx::hook",
+        "firing hook_name={hook_name} event={event} mailbox={mailbox} template={template_tag} run_as={run_as}",
+        hook_name = hook_name,
+        event = hook.event.as_str(),
+        mailbox = mailbox,
+        template_tag = pre_fire_template_tag,
+        run_as = run_as,
+    );
 
     // --- Spawn -------------------------------------------------------------
     let outcome_result = spawn_sandboxed(&argv, stdin_payload, &run_as, timeout, env);
@@ -1775,5 +1820,157 @@ cmd = "echo legacy"
             "log line should carry template=echoer"
         );
         assert!(std::fs::read_to_string(&out_path).unwrap().contains("hi"));
+    }
+
+    #[tracing_test::traced_test]
+    #[test]
+    fn execute_on_receive_zero_hooks_emits_no_hooks_log() {
+        let mailbox = MailboxConfig {
+            address: "*@test.com".to_string(),
+            hooks: vec![],
+            trust: Some("none".to_string()),
+            trusted_senders: Some(vec![]),
+        };
+        let meta = sample_metadata();
+        let tmp = tempfile::TempDir::new().unwrap();
+        let filepath = tmp.path().join("test.md");
+        let ctx = OnReceiveContext {
+            filepath: &filepath,
+            metadata: &meta,
+        };
+        execute_on_receive(&sample_config(), &mailbox, &ctx);
+
+        assert!(logs_contain("aimx::hook"));
+        assert!(logs_contain(
+            "No hooks found for event=on_receive mailbox=catchall"
+        ));
+    }
+
+    #[tracing_test::traced_test]
+    #[test]
+    fn execute_on_receive_skipped_by_gate_emits_skip_log() {
+        // A regular hook with trusted=none fails the trust gate, so it
+        // must emit the skip log rather than fire.
+        let tmp = tempfile::TempDir::new().unwrap();
+        let marker = tmp.path().join("fired");
+        let mut hook = basic_hook("gated");
+        hook.cmd = format!("touch {}", marker.display());
+        let mailbox = MailboxConfig {
+            address: "*@test.com".to_string(),
+            hooks: vec![hook],
+            trust: Some("none".to_string()),
+            trusted_senders: Some(vec![]),
+        };
+        let mut meta = sample_metadata();
+        meta.trusted = "none".to_string();
+        let filepath = tmp.path().join("test.md");
+        let ctx = OnReceiveContext {
+            filepath: &filepath,
+            metadata: &meta,
+        };
+        execute_on_receive(&sample_config(), &mailbox, &ctx);
+
+        assert!(!marker.exists(), "gated hook must not fire");
+        assert!(logs_contain("hook_name=gated"));
+        assert!(logs_contain("event=on_receive"));
+        assert!(logs_contain("mailbox=catchall"));
+        assert!(logs_contain("skipped"));
+        assert!(logs_contain("trusted=none"));
+        assert!(logs_contain("dangerously_support_untrusted=false"));
+    }
+
+    #[tracing_test::traced_test]
+    #[test]
+    fn execute_on_receive_emits_pre_fire_log_before_summary() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let marker = tmp.path().join("fired");
+        let mut hook = basic_hook("firing_hook");
+        hook.cmd = format!("touch {}", marker.display());
+        let mailbox = MailboxConfig {
+            address: "*@test.com".to_string(),
+            hooks: vec![hook],
+            trust: Some("none".to_string()),
+            trusted_senders: Some(vec![]),
+        };
+        let mut meta = sample_metadata();
+        meta.trusted = "true".to_string();
+        let filepath = tmp.path().join("test.md");
+        std::fs::write(&filepath, b"test\n").ok();
+        let ctx = OnReceiveContext {
+            filepath: &filepath,
+            metadata: &meta,
+        };
+        execute_on_receive(&sample_config(), &mailbox, &ctx);
+
+        assert!(marker.exists());
+        assert!(logs_contain("firing hook_name=firing_hook"));
+        assert!(logs_contain("event=on_receive"));
+        assert!(logs_contain("mailbox=catchall"));
+        // Post-fire summary is still emitted.
+        assert!(logs_contain("exit_code="));
+    }
+
+    #[tracing_test::traced_test]
+    #[test]
+    fn execute_after_send_zero_hooks_emits_no_hooks_log() {
+        let mailbox = MailboxConfig {
+            address: "alice@test.com".to_string(),
+            hooks: vec![],
+            trust: None,
+            trusted_senders: None,
+        };
+        let ctx = AfterSendContext {
+            mailbox: "alice",
+            from: "alice@test.com",
+            to: "bob@example.com",
+            subject: "Hi",
+            filepath: "",
+            message_id: "<m@test.com>",
+            send_status: SendStatus::Delivered,
+        };
+        execute_after_send(&sample_config(), &mailbox, &ctx);
+
+        assert!(logs_contain(
+            "No hooks found for event=after_send mailbox=alice"
+        ));
+    }
+
+    #[tracing_test::traced_test]
+    #[test]
+    fn execute_after_send_emits_pre_fire_log() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let marker = tmp.path().join("fired");
+        let hook = Hook {
+            name: Some("after_hook".to_string()),
+            event: HookEvent::AfterSend,
+            r#type: "cmd".to_string(),
+            cmd: format!("touch {}", marker.display()),
+            dangerously_support_untrusted: false,
+            origin: crate::hook::HookOrigin::Operator,
+            template: None,
+            params: std::collections::BTreeMap::new(),
+            run_as: None,
+        };
+        let mailbox = MailboxConfig {
+            address: "alice@test.com".to_string(),
+            hooks: vec![hook],
+            trust: None,
+            trusted_senders: None,
+        };
+        let ctx = AfterSendContext {
+            mailbox: "alice",
+            from: "alice@test.com",
+            to: "bob@example.com",
+            subject: "Hi",
+            filepath: "",
+            message_id: "<m@test.com>",
+            send_status: SendStatus::Delivered,
+        };
+        execute_after_send(&sample_config(), &mailbox, &ctx);
+
+        assert!(marker.exists());
+        assert!(logs_contain("firing hook_name=after_hook"));
+        assert!(logs_contain("event=after_send"));
+        assert!(logs_contain("mailbox=alice"));
     }
 }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -13,6 +13,11 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 pub fn run(rcpt: &str, config: Config) -> Result<(), Box<dyn std::error::Error>> {
+    // Install the shared tracing subscriber so the INFO/WARN lines emitted
+    // below land on stderr for the manual stdin path. `aimx serve` installs
+    // the subscriber itself before any in-process ingest runs, so we do not
+    // call `logging::init` from `ingest_email`.
+    crate::logging::init();
     let mut raw = Vec::new();
     std::io::stdin().read_to_end(&mut raw)?;
     // Manual stdin path: no SMTP session, so received_from_ip is the
@@ -48,9 +53,19 @@ pub fn ingest_email(
 
     std::fs::create_dir_all(&inbox_dir)?;
 
-    let message = MessageParser::default()
-        .parse(raw)
-        .ok_or("Failed to parse email")?;
+    let message = match MessageParser::default().parse(raw) {
+        Some(m) => m,
+        None => {
+            tracing::warn!(
+                target: "aimx::ingest",
+                "Failed to parse email rcpt={rcpt} mailbox={mailbox} size_bytes={size}",
+                rcpt = rcpt,
+                mailbox = mailbox,
+                size = raw.len(),
+            );
+            return Err("Failed to parse email".into());
+        }
+    };
 
     let from = message
         .from()
@@ -64,6 +79,15 @@ pub fn ingest_email(
                 .unwrap_or_default()
         })
         .unwrap_or_default();
+
+    tracing::info!(
+        target: "aimx::ingest",
+        "received email rcpt={rcpt} mailbox={mailbox} size_bytes={size} from={from}",
+        rcpt = rcpt,
+        mailbox = mailbox,
+        size = raw.len(),
+        from = from,
+    );
 
     let to = message
         .to()
@@ -157,6 +181,15 @@ pub fn ingest_email(
 
     let auth_results = verify_auth(raw, received_from_ip, envelope_mail_from);
 
+    tracing::info!(
+        target: "aimx::ingest",
+        "auth result dkim={dkim} spf={spf} dmarc={dmarc} rcpt={rcpt}",
+        dkim = auth_results.dkim,
+        spf = auth_results.spf,
+        dmarc = auth_results.dmarc,
+        rcpt = rcpt,
+    );
+
     let trusted_value = config
         .mailboxes
         .get(&mailbox)
@@ -207,7 +240,14 @@ pub fn ingest_email(
         }
     };
 
-    let attachments = write_attachments(&parent_dir, prepared_attachments).inspect_err(|_| {
+    let attachments = write_attachments(&parent_dir, prepared_attachments).inspect_err(|e| {
+        tracing::warn!(
+            target: "aimx::ingest",
+            "attachment write failed mailbox={mailbox} path={path}: {err}",
+            mailbox = mailbox,
+            path = parent_dir.display(),
+            err = e,
+        );
         cleanup_bundle();
     })?;
 
@@ -248,9 +288,27 @@ pub fn ingest_email(
         labels: vec![],
     };
 
-    write_markdown(&md_path, &meta, &body).inspect_err(|_| {
+    write_markdown(&md_path, &meta, &body).inspect_err(|e| {
+        tracing::warn!(
+            target: "aimx::ingest",
+            "markdown write failed mailbox={mailbox} path={path}: {err}",
+            mailbox = mailbox,
+            path = md_path.display(),
+            err = e,
+        );
         cleanup_bundle();
     })?;
+
+    let attachments_count = meta.attachments.len();
+
+    tracing::info!(
+        target: "aimx::ingest",
+        "stored email id={id} path={path} mailbox={mailbox} attachments={attachments}",
+        id = id,
+        path = md_path.display(),
+        mailbox = mailbox,
+        attachments = attachments_count,
+    );
 
     drop(_guard);
 
@@ -2207,5 +2265,82 @@ mod tests {
             table1.get("thread_id").unwrap().as_str().unwrap(),
             table2.get("thread_id").unwrap().as_str().unwrap(),
         );
+    }
+
+    #[tracing_test::traced_test]
+    #[test]
+    fn ingest_email_emits_received_auth_stored_logs() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let locks = test_locks();
+        ingest_email(
+            &config,
+            &locks,
+            "alice@test.com",
+            plain_text_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
+
+        assert!(logs_contain("aimx::ingest"));
+        assert!(logs_contain("received email"));
+        assert!(logs_contain("rcpt=alice@test.com"));
+        assert!(logs_contain("mailbox=alice"));
+        assert!(logs_contain("size_bytes="));
+        assert!(logs_contain("from=sender@example.com"));
+
+        assert!(logs_contain("auth result"));
+        assert!(logs_contain("dkim="));
+        assert!(logs_contain("spf="));
+        assert!(logs_contain("dmarc="));
+
+        assert!(logs_contain("stored email"));
+        assert!(logs_contain("id="));
+        assert!(logs_contain("path="));
+        assert!(logs_contain("attachments=0"));
+
+        // Trust log also fires.
+        assert!(logs_contain("aimx::trust"));
+    }
+
+    #[tracing_test::traced_test]
+    #[test]
+    fn ingest_email_logs_attachments_count_when_present() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let locks = test_locks();
+        ingest_email(
+            &config,
+            &locks,
+            "alice@test.com",
+            attachment_eml(),
+            sentinel_ip(),
+            None,
+        )
+        .unwrap();
+
+        assert!(logs_contain("stored email"));
+        assert!(logs_contain("attachments=1"));
+    }
+
+    #[tracing_test::traced_test]
+    #[test]
+    fn ingest_email_emits_warn_on_parse_failure() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let locks = test_locks();
+        // Raw bytes that mail-parser can't make sense of.
+        let bogus: &[u8] = b"";
+        let result = ingest_email(
+            &config,
+            &locks,
+            "alice@test.com",
+            bogus,
+            sentinel_ip(),
+            None,
+        );
+        assert!(result.is_err(), "empty input must propagate parse failure");
+        assert!(logs_contain("Failed to parse email"));
     }
 }

--- a/src/logging.rs
+++ b/src/logging.rs
@@ -1,0 +1,23 @@
+//! Shared tracing subscriber initializer.
+//!
+//! Installs a global `tracing_subscriber::fmt` layer writing to stderr.
+//! `EnvFilter` honors `RUST_LOG`, falling back to `info` so operators
+//! always get the structured `aimx::hook`, `aimx::ingest`, and
+//! `aimx::trust` lines without opting in.
+//!
+//! Idempotent: repeat calls (e.g. integration tests re-entering
+//! `serve::run` or `ingest::run` in-process) swallow the duplicate-
+//! subscriber error so the first install wins.
+
+use tracing_subscriber::EnvFilter;
+
+/// Install the global tracing subscriber. Safe to call more than once.
+pub fn init() {
+    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
+    let _ = tracing_subscriber::fmt()
+        .with_env_filter(filter)
+        .with_writer(std::io::stderr)
+        .with_target(true)
+        .compact()
+        .try_init();
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod hook_substitute;
 mod hook_templates_defaults;
 mod hooks;
 mod ingest;
+mod logging;
 mod logs;
 mod mailbox;
 mod mailbox_handler;

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -230,28 +230,6 @@ pub fn log_dkim_startup_check(outcome: &DkimStartupCheck, domain: &str, selector
     }
 }
 
-/// Idempotently install the global tracing subscriber. Called on
-/// `aimx serve` startup so structured `tracing::info!` records (notably
-/// the per-fire `aimx::hook` line that doctor parses for fire counts)
-/// land in stderr / journalctl.
-///
-/// `RUST_LOG` (env-filter) overrides the default `info` level so
-/// operators can debug-trace specific modules without a rebuild.
-fn init_tracing_subscriber() {
-    use tracing_subscriber::EnvFilter;
-    let filter = EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("info"));
-    // `try_init` returns Err when a subscriber is already installed,
-    // which is the case under integration-test re-entry. We swallow
-    // the error: the first install wins and subsequent calls are
-    // no-ops, exactly the contract we want.
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(filter)
-        .with_writer(std::io::stderr)
-        .with_target(true)
-        .compact()
-        .try_init();
-}
-
 fn truncate(s: &str, n: usize) -> String {
     if s.len() <= n {
         s.to_string()
@@ -443,7 +421,7 @@ async fn run_serve(
     // `try_init` keeps re-runs (e.g. test harnesses that re-enter
     // `run_serve` in-process) from panicking on a duplicate global
     // subscriber; the first init wins.
-    init_tracing_subscriber();
+    crate::logging::init();
 
     // Refresh the agent-facing README if the baked-in version differs from
     // what is on disk. Runs before any listener is bound so the file is

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -83,23 +83,52 @@ pub fn evaluate_trust(
     from: &str,
 ) -> TrustedValue {
     let trust = mailbox.effective_trust(config);
-    if trust == "none" {
-        return TrustedValue::None;
-    }
+    let sender_bare = extract_email_for_match(from);
+    let mailbox_name = mailbox_key_for_log(config, mailbox);
 
-    if trust == "verified" {
+    let (result, sender_allowlisted) = if trust == "none" {
+        (TrustedValue::None, false)
+    } else if trust == "verified" {
         let senders = mailbox.effective_trusted_senders(config);
         let sender_allowlisted = is_sender_in_trusted_senders(senders, from);
         let dkim_passed = auth.dkim == "pass";
 
         if sender_allowlisted && dkim_passed {
-            return TrustedValue::True;
+            (TrustedValue::True, sender_allowlisted)
+        } else {
+            (TrustedValue::False, sender_allowlisted)
         }
-        return TrustedValue::False;
-    }
+    } else {
+        // Unknown trust value: fail closed.
+        (TrustedValue::False, false)
+    };
 
-    // Unknown trust value: fail closed.
-    TrustedValue::False
+    tracing::info!(
+        target: "aimx::trust",
+        "trust eval mailbox={mailbox} policy={policy} sender={sender} dkim={dkim} sender_allowlisted={sender_allowlisted} result={result}",
+        mailbox = mailbox_name,
+        policy = trust,
+        sender = sender_bare,
+        dkim = auth.dkim,
+        sender_allowlisted = sender_allowlisted,
+        result = result.as_str(),
+    );
+
+    result
+}
+
+/// Best-effort resolution of the mailbox's display name for logs.
+/// `MailboxConfig` doesn't carry its own key, so we search the `Config`
+/// map for a reverse-lookup. Falls back to the mailbox `address` when
+/// the caller constructed an ad-hoc `MailboxConfig` not in the map
+/// (e.g. unit tests).
+fn mailbox_key_for_log(config: &Config, mailbox: &MailboxConfig) -> String {
+    for (name, mb) in &config.mailboxes {
+        if mb.address == mailbox.address {
+            return name.clone();
+        }
+    }
+    mailbox.address.clone()
 }
 
 fn extract_email_for_match(from: &str) -> String {
@@ -133,6 +162,7 @@ mod tests {
     use crate::frontmatter::AuthResults;
     use std::collections::HashMap;
     use std::path::PathBuf;
+    use tracing_test::traced_test;
 
     fn bare_config() -> Config {
         Config {
@@ -384,6 +414,54 @@ mod tests {
         for trusted in [TrustedValue::None, TrustedValue::False, TrustedValue::True] {
             assert!(should_fire_on_receive(&yolo, trusted));
         }
+    }
+
+    #[traced_test]
+    #[test]
+    fn evaluate_trust_emits_aimx_trust_log_none() {
+        let cfg = bare_config();
+        let mb = mailbox_none();
+        let _ = evaluate_trust(&cfg, &mb, &auth("pass"), "anyone@example.com");
+        assert!(logs_contain("aimx::trust"));
+        assert!(logs_contain("trust eval"));
+        assert!(logs_contain("policy=none"));
+        assert!(logs_contain("result=none"));
+    }
+
+    #[traced_test]
+    #[test]
+    fn evaluate_trust_emits_aimx_trust_log_verified_true() {
+        let cfg = bare_config();
+        let mb = mailbox_verified(vec!["*@gmail.com".to_string()]);
+        let _ = evaluate_trust(&cfg, &mb, &auth("pass"), "alice@gmail.com");
+        assert!(logs_contain("aimx::trust"));
+        assert!(logs_contain("policy=verified"));
+        assert!(logs_contain("sender=alice@gmail.com"));
+        assert!(logs_contain("dkim=pass"));
+        assert!(logs_contain("sender_allowlisted=true"));
+        assert!(logs_contain("result=true"));
+    }
+
+    #[traced_test]
+    #[test]
+    fn evaluate_trust_emits_aimx_trust_log_verified_false_dkim_fail() {
+        let cfg = bare_config();
+        let mb = mailbox_verified(vec!["*@gmail.com".to_string()]);
+        let _ = evaluate_trust(&cfg, &mb, &auth("fail"), "alice@gmail.com");
+        assert!(logs_contain("policy=verified"));
+        assert!(logs_contain("dkim=fail"));
+        assert!(logs_contain("sender_allowlisted=true"));
+        assert!(logs_contain("result=false"));
+    }
+
+    #[traced_test]
+    #[test]
+    fn evaluate_trust_emits_aimx_trust_log_not_allowlisted() {
+        let cfg = bare_config();
+        let mb = mailbox_verified(vec!["*@company.com".to_string()]);
+        let _ = evaluate_trust(&cfg, &mb, &auth("pass"), "alice@gmail.com");
+        assert!(logs_contain("sender_allowlisted=false"));
+        assert!(logs_contain("result=false"));
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -200,6 +200,29 @@ fn ingest_plain_fixture_full_pipeline() {
 }
 
 #[test]
+fn ingest_emits_tracing_logs_on_stderr() {
+    // Smoke test for the logging refactor: the stdin `aimx ingest` path
+    // now installs a tracing subscriber on entry, so stderr must carry
+    // the `aimx::ingest` / `aimx::trust` structured records.
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let eml = std::fs::read("tests/fixtures/plain.eml").unwrap();
+
+    aimx_cmd(tmp.path())
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("ingest")
+        .arg("catchall@agent.example.com")
+        .write_stdin(eml)
+        .assert()
+        .success()
+        .stderr(predicate::str::contains("aimx::ingest"))
+        .stderr(predicate::str::contains("received email"))
+        .stderr(predicate::str::contains("stored email"))
+        .stderr(predicate::str::contains("aimx::trust"));
+}
+
+#[test]
 fn ingest_html_fixture_full_pipeline() {
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());


### PR DESCRIPTION
## Summary

Add debug-focused `tracing` logs throughout the inbound ingest pipeline and the hook dispatcher so operators can trace why a given email was (or wasn't) trusted and whether hooks fired. `tracing` is already initialized in `aimx serve`; this change fills the silence in `ingest.rs` / `trust.rs` and extends the existing `aimx::hook` logs to cover the "no hooks" and "hook skipped by trust gate" cases the user called out.

## Requirements

- [x] Ingest emits INFO-level logs on inbound path (`received email` / `auth result` / `stored email` + WARNs on parse / attachment / markdown-write failure, all at `target: "aimx::ingest"`)
- [x] Trust evaluation emits one INFO log per email at `target: "aimx::trust"` with `policy`, `sender`, `dkim`, `sender_allowlisted`, and `result`
- [x] Hook dispatcher emits "no hooks" and "skipped by gate" events, plus a pre-fire `firing hook_name=...` line preceding the existing post-fire summary
- [x] `aimx ingest` CLI path initializes a tracing subscriber via the shared `logging::init()` so stdin-piped runs surface logs on stderr
- [x] Log format consistent with existing `aimx::hook` style — compact `key=value` pairs on a single line
- [x] Unit tests exist for every new log line (via `tracing-test::traced_test` / `logs_contain`)
- [x] Integration tests continue to pass; added `ingest_emits_tracing_logs_on_stderr` smoke test
- [x] No behavior change beyond logging — trust outcomes, hook fire decisions, file paths, attachments all bit-identical

## Out of scope

- Changing log destinations (stderr stays the sink; no file rotation, no syslog).
- Redesigning the `tracing` target hierarchy beyond adding `aimx::ingest` and `aimx::trust`.
- Structured JSON logs — the existing human-readable `key=value` format is the target.
- Adding logs to `send_handler.rs`, `mcp.rs`, or `setup.rs` (different concerns, not in the request).
- Post-fire hook summary changes — the existing line at `hook.rs` stays as-is.
- Redacting PII (from/subject/message-id) from logs — matches existing behavior.
- DKIM signature body / header details at DEBUG — can be added later if requested.

## Technical approach

- **Module layout.** Extracted `init_tracing_subscriber` out of `serve.rs` into `src/logging.rs` exposing `pub fn init()`, registered via `pub mod logging;` in `main.rs`. Keeps the idempotent `try_init()` + stderr writer + `EnvFilter` default `info` exactly as-is. `serve::run` and `ingest::run` both call `logging::init()`; `ingest_email` does not (it runs under `aimx serve` where the subscriber is already installed).
- **Ingest log sites.** Four new `tracing::info!` calls (`received email`, `auth result`, `stored email`) and three `tracing::warn!` calls wrapping parse / attachment-write / markdown-write failures before propagation.
- **Trust log site.** A single `tracing::info!` at the end of `evaluate_trust` that reports the full decision as `trust eval mailbox=... policy=... sender=... dkim=... sender_allowlisted=... result=...`. Signature preserved; logging is a pure side-effect. A `mailbox_key_for_log` helper reverse-looks-up the mailbox name from `Config.mailboxes` since `MailboxConfig` doesn't carry its own key.
- **Hook log sites.** `execute_on_receive` collects hooks into a `Vec` up-front; empty-list case emits `No hooks found for event=on_receive mailbox=<name>`, otherwise per-iteration gate misses emit the skip log. `execute_after_send` mirrors the empty-list behavior. `run_and_log` emits `firing hook_name=... event=... mailbox=... template=... run_as=...` right before `spawn_sandboxed`, complementing the existing post-fire summary.
- **Test strategy.** `tracing-test::traced_test` on each new unit test asserting `logs_contain("...")` for the expected substrings. Integration smoke test `ingest_emits_tracing_logs_on_stderr` uses `assert_cmd` + `predicate::str::contains` on stderr.

## Test plan

- [x] Unit: `trust::evaluate_trust` emits one `aimx::trust` log per outcome (4 new tests covering none / verified-pass / dkim-fail / not-allowlisted).
- [x] Unit: `hook::execute_on_receive` on a mailbox with zero `on_receive` hooks emits the `No hooks found` log.
- [x] Unit: `hook::execute_on_receive` with a hook failing the trust gate emits the skip log and does not invoke the sandbox.
- [x] Unit: `hook::execute_on_receive` with a firing hook emits both the pre-fire `firing` log and the post-fire `exit_code=` summary.
- [x] Unit: `hook::execute_after_send` with zero `after_send` hooks emits the `No hooks found for event=after_send` log.
- [x] Unit: `hook::execute_after_send` with a firing hook emits the pre-fire log.
- [x] Unit: `ingest::ingest_email` on a plain `.eml` emits `received email` + `auth result` + `stored email` + an `aimx::trust` line; attachments count is correctly reported for an `.eml` with one attachment.
- [x] Unit: `ingest::ingest_email` on bogus input emits the WARN parse-failure log and propagates the error.
- [x] Integration: `ingest_emits_tracing_logs_on_stderr` asserts stderr carries `aimx::ingest` + `received email` + `stored email` + `aimx::trust` when running the binary with `--data-dir`.
- [x] Regression: full `cargo test` green on the main crate (1025 unit tests + 96 integration tests + 3 pre-existing `#[ignore]`; 0 failures).
- [x] `cargo clippy -- -D warnings` clean.
- [x] `cargo fmt --check` clean.

## Notes

- `MailboxConfig` does not carry its own key, so the trust log uses a small reverse-lookup (`mailbox_key_for_log`) against `Config.mailboxes`. Falls back to `mailbox.address` for ad-hoc configs not in the map (e.g. `trust.rs` unit tests). This means unit-test log lines show `mailbox=*@test.com`, while real ingest shows the resolved name like `mailbox=alice`.
- The pre-fire `firing` log lives inside `run_and_log` rather than at the call site so it sees the resolved `run_as` and `template_tag` — same values the post-fire summary uses.
- `logging::init()` keeps the first-install-wins contract via `try_init()`; tests re-entering `run` in-process swallow the duplicate-subscriber error silently.
