### PR TITLE
fix(book): include Security page in SUMMARY so mdBook builds it

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -41,6 +41,7 @@ jobs:
           test -f website/dist/index.html
           test -f website/dist/book/index.html
           test -f website/dist/book/faq.html
+          test -f website/dist/book/security.html
           test -f website/dist/assets/aimx-pigeon.svg
 
       - name: Add CNAME for custom domain

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -8,6 +8,7 @@
 - [Mailboxes & Email](mailboxes.md)
 - [Hooks & Trust](hooks.md)
 - [Hook Recipes](hook-recipes.md)
+- [Security](security.md)
 - [MCP Server](mcp.md)
 - [Agent Integration](agent-integration.md)
 - [CLI Reference](cli.md)


### PR DESCRIPTION
## Summary

- `book/security.md` was added in #120 and linked from the Introduction's "Guide contents" table, but mdBook treats `SUMMARY.md` as the authoritative page list — the Introduction table is just body content. Without a `- [Security](security.md)` line in `SUMMARY.md`, mdBook never rendered the page and `https://aimx.email/book/security.html` 404s.
- Add the Security entry to `SUMMARY.md` between Hook Recipes and MCP Server, matching the order in the Introduction table.
- Add `test -f website/dist/book/security.html` to the `Verify output` step in `.github/workflows/site.yml` so a future page-missing-from-SUMMARY regression fails CI instead of shipping a silent 404.

## Test plan

- [x] Local `cd website && make build` now emits `dist/book/security.html` (previously absent) and the sidebar TOC lists the Security page.
- [ ] After merge, `https://aimx.email/book/security.html` resolves to the rendered page.