### PR TITLE
[Sprint 4] SO_PEERCRED UDS authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,15 @@ jobs:
         run: |
           sudo -E env "PATH=$PATH" AIMX_INTEGRATION_SUDO=1 cargo test --test isolation -- --ignored
 
+      # Sprint 4 S4-4: root-gated UDS authz integration test. Reuses
+      # the `aimx-it-alice` / `aimx-it-bob` fixture from Sprint 2 and
+      # asserts that bob cannot SEND/MARK-READ/HOOK-CREATE as alice
+      # over the UDS. Same runtime gating (AIMX_INTEGRATION_SUDO=1 +
+      # sudo + PATH propagation) as the isolation test above.
+      - name: Run UDS authz integration test (root)
+        run: |
+          sudo -E env "PATH=$PATH" AIMX_INTEGRATION_SUDO=1 cargo test --test uds_authz -- --ignored
+
   verifier-tests:
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,6 +76,23 @@ jobs:
         run: |
           sudo -E env "PATH=$PATH" AIMX_INTEGRATION_SUDO=1 cargo test --test uds_authz -- --ignored
 
+      # Sprint 4 review NB-1: the five MAILBOX-CRUD UDS integration
+      # tests in `tests/integration.rs` are `#[ignore]`-gated because
+      # `MAILBOX-CREATE` / `MAILBOX-DELETE` are root-only (PRD §6.5)
+      # and the daemon chowns freshly-created mailbox dirs to the
+      # configured owner — a non-root `cargo test` cannot exercise the
+      # code path. This step runs them explicitly under sudo, one name
+      # per `--exact`, so any future skip regresses here rather than
+      # silently.
+      - name: Run MAILBOX-CRUD integration tests (root)
+        run: |
+          sudo -E env "PATH=$PATH" AIMX_INTEGRATION_SUDO=1 cargo test --test integration -- --ignored --exact \
+            mailbox_create_via_uds_hotswaps_config_and_routes_new_mail \
+            mailbox_delete_via_uds_refuses_nonempty_and_succeeds_after_cleanup \
+            mailbox_delete_force_yes_wipes_contents_and_succeeds \
+            mailbox_delete_force_without_yes_prompts_and_aborts_on_n \
+            concurrent_mailbox_create_and_ingest_does_not_deadlock
+
   verifier-tests:
     runs-on: ubuntu-latest
     defaults:

--- a/src/hook_handler.rs
+++ b/src/hook_handler.rs
@@ -41,7 +41,7 @@ use crate::send_protocol::{
     AckResponse, ErrCode, HookCreateRequest, HookDeleteRequest, HookTemplateCreateBody,
 };
 use crate::state_handler::StateContext;
-use crate::uds_authz::{Caller, enforce_mailbox_owner_or_root, log_decision};
+use crate::uds_authz::{Caller, LogDecision, enforce_mailbox_owner_or_root, log_decision};
 
 /// Handle an `AIMX/1 HOOK-CREATE` request. Template-only. Takes the
 /// per-mailbox write lock for the addressed mailbox (outer) plus
@@ -106,7 +106,7 @@ pub async fn handle_hook_create(
                 "HOOK-CREATE",
                 caller,
                 Some(&req.mailbox),
-                "reject",
+                LogDecision::Reject,
                 Some("mailbox not found"),
             );
             return AckResponse::Err {
@@ -292,7 +292,7 @@ pub async fn handle_hook_delete(
                 "HOOK-DELETE",
                 caller,
                 None,
-                "reject",
+                LogDecision::Reject,
                 Some("hook not found"),
             );
             return AckResponse::Err {
@@ -305,10 +305,24 @@ pub async fn handle_hook_delete(
     // Sprint 4 §6.5: the caller must own the target mailbox OR be
     // root. Runs before the origin check so a non-owner never learns
     // whether the hook is MCP- or operator-origin.
-    if let Some(mailbox_cfg) = current.mailboxes.get(&owner)
-        && let Err(reject) =
-            enforce_mailbox_owner_or_root("HOOK-DELETE", caller, &owner, mailbox_cfg)
-    {
+    //
+    // `owner` came from the same `current.mailboxes` iteration above
+    // so the `None` branch is unreachable today. Handle it explicitly
+    // with `ENOENT` so authz can't be silently skipped if a future
+    // refactor separates the owner-scan and lookup steps.
+    let mailbox_cfg = match current.mailboxes.get(&owner) {
+        Some(m) => m,
+        None => {
+            return AckResponse::Err {
+                code: ErrCode::Enoent,
+                reason: format!(
+                    "mailbox '{owner}' resolved but not found in config \
+                     (race with concurrent MAILBOX-DELETE)"
+                ),
+            };
+        }
+    };
+    if let Err(reject) = enforce_mailbox_owner_or_root("HOOK-DELETE", caller, &owner, mailbox_cfg) {
         return AckResponse::Err {
             code: reject.code,
             reason: reject.reason,

--- a/src/hook_handler.rs
+++ b/src/hook_handler.rs
@@ -41,6 +41,7 @@ use crate::send_protocol::{
     AckResponse, ErrCode, HookCreateRequest, HookDeleteRequest, HookTemplateCreateBody,
 };
 use crate::state_handler::StateContext;
+use crate::uds_authz::{Caller, enforce_mailbox_owner_or_root, log_decision};
 
 /// Handle an `AIMX/1 HOOK-CREATE` request. Template-only. Takes the
 /// per-mailbox write lock for the addressed mailbox (outer) plus
@@ -50,6 +51,7 @@ pub async fn handle_hook_create(
     state_ctx: &StateContext,
     mb_ctx: &MailboxContext,
     req: &HookCreateRequest,
+    caller: &Caller,
 ) -> AckResponse {
     // --- Parse JSON body (rejects `cmd`, `run_as`, etc. via `deny_unknown_fields`).
     let body: HookTemplateCreateBody = match serde_json::from_slice(&req.body) {
@@ -94,11 +96,32 @@ pub async fn handle_hook_create(
 
     let current = mb_ctx.config_handle.load();
 
-    // --- Resolve mailbox.
-    if !current.mailboxes.contains_key(&req.mailbox) {
+    // --- Resolve mailbox. Sprint 4 §6.5: unknown mailbox returns
+    // `ENOENT` (not `EACCES`) so the authz check itself cannot leak
+    // which mailboxes exist. Authz runs after the mailbox is found.
+    let mailbox_cfg = match current.mailboxes.get(&req.mailbox) {
+        Some(m) => m,
+        None => {
+            log_decision(
+                "HOOK-CREATE",
+                caller,
+                Some(&req.mailbox),
+                "reject",
+                Some("mailbox not found"),
+            );
+            return AckResponse::Err {
+                code: ErrCode::Enoent,
+                reason: format!("mailbox '{}' does not exist", req.mailbox),
+            };
+        }
+    };
+
+    if let Err(reject) =
+        enforce_mailbox_owner_or_root("HOOK-CREATE", caller, &req.mailbox, mailbox_cfg)
+    {
         return AckResponse::Err {
-            code: ErrCode::Mailbox,
-            reason: format!("mailbox '{}' does not exist", req.mailbox),
+            code: reject.code,
+            reason: reject.reason,
         };
     }
 
@@ -242,6 +265,7 @@ pub async fn handle_hook_delete(
     state_ctx: &StateContext,
     mb_ctx: &MailboxContext,
     req: &HookDeleteRequest,
+    caller: &Caller,
 ) -> AckResponse {
     if !is_valid_hook_name(&req.name) {
         return AckResponse::Err {
@@ -264,12 +288,32 @@ pub async fn handle_hook_delete(
     let owner = match owner {
         Some(n) => n,
         None => {
+            log_decision(
+                "HOOK-DELETE",
+                caller,
+                None,
+                "reject",
+                Some("hook not found"),
+            );
             return AckResponse::Err {
-                code: ErrCode::NotFound,
+                code: ErrCode::Enoent,
                 reason: format!("hook '{}' not found", req.name),
             };
         }
     };
+
+    // Sprint 4 §6.5: the caller must own the target mailbox OR be
+    // root. Runs before the origin check so a non-owner never learns
+    // whether the hook is MCP- or operator-origin.
+    if let Some(mailbox_cfg) = current.mailboxes.get(&owner)
+        && let Err(reject) =
+            enforce_mailbox_owner_or_root("HOOK-DELETE", caller, &owner, mailbox_cfg)
+    {
+        return AckResponse::Err {
+            code: reject.code,
+            reason: reject.reason,
+        };
+    }
 
     // Origin check: before acquiring any locks, refuse operator-origin
     // hooks up front so callers get a precise error without waiting on
@@ -488,7 +532,7 @@ mod tests {
             name: Some("my_hook".into()),
             body: body(&[("prompt", "hello world")]),
         };
-        match handle_hook_create(&state_ctx, &mb_ctx, &req).await {
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Ok => {}
             other => panic!("expected Ok, got {other:?}"),
         }
@@ -522,7 +566,7 @@ mod tests {
             body: body(&[("prompt", "anon")]),
         };
         assert!(matches!(
-            handle_hook_create(&state_ctx, &mb_ctx, &req).await,
+            handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await,
             AckResponse::Ok
         ));
         let live = mb_ctx.config_handle.load();
@@ -542,7 +586,7 @@ mod tests {
             name: None,
             body: json.to_vec(),
         };
-        match handle_hook_create(&state_ctx, &mb_ctx, &req).await {
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Validation);
                 assert!(reason.contains("cmd"), "{reason}");
@@ -566,7 +610,7 @@ mod tests {
             name: None,
             body: json.to_vec(),
         };
-        match handle_hook_create(&state_ctx, &mb_ctx, &req).await {
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Validation);
                 assert!(reason.contains("run_as"), "{reason}");
@@ -588,7 +632,7 @@ mod tests {
             name: None,
             body: json.to_vec(),
         };
-        match handle_hook_create(&state_ctx, &mb_ctx, &req).await {
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Validation);
                 assert!(reason.contains("dangerously_support_untrusted"), "{reason}");
@@ -609,7 +653,7 @@ mod tests {
             name: None,
             body: body(&[]),
         };
-        match handle_hook_create(&state_ctx, &mb_ctx, &req).await {
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Validation);
                 assert!(reason.contains("unknown-template"), "{reason}");
@@ -631,7 +675,7 @@ mod tests {
             name: None,
             body: body(&[]),
         };
-        match handle_hook_create(&state_ctx, &mb_ctx, &req).await {
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Validation);
                 assert!(reason.contains("missing-param"), "{reason}");
@@ -653,7 +697,7 @@ mod tests {
             name: None,
             body: body(&[("prompt", "hi"), ("bogus", "zz")]),
         };
-        match handle_hook_create(&state_ctx, &mb_ctx, &req).await {
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Validation);
                 assert!(reason.contains("unknown-param"), "{reason}");
@@ -684,7 +728,7 @@ mod tests {
             name: None,
             body: body(&[("prompt", "hi")]),
         };
-        match handle_hook_create(&state_ctx, &mb_ctx, &req).await {
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Validation);
                 assert!(reason.contains("event-not-allowed"), "{reason}");
@@ -705,12 +749,12 @@ mod tests {
             name: None,
             body: body(&[("prompt", "hi")]),
         };
-        match handle_hook_create(&state_ctx, &mb_ctx, &req).await {
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
-                assert_eq!(code, ErrCode::Mailbox);
+                assert_eq!(code, ErrCode::Enoent);
                 assert!(reason.contains("ghost"), "{reason}");
             }
-            other => panic!("expected Err(MAILBOX), got {other:?}"),
+            other => panic!("expected Err(ENOENT), got {other:?}"),
         }
     }
 
@@ -726,7 +770,7 @@ mod tests {
             name: None,
             body: body(&[("prompt", "hi")]),
         };
-        match handle_hook_create(&state_ctx, &mb_ctx, &req).await {
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Validation);
                 assert!(reason.contains("invalid event"), "{reason}");
@@ -747,7 +791,7 @@ mod tests {
             name: Some("bad name!".into()),
             body: body(&[("prompt", "hi")]),
         };
-        match handle_hook_create(&state_ctx, &mb_ctx, &req).await {
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Validation);
                 assert!(reason.contains("invalid hook name"), "{reason}");
@@ -769,7 +813,7 @@ mod tests {
             body: body(&[("prompt", "hi")]),
         };
         assert!(matches!(
-            handle_hook_create(&state_ctx, &mb_ctx, &req1).await,
+            handle_hook_create(&state_ctx, &mb_ctx, &req1, &Caller::internal_root()).await,
             AckResponse::Ok
         ));
 
@@ -780,7 +824,7 @@ mod tests {
             name: Some("dup".into()),
             body: body(&[("prompt", "hi2")]),
         };
-        match handle_hook_create(&state_ctx, &mb_ctx, &req2).await {
+        match handle_hook_create(&state_ctx, &mb_ctx, &req2, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Validation);
                 assert!(reason.contains("name-conflict"), "{reason}");
@@ -801,7 +845,7 @@ mod tests {
             name: None,
             body: b"not-json-at-all".to_vec(),
         };
-        match handle_hook_create(&state_ctx, &mb_ctx, &req).await {
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Validation);
                 assert!(reason.contains("malformed HOOK-CREATE body"), "{reason}");
@@ -825,7 +869,7 @@ mod tests {
             name: None,
             body: body(&[("prompt", "a\0b")]),
         };
-        match handle_hook_create(&state_ctx, &mb_ctx, &req).await {
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Validation);
                 assert!(reason.contains("param-invalid"), "{reason}");
@@ -874,7 +918,7 @@ mod tests {
             body: body(&[("prompt", "hi")]),
         };
         assert!(matches!(
-            handle_hook_create(&state_ctx, &mb_ctx, &req).await,
+            handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await,
             AckResponse::Ok
         ));
 
@@ -882,7 +926,7 @@ mod tests {
             name: "mcp_hook".into(),
         };
         assert!(matches!(
-            handle_hook_delete(&state_ctx, &mb_ctx, &del).await,
+            handle_hook_delete(&state_ctx, &mb_ctx, &del, &Caller::internal_root()).await,
             AckResponse::Ok
         ));
 
@@ -901,7 +945,7 @@ mod tests {
         let del = HookDeleteRequest {
             name: "operator_hook".into(),
         };
-        match handle_hook_delete(&state_ctx, &mb_ctx, &del).await {
+        match handle_hook_delete(&state_ctx, &mb_ctx, &del, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Validation);
                 assert!(reason.contains("origin-protected"), "{reason}");
@@ -916,15 +960,15 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn hook_delete_unknown_name_returns_notfound() {
+    async fn hook_delete_unknown_name_returns_enoent() {
         let tmp = TempDir::new().unwrap();
         let (state_ctx, mb_ctx) = contexts(&tmp);
         let del = HookDeleteRequest {
             name: "nope".into(),
         };
-        match handle_hook_delete(&state_ctx, &mb_ctx, &del).await {
-            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::NotFound),
-            other => panic!("expected Err(NOTFOUND), got {other:?}"),
+        match handle_hook_delete(&state_ctx, &mb_ctx, &del, &Caller::internal_root()).await {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Enoent),
+            other => panic!("expected Err(ENOENT), got {other:?}"),
         }
     }
 
@@ -935,7 +979,7 @@ mod tests {
         let del = HookDeleteRequest {
             name: "bad name!".into(),
         };
-        match handle_hook_delete(&state_ctx, &mb_ctx, &del).await {
+        match handle_hook_delete(&state_ctx, &mb_ctx, &del, &Caller::internal_root()).await {
             AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Validation),
             other => panic!("expected Err(VALIDATION), got {other:?}"),
         }
@@ -966,7 +1010,7 @@ mod tests {
                     name: Some(name.clone()),
                     body: body(&[("prompt", "hi")]),
                 };
-                handle_hook_create(&s, &m, &req).await
+                handle_hook_create(&s, &m, &req, &Caller::internal_root()).await
             }));
         }
         for h in handles {

--- a/src/mailbox_handler.rs
+++ b/src/mailbox_handler.rs
@@ -44,6 +44,7 @@ use crate::config::{Config, ConfigHandle, MailboxConfig};
 use crate::ownership::chown_as_owner;
 use crate::send_protocol::{AckResponse, ErrCode, MailboxCrudRequest};
 use crate::state_handler::StateContext;
+use crate::uds_authz::{Caller, enforce_root};
 
 /// Process-wide mutex around the `config.toml` read-modify-write critical
 /// section. Symmetric in spirit to `send_handler::SENT_WRITE_LOCK`: a
@@ -83,11 +84,26 @@ pub async fn handle_mailbox_crud(
     state_ctx: &StateContext,
     mb_ctx: &MailboxContext,
     req: &MailboxCrudRequest,
+    caller: &Caller,
 ) -> AckResponse {
     if let Err(e) = crate::mailbox::validate_mailbox_name(&req.name) {
         return AckResponse::Err {
             code: ErrCode::Validation,
             reason: e,
+        };
+    }
+
+    // Sprint 4 §6.5: MAILBOX-CREATE / MAILBOX-DELETE are root-only.
+    // Non-root callers get EACCES before any lock is acquired.
+    let verb = if req.create {
+        "MAILBOX-CREATE"
+    } else {
+        "MAILBOX-DELETE"
+    };
+    if let Err(reject) = enforce_root(verb, caller, Some(&req.name)) {
+        return AckResponse::Err {
+            code: reject.code,
+            reason: reject.reason,
         };
     }
 
@@ -511,7 +527,7 @@ mod tests {
             owner: Some("testowner".into()),
         };
         assert!(matches!(
-            handle_mailbox_crud(&state_ctx, &mb_ctx, &req).await,
+            handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await,
             AckResponse::Ok
         ));
 
@@ -538,7 +554,7 @@ mod tests {
             create: true,
             owner: Some("testowner".into()),
         };
-        match handle_mailbox_crud(&state_ctx, &mb_ctx, &req).await {
+        match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Mailbox);
                 assert!(reason.contains("already exists"), "{reason}");
@@ -557,7 +573,7 @@ mod tests {
             create: true,
             owner: Some("testowner".into()),
         };
-        match handle_mailbox_crud(&state_ctx, &mb_ctx, &req).await {
+        match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Validation),
             other => panic!("expected Err(VALIDATION), got {other:?}"),
         }
@@ -574,7 +590,7 @@ mod tests {
                 create: true,
                 owner: Some("testowner".into()),
             };
-            match handle_mailbox_crud(&state_ctx, &mb_ctx, &req).await {
+            match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
                 AckResponse::Err { code, .. } => {
                     assert_eq!(code, ErrCode::Validation, "name {bad:?}")
                 }
@@ -596,7 +612,7 @@ mod tests {
             owner: Some("testowner".into()),
         };
         assert!(matches!(
-            handle_mailbox_crud(&state_ctx, &mb_ctx, &req).await,
+            handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await,
             AckResponse::Ok
         ));
 
@@ -607,7 +623,7 @@ mod tests {
             owner: None,
         };
         assert!(matches!(
-            handle_mailbox_crud(&state_ctx, &mb_ctx, &req).await,
+            handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await,
             AckResponse::Ok
         ));
 
@@ -629,7 +645,7 @@ mod tests {
             owner: Some("testowner".into()),
         };
         assert!(matches!(
-            handle_mailbox_crud(&state_ctx, &mb_ctx, &req).await,
+            handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await,
             AckResponse::Ok
         ));
 
@@ -643,7 +659,7 @@ mod tests {
             create: false,
             owner: None,
         };
-        match handle_mailbox_crud(&state_ctx, &mb_ctx, &req).await {
+        match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::NonEmpty);
                 assert!(
@@ -668,7 +684,7 @@ mod tests {
             create: false,
             owner: None,
         };
-        match handle_mailbox_crud(&state_ctx, &mb_ctx, &req).await {
+        match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Mailbox);
                 assert!(reason.contains("catchall"), "{reason}");
@@ -687,7 +703,7 @@ mod tests {
             create: false,
             owner: None,
         };
-        match handle_mailbox_crud(&state_ctx, &mb_ctx, &req).await {
+        match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Mailbox);
                 assert!(reason.contains("does not exist"), "{reason}");
@@ -726,7 +742,7 @@ mod tests {
             create: true,
             owner: Some("testowner".into()),
         };
-        match handle_mailbox_crud(&state_ctx, &bad_ctx, &req).await {
+        match handle_mailbox_crud(&state_ctx, &bad_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Io),
             other => panic!("expected Err(IO), got {other:?}"),
         }
@@ -841,7 +857,7 @@ mod tests {
             owner: Some("testowner".into()),
         };
         assert!(matches!(
-            handle_mailbox_crud(&state_ctx, &mb_ctx, &req).await,
+            handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await,
             AckResponse::Ok
         ));
 
@@ -887,7 +903,12 @@ mod tests {
             folder: crate::send_protocol::MarkFolder::Inbox,
             read: true,
         };
-        let resp = crate::state_handler::handle_mark(&state_ctx, &mark_req).await;
+        let resp = crate::state_handler::handle_mark(
+            &state_ctx,
+            &mark_req,
+            &crate::uds_authz::Caller::internal_root(),
+        )
+        .await;
         assert!(matches!(resp, AckResponse::Ok), "{resp:?}");
 
         let reread = std::fs::read_to_string(inbox.join("2025-06-01-001.md")).unwrap();
@@ -925,7 +946,7 @@ mod tests {
                     create: true,
                     owner: Some("testowner".into()),
                 };
-                handle_mailbox_crud(&s, &m, &req).await
+                handle_mailbox_crud(&s, &m, &req, &Caller::internal_root()).await
             }));
         }
         for h in handles {
@@ -974,7 +995,7 @@ mod tests {
             create: true,
             owner: None,
         };
-        match handle_mailbox_crud(&state_ctx, &mb_ctx, &req).await {
+        match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Validation);
                 assert!(reason.contains("Owner:"), "{reason}");
@@ -996,7 +1017,7 @@ mod tests {
             create: true,
             owner: Some("ghost".into()),
         };
-        match handle_mailbox_crud(&state_ctx, &mb_ctx, &req).await {
+        match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Validation);
                 assert!(reason.contains("ghost"), "{reason}");
@@ -1046,7 +1067,7 @@ mod tests {
         // some exotic CI, in which case the conflict check flips to
         // "already correct" and the create succeeds. Accept either
         // Ok or Conflict so the test is portable.
-        match handle_mailbox_crud(&state_ctx, &mb_ctx, &req).await {
+        match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Conflict, "{reason}");
                 assert!(
@@ -1112,7 +1133,7 @@ mod tests {
             create: true,
             owner: Some("nobody".into()),
         };
-        match handle_mailbox_crud(&state_ctx, &mb_ctx, &req).await {
+        match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, .. } => {
                 // Either Conflict (pre-existing dir owner mismatch) or
                 // Io (chown failed). Both are valid outcomes for the
@@ -1168,7 +1189,7 @@ mod tests {
         };
         assert!(
             matches!(
-                handle_mailbox_crud(&state_ctx, &mb_ctx, &req).await,
+                handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await,
                 AckResponse::Ok
             ),
             "idempotent re-create should succeed"

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ mod state_handler;
 mod term;
 mod transport;
 mod trust;
+mod uds_authz;
 mod uninstall;
 mod user_resolver;
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1007,19 +1007,12 @@ pub(crate) fn parse_ack_response(buf: &[u8]) -> MarkOutcome {
     }
     if let Some(err_body) = rest.strip_prefix("ERR ") {
         let (code_str, reason) = err_body.split_once(' ').unwrap_or((err_body, ""));
-        let code = match code_str {
-            "MAILBOX" => ErrCode::Mailbox,
-            "DOMAIN" => ErrCode::Domain,
-            "SIGN" => ErrCode::Sign,
-            "DELIVERY" => ErrCode::Delivery,
-            "TEMP" => ErrCode::Temp,
-            "MALFORMED" => ErrCode::Malformed,
-            "PROTOCOL" => ErrCode::Protocol,
-            "NOTFOUND" => ErrCode::NotFound,
-            "IO" => ErrCode::Io,
-            // MAILBOX-CRUD verbs report these codes.
-            "VALIDATION" => ErrCode::Validation,
-            "NONEMPTY" => ErrCode::NonEmpty,
+        // Sprint 4: prefer the structured `Code:` header if the daemon
+        // emitted one, fall back to the legacy inline token.
+        let header = parse_ack_code_header(text);
+        let code = match (header, ErrCode::from_str(code_str)) {
+            (Some(h), _) => h,
+            (None, Some(inline)) => inline,
             _ => {
                 return MarkOutcome::Malformed(format!(
                     "unknown ERR code {code_str:?} in response"
@@ -1032,6 +1025,22 @@ pub(crate) fn parse_ack_response(buf: &[u8]) -> MarkOutcome {
         };
     }
     MarkOutcome::Malformed(format!("unexpected response: {line:?}"))
+}
+
+fn parse_ack_code_header(text: &str) -> Option<ErrCode> {
+    for line in text.lines().skip(1) {
+        let line = line.trim_end_matches('\r');
+        if line.is_empty() {
+            break;
+        }
+        if let Some(v) = line.strip_prefix("Code: ") {
+            return ErrCode::from_str(v.trim());
+        }
+        if let Some(v) = line.strip_prefix("Code:") {
+            return ErrCode::from_str(v.trim());
+        }
+    }
+    None
 }
 
 #[tool_handler]

--- a/src/send.rs
+++ b/src/send.rs
@@ -260,18 +260,13 @@ fn parse_response_line(buf: &[u8]) -> SubmitOutcome {
     }
     if let Some(err_body) = rest.strip_prefix("ERR ") {
         let (code_str, reason) = err_body.split_once(' ').unwrap_or((err_body, ""));
-        let code = match code_str {
-            "MAILBOX" => ErrCode::Mailbox,
-            "DOMAIN" => ErrCode::Domain,
-            "SIGN" => ErrCode::Sign,
-            "DELIVERY" => ErrCode::Delivery,
-            "TEMP" => ErrCode::Temp,
-            "MALFORMED" => ErrCode::Malformed,
-            "PROTOCOL" => ErrCode::Protocol,
-            "NOTFOUND" => ErrCode::NotFound,
-            "IO" => ErrCode::Io,
-            "VALIDATION" => ErrCode::Validation,
-            "NONEMPTY" => ErrCode::NonEmpty,
+        // Sprint 4: the frame may carry a follow-up `Code:` header on
+        // subsequent lines. We scan for it so clients can branch on
+        // the structured code even if the status-line token drifts.
+        let header_code = header_code(text);
+        let code = match (header_code, ErrCode::from_str(code_str)) {
+            (Some(h), _) => h,
+            (None, Some(inline)) => inline,
             _ => {
                 return SubmitOutcome::Malformed(format!(
                     "unknown ERR code {code_str:?} in response"
@@ -285,6 +280,25 @@ fn parse_response_line(buf: &[u8]) -> SubmitOutcome {
     }
 
     SubmitOutcome::Malformed(format!("unexpected response: {line:?}"))
+}
+
+/// Extract the first `Code:` header from the response text, if present.
+/// Introduced in Sprint 4 so the structured code on the wire survives
+/// any future change to the status-line token.
+fn header_code(text: &str) -> Option<ErrCode> {
+    for line in text.lines().skip(1) {
+        let line = line.trim_end_matches('\r');
+        if line.is_empty() {
+            break;
+        }
+        if let Some(v) = line.strip_prefix("Code: ") {
+            return ErrCode::from_str(v.trim());
+        }
+        if let Some(v) = line.strip_prefix("Code:") {
+            return ErrCode::from_str(v.trim());
+        }
+    }
+    None
 }
 
 /// Is the current process running as root? Factored out so tests can override.
@@ -1005,6 +1019,8 @@ mod tests {
 
     #[test]
     fn parse_response_unknown_err_code() {
+        // Neither the inline token nor a Code: header resolves — the
+        // client surfaces Malformed so downstream tooling can flag it.
         let buf = b"AIMX/1 ERR SPLORG something\n";
         assert!(matches!(
             parse_response_line(buf),
@@ -1018,6 +1034,36 @@ mod tests {
             parse_response_line(b""),
             SubmitOutcome::Malformed(_)
         ));
+    }
+
+    #[test]
+    fn parse_response_eacces_via_inline_and_header() {
+        // Sprint 4 S4-3: a response carrying both the legacy inline
+        // `EACCES` token AND a structured `Code:` header is parseable
+        // back into the same `ErrCode::Eaccess` variant.
+        let buf = b"AIMX/1 ERR EACCES not owner\nCode: EACCES\n\n";
+        match parse_response_line(buf) {
+            SubmitOutcome::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Eaccess);
+                assert_eq!(reason, "not owner");
+            }
+            other => panic!("expected Err(EACCES), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_response_enoent_header_takes_precedence() {
+        // If the Code: header disagrees with the inline token, the
+        // structured header wins. This future-proofs against the
+        // status line drifting past the enum vocabulary.
+        let buf = b"AIMX/1 ERR UNKNOWN not found\nCode: ENOENT\n\n";
+        match parse_response_line(buf) {
+            SubmitOutcome::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Enoent);
+                assert_eq!(reason, "not found");
+            }
+            other => panic!("expected Err(ENOENT), got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/send_handler.rs
+++ b/src/send_handler.rs
@@ -27,6 +27,7 @@ use crate::ownership::chown_as_owner;
 use crate::send_protocol::{ErrCode, SendRequest, SendResponse};
 use crate::slug::{allocate_filename, slugify};
 use crate::transport::{MailTransport, TransportError};
+use crate::uds_authz::{Caller, enforce_mailbox_owner_or_root};
 
 /// Process-scoped lock guarding the outbound critical section: filename
 /// allocation + file/directory creation. The daemon is the single writer
@@ -75,8 +76,8 @@ pub struct SendContext {
 /// header out of the body → validate the sender domain matches config →
 /// DKIM-sign → deliver via MX. Every error path maps to a stable
 /// [`ErrCode`].
-pub async fn handle_send(req: SendRequest, ctx: &SendContext) -> SendResponse {
-    handle_send_with_signer(req, ctx, dkim::sign_message).await
+pub async fn handle_send(req: SendRequest, ctx: &SendContext, caller: &Caller) -> SendResponse {
+    handle_send_with_signer(req, ctx, caller, dkim::sign_message).await
 }
 
 /// Generic form of [`handle_send`] parameterized on the DKIM signer so tests
@@ -85,6 +86,7 @@ pub async fn handle_send(req: SendRequest, ctx: &SendContext) -> SendResponse {
 pub(crate) async fn handle_send_with_signer<F>(
     req: SendRequest,
     ctx: &SendContext,
+    caller: &Caller,
     signer: F,
 ) -> SendResponse
 where
@@ -179,6 +181,19 @@ where
             };
         }
     };
+
+    // Sprint 4 §6.5: authorize the caller against the resolved
+    // mailbox. Non-owners (other than root) get EACCES so a uid bound
+    // to mailbox `bob` cannot spoof `From: alice@domain`.
+    if let Some(mailbox_cfg) = config.mailboxes.get(&from_mailbox)
+        && let Err(reject) =
+            enforce_mailbox_owner_or_root("SEND", caller, &from_mailbox, mailbox_cfg)
+    {
+        return SendResponse::Err {
+            code: reject.code,
+            reason: reject.reason,
+        };
+    }
 
     let to_header = match headers.get("To") {
         Some(v) => v.clone(),
@@ -761,7 +776,7 @@ mod tests {
         let req = SendRequest {
             body: body("alice@example.com"),
         };
-        let resp = handle_send(req, &ctx).await;
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
         match resp {
             SendResponse::Ok { message_id } => {
                 assert_eq!(message_id, "<abc@example.com>");
@@ -791,7 +806,7 @@ mod tests {
         let req = SendRequest {
             body: body("bogus@example.com"),
         };
-        let resp = handle_send(req, &ctx).await;
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
         match resp {
             SendResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Mailbox);
@@ -817,7 +832,7 @@ mod tests {
         let req = SendRequest {
             body: body("catchall@example.com"),
         };
-        let resp = handle_send(req, &ctx).await;
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
         match resp {
             SendResponse::Err { code, .. } => assert_eq!(code, ErrCode::Mailbox),
             other => panic!("expected Err(MAILBOX), got {other:?}"),
@@ -834,7 +849,7 @@ mod tests {
         let req = SendRequest {
             body: body("alice@other.org"),
         };
-        let resp = handle_send(req, &ctx).await;
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
         match resp {
             SendResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Domain);
@@ -854,7 +869,7 @@ mod tests {
         let req = SendRequest {
             body: body("alice@EXAMPLE.COM"),
         };
-        let resp = handle_send(req, &ctx).await;
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
         assert!(matches!(resp, SendResponse::Ok { .. }), "{resp:?}");
     }
 
@@ -870,7 +885,7 @@ mod tests {
         let req = SendRequest {
             body: body("alice@example.com"),
         };
-        let resp = handle_send(req, &ctx).await;
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
         assert!(matches!(resp, SendResponse::Ok { .. }), "{resp:?}");
     }
 
@@ -886,7 +901,7 @@ mod tests {
         let req = SendRequest {
             body: body("Alice <alice@example.com>"),
         };
-        let resp = handle_send(req, &ctx).await;
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
         assert!(matches!(resp, SendResponse::Ok { .. }), "{resp:?}");
     }
 
@@ -904,7 +919,7 @@ mod tests {
                      hello\r\n"
             .to_vec();
         let req = SendRequest { body };
-        let resp = handle_send(req, &ctx).await;
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
         match resp {
             SendResponse::Err { code, .. } => assert_eq!(code, ErrCode::Malformed),
             other => panic!("expected Err, got {other:?}"),
@@ -923,7 +938,7 @@ mod tests {
         let req = SendRequest {
             body: body("alice@example.com"),
         };
-        let resp = handle_send(req, &ctx).await;
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
         match resp {
             SendResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Delivery);
@@ -945,7 +960,7 @@ mod tests {
         let req = SendRequest {
             body: body("alice@example.com"),
         };
-        let resp = handle_send(req, &ctx).await;
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
         match resp {
             SendResponse::Err { code, .. } => assert_eq!(code, ErrCode::Temp),
             other => panic!("expected Err, got {other:?}"),
@@ -1061,7 +1076,7 @@ mod tests {
                      hello\r\n"
             .to_vec();
         let req = SendRequest { body };
-        let resp = handle_send(req, &ctx).await;
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
         assert!(matches!(resp, SendResponse::Ok { .. }), "{resp:?}");
     }
 
@@ -1080,7 +1095,7 @@ mod tests {
                      hello\r\n"
             .to_vec();
         let req = SendRequest { body };
-        let resp = handle_send(req, &ctx).await;
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
         match resp {
             SendResponse::Ok { message_id } => {
                 assert!(
@@ -1122,7 +1137,8 @@ mod tests {
          -> Result<Vec<u8>, Box<dyn std::error::Error>> {
             Err("simulated DKIM signing failure".into())
         };
-        let resp = handle_send_with_signer(req, &ctx, failing_signer).await;
+        let resp =
+            handle_send_with_signer(req, &ctx, &Caller::internal_root(), failing_signer).await;
         match resp {
             SendResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Sign);
@@ -1146,7 +1162,7 @@ mod tests {
         let req = SendRequest {
             body: body("alice@example.com"),
         };
-        let resp = handle_send(req, &ctx).await;
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
         assert!(matches!(resp, SendResponse::Ok { .. }), "{resp:?}");
 
         let sent_dir = data_dir.path().join("sent").join("alice");
@@ -1179,7 +1195,7 @@ mod tests {
         let req = SendRequest {
             body: body("alice@example.com"),
         };
-        let resp = handle_send(req, &ctx).await;
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
         assert!(matches!(resp, SendResponse::Err { .. }), "{resp:?}");
 
         let sent_dir = data_dir.path().join("sent").join("alice");
@@ -1208,7 +1224,7 @@ mod tests {
         let req = SendRequest {
             body: body("alice@example.com"),
         };
-        let resp = handle_send(req, &ctx).await;
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
         assert!(matches!(resp, SendResponse::Err { .. }), "{resp:?}");
 
         let sent_dir = data_dir.path().join("sent").join("alice");
@@ -1232,7 +1248,7 @@ mod tests {
         let req = SendRequest {
             body: body("alice@example.com"),
         };
-        let resp = handle_send(req, &ctx).await;
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
         assert!(matches!(resp, SendResponse::Ok { .. }));
 
         let sent_dir = data_dir.path().join("sent").join("alice");
@@ -1334,7 +1350,7 @@ mod tests {
         let req = SendRequest {
             body: body("alice@example.com"),
         };
-        let resp = handle_send(req, &ctx).await;
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
         assert!(matches!(resp, SendResponse::Ok { .. }));
 
         let sent_dir = data_dir.path().join("sent").join("alice");

--- a/src/send_handler.rs
+++ b/src/send_handler.rs
@@ -185,10 +185,25 @@ where
     // Sprint 4 §6.5: authorize the caller against the resolved
     // mailbox. Non-owners (other than root) get EACCES so a uid bound
     // to mailbox `bob` cannot spoof `From: alice@domain`.
-    if let Some(mailbox_cfg) = config.mailboxes.get(&from_mailbox)
-        && let Err(reject) =
-            enforce_mailbox_owner_or_root("SEND", caller, &from_mailbox, mailbox_cfg)
-    {
+    //
+    // `resolve_concrete_mailbox` above guarantees the mailbox exists
+    // in `config.mailboxes`, so the `None` branch is unreachable today.
+    // We handle it explicitly with `ENOENT` rather than letting authz
+    // be silently skipped if a future refactor splits the resolve /
+    // lookup pair.
+    let mailbox_cfg = match config.mailboxes.get(&from_mailbox) {
+        Some(m) => m,
+        None => {
+            return SendResponse::Err {
+                code: ErrCode::Mailbox,
+                reason: format!(
+                    "mailbox '{from_mailbox}' resolved but not found in config \
+                     (race with concurrent MAILBOX-DELETE)"
+                ),
+            };
+        }
+    };
+    if let Err(reject) = enforce_mailbox_owner_or_root("SEND", caller, &from_mailbox, mailbox_cfg) {
         return SendResponse::Err {
             code: reject.code,
             reason: reject.reason,

--- a/src/send_protocol.rs
+++ b/src/send_protocol.rs
@@ -253,6 +253,18 @@ pub enum ErrCode {
     /// owner. Ambiguous state — operator must fix it with `chown`
     /// before the daemon will claim the directories. Sprint 2 §6.3.
     Conflict,
+    /// Sprint 4 §6.5: the caller's uid (from `SO_PEERCRED`) is not
+    /// authorized for the requested verb on the target mailbox, and
+    /// is not root. Mirrors POSIX `EACCES` for operator ergonomics.
+    Eaccess,
+    /// Sprint 4 §6.5: the target resource referenced by the verb
+    /// (mailbox, hook, template) does not exist. Distinct from
+    /// [`ErrCode::NotFound`] so authz helpers can signal
+    /// "unknown-target" vs "unknown-email-id" without overloading the
+    /// legacy code. Emitted instead of `EACCES` whenever the caller's
+    /// authz outcome is leaked by the existence-check itself (PRD
+    /// §6.5 leak-free shape).
+    Enoent,
 }
 
 impl ErrCode {
@@ -270,7 +282,33 @@ impl ErrCode {
             ErrCode::Validation => "VALIDATION",
             ErrCode::NonEmpty => "NONEMPTY",
             ErrCode::Conflict => "ECONFLICT",
+            ErrCode::Eaccess => "EACCES",
+            ErrCode::Enoent => "ENOENT",
         }
+    }
+
+    /// Parse a wire-level code string back into the tagged enum.
+    /// Returns `None` for unknown strings so clients distinguish
+    /// "daemon drifted past our vocabulary" from "daemon reported X".
+    pub fn from_str(s: &str) -> Option<Self> {
+        let v = match s {
+            "MAILBOX" => ErrCode::Mailbox,
+            "DOMAIN" => ErrCode::Domain,
+            "SIGN" => ErrCode::Sign,
+            "DELIVERY" => ErrCode::Delivery,
+            "TEMP" => ErrCode::Temp,
+            "MALFORMED" => ErrCode::Malformed,
+            "PROTOCOL" => ErrCode::Protocol,
+            "NOTFOUND" => ErrCode::NotFound,
+            "IO" => ErrCode::Io,
+            "VALIDATION" => ErrCode::Validation,
+            "NONEMPTY" => ErrCode::NonEmpty,
+            "ECONFLICT" => ErrCode::Conflict,
+            "EACCES" => ErrCode::Eaccess,
+            "ENOENT" => ErrCode::Enoent,
+            _ => return None,
+        };
+        Some(v)
     }
 }
 
@@ -907,8 +945,19 @@ where
     Ok(Some(s))
 }
 
-/// Write a `SendResponse` frame to `writer` and flush. The frame ends with a
-/// single `\n`. No body, no content-length.
+/// Write a `SendResponse` frame to `writer` and flush.
+///
+/// Wire format:
+/// ```text
+/// AIMX/1 OK <message-id>\n           (success)
+/// AIMX/1 ERR <CODE> <reason>\n       (error, status line)
+/// Code: <CODE>\n                     (Sprint 4: structured header)
+/// \n                                 (terminator)
+/// ```
+///
+/// The legacy inline `<CODE>` on the status line is preserved so older
+/// clients that only parse the first line keep working. New clients
+/// read the `Code:` header off the second line for stable branching.
 pub async fn write_response<W>(
     writer: &mut W,
     response: &SendResponse,
@@ -916,23 +965,30 @@ pub async fn write_response<W>(
 where
     W: AsyncWrite + Unpin,
 {
-    let line = match response {
+    let payload = match response {
         SendResponse::Ok { message_id } => {
             let id = sanitize_inline(message_id);
             format!("AIMX/1 OK {id}\n")
         }
         SendResponse::Err { code, reason } => {
             let r = sanitize_inline(reason);
-            format!("AIMX/1 ERR {} {r}\n", code.as_str())
+            format!(
+                "AIMX/1 ERR {code} {r}\nCode: {code}\n\n",
+                code = code.as_str()
+            )
         }
     };
-    writer.write_all(line.as_bytes()).await?;
+    writer.write_all(payload.as_bytes()).await?;
     writer.flush().await?;
     Ok(())
 }
 
 /// Write an `AckResponse` frame (bodyless OK / ERR) to `writer` and flush.
 /// Used for MARK-READ / MARK-UNREAD and future bodyless verbs.
+///
+/// Wire format matches [`write_response`]: the error form carries both
+/// the legacy inline `<CODE>` token on the status line AND an explicit
+/// `Code:` header on the next line.
 pub async fn write_ack_response<W>(
     writer: &mut W,
     response: &AckResponse,
@@ -940,14 +996,17 @@ pub async fn write_ack_response<W>(
 where
     W: AsyncWrite + Unpin,
 {
-    let line = match response {
+    let payload = match response {
         AckResponse::Ok => "AIMX/1 OK\n".to_string(),
         AckResponse::Err { code, reason } => {
             let r = sanitize_inline(reason);
-            format!("AIMX/1 ERR {} {r}\n", code.as_str())
+            format!(
+                "AIMX/1 ERR {code} {r}\nCode: {code}\n\n",
+                code = code.as_str()
+            )
         }
     };
-    writer.write_all(line.as_bytes()).await?;
+    writer.write_all(payload.as_bytes()).await?;
     writer.flush().await?;
     Ok(())
 }
@@ -1280,6 +1339,8 @@ mod tests {
             (ErrCode::Validation, "VALIDATION"),
             (ErrCode::NonEmpty, "NONEMPTY"),
             (ErrCode::Conflict, "ECONFLICT"),
+            (ErrCode::Eaccess, "EACCES"),
+            (ErrCode::Enoent, "ENOENT"),
         ] {
             let (mut client, mut server) = duplex(256);
             write_response(
@@ -1296,7 +1357,8 @@ mod tests {
             tokio::io::AsyncReadExt::read_to_end(&mut server, &mut buf)
                 .await
                 .unwrap();
-            let expected = format!("AIMX/1 ERR {label} nope\n");
+            // Sprint 4 wire format: legacy status line + `Code:` header.
+            let expected = format!("AIMX/1 ERR {label} nope\nCode: {label}\n\n");
             assert_eq!(buf, expected.as_bytes());
         }
     }
@@ -1318,7 +1380,7 @@ mod tests {
         tokio::io::AsyncReadExt::read_to_end(&mut server, &mut buf)
             .await
             .unwrap();
-        assert_eq!(buf, b"AIMX/1 ERR DELIVERY badreason\n");
+        assert_eq!(buf, b"AIMX/1 ERR DELIVERY badreason\nCode: DELIVERY\n\n");
     }
 
     #[tokio::test]
@@ -1349,7 +1411,32 @@ mod tests {
         tokio::io::AsyncReadExt::read_to_end(&mut server, &mut buf)
             .await
             .unwrap();
-        assert_eq!(buf, b"AIMX/1 ERR NOTFOUND missing\n");
+        assert_eq!(buf, b"AIMX/1 ERR NOTFOUND missing\nCode: NOTFOUND\n\n");
+    }
+
+    #[tokio::test]
+    async fn write_ack_err_eacces_includes_code_header() {
+        let (mut client, mut server) = duplex(256);
+        write_ack_response(
+            &mut client,
+            &AckResponse::Err {
+                code: ErrCode::Eaccess,
+                reason: "not owner".into(),
+            },
+        )
+        .await
+        .unwrap();
+        drop(client);
+        let mut buf = Vec::new();
+        tokio::io::AsyncReadExt::read_to_end(&mut server, &mut buf)
+            .await
+            .unwrap();
+        let text = String::from_utf8_lossy(&buf);
+        // Both the legacy inline code and the `Code:` header must be
+        // present so clients can pick either. The sprint AC says "a
+        // client reading the frame can deserialize both".
+        assert!(text.contains("AIMX/1 ERR EACCES not owner"));
+        assert!(text.contains("Code: EACCES"));
     }
 
     // ----- MARK-READ / MARK-UNREAD verbs -----------------------------

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -741,17 +741,37 @@ async fn run_send_listener(
             accept = listener.accept() => {
                 match accept {
                     Ok((stream, _addr)) => {
-                        let peer = peer_credentials(&stream);
+                        // Sprint 4 S4-1: capture SO_PEERCRED at accept
+                        // time so every verb handler sees the caller's
+                        // uid/gid/pid before any body bytes are read.
+                        let caller = match crate::uds_authz::caller_from_stream(&stream) {
+                            Ok(c) => c,
+                            Err(reason) => {
+                                eprintln!("[send] peer_cred unavailable: {reason}");
+                                let (_reader, mut writer) = stream.into_split();
+                                let _ = send_protocol::write_ack_response(
+                                    &mut writer,
+                                    &send_protocol::AckResponse::Err {
+                                        code: send_protocol::ErrCode::Eaccess,
+                                        reason,
+                                    },
+                                )
+                                .await;
+                                use tokio::io::AsyncWriteExt;
+                                let _ = writer.shutdown().await;
+                                continue;
+                            }
+                        };
                         eprintln!(
                             "[send] accepted: peer_uid={} peer_pid={}",
-                            peer.uid_str(),
-                            peer.pid_str()
+                            caller.uid,
+                            caller.pid.map(|v| v.to_string()).unwrap_or_else(|| "?".into())
                         );
                         let send_ctx = Arc::clone(&send_ctx);
                         let state_ctx = Arc::clone(&state_ctx);
                         let mb_ctx = Arc::clone(&mb_ctx);
                         tokio::spawn(async move {
-                            handle_uds_connection(stream, send_ctx, state_ctx, mb_ctx).await;
+                            handle_uds_connection(stream, send_ctx, state_ctx, mb_ctx, caller).await;
                         });
                     }
                     Err(e) => {
@@ -779,9 +799,17 @@ async fn handle_uds_connection(
     send_ctx: Arc<SendContext>,
     state_ctx: Arc<StateContext>,
     mb_ctx: Arc<MailboxContext>,
+    caller: crate::uds_authz::Caller,
 ) {
-    handle_uds_connection_with_timeout(stream, send_ctx, state_ctx, mb_ctx, UDS_REQUEST_TIMEOUT)
-        .await;
+    handle_uds_connection_with_timeout(
+        stream,
+        send_ctx,
+        state_ctx,
+        mb_ctx,
+        caller,
+        UDS_REQUEST_TIMEOUT,
+    )
+    .await;
 }
 
 /// One-frame-per-connection dispatcher. Reads a single `AIMX/1` request
@@ -794,6 +822,7 @@ async fn handle_uds_connection_with_timeout(
     send_ctx: Arc<SendContext>,
     state_ctx: Arc<StateContext>,
     mb_ctx: Arc<MailboxContext>,
+    caller: crate::uds_authz::Caller,
     timeout: std::time::Duration,
 ) {
     use send_protocol::{AckResponse, ErrCode, ParseError, Request, SendResponse};
@@ -808,28 +837,31 @@ async fn handle_uds_connection_with_timeout(
     let (reply, parse_failed) =
         match tokio::time::timeout(timeout, send_protocol::parse_request(&mut reader)).await {
             Ok(Ok(Request::Send(req))) => (
-                Reply::Send(crate::send_handler::handle_send(req, &send_ctx).await),
+                Reply::Send(crate::send_handler::handle_send(req, &send_ctx, &caller).await),
                 false,
             ),
             Ok(Ok(Request::Mark(req))) => (
-                Reply::Ack(crate::state_handler::handle_mark(&state_ctx, &req).await),
+                Reply::Ack(crate::state_handler::handle_mark(&state_ctx, &req, &caller).await),
                 false,
             ),
             Ok(Ok(Request::MailboxCrud(req))) => (
                 Reply::Ack(
-                    crate::mailbox_handler::handle_mailbox_crud(&state_ctx, &mb_ctx, &req).await,
+                    crate::mailbox_handler::handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &caller)
+                        .await,
                 ),
                 false,
             ),
             Ok(Ok(Request::HookCreate(req))) => (
                 Reply::Ack(
-                    crate::hook_handler::handle_hook_create(&state_ctx, &mb_ctx, &req).await,
+                    crate::hook_handler::handle_hook_create(&state_ctx, &mb_ctx, &req, &caller)
+                        .await,
                 ),
                 false,
             ),
             Ok(Ok(Request::HookDelete(req))) => (
                 Reply::Ack(
-                    crate::hook_handler::handle_hook_delete(&state_ctx, &mb_ctx, &req).await,
+                    crate::hook_handler::handle_hook_delete(&state_ctx, &mb_ctx, &req, &caller)
+                        .await,
                 ),
                 false,
             ),
@@ -891,41 +923,6 @@ async fn handle_uds_connection_with_timeout(
         eprintln!("[send] failed to write response: {e}");
     }
     let _ = writer.shutdown().await;
-}
-
-/// Peer-credential snapshot for logging. `None` on platforms/errors where
-/// the kernel could not supply credentials, e.g. the client closed before
-/// we asked. Used only for journald diagnostics (FR-18b), never for
-/// authorization.
-struct PeerCred {
-    uid: Option<u32>,
-    pid: Option<i32>,
-}
-
-impl PeerCred {
-    fn uid_str(&self) -> String {
-        self.uid
-            .map(|v| v.to_string())
-            .unwrap_or_else(|| "?".into())
-    }
-    fn pid_str(&self) -> String {
-        self.pid
-            .map(|v| v.to_string())
-            .unwrap_or_else(|| "?".into())
-    }
-}
-
-fn peer_credentials(stream: &tokio::net::UnixStream) -> PeerCred {
-    match stream.peer_cred() {
-        Ok(c) => PeerCred {
-            uid: Some(c.uid()),
-            pid: c.pid(),
-        },
-        Err(_) => PeerCred {
-            uid: None,
-            pid: None,
-        },
-    }
 }
 
 fn can_read_tls(cert: &std::path::Path, key: &std::path::Path) -> bool {
@@ -1876,12 +1873,24 @@ mod tests {
             });
             let transport: Arc<dyn MailTransport + Send + Sync> = captor.clone();
 
+            // Sprint 4: the UDS now enforces per-mailbox ownership via
+            // SO_PEERCRED, so the mailbox owner must match the uid the
+            // test client connects under. Resolve the running uid back
+            // to a username so this test passes for any CI user (root
+            // on the integration-isolation job, `runner`/`ubuntu`
+            // locally).
+            let caller_uid = unsafe { libc::geteuid() };
+            let caller_username = crate::uds_authz::Caller::new(caller_uid, caller_uid, None)
+                .username()
+                .unwrap_or("root")
+                .to_string();
+
             let mut mailboxes = HashMap::new();
             mailboxes.insert(
                 "alice".to_string(),
                 crate::config::MailboxConfig {
                     address: "alice@example.com".to_string(),
-                    owner: "root".to_string(),
+                    owner: caller_username.clone(),
                     hooks: vec![],
                     trust: None,
                     trusted_senders: None,
@@ -1998,6 +2007,7 @@ mod tests {
                         send_ctx,
                         state_ctx,
                         mb_ctx,
+                        crate::uds_authz::Caller::internal_root(),
                         std::time::Duration::from_secs(1),
                     )
                     .await;

--- a/src/state_handler.rs
+++ b/src/state_handler.rs
@@ -134,17 +134,22 @@ pub async fn handle_mark(ctx: &StateContext, req: &MarkRequest, caller: &Caller)
     // is absent so the authz check itself cannot leak which mailboxes
     // exist. Once the mailbox resolves, the ownership check runs.
     let config_snapshot = ctx.config_handle.load();
-    if !config_snapshot.mailboxes.contains_key(&req.mailbox) {
-        return AckResponse::Err {
-            code: ErrCode::Enoent,
-            reason: format!("mailbox '{}' does not exist", req.mailbox),
-        };
-    }
-    let mailbox_cfg = config_snapshot.mailboxes.get(&req.mailbox).cloned();
+    // `contains_key` + `get` is split to keep the existence check out
+    // of the authz error path, but the `get` must succeed on the
+    // snapshot we just checked. We match explicitly on `None` and
+    // return `ENOENT` so authz can never be silently skipped if a
+    // future refactor drops the `contains_key` pre-check.
+    let mailbox_cfg = match config_snapshot.mailboxes.get(&req.mailbox) {
+        Some(m) => m.clone(),
+        None => {
+            return AckResponse::Err {
+                code: ErrCode::Enoent,
+                reason: format!("mailbox '{}' does not exist", req.mailbox),
+            };
+        }
+    };
     let verb = if req.read { "MARK-READ" } else { "MARK-UNREAD" };
-    if let Some(cfg) = &mailbox_cfg
-        && let Err(reject) = enforce_mailbox_owner_or_root(verb, caller, &req.mailbox, cfg)
-    {
+    if let Err(reject) = enforce_mailbox_owner_or_root(verb, caller, &req.mailbox, &mailbox_cfg) {
         return AckResponse::Err {
             code: reject.code,
             reason: reject.reason,
@@ -256,21 +261,19 @@ pub async fn handle_mark(ctx: &StateContext, req: &MarkRequest, caller: &Caller)
             reason: format!("failed to write {}: {e}", tmp_path.display()),
         };
     }
-    if let Some(mb_cfg) = &mailbox_cfg {
-        // Chown + chmod BEFORE the rename publishes the new inode. A
-        // failure here is not fatal for the MARK operation (the
-        // containing dir is `0o700 <owner>:<owner>` so the file is
-        // still safe from non-owners even if ownership drifts) but we
-        // log so doctor can surface the drift.
-        if let Err(e) = chown_as_owner(&tmp_path, mb_cfg, 0o600) {
-            tracing::warn!(
-                target: "aimx::state",
-                "chown temp file failed mailbox={mailbox} path={path} err={err}",
-                mailbox = req.mailbox,
-                path = tmp_path.display(),
-                err = e,
-            );
-        }
+    // Chown + chmod BEFORE the rename publishes the new inode. A
+    // failure here is not fatal for the MARK operation (the
+    // containing dir is `0o700 <owner>:<owner>` so the file is
+    // still safe from non-owners even if ownership drifts) but we
+    // log so doctor can surface the drift.
+    if let Err(e) = chown_as_owner(&tmp_path, &mailbox_cfg, 0o600) {
+        tracing::warn!(
+            target: "aimx::state",
+            "chown temp file failed mailbox={mailbox} path={path} err={err}",
+            mailbox = req.mailbox,
+            path = tmp_path.display(),
+            err = e,
+        );
     }
     if let Err(e) = std::fs::rename(&tmp_path, &filepath) {
         let _ = std::fs::remove_file(&tmp_path);

--- a/src/state_handler.rs
+++ b/src/state_handler.rs
@@ -33,6 +33,7 @@ use crate::mailbox_locks::MailboxLocks;
 use crate::mcp::resolve_email_path;
 use crate::ownership::chown_as_owner;
 use crate::send_protocol::{AckResponse, ErrCode, MarkFolder, MarkRequest};
+use crate::uds_authz::{Caller, enforce_mailbox_owner_or_root};
 
 /// Per-connection shared state for the MARK verbs (and the MAILBOX-CRUD
 /// verbs, which share the per-mailbox lock map so their config.toml
@@ -121,21 +122,34 @@ fn folder_dir(data_dir: &Path, mailbox: &str, folder: MarkFolder) -> PathBuf {
 /// read → rewrite critical section. The lock is shared with the
 /// inbound-ingest writer so MARK and ingest serialize against each
 /// other, not just against other MARK calls.
-pub async fn handle_mark(ctx: &StateContext, req: &MarkRequest) -> AckResponse {
+pub async fn handle_mark(ctx: &StateContext, req: &MarkRequest, caller: &Caller) -> AckResponse {
     if let Err(e) = validate_id(&req.id) {
         return e;
     }
 
     // Mailbox existence is resolved live through the handle so a
     // freshly-created mailbox is immediately target-able from MARK.
+    //
+    // Sprint 4 §6.5: we return `ENOENT` (not `EACCES`) when the mailbox
+    // is absent so the authz check itself cannot leak which mailboxes
+    // exist. Once the mailbox resolves, the ownership check runs.
     let config_snapshot = ctx.config_handle.load();
     if !config_snapshot.mailboxes.contains_key(&req.mailbox) {
         return AckResponse::Err {
-            code: ErrCode::Mailbox,
+            code: ErrCode::Enoent,
             reason: format!("mailbox '{}' does not exist", req.mailbox),
         };
     }
     let mailbox_cfg = config_snapshot.mailboxes.get(&req.mailbox).cloned();
+    let verb = if req.read { "MARK-READ" } else { "MARK-UNREAD" };
+    if let Some(cfg) = &mailbox_cfg
+        && let Err(reject) = enforce_mailbox_owner_or_root(verb, caller, &req.mailbox, cfg)
+    {
+        return AckResponse::Err {
+            code: reject.code,
+            reason: reject.reason,
+        };
+    }
 
     let lock = ctx.lock_for(&req.mailbox);
     let _guard = lock.lock().await;
@@ -358,7 +372,7 @@ mod tests {
             folder: MarkFolder::Inbox,
             read: true,
         };
-        match handle_mark(&sctx, &req).await {
+        match handle_mark(&sctx, &req, &Caller::internal_root()).await {
             AckResponse::Ok => {}
             other => panic!("expected Ok, got {other:?}"),
         }
@@ -385,7 +399,10 @@ mod tests {
             folder: MarkFolder::Inbox,
             read: false,
         };
-        assert!(matches!(handle_mark(&sctx, &req).await, AckResponse::Ok));
+        assert!(matches!(
+            handle_mark(&sctx, &req, &Caller::internal_root()).await,
+            AckResponse::Ok
+        ));
 
         let content = std::fs::read_to_string(inbox.join("2025-06-01-001.md")).unwrap();
         let fm: InboundFrontmatter =
@@ -403,9 +420,11 @@ mod tests {
             folder: MarkFolder::Inbox,
             read: true,
         };
-        match handle_mark(&sctx, &req).await {
+        match handle_mark(&sctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
-                assert_eq!(code, ErrCode::Mailbox);
+                // Sprint 4 §6.5: unknown mailbox returns ENOENT so the
+                // authz check cannot leak which mailboxes exist.
+                assert_eq!(code, ErrCode::Enoent);
                 assert!(reason.contains("ghost"), "{reason}");
             }
             other => panic!("expected Err, got {other:?}"),
@@ -423,7 +442,7 @@ mod tests {
             folder: MarkFolder::Inbox,
             read: true,
         };
-        match handle_mark(&sctx, &req).await {
+        match handle_mark(&sctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::NotFound),
             other => panic!("expected Err, got {other:?}"),
         }
@@ -439,7 +458,7 @@ mod tests {
             folder: MarkFolder::Inbox,
             read: true,
         };
-        match handle_mark(&sctx, &req).await {
+        match handle_mark(&sctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::NotFound);
                 assert!(reason.contains("invalid characters"), "{reason}");
@@ -462,7 +481,10 @@ mod tests {
             folder: MarkFolder::Sent,
             read: true,
         };
-        assert!(matches!(handle_mark(&sctx, &req).await, AckResponse::Ok));
+        assert!(matches!(
+            handle_mark(&sctx, &req, &Caller::internal_root()).await,
+            AckResponse::Ok
+        ));
 
         let fm: InboundFrontmatter = toml::from_str(
             std::fs::read_to_string(sent.join("2025-06-02-001.md"))
@@ -495,7 +517,10 @@ mod tests {
             folder: MarkFolder::Inbox,
             read: true,
         };
-        assert!(matches!(handle_mark(&sctx, &req).await, AckResponse::Ok));
+        assert!(matches!(
+            handle_mark(&sctx, &req, &Caller::internal_root()).await,
+            AckResponse::Ok
+        ));
 
         let content = std::fs::read_to_string(bundle.join("2025-06-03-001.md")).unwrap();
         let fm: InboundFrontmatter =
@@ -525,7 +550,7 @@ mod tests {
             folder: MarkFolder::Inbox,
             read: true,
         };
-        match handle_mark(&sctx, &req).await {
+        match handle_mark(&sctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Io);
                 assert!(
@@ -552,7 +577,10 @@ mod tests {
             read: true,
         };
         let before = chrono::Utc::now();
-        assert!(matches!(handle_mark(&sctx, &req).await, AckResponse::Ok));
+        assert!(matches!(
+            handle_mark(&sctx, &req, &Caller::internal_root()).await,
+            AckResponse::Ok
+        ));
         let after = chrono::Utc::now();
 
         let content = std::fs::read_to_string(inbox.join("2025-06-01-001.md")).unwrap();
@@ -581,7 +609,10 @@ mod tests {
             folder: MarkFolder::Inbox,
             read: false,
         };
-        assert!(matches!(handle_mark(&sctx, &req).await, AckResponse::Ok));
+        assert!(matches!(
+            handle_mark(&sctx, &req, &Caller::internal_root()).await,
+            AckResponse::Ok
+        ));
 
         let content = std::fs::read_to_string(inbox.join("2025-06-01-001.md")).unwrap();
         // Field must be removed entirely, not serialized as `null`
@@ -619,7 +650,7 @@ mod tests {
 
         // First MARK-READ.
         assert!(matches!(
-            handle_mark(&sctx, &req_read).await,
+            handle_mark(&sctx, &req_read, &Caller::internal_root()).await,
             AckResponse::Ok
         ));
         let content = std::fs::read_to_string(inbox.join("2025-06-01-001.md")).unwrap();
@@ -629,7 +660,7 @@ mod tests {
 
         // MARK-UNREAD clears it.
         assert!(matches!(
-            handle_mark(&sctx, &req_unread).await,
+            handle_mark(&sctx, &req_unread, &Caller::internal_root()).await,
             AckResponse::Ok
         ));
         let content = std::fs::read_to_string(inbox.join("2025-06-01-001.md")).unwrap();
@@ -643,7 +674,7 @@ mod tests {
 
         // Second MARK-READ writes a fresh, later timestamp.
         assert!(matches!(
-            handle_mark(&sctx, &req_read).await,
+            handle_mark(&sctx, &req_read, &Caller::internal_root()).await,
             AckResponse::Ok
         ));
         let content = std::fs::read_to_string(inbox.join("2025-06-01-001.md")).unwrap();
@@ -720,7 +751,10 @@ mod tests {
             folder: MarkFolder::Inbox,
             read: true,
         };
-        assert!(matches!(handle_mark(&sctx, &req).await, AckResponse::Ok));
+        assert!(matches!(
+            handle_mark(&sctx, &req, &Caller::internal_root()).await,
+            AckResponse::Ok
+        ));
 
         let target = inbox.join("2025-06-01-001.md");
         let md = std::fs::metadata(&target).unwrap();
@@ -812,7 +846,10 @@ mod tests {
         };
         // chown will fail (EPERM) but the handler must still return Ok.
         assert!(
-            matches!(handle_mark(&sctx, &req).await, AckResponse::Ok),
+            matches!(
+                handle_mark(&sctx, &req, &Caller::internal_root()).await,
+                AckResponse::Ok
+            ),
             "chown failure must be non-fatal"
         );
 
@@ -870,7 +907,7 @@ mod tests {
             folder: MarkFolder::Inbox,
             read: true,
         };
-        match handle_mark(&sctx, &req).await {
+        match handle_mark(&sctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Io),
             other => panic!("expected Err(Io), got {other:?}"),
         }

--- a/src/uds_authz.rs
+++ b/src/uds_authz.rs
@@ -65,7 +65,11 @@ impl Caller {
     }
 
     /// Construct an explicit caller (tests and internal dispatchers).
-    #[allow(dead_code)]
+    ///
+    /// Gated behind `#[cfg(test)]` because every production call site
+    /// uses [`Caller::from_ucred`] instead. Tests and integration
+    /// fixtures that synthesize a caller go through this constructor.
+    #[cfg(test)]
     pub fn new(uid: u32, gid: u32, pid: Option<i32>) -> Self {
         Self {
             uid,
@@ -79,7 +83,12 @@ impl Caller {
     /// the in-process inbound ingest path which never crosses the UDS.
     /// Also convenient for tests and harnesses that bypass the real
     /// SO_PEERCRED path.
-    #[allow(dead_code)]
+    ///
+    /// Gated behind `#[cfg(test)]`: production call sites either go
+    /// through [`Caller::from_ucred`] after a real `SO_PEERCRED`
+    /// handshake, or (for the in-process ingest path) synthesize a
+    /// caller via platform APIs rather than this helper.
+    #[cfg(test)]
     pub fn internal_root() -> Self {
         Self::new(0, 0, None)
     }
@@ -210,6 +219,27 @@ pub fn require_root(caller: &Caller) -> Result<AuthzDecision, AuthzReject> {
     }
 }
 
+/// Decision value passed to [`log_decision`]. Typed so the compiler —
+/// rather than a string-match wildcard — catches new variants: if a
+/// future caller invents a fourth outcome, it has to add an arm here
+/// instead of silently falling through to a "debug accept" line.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LogDecision {
+    Accept,
+    RootBypass,
+    Reject,
+}
+
+impl LogDecision {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            LogDecision::Accept => "accept",
+            LogDecision::RootBypass => "root_bypass",
+            LogDecision::Reject => "reject",
+        }
+    }
+}
+
 /// Emit a structured tracing event under `aimx::uds` describing one
 /// authz decision. `verb` / `mailbox` / `decision` identify the event;
 /// `caller_uid` / `caller_username` identify the actor.
@@ -217,38 +247,39 @@ pub fn log_decision(
     verb: &str,
     caller: &Caller,
     mailbox: Option<&str>,
-    decision: &str,
+    decision: LogDecision,
     reason: Option<&str>,
 ) {
     let mailbox = mailbox.unwrap_or("");
     let reason = reason.unwrap_or("");
+    let decision_str = decision.as_str();
     match decision {
-        "reject" => tracing::warn!(
+        LogDecision::Reject => tracing::warn!(
             target: "aimx::uds",
             verb = verb,
             caller_uid = caller.uid,
             caller_username = caller.username_display(),
             mailbox = mailbox,
-            decision = decision,
+            decision = decision_str,
             reason = reason,
             "uds authz reject"
         ),
-        "root_bypass" => tracing::info!(
+        LogDecision::RootBypass => tracing::info!(
             target: "aimx::uds",
             verb = verb,
             caller_uid = caller.uid,
             caller_username = caller.username_display(),
             mailbox = mailbox,
-            decision = decision,
+            decision = decision_str,
             "uds authz root_bypass"
         ),
-        _ => tracing::debug!(
+        LogDecision::Accept => tracing::debug!(
             target: "aimx::uds",
             verb = verb,
             caller_uid = caller.uid,
             caller_username = caller.username_display(),
             mailbox = mailbox,
-            decision = decision,
+            decision = decision_str,
             "uds authz accept"
         ),
     }
@@ -265,11 +296,17 @@ pub fn enforce_mailbox_owner_or_root(
 ) -> Result<(), AuthzReject> {
     match require_mailbox_owner_or_root(caller, mailbox_name, mailbox) {
         Ok(AuthzDecision::Accept) => {
-            log_decision(verb, caller, Some(mailbox_name), "accept", None);
+            log_decision(verb, caller, Some(mailbox_name), LogDecision::Accept, None);
             Ok(())
         }
         Ok(AuthzDecision::RootBypass) => {
-            log_decision(verb, caller, Some(mailbox_name), "root_bypass", None);
+            log_decision(
+                verb,
+                caller,
+                Some(mailbox_name),
+                LogDecision::RootBypass,
+                None,
+            );
             Ok(())
         }
         Err(reject) => {
@@ -277,7 +314,7 @@ pub fn enforce_mailbox_owner_or_root(
                 verb,
                 caller,
                 Some(mailbox_name),
-                "reject",
+                LogDecision::Reject,
                 Some(&reject.reason),
             );
             Err(reject)
@@ -295,11 +332,17 @@ pub fn enforce_root(
 ) -> Result<(), AuthzReject> {
     match require_root(caller) {
         Ok(_) => {
-            log_decision(verb, caller, mailbox_hint, "accept", None);
+            log_decision(verb, caller, mailbox_hint, LogDecision::Accept, None);
             Ok(())
         }
         Err(reject) => {
-            log_decision(verb, caller, mailbox_hint, "reject", Some(&reject.reason));
+            log_decision(
+                verb,
+                caller,
+                mailbox_hint,
+                LogDecision::Reject,
+                Some(&reject.reason),
+            );
             Err(reject)
         }
     }
@@ -308,7 +351,6 @@ pub fn enforce_root(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::collections::HashMap;
 
     fn mb(owner: &str) -> MailboxConfig {
         MailboxConfig {
@@ -444,12 +486,5 @@ mod tests {
         assert_eq!(err.code, ErrCode::Eaccess);
         assert!(logs_contain("decision=\"reject\""));
         assert!(logs_contain("verb=\"MAILBOX-CREATE\""));
-    }
-
-    // Pull in HashMap just so the import isn't flagged unused if a
-    // follow-up test wants to simulate a Config lookup. Not material.
-    #[allow(dead_code)]
-    fn _hashmap_sanity() -> HashMap<&'static str, ()> {
-        HashMap::new()
     }
 }

--- a/src/uds_authz.rs
+++ b/src/uds_authz.rs
@@ -1,0 +1,455 @@
+//! Sprint 4 — `SO_PEERCRED` UDS authentication.
+//!
+//! Captures the caller's `{uid, gid, pid, username}` at accept time and
+//! exposes authorization helpers that every UDS verb handler consults
+//! before touching state. The PRD §6.5 authz table lives here as code:
+//!
+//! | Verb                                    | Rule                                    |
+//! |-----------------------------------------|-----------------------------------------|
+//! | `SEND`                                  | caller uid owns the `From:` mailbox, OR is root |
+//! | `MARK-READ` / `MARK-UNREAD`             | caller uid owns the target mailbox, OR is root |
+//! | `MAILBOX-CREATE` / `MAILBOX-DELETE`     | root only                               |
+//! | `HOOK-CREATE` / `HOOK-DELETE`           | caller uid owns the target mailbox, OR is root |
+//!
+//! Root is a blanket bypass on every ownership check (`decision =
+//! "root_bypass"`), logged at info level so `aimx logs` reveals the
+//! escalation.
+
+use std::sync::OnceLock;
+
+use tokio::net::UnixStream;
+use tokio::net::unix::UCred;
+
+use crate::config::MailboxConfig;
+use crate::send_protocol::ErrCode;
+
+/// Peer-credentials snapshot taken at `accept()` time. `username` is
+/// resolved lazily on the first call to [`Caller::username`] and then
+/// memoized; `getpwuid` misses produce `None` so unknown uids don't
+/// crash the handler.
+#[derive(Debug)]
+pub struct Caller {
+    pub uid: u32,
+    pub gid: u32,
+    pub pid: Option<i32>,
+    username_cache: OnceLock<Option<String>>,
+}
+
+impl Clone for Caller {
+    fn clone(&self) -> Self {
+        let cache = OnceLock::new();
+        if let Some(v) = self.username_cache.get() {
+            let _ = cache.set(v.clone());
+        }
+        Self {
+            uid: self.uid,
+            gid: self.gid,
+            pid: self.pid,
+            username_cache: cache,
+        }
+    }
+}
+
+impl Caller {
+    /// Construct from raw `tokio::net::unix::UCred`. The production
+    /// accept loop in `src/serve.rs` calls `peer_cred()` on the freshly
+    /// accepted `UnixStream` and feeds the value through this helper
+    /// so username resolution stays lazy.
+    pub fn from_ucred(cred: UCred) -> Self {
+        Self {
+            uid: cred.uid(),
+            gid: cred.gid(),
+            pid: cred.pid(),
+            username_cache: OnceLock::new(),
+        }
+    }
+
+    /// Construct an explicit caller (tests and internal dispatchers).
+    #[allow(dead_code)]
+    pub fn new(uid: u32, gid: u32, pid: Option<i32>) -> Self {
+        Self {
+            uid,
+            gid,
+            pid,
+            username_cache: OnceLock::new(),
+        }
+    }
+
+    /// A root (uid 0) caller used where no real credentials exist, e.g.
+    /// the in-process inbound ingest path which never crosses the UDS.
+    /// Also convenient for tests and harnesses that bypass the real
+    /// SO_PEERCRED path.
+    #[allow(dead_code)]
+    pub fn internal_root() -> Self {
+        Self::new(0, 0, None)
+    }
+
+    /// Lazily resolve the caller's username via `getpwuid(3)`. Root is
+    /// always `Some("root")`. Unknown uids return `None`.
+    pub fn username(&self) -> Option<&str> {
+        self.username_cache
+            .get_or_init(|| lookup_username(self.uid))
+            .as_deref()
+    }
+
+    /// Log-friendly rendering of the caller's username, falling back to
+    /// `"?"` so emitted tracing fields are always populated.
+    pub fn username_display(&self) -> &str {
+        self.username().unwrap_or("?")
+    }
+
+    pub fn is_root(&self) -> bool {
+        self.uid == 0
+    }
+}
+
+fn lookup_username(uid: u32) -> Option<String> {
+    // Fast path: root is guaranteed by POSIX. Avoids a `getpwuid(0)`
+    // call — test resolvers and minimal container images alike have
+    // been known to return null for it.
+    if uid == 0 {
+        return Some("root".to_string());
+    }
+    // SAFETY: `getpwuid` reads a process-global static; we copy the
+    // `pw_name` C string into an owned `String` before returning so
+    // callers never dereference it after another `getpw*` call.
+    unsafe {
+        let pw = libc::getpwuid(uid as libc::uid_t);
+        if pw.is_null() {
+            return None;
+        }
+        let name_ptr = (*pw).pw_name;
+        if name_ptr.is_null() {
+            return None;
+        }
+        let cstr = std::ffi::CStr::from_ptr(name_ptr);
+        cstr.to_str().ok().map(str::to_string)
+    }
+}
+
+/// Peer-credential extraction. Returns `Err(ErrCode::Validation)` with
+/// a `peer cred unavailable` reason when the kernel can't supply creds
+/// (closed connection, non-UDS socket, etc.). Callers forward the
+/// error verbatim to the client.
+pub fn caller_from_stream(stream: &UnixStream) -> Result<Caller, String> {
+    match stream.peer_cred() {
+        Ok(c) => Ok(Caller::from_ucred(c)),
+        Err(e) => Err(format!("peer cred unavailable: {e}")),
+    }
+}
+
+/// Decision returned from an authz check. Handlers reject on
+/// [`AuthzDecision::Reject`] and continue otherwise; the `RootBypass`
+/// variant carries the info-log side-effect that fires from the helper.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthzDecision {
+    Accept,
+    RootBypass,
+}
+
+/// Authz error with a stable `code` for the wire plus a human reason.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthzReject {
+    pub code: ErrCode,
+    pub reason: String,
+}
+
+/// Require the caller to own `mailbox`, or be root. Used by `SEND`,
+/// `MARK-READ`, `MARK-UNREAD`, `HOOK-CREATE`, `HOOK-DELETE`.
+pub fn require_mailbox_owner_or_root(
+    caller: &Caller,
+    mailbox_name: &str,
+    mailbox: &MailboxConfig,
+) -> Result<AuthzDecision, AuthzReject> {
+    if caller.is_root() {
+        return Ok(AuthzDecision::RootBypass);
+    }
+    let caller_name = match caller.username() {
+        Some(n) => n,
+        None => {
+            return Err(AuthzReject {
+                code: ErrCode::Eaccess,
+                reason: format!(
+                    "caller uid {} has no resolvable username; cannot authorize against mailbox '{mailbox_name}'",
+                    caller.uid
+                ),
+            });
+        }
+    };
+    if caller_name == mailbox.owner {
+        Ok(AuthzDecision::Accept)
+    } else {
+        Err(AuthzReject {
+            code: ErrCode::Eaccess,
+            reason: format!(
+                "caller '{caller_name}' is not the owner of mailbox '{mailbox_name}' \
+                 (owner: '{}')",
+                mailbox.owner
+            ),
+        })
+    }
+}
+
+/// Require the caller to be root. Used by `MAILBOX-CREATE` and
+/// `MAILBOX-DELETE` per PRD §6.5.
+pub fn require_root(caller: &Caller) -> Result<AuthzDecision, AuthzReject> {
+    if caller.is_root() {
+        // Not a "bypass" — root is the required identity here, not an
+        // escalation past an ownership rule. Surface as Accept so the
+        // structured log says `decision = "accept"`.
+        Ok(AuthzDecision::Accept)
+    } else {
+        Err(AuthzReject {
+            code: ErrCode::Eaccess,
+            reason: format!(
+                "mailbox CRUD is root-only (caller uid {} / '{}')",
+                caller.uid,
+                caller.username_display()
+            ),
+        })
+    }
+}
+
+/// Emit a structured tracing event under `aimx::uds` describing one
+/// authz decision. `verb` / `mailbox` / `decision` identify the event;
+/// `caller_uid` / `caller_username` identify the actor.
+pub fn log_decision(
+    verb: &str,
+    caller: &Caller,
+    mailbox: Option<&str>,
+    decision: &str,
+    reason: Option<&str>,
+) {
+    let mailbox = mailbox.unwrap_or("");
+    let reason = reason.unwrap_or("");
+    match decision {
+        "reject" => tracing::warn!(
+            target: "aimx::uds",
+            verb = verb,
+            caller_uid = caller.uid,
+            caller_username = caller.username_display(),
+            mailbox = mailbox,
+            decision = decision,
+            reason = reason,
+            "uds authz reject"
+        ),
+        "root_bypass" => tracing::info!(
+            target: "aimx::uds",
+            verb = verb,
+            caller_uid = caller.uid,
+            caller_username = caller.username_display(),
+            mailbox = mailbox,
+            decision = decision,
+            "uds authz root_bypass"
+        ),
+        _ => tracing::debug!(
+            target: "aimx::uds",
+            verb = verb,
+            caller_uid = caller.uid,
+            caller_username = caller.username_display(),
+            mailbox = mailbox,
+            decision = decision,
+            "uds authz accept"
+        ),
+    }
+}
+
+/// Convenience: evaluate + log in one call. Used by handlers that want
+/// the structured log for every decision (accept + reject + root_bypass)
+/// without duplicating the match arms.
+pub fn enforce_mailbox_owner_or_root(
+    verb: &str,
+    caller: &Caller,
+    mailbox_name: &str,
+    mailbox: &MailboxConfig,
+) -> Result<(), AuthzReject> {
+    match require_mailbox_owner_or_root(caller, mailbox_name, mailbox) {
+        Ok(AuthzDecision::Accept) => {
+            log_decision(verb, caller, Some(mailbox_name), "accept", None);
+            Ok(())
+        }
+        Ok(AuthzDecision::RootBypass) => {
+            log_decision(verb, caller, Some(mailbox_name), "root_bypass", None);
+            Ok(())
+        }
+        Err(reject) => {
+            log_decision(
+                verb,
+                caller,
+                Some(mailbox_name),
+                "reject",
+                Some(&reject.reason),
+            );
+            Err(reject)
+        }
+    }
+}
+
+/// Convenience for verbs whose mailbox identity is not known up front
+/// (e.g. `MAILBOX-CREATE` / `MAILBOX-DELETE`). Logs without a `mailbox`
+/// field.
+pub fn enforce_root(
+    verb: &str,
+    caller: &Caller,
+    mailbox_hint: Option<&str>,
+) -> Result<(), AuthzReject> {
+    match require_root(caller) {
+        Ok(_) => {
+            log_decision(verb, caller, mailbox_hint, "accept", None);
+            Ok(())
+        }
+        Err(reject) => {
+            log_decision(verb, caller, mailbox_hint, "reject", Some(&reject.reason));
+            Err(reject)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn mb(owner: &str) -> MailboxConfig {
+        MailboxConfig {
+            address: "alice@example.com".into(),
+            owner: owner.into(),
+            hooks: vec![],
+            trust: None,
+            trusted_senders: None,
+            allow_root_catchall: false,
+        }
+    }
+
+    #[test]
+    fn caller_internal_root_is_root() {
+        let c = Caller::internal_root();
+        assert!(c.is_root());
+        assert_eq!(c.username(), Some("root"));
+    }
+
+    #[test]
+    fn caller_clone_preserves_cached_username() {
+        let c = Caller::internal_root();
+        let _ = c.username();
+        let c2 = c.clone();
+        assert_eq!(c2.username(), Some("root"));
+    }
+
+    #[test]
+    fn lookup_unknown_uid_returns_none() {
+        // 32-bit max UID is reserved for "nobody" on some systems but
+        // typically unmapped on CI runners.
+        assert!(lookup_username(4_294_967_294).is_none());
+    }
+
+    #[test]
+    fn require_mailbox_owner_or_root_accepts_owner_by_name() {
+        // Simulate a caller whose username resolves to "alice".
+        let c = Caller::new(1001, 1001, None);
+        let _ = c.username_cache.set(Some("alice".to_string()));
+        let m = mb("alice");
+        assert_eq!(
+            require_mailbox_owner_or_root(&c, "alice", &m).unwrap(),
+            AuthzDecision::Accept
+        );
+    }
+
+    #[test]
+    fn require_mailbox_owner_or_root_rejects_non_owner() {
+        let c = Caller::new(1002, 1002, None);
+        let _ = c.username_cache.set(Some("bob".to_string()));
+        let m = mb("alice");
+        let err = require_mailbox_owner_or_root(&c, "alice", &m).unwrap_err();
+        assert_eq!(err.code, ErrCode::Eaccess);
+        assert!(err.reason.contains("bob"));
+        assert!(err.reason.contains("alice"));
+    }
+
+    #[test]
+    fn require_mailbox_owner_or_root_root_is_bypass() {
+        let c = Caller::internal_root();
+        let m = mb("alice");
+        assert_eq!(
+            require_mailbox_owner_or_root(&c, "alice", &m).unwrap(),
+            AuthzDecision::RootBypass
+        );
+    }
+
+    #[test]
+    fn require_mailbox_owner_or_root_unresolvable_uid_rejects() {
+        let c = Caller::new(4_294_967_294, 4_294_967_294, None);
+        let _ = c.username_cache.set(None);
+        let m = mb("alice");
+        let err = require_mailbox_owner_or_root(&c, "alice", &m).unwrap_err();
+        assert_eq!(err.code, ErrCode::Eaccess);
+        assert!(err.reason.contains("no resolvable username"));
+    }
+
+    #[test]
+    fn require_root_rejects_non_root() {
+        let c = Caller::new(1002, 1002, None);
+        let _ = c.username_cache.set(Some("bob".to_string()));
+        let err = require_root(&c).unwrap_err();
+        assert_eq!(err.code, ErrCode::Eaccess);
+        assert!(err.reason.contains("bob"));
+    }
+
+    #[test]
+    fn require_root_accepts_root() {
+        let c = Caller::internal_root();
+        assert_eq!(require_root(&c).unwrap(), AuthzDecision::Accept);
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn enforce_mailbox_owner_or_root_logs_accept() {
+        let c = Caller::new(1001, 1001, None);
+        let _ = c.username_cache.set(Some("alice".to_string()));
+        let m = mb("alice");
+        enforce_mailbox_owner_or_root("SEND", &c, "alice", &m).unwrap();
+        assert!(logs_contain("decision=\"accept\""));
+        assert!(logs_contain("verb=\"SEND\""));
+        assert!(logs_contain("caller_username=\"alice\""));
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn enforce_mailbox_owner_or_root_logs_root_bypass() {
+        let c = Caller::internal_root();
+        let m = mb("alice");
+        enforce_mailbox_owner_or_root("SEND", &c, "alice", &m).unwrap();
+        assert!(logs_contain("decision=\"root_bypass\""));
+        assert!(logs_contain("caller_uid=0"));
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn enforce_mailbox_owner_or_root_logs_reject() {
+        let c = Caller::new(1002, 1002, None);
+        let _ = c.username_cache.set(Some("bob".to_string()));
+        let m = mb("alice");
+        let err = enforce_mailbox_owner_or_root("SEND", &c, "alice", &m).unwrap_err();
+        assert_eq!(err.code, ErrCode::Eaccess);
+        assert!(logs_contain("decision=\"reject\""));
+        assert!(logs_contain("caller_username=\"bob\""));
+    }
+
+    #[test]
+    #[tracing_test::traced_test]
+    fn enforce_root_logs_reject() {
+        let c = Caller::new(1002, 1002, None);
+        let _ = c.username_cache.set(Some("bob".to_string()));
+        let err = enforce_root("MAILBOX-CREATE", &c, Some("alice")).unwrap_err();
+        assert_eq!(err.code, ErrCode::Eaccess);
+        assert!(logs_contain("decision=\"reject\""));
+        assert!(logs_contain("verb=\"MAILBOX-CREATE\""));
+    }
+
+    // Pull in HashMap just so the import isn't flagged unused if a
+    // follow-up test wants to simulate a Config lookup. Not material.
+    #[allow(dead_code)]
+    fn _hashmap_sanity() -> HashMap<&'static str, ()> {
+        HashMap::new()
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -531,18 +531,37 @@ fn skip_if_mailbox_crud_not_root() -> bool {
     true
 }
 
-/// Resolve the current Linux username via `getpwuid`. Used by Sprint 2
-/// tests that create mailboxes in a tmpdir: the daemon chowns the new
-/// mailbox dirs to the configured owner's uid, so on a non-root CI
-/// runner the owner must be the tester's own username (chown-to-self
-/// is a zero-effect syscall every user can issue). Falls back to
-/// `"root"` when `getpwuid` misses so behaviour on exotic runners
-/// still has a sane default.
+/// Resolve a non-root Linux username suitable for use as a test mailbox
+/// `owner`. Used by Sprint 2+ tests that create mailboxes in a tmpdir:
+/// the daemon chowns the new mailbox dirs to the configured owner's
+/// uid, so on a non-root CI runner the owner must be the tester's own
+/// username (chown-to-self is a zero-effect syscall every user can
+/// issue).
+///
+/// Sprint 3 §6.2 forbids `owner = "root"` on non-catchall mailboxes, so
+/// when the test process runs as root (Sprint 4 root-gated CI step
+/// under `sudo`) we must pick a non-root username. Prefer `SUDO_USER`
+/// — the invoking non-root user — when it points at a real passwd
+/// entry (the normal CI path, where `sudo` preserves the env). Fall
+/// back to `nobody` otherwise (always present on Linux, matches the
+/// owner regex, and resolves via `getpwnam` → no hard reject; an
+/// `OrphanMailboxOwner` warning at worst). Under authz the test CLI
+/// runs as root and takes the `RootBypass` path, so the owner uid
+/// doesn't need to match the caller.
 fn current_username() -> String {
     let uid = unsafe { libc::geteuid() };
+    if uid == 0 {
+        if let Some(sudo_user) = std::env::var_os("SUDO_USER") {
+            let name = sudo_user.to_string_lossy().into_owned();
+            if !name.is_empty() && name != "root" {
+                return name;
+            }
+        }
+        return "nobody".to_string();
+    }
     let pw = unsafe { libc::getpwuid(uid) };
     if pw.is_null() {
-        return "root".to_string();
+        return "nobody".to_string();
     }
     let cstr = unsafe { std::ffi::CStr::from_ptr((*pw).pw_name) };
     cstr.to_string_lossy().into_owned()
@@ -1961,11 +1980,38 @@ fn start_serve(tmp: &Path, port: u16) -> std::process::Child {
     let started = std::time::Instant::now();
     loop {
         if started.elapsed() > std::time::Duration::from_secs(30) {
-            child.kill().unwrap();
-            panic!("aimx serve did not start within 30s");
+            // Kill the daemon, then drain its stderr so the panic
+            // message carries whatever the daemon logged before it
+            // failed to bind. Without this, timeouts surface as the
+            // bare "did not start within 30s" panic with zero
+            // diagnostic (Sprint 4 CI cycle 3 regression).
+            let _ = child.kill();
+            let mut stderr_buf = String::new();
+            if let Some(mut err) = child.stderr.take() {
+                use std::io::Read as _;
+                let _ = err.read_to_string(&mut stderr_buf);
+            }
+            panic!(
+                "aimx serve did not start within 30s on port {port}; stderr: {}",
+                stderr_buf.trim()
+            );
         }
         if std::net::TcpStream::connect(format!("127.0.0.1:{port}")).is_ok() {
             break;
+        }
+        // Early-exit detection: if the daemon died before binding, no
+        // amount of polling on `port` will succeed. Surface its stderr
+        // immediately instead of waiting the full 30s.
+        if let Ok(Some(status)) = child.try_wait() {
+            let mut stderr_buf = String::new();
+            if let Some(mut err) = child.stderr.take() {
+                use std::io::Read as _;
+                let _ = err.read_to_string(&mut stderr_buf);
+            }
+            panic!(
+                "aimx serve exited early with {status:?} before binding port {port}; stderr: {}",
+                stderr_buf.trim()
+            );
         }
         std::thread::sleep(std::time::Duration::from_millis(100));
     }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3080,6 +3080,7 @@ fn mcp_mark_read_concurrent_with_inbound_ingest() {
 
 #[cfg(unix)]
 #[test]
+#[ignore = "requires root (Sprint 4 §6.5: MAILBOX-CRUD is root-only); run via the CI mailbox-crud-root step or AIMX_INTEGRATION_SUDO=1 sudo"]
 fn mailbox_create_via_uds_hotswaps_config_and_routes_new_mail() {
     if skip_if_mailbox_crud_not_root() {
         return;
@@ -3206,6 +3207,7 @@ fn mailbox_create_without_daemon_falls_back_and_prints_restart_hint() {
 
 #[cfg(unix)]
 #[test]
+#[ignore = "requires root (Sprint 4 §6.5: MAILBOX-CRUD is root-only); run via the CI mailbox-crud-root step or AIMX_INTEGRATION_SUDO=1 sudo"]
 fn mailbox_delete_via_uds_refuses_nonempty_and_succeeds_after_cleanup() {
     if skip_if_mailbox_crud_not_root() {
         return;
@@ -3310,6 +3312,7 @@ fn mailbox_delete_via_uds_refuses_nonempty_and_succeeds_after_cleanup() {
 
 #[cfg(unix)]
 #[test]
+#[ignore = "requires root (Sprint 4 §6.5: MAILBOX-CRUD is root-only); run via the CI mailbox-crud-root step or AIMX_INTEGRATION_SUDO=1 sudo"]
 fn mailbox_delete_force_yes_wipes_contents_and_succeeds() {
     if skip_if_mailbox_crud_not_root() {
         return;
@@ -3371,6 +3374,7 @@ fn mailbox_delete_force_yes_wipes_contents_and_succeeds() {
 
 #[cfg(unix)]
 #[test]
+#[ignore = "requires root (Sprint 4 §6.5: MAILBOX-CRUD is root-only); run via the CI mailbox-crud-root step or AIMX_INTEGRATION_SUDO=1 sudo"]
 fn mailbox_delete_force_without_yes_prompts_and_aborts_on_n() {
     if skip_if_mailbox_crud_not_root() {
         return;
@@ -3769,6 +3773,7 @@ fn concurrent_ingest_burst_and_mark_same_mailbox_no_torn_writes() {
 
 #[cfg(unix)]
 #[test]
+#[ignore = "requires root (Sprint 4 §6.5: MAILBOX-CRUD is root-only); run via the CI mailbox-crud-root step or AIMX_INTEGRATION_SUDO=1 sudo"]
 fn concurrent_mailbox_create_and_ingest_does_not_deadlock() {
     if skip_if_mailbox_crud_not_root() {
         return;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -51,8 +51,12 @@ fn install_cached_dkim_keys(tmp: &Path) {
 }
 
 fn setup_test_env(tmp: &Path) -> String {
+    // Sprint 4 §6.5: the UDS now enforces per-mailbox ownership. Tests
+    // that drive MCP / UDS as the current user need alice's owner to
+    // match the running uid so the authz check accepts.
+    let owner = current_username();
     let config_content = format!(
-        "domain = \"agent.example.com\"\ndata_dir = \"{}\"\n\n[mailboxes.catchall]\naddress = \"*@agent.example.com\"\nowner = \"aimx-catchall\"\n\n[mailboxes.alice]\naddress = \"alice@agent.example.com\"\nowner = \"ops\"\n",
+        "domain = \"agent.example.com\"\ndata_dir = \"{}\"\n\n[mailboxes.catchall]\naddress = \"*@agent.example.com\"\nowner = \"aimx-catchall\"\n\n[mailboxes.alice]\naddress = \"alice@agent.example.com\"\nowner = \"{owner}\"\n",
         tmp.display()
     );
     std::fs::create_dir_all(tmp.join("inbox").join("catchall")).unwrap();
@@ -508,6 +512,23 @@ fn dkim_keygen_permission_denied_error_mentions_path_and_override() {
 
 fn aimx_binary_path() -> std::path::PathBuf {
     assert_cmd::cargo::cargo_bin("aimx")
+}
+
+/// Sprint 4 §6.5: `MAILBOX-CREATE` / `MAILBOX-DELETE` over UDS are
+/// root-only. Tests that exercise the CLI via UDS need to bail out
+/// when not running as root so a casual `cargo test` doesn't surface
+/// EACCES as a pretend bug. The CI `integration-isolation` job sets
+/// `AIMX_INTEGRATION_SUDO=1` and runs under sudo, so these tests
+/// execute there; non-root local runs skip them with a single stderr
+/// line so the cause is obvious.
+fn skip_if_mailbox_crud_not_root() -> bool {
+    if unsafe { libc::geteuid() } == 0 {
+        return false;
+    }
+    eprintln!(
+        "skipping mailbox-CRUD UDS test: requires root (Sprint 4 §6.5 makes MAILBOX-CRUD root-only)"
+    );
+    true
 }
 
 /// Resolve the current Linux username via `getpwuid`. Used by Sprint 2
@@ -1905,8 +1926,9 @@ fn serve_e2e_connection_refused_after_shutdown() {
 }
 
 fn setup_test_env_with_bob(tmp: &Path) -> String {
+    let owner = current_username();
     let config_content = format!(
-        "domain = \"agent.example.com\"\ndata_dir = \"{}\"\n\n[mailboxes.catchall]\naddress = \"*@agent.example.com\"\nowner = \"aimx-catchall\"\n\n[mailboxes.alice]\naddress = \"alice@agent.example.com\"\nowner = \"ops\"\n\n[mailboxes.bob]\naddress = \"bob@agent.example.com\"\nowner = \"ops\"\n",
+        "domain = \"agent.example.com\"\ndata_dir = \"{}\"\n\n[mailboxes.catchall]\naddress = \"*@agent.example.com\"\nowner = \"aimx-catchall\"\n\n[mailboxes.alice]\naddress = \"alice@agent.example.com\"\nowner = \"{owner}\"\n\n[mailboxes.bob]\naddress = \"bob@agent.example.com\"\nowner = \"{owner}\"\n",
         tmp.display()
     );
     std::fs::create_dir_all(tmp.join("inbox").join("catchall")).unwrap();
@@ -2734,6 +2756,7 @@ fn after_send_hook_fires_with_delivered_status() {
 
     // Overwrite config.toml with an after_send hook on `alice`.
     let sentinel = tmp.path().join("after_send.sentinel");
+    let owner = current_username();
     let config = format!(
         r#"domain = "agent.example.com"
 data_dir = "{data_dir}"
@@ -2744,7 +2767,7 @@ owner = "aimx-catchall"
 
 [mailboxes.alice]
 address = "alice@agent.example.com"
-owner = "ops"
+owner = "{owner}"
 
 [[mailboxes.alice.hooks]]
 name = "aftersendhk1"
@@ -3058,6 +3081,9 @@ fn mcp_mark_read_concurrent_with_inbound_ingest() {
 #[cfg(unix)]
 #[test]
 fn mailbox_create_via_uds_hotswaps_config_and_routes_new_mail() {
+    if skip_if_mailbox_crud_not_root() {
+        return;
+    }
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
 
@@ -3181,6 +3207,9 @@ fn mailbox_create_without_daemon_falls_back_and_prints_restart_hint() {
 #[cfg(unix)]
 #[test]
 fn mailbox_delete_via_uds_refuses_nonempty_and_succeeds_after_cleanup() {
+    if skip_if_mailbox_crud_not_root() {
+        return;
+    }
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
 
@@ -3282,6 +3311,9 @@ fn mailbox_delete_via_uds_refuses_nonempty_and_succeeds_after_cleanup() {
 #[cfg(unix)]
 #[test]
 fn mailbox_delete_force_yes_wipes_contents_and_succeeds() {
+    if skip_if_mailbox_crud_not_root() {
+        return;
+    }
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
 
@@ -3340,6 +3372,9 @@ fn mailbox_delete_force_yes_wipes_contents_and_succeeds() {
 #[cfg(unix)]
 #[test]
 fn mailbox_delete_force_without_yes_prompts_and_aborts_on_n() {
+    if skip_if_mailbox_crud_not_root() {
+        return;
+    }
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
 
@@ -3735,6 +3770,9 @@ fn concurrent_ingest_burst_and_mark_same_mailbox_no_torn_writes() {
 #[cfg(unix)]
 #[test]
 fn concurrent_mailbox_create_and_ingest_does_not_deadlock() {
+    if skip_if_mailbox_crud_not_root() {
+        return;
+    }
     // MAILBOX-CREATE takes the outer per-mailbox lock, then the inner
     // process-wide CONFIG_WRITE_LOCK (see `crate::mailbox_locks`).
     // Inbound ingest to the same mailbox takes only the outer lock.
@@ -4384,6 +4422,7 @@ fn setup_test_env_with_template(tmp: &Path) -> String {
     // Sprint 2 will introduce a real non-root test user and flip this
     // back to exercise the orphan-tolerance path the earlier comment
     // described.
+    let owner = current_username();
     let config_content = format!(
         "domain = \"agent.example.com\"\ndata_dir = \"{}\"\n\n\
          [[hook_template]]\n\
@@ -4400,7 +4439,7 @@ fn setup_test_env_with_template(tmp: &Path) -> String {
          owner = \"aimx-catchall\"\n\n\
          [mailboxes.alice]\n\
          address = \"alice@agent.example.com\"\n\
-         owner = \"ops\"\n",
+         owner = \"{owner}\"\n",
         tmp.display()
     );
     std::fs::create_dir_all(tmp.join("inbox").join("catchall")).unwrap();
@@ -4836,6 +4875,7 @@ fn hook_templates_end_to_end_mcp_to_sandbox() {
     // Sprint 1 S1-2) still resolves the template to an active template
     // and the alice mailbox to an active mailbox. The invariant check
     // still holds: the `root` hook run_as is allowed for any owner.
+    let owner = current_username();
     let config_content = format!(
         r#"domain = "agent.example.com"
 data_dir = "{data_dir}"
@@ -4856,7 +4896,7 @@ owner = "aimx-catchall"
 
 [mailboxes.alice]
 address = "alice@agent.example.com"
-owner = "ops"
+owner = "{owner}"
 "#,
         data_dir = tmp.path().display(),
         mock = mock_curl_path.display(),

--- a/tests/uds_authz.rs
+++ b/tests/uds_authz.rs
@@ -1,0 +1,465 @@
+//! Sprint 4 S4-4: cross-user UDS authz integration test.
+//!
+//! Reuses the `aimx-it-alice` / `aimx-it-bob` fixture from Sprint 2
+//! (`tests/isolation.rs`). Spins up a real `aimx serve` subprocess under
+//! a tempdir, then issues raw `AIMX/1` frames under bob's uid via
+//! `runuser -u aimx-it-bob python3 -c ...`. Every attack must come
+//! back with `AIMX/1 ERR EACCES`. The root control run succeeds and
+//! emits the `decision="root_bypass"` info log captured from the
+//! serve subprocess's stderr.
+//!
+//! Gated on both `#[ignore]` and `AIMX_INTEGRATION_SUDO=1` so it only
+//! runs inside the CI step that explicitly elevates.
+//!
+//! Teardown uses a `Drop` guard so `userdel` and the killed serve
+//! subprocess are cleaned up even on assertion failure.
+
+#![cfg(unix)]
+
+use std::io::Read;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Stdio};
+use std::time::{Duration, Instant};
+
+const ALICE: &str = "aimx-it-alice";
+const BOB: &str = "aimx-it-bob";
+
+/// RAII guard: kill the serve subprocess and remove the test users on
+/// drop. Drop runs on assertion failure too, so the CI step stays
+/// hermetic.
+struct Teardown {
+    serve: Option<Child>,
+}
+
+impl Drop for Teardown {
+    fn drop(&mut self) {
+        if let Some(mut child) = self.serve.take() {
+            let _ = child.kill();
+            let _ = child.wait();
+        }
+        let _ = Command::new("userdel").arg(ALICE).status();
+        let _ = Command::new("userdel").arg(BOB).status();
+    }
+}
+
+fn useradd(name: &str) {
+    let status = Command::new("useradd")
+        .arg("--system")
+        .arg("--no-create-home")
+        .arg("--shell")
+        .arg("/usr/sbin/nologin")
+        .arg(name)
+        .status()
+        .expect("failed to spawn useradd");
+    assert!(
+        status.success() || {
+            let check = Command::new("id").arg(name).status().ok();
+            matches!(check, Some(s) if s.success())
+        },
+        "useradd failed for {name}"
+    );
+}
+
+fn aimx_binary_path() -> PathBuf {
+    PathBuf::from(env!("CARGO_BIN_EXE_aimx"))
+}
+
+fn wait_for_socket(path: &Path) -> bool {
+    let deadline = Instant::now() + Duration::from_secs(15);
+    while Instant::now() < deadline {
+        if path.exists() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    false
+}
+
+/// Raw `AIMX/1 SEND` framing. The daemon parses `From:` out of the
+/// body to resolve the sender mailbox and runs authz against the
+/// caller's uid. bob as alice: EACCES.
+fn raw_send_frame(from: &str, to: &str) -> String {
+    let body = format!(
+        "From: {from}\r\n\
+         To: {to}\r\n\
+         Subject: authz test\r\n\
+         Date: Thu, 01 Jan 2026 12:00:00 +0000\r\n\
+         Message-ID: <authz-test@example.com>\r\n\
+         \r\n\
+         authz body\r\n"
+    );
+    format!(
+        "AIMX/1 SEND\r\nContent-Length: {}\r\n\r\n{body}",
+        body.len()
+    )
+}
+
+/// Raw `AIMX/1 MARK-READ` framing.
+fn raw_mark_frame(mailbox: &str, id: &str) -> String {
+    format!(
+        "AIMX/1 MARK-READ\r\nMailbox: {mailbox}\r\nId: {id}\r\nFolder: inbox\r\nContent-Length: 0\r\n\r\n"
+    )
+}
+
+/// Raw `AIMX/1 HOOK-CREATE` framing with a trivial JSON body. The
+/// template the hook refers to does not need to exist — authz runs
+/// before template resolution per PRD §6.5 (authz mismatch ⇒ EACCES,
+/// unknown mailbox ⇒ ENOENT).
+fn raw_hook_create_frame(mailbox: &str) -> String {
+    let body = "{\"params\":{}}";
+    format!(
+        "AIMX/1 HOOK-CREATE\r\nMailbox: {mailbox}\r\nEvent: on_receive\r\nTemplate: invoke-claude\r\nContent-Length: {}\r\n\r\n{body}",
+        body.len()
+    )
+}
+
+/// Connect to the socket as `user` via `runuser` + Python, write the
+/// supplied raw frame, read the framed response. Python is the
+/// path-of-least-resistance here because every Ubuntu CI runner ships
+/// `python3` and we avoid adding a separate test helper binary.
+///
+/// The Python script is written to a tempfile (rather than passed via
+/// `-c`) so multi-line `while` loops keep their indentation — `-c` on
+/// some shells collapses newlines into spaces, which breaks Python's
+/// significant whitespace.
+fn send_frame_as(user: Option<&str>, socket: &Path, frame: &[u8]) -> Vec<u8> {
+    let script_dir = std::env::temp_dir().join(format!(
+        "aimx-uds-authz-py-{}-{}",
+        std::process::id(),
+        rand_suffix()
+    ));
+    std::fs::create_dir_all(&script_dir).unwrap();
+    // Script must be world-readable so the `runuser` target can
+    // execute it. The frame blob is injected as a base64 literal so
+    // arbitrary bytes (including CR/LF and quotes) survive the round
+    // trip through the shell and Python's source parser.
+    let b64 = base64_encode(frame);
+    let socket_str = socket.display().to_string();
+    let py = format!(
+        r#"import socket, sys, base64
+frame = base64.b64decode("{b64}")
+s = socket.socket(socket.AF_UNIX)
+s.connect("{socket_str}")
+s.sendall(frame)
+s.shutdown(socket.SHUT_WR)
+buf = b""
+while True:
+    chunk = s.recv(4096)
+    if not chunk:
+        break
+    buf += chunk
+sys.stdout.buffer.write(buf)
+"#
+    );
+    let script_path = script_dir.join("client.py");
+    std::fs::write(&script_path, py).unwrap();
+    std::fs::set_permissions(&script_dir, PermissionsExt::from_mode(0o755)).unwrap();
+    std::fs::set_permissions(&script_path, PermissionsExt::from_mode(0o644)).unwrap();
+
+    let output = match user {
+        Some(u) => Command::new("runuser")
+            .arg("-u")
+            .arg(u)
+            .arg("--")
+            .arg("python3")
+            .arg(&script_path)
+            .output()
+            .expect("failed to spawn runuser python3"),
+        None => Command::new("python3")
+            .arg(&script_path)
+            .output()
+            .expect("failed to spawn python3"),
+    };
+    let _ = std::fs::remove_dir_all(&script_dir);
+    assert!(
+        output.status.success(),
+        "python3 UDS client exited non-zero (user={user:?}): stderr={}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    output.stdout
+}
+
+fn rand_suffix() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(0)
+}
+
+/// Tiny standalone base64 encoder — integration tests can't pull in
+/// the crate's `base64` dep without adding it to dev-dependencies,
+/// which would drag an extra build for one 20-line helper.
+fn base64_encode(input: &[u8]) -> String {
+    const ALPHA: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
+    let mut i = 0;
+    while i + 3 <= input.len() {
+        let a = input[i];
+        let b = input[i + 1];
+        let c = input[i + 2];
+        out.push(ALPHA[(a >> 2) as usize] as char);
+        out.push(ALPHA[(((a & 0b11) << 4) | (b >> 4)) as usize] as char);
+        out.push(ALPHA[(((b & 0b1111) << 2) | (c >> 6)) as usize] as char);
+        out.push(ALPHA[(c & 0b111111) as usize] as char);
+        i += 3;
+    }
+    let remainder = input.len() - i;
+    if remainder == 1 {
+        let a = input[i];
+        out.push(ALPHA[(a >> 2) as usize] as char);
+        out.push(ALPHA[((a & 0b11) << 4) as usize] as char);
+        out.push_str("==");
+    } else if remainder == 2 {
+        let a = input[i];
+        let b = input[i + 1];
+        out.push(ALPHA[(a >> 2) as usize] as char);
+        out.push(ALPHA[(((a & 0b11) << 4) | (b >> 4)) as usize] as char);
+        out.push(ALPHA[((b & 0b1111) << 2) as usize] as char);
+        out.push('=');
+    }
+    out
+}
+
+#[test]
+fn base64_encode_roundtrip_matches_stdlib_reference() {
+    // Quick smoke test so a subtle bit-twiddling bug doesn't silently
+    // corrupt the wire frames the integration test submits.
+    assert_eq!(base64_encode(b""), "");
+    assert_eq!(base64_encode(b"f"), "Zg==");
+    assert_eq!(base64_encode(b"fo"), "Zm8=");
+    assert_eq!(base64_encode(b"foo"), "Zm9v");
+    assert_eq!(base64_encode(b"foob"), "Zm9vYg==");
+    assert_eq!(base64_encode(b"fooba"), "Zm9vYmE=");
+    assert_eq!(base64_encode(b"foobar"), "Zm9vYmFy");
+}
+
+fn chown_dir(path: &Path, uid: u32, gid: u32) {
+    let c = std::ffi::CString::new(path.as_os_str().as_encoded_bytes()).unwrap();
+    unsafe {
+        libc::chown(c.as_ptr(), uid, gid);
+        libc::chmod(c.as_ptr(), 0o700);
+    }
+}
+
+fn uid_of(name: &str) -> u32 {
+    let output = Command::new("id")
+        .arg("-u")
+        .arg(name)
+        .output()
+        .expect("failed to run id -u");
+    assert!(output.status.success());
+    String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse::<u32>()
+        .expect("uid must parse")
+}
+
+#[test]
+#[ignore]
+fn bob_cannot_impersonate_alice_over_uds() {
+    if std::env::var_os("AIMX_INTEGRATION_SUDO").is_none() {
+        eprintln!("AIMX_INTEGRATION_SUDO is not set; skipping (test requires root + user-create).");
+        return;
+    }
+    assert_eq!(
+        unsafe { libc::geteuid() },
+        0,
+        "uds_authz must run as root (AIMX_INTEGRATION_SUDO=1 + sudo)"
+    );
+
+    let mut teardown = Teardown { serve: None };
+    useradd(ALICE);
+    useradd(BOB);
+    let alice_uid = uid_of(ALICE);
+
+    let tmp_root = std::env::temp_dir().join(format!("aimx-uds-authz-{}", std::process::id()));
+    std::fs::create_dir_all(&tmp_root).unwrap();
+    std::fs::set_permissions(&tmp_root, PermissionsExt::from_mode(0o755)).unwrap();
+
+    let data_dir = tmp_root.join("data");
+    std::fs::create_dir_all(data_dir.join("inbox")).unwrap();
+    std::fs::set_permissions(&data_dir, PermissionsExt::from_mode(0o755)).unwrap();
+    std::fs::set_permissions(data_dir.join("inbox"), PermissionsExt::from_mode(0o755)).unwrap();
+
+    // Pre-create alice's inbox dir with the right ownership so a later
+    // ingest (if any — not strictly needed for authz rejection tests)
+    // has somewhere to drop mail.
+    let alice_inbox = data_dir.join("inbox").join(ALICE);
+    std::fs::create_dir_all(&alice_inbox).unwrap();
+    chown_dir(&alice_inbox, alice_uid, alice_uid);
+
+    let config_content = format!(
+        "domain = \"it.example.com\"\n\
+         data_dir = \"{data_dir}\"\n\
+         dkim_selector = \"aimx\"\n\n\
+         [mailboxes.catchall]\n\
+         address = \"*@it.example.com\"\n\
+         owner = \"aimx-catchall\"\n\n\
+         [mailboxes.{alice}]\n\
+         address = \"{alice}@it.example.com\"\n\
+         owner = \"{alice}\"\n\n\
+         [mailboxes.{bob}]\n\
+         address = \"{bob}@it.example.com\"\n\
+         owner = \"{bob}\"\n",
+        data_dir = data_dir.display(),
+        alice = ALICE,
+        bob = BOB,
+    );
+    let config_path = tmp_root.join("config.toml");
+    std::fs::write(&config_path, &config_content).unwrap();
+    std::fs::set_permissions(&config_path, PermissionsExt::from_mode(0o644)).unwrap();
+
+    // Generate a DKIM key pair under AIMX_CONFIG_DIR. `aimx serve`
+    // loads the private key at startup and refuses to run without it.
+    let keygen_status = Command::new(aimx_binary_path())
+        .env("AIMX_CONFIG_DIR", &tmp_root)
+        .env("AIMX_DATA_DIR", &data_dir)
+        .arg("dkim-keygen")
+        .arg("--force")
+        .status()
+        .expect("dkim-keygen failed to spawn");
+    assert!(keygen_status.success(), "dkim-keygen failed");
+
+    // Pre-create the aimx-catchall system user. The invariant in
+    // `config.toml` above names it as the catchall owner; if the host
+    // doesn't have it, `Config::load` would flag it as orphan and make
+    // the catchall mailbox inactive. That's fine for this test (we
+    // never exercise catchall), but the resolved Config needs to load
+    // cleanly for `aimx serve` to proceed.
+    let _ = Command::new("useradd")
+        .arg("--system")
+        .arg("--no-create-home")
+        .arg("--shell")
+        .arg("/usr/sbin/nologin")
+        .arg("aimx-catchall")
+        .status();
+
+    // Runtime directory holds the aimx.sock. AIMX_RUNTIME_DIR is the
+    // test-friendly override, used by the existing codebase so cargo
+    // test runs don't collide with /run/aimx/.
+    let runtime_dir = tmp_root.join("run");
+    std::fs::create_dir_all(&runtime_dir).unwrap();
+    std::fs::set_permissions(&runtime_dir, PermissionsExt::from_mode(0o755)).unwrap();
+
+    // Bind SMTP on an ephemeral port on loopback; the authz test
+    // never drives inbound so the exact port doesn't matter, it
+    // just needs to bind successfully.
+    //
+    // AIMX_TEST_MAIL_DROP redirects outbound MX delivery to disk so
+    // the root SEND control below doesn't blackhole into the real
+    // internet.
+    let mail_drop = tmp_root.join("mail_drop");
+    std::fs::create_dir_all(&mail_drop).unwrap();
+
+    let serve = Command::new(aimx_binary_path())
+        .env("AIMX_CONFIG_DIR", &tmp_root)
+        .env("AIMX_DATA_DIR", &data_dir)
+        .env("AIMX_RUNTIME_DIR", &runtime_dir)
+        .env("AIMX_TEST_MAIL_DROP", &mail_drop)
+        .arg("serve")
+        .arg("--bind")
+        .arg("127.0.0.1:0")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("aimx serve failed to spawn");
+    teardown.serve = Some(serve);
+
+    let socket_path = runtime_dir.join("aimx.sock");
+    assert!(
+        wait_for_socket(&socket_path),
+        "aimx.sock did not appear at {} within 15s",
+        socket_path.display()
+    );
+    // World-writable so bob can connect. Matches the production
+    // `0o666` bind mode.
+    std::fs::set_permissions(&socket_path, PermissionsExt::from_mode(0o666)).unwrap();
+
+    // --- Attack 1: bob SENDs as alice. Must be EACCES. ---
+    let resp_bytes = send_frame_as(
+        Some(BOB),
+        &socket_path,
+        raw_send_frame(
+            &format!("{ALICE}@it.example.com"),
+            "victim@external.example",
+        )
+        .as_bytes(),
+    );
+    let resp = String::from_utf8_lossy(&resp_bytes);
+    assert!(
+        resp.contains("AIMX/1 ERR EACCES") || resp.contains("Code: EACCES"),
+        "bob SEND as alice must be EACCES; got: {resp:?}"
+    );
+
+    // --- Attack 2: bob MARK-READ's an email in alice's mailbox. Must be EACCES. ---
+    let resp_bytes = send_frame_as(
+        Some(BOB),
+        &socket_path,
+        raw_mark_frame(ALICE, "2026-01-01-nothing").as_bytes(),
+    );
+    let resp = String::from_utf8_lossy(&resp_bytes);
+    assert!(
+        resp.contains("AIMX/1 ERR EACCES") || resp.contains("Code: EACCES"),
+        "bob MARK-READ on alice must be EACCES; got: {resp:?}"
+    );
+
+    // --- Attack 3: bob HOOK-CREATE on alice's mailbox. Must be EACCES. ---
+    let resp_bytes = send_frame_as(
+        Some(BOB),
+        &socket_path,
+        raw_hook_create_frame(ALICE).as_bytes(),
+    );
+    let resp = String::from_utf8_lossy(&resp_bytes);
+    assert!(
+        resp.contains("AIMX/1 ERR EACCES") || resp.contains("Code: EACCES"),
+        "bob HOOK-CREATE on alice must be EACCES; got: {resp:?}"
+    );
+
+    // --- Control: root MARK-READ on alice's (nonexistent) email
+    // returns NOTFOUND rather than EACCES, proving root bypassed the
+    // ownership check. The authz path fires and emits a
+    // `decision="root_bypass"` info log (captured from serve stderr
+    // below). ---
+    let resp_bytes = send_frame_as(None, &socket_path, raw_mark_frame(ALICE, "nope").as_bytes());
+    let resp = String::from_utf8_lossy(&resp_bytes);
+    assert!(
+        resp.contains("AIMX/1 OK")
+            || resp.contains("AIMX/1 ERR NOTFOUND")
+            || resp.contains("Code: NOTFOUND"),
+        "root MARK-READ should bypass authz and hit file-not-found; got: {resp:?}"
+    );
+
+    // Drop the teardown (stops serve + userdels). Stderr of the
+    // serve subprocess captures the structured `aimx::uds` log lines.
+    // We pull them out below before the Drop runs so the `root_bypass`
+    // assertion has something to look at.
+    let mut child = teardown.serve.take().expect("serve child must exist");
+    let _ = child.kill();
+    let mut stderr = String::new();
+    if let Some(mut s) = child.stderr.take() {
+        let _ = s.read_to_string(&mut stderr);
+    }
+    if let Some(mut s) = child.stdout.take() {
+        let mut out = String::new();
+        let _ = s.read_to_string(&mut out);
+        // Merge into `stderr` for simpler grepping; both streams can
+        // carry the `tracing` records depending on how the runtime
+        // attaches the subscriber.
+        stderr.push_str(&out);
+    }
+    let _ = child.wait();
+
+    // The root_bypass line is emitted at info level. Accept either
+    // `decision="root_bypass"` (structured field) or the log-line
+    // literal for robustness against subscriber format changes.
+    assert!(
+        stderr.contains("root_bypass") || stderr.contains("root-bypass"),
+        "serve stderr must contain a root_bypass info log; stderr was:\n{stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&tmp_root);
+    // teardown.serve is None; remaining Drop only removes users.
+    drop(teardown);
+}


### PR DESCRIPTION
## Summary

- Every UDS verb now authorizes the caller via `SO_PEERCRED` against the resolved mailbox owner (or requires root for `MAILBOX-CREATE` / `MAILBOX-DELETE`).
- Cross-user attacks (bob `SEND`ing as alice, `MARK-READ`ing alice's mailbox, creating hooks on alice's mailbox) return `AIMX/1 ERR EACCES` with a structured `Code: EACCES` header.
- Root bypasses every ownership check and each bypass emits a `tracing::info!` line under `aimx::uds` for audit.
- Implements PRD §6.5 in full: EACCES, ENOENT, root_bypass logging, and a cross-user root-gated integration test.

## Stories

- **S4-1** — `Caller { uid, gid, pid, username }` plumbed from `accept()` into every handler (`send_handler`, `state_handler`, `mailbox_handler`, `hook_handler`). Username is lazy-memoized via `getpwuid`.
- **S4-2** — `require_mailbox_owner_or_root` / `require_root` helpers in new `src/uds_authz.rs`. `HOOK-CREATE` authz runs after mailbox resolution; unknown mailbox → `ENOENT` (not EACCES, avoiding the existence side-channel).
- **S4-3** — `ErrCode` gains `Eaccess` / `Enoent`. Error frames carry both the legacy inline token and an explicit `Code:` header on the following line; existing single-line clients continue to parse. `tracing-test`-backed assertions for every authz decision.
- **S4-4** — `tests/uds_authz.rs` spawns a real `aimx serve` subprocess, issues raw `AIMX/1` frames via `runuser -u aimx-it-bob python3`, and asserts EACCES on SEND / MARK-READ / HOOK-CREATE. Root control emits `root_bypass`. `Drop` guard kills the daemon + userdels fixtures on scope exit. CI `integration-isolation` job extended.

## Test plan

- [x] `cargo test` — 1207 tests pass across bin + integration + uds_authz
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `sudo -E env "PATH=$PATH" AIMX_INTEGRATION_SUDO=1 cargo test --test uds_authz -- --ignored` — bob-as-alice attacks each return EACCES, root control emits `root_bypass`