### PR TITLE
[Sprint 5] TEMPLATE-* UDS verbs

### DIFF
--- a/src/agent_setup.rs
+++ b/src/agent_setup.rs
@@ -366,6 +366,82 @@ pub fn find_agent(name: &str) -> Option<&'static AgentSpec> {
     registry().iter().find(|a| a.name == name)
 }
 
+/// Reasons `derive_template_name` refuses an input.
+///
+/// Sprint 5 §6.1 / §8.2: both parts of `invoke-<agent>-<username>` must
+/// match `[a-z0-9-]+` because the template-name validator used by
+/// `Config::load` rejects anything else. Usernames that fall outside the
+/// charset can still own mailboxes (operators can hand-author templates
+/// in `config.toml`), but they cannot use `agent-setup`'s template
+/// registration because the derived name would fail validation.
+// Callers land in Sprint 6 (`aimx agent-setup` TEMPLATE-CREATE wiring);
+// the type is already `pub` so the binary dead-code lint for an unused
+// but public API must be silenced here.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TemplateNameError {
+    EmptyAgentSlug,
+    EmptyUsername,
+    InvalidAgentSlug(String),
+    InvalidUsername(String),
+}
+
+impl std::fmt::Display for TemplateNameError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TemplateNameError::EmptyAgentSlug => write!(f, "agent slug is empty"),
+            TemplateNameError::EmptyUsername => write!(f, "username is empty"),
+            TemplateNameError::InvalidAgentSlug(s) => write!(
+                f,
+                "agent slug '{s}' is not a valid template name component (must match [a-z0-9-]+)"
+            ),
+            TemplateNameError::InvalidUsername(s) => write!(
+                f,
+                "username '{s}' contains characters not valid for template names. \
+                 Hand-author a template in config.toml."
+            ),
+        }
+    }
+}
+
+impl std::error::Error for TemplateNameError {}
+
+/// Derive the canonical template name `invoke-<agent>-<username>` per
+/// PRD §6.6. Both parts must match `[a-z0-9-]+`. Rejects empty
+/// components, uppercase letters, underscores, and non-ASCII characters.
+///
+/// `agent-setup` uses this helper both when registering a new template
+/// (`TEMPLATE-CREATE`) and when re-detecting the binary path
+/// (`TEMPLATE-UPDATE` on `--redetect`). Keeping one derivation
+/// guarantees idempotence: re-running the command always targets the
+/// same name.
+// Consumed by Sprint 6 (`aimx agent-setup` TEMPLATE-CREATE wiring). The
+// fn is already `pub` for that future call site; silence the binary
+// dead-code lint until the wiring lands.
+#[allow(dead_code)]
+pub fn derive_template_name(agent_slug: &str, username: &str) -> Result<String, TemplateNameError> {
+    if agent_slug.is_empty() {
+        return Err(TemplateNameError::EmptyAgentSlug);
+    }
+    if username.is_empty() {
+        return Err(TemplateNameError::EmptyUsername);
+    }
+    if !is_valid_template_name_component(agent_slug) {
+        return Err(TemplateNameError::InvalidAgentSlug(agent_slug.to_string()));
+    }
+    if !is_valid_template_name_component(username) {
+        return Err(TemplateNameError::InvalidUsername(username.to_string()));
+    }
+    Ok(format!("invoke-{agent_slug}-{username}"))
+}
+
+#[allow(dead_code)]
+fn is_valid_template_name_component(s: &str) -> bool {
+    !s.is_empty()
+        && s.bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+}
+
 /// Trait used to make installs testable without touching the real `$HOME`
 /// or real uid.
 pub trait AgentEnv {
@@ -1028,6 +1104,55 @@ mod tests {
         fn read_line(&self) -> io::Result<String> {
             Ok(self.responses.borrow_mut().remove(0))
         }
+    }
+
+    #[test]
+    fn derive_template_name_happy_path() {
+        assert_eq!(
+            derive_template_name("claude-code", "sam").unwrap(),
+            "invoke-claude-code-sam"
+        );
+        assert_eq!(
+            derive_template_name("codex", "alice").unwrap(),
+            "invoke-codex-alice"
+        );
+    }
+
+    #[test]
+    fn derive_template_name_rejects_uppercase_username() {
+        let err = derive_template_name("claude-code", "Sam").unwrap_err();
+        assert!(matches!(err, TemplateNameError::InvalidUsername(ref s) if s == "Sam"));
+        assert!(err.to_string().contains("Hand-author"));
+    }
+
+    #[test]
+    fn derive_template_name_rejects_underscore_in_username() {
+        let err = derive_template_name("claude-code", "deploy_user").unwrap_err();
+        assert!(matches!(err, TemplateNameError::InvalidUsername(_)));
+    }
+
+    #[test]
+    fn derive_template_name_rejects_empty_username() {
+        let err = derive_template_name("claude-code", "").unwrap_err();
+        assert_eq!(err, TemplateNameError::EmptyUsername);
+    }
+
+    #[test]
+    fn derive_template_name_rejects_empty_agent_slug() {
+        let err = derive_template_name("", "sam").unwrap_err();
+        assert_eq!(err, TemplateNameError::EmptyAgentSlug);
+    }
+
+    #[test]
+    fn derive_template_name_rejects_invalid_agent_slug() {
+        let err = derive_template_name("Claude_Code", "sam").unwrap_err();
+        assert!(matches!(err, TemplateNameError::InvalidAgentSlug(_)));
+    }
+
+    #[test]
+    fn derive_template_name_rejects_non_ascii_username() {
+        let err = derive_template_name("claude-code", "samé").unwrap_err();
+        assert!(matches!(err, TemplateNameError::InvalidUsername(_)));
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1090,6 +1090,21 @@ fn is_valid_template_name(s: &str) -> bool {
             .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
 }
 
+/// Public wrapper for [`is_valid_template_name`] exposed for the UDS
+/// `TEMPLATE-*` parsers. Mirrors the `[a-z0-9-]+` rule used by
+/// [`validate_hook_templates`].
+pub fn is_valid_template_name_str(s: &str) -> bool {
+    is_valid_template_name(s)
+}
+
+/// True if `cmd[0]` would fail the placeholder check in
+/// [`validate_hook_templates`]. Exposed for the UDS `TEMPLATE-*`
+/// parsers so they can reject obviously-malformed bodies before handler
+/// dispatch.
+pub fn cmd_zero_contains_placeholder(binary: &str) -> bool {
+    iter_placeholders(binary).next().is_some()
+}
+
 /// Charset predicate for `[[hook_template]].params` entries and the
 /// placeholder names surfaced by [`iter_placeholders`]. Kept in lockstep
 /// with the parser so operators get a precise "invalid param name" error

--- a/src/hook_handler.rs
+++ b/src/hook_handler.rs
@@ -1543,31 +1543,15 @@ mod tests {
 
     #[tokio::test]
     async fn template_create_rejects_when_validator_fails() {
-        // Invariant: validate_hook_templates runs on the full templates
-        // vec before any disk write. Seed the payload with a name that
-        // collides with a reserved-name rule caught only by the
-        // load-time validator (e.g. a duplicate name). Duplicate-name
-        // rejection lands as ECONFLICT earlier, so we use a payload
-        // that slips past parse-time shape checks but fails the deeper
-        // validator — here, a param that references an unknown
-        // placeholder.
+        // Invariant: `validate_hook_templates` runs on the full template
+        // vec before any disk write. Construct a payload that slips past
+        // the parse-time shape check but fails the deeper on-config
+        // validator: here, a declared param that collides with the
+        // `{mailbox}` builtin.
         let tmp = TempDir::new().unwrap();
         let (_s, mb_ctx) = contexts(&tmp);
 
-        // Build manually to bypass UdsTemplatePayload::validate shape
-        // rule that every declared param must appear in cmd. The deeper
-        // validator still catches the mismatch.
         let mut bad = payload("invoke-bad-sam", "sam");
-        bad.cmd = vec!["/usr/bin/echo".into(), "{unknown}".into()];
-        bad.params = vec!["prompt".into()];
-        // Skip the parse-time validate() (which would reject "unused
-        // param"); call the handler with this payload directly.
-        // Instead we exercise the on-config validator by using a
-        // scenario it catches but the parser allows.
-        // One such case: `allowed_events = []` — parse-time validate
-        // rejects it too. Instead, construct a scenario where the
-        // parser passes (param is referenced) but the on-config
-        // validator fails (declared param collides with a builtin).
         bad.cmd = vec!["/usr/bin/echo".into(), "{event}".into(), "{mailbox}".into()];
         bad.params = vec!["mailbox".into()];
 
@@ -1623,6 +1607,237 @@ mod tests {
                 .hook_templates
                 .iter()
                 .any(|t| t.name == "invoke-foo-sam")
+        );
+    }
+
+    #[tokio::test]
+    async fn template_update_persists_to_disk() {
+        let tmp = TempDir::new().unwrap();
+        let (_s, mb_ctx) = contexts(&tmp);
+        let create = crate::send_protocol::TemplateCreateRequest {
+            payload: payload("invoke-claude-sam", "sam"),
+        };
+        assert!(matches!(
+            handle_template_create(&mb_ctx, &create, &Caller::internal_root()).await,
+            AckResponse::Ok
+        ));
+
+        let mut new_payload = payload("invoke-claude-sam", "sam");
+        new_payload.description = "rewritten-on-disk".into();
+        new_payload.cmd = vec!["/usr/local/bin/claude".into(), "{prompt}".into()];
+        let update = crate::send_protocol::TemplateUpdateRequest {
+            name: "invoke-claude-sam".into(),
+            payload: new_payload,
+        };
+        let caller = Caller::with_username(1001, 1001, "sam");
+        assert!(matches!(
+            handle_template_update(&mb_ctx, &update, &caller).await,
+            AckResponse::Ok
+        ));
+
+        let reloaded = Config::load_ignore_warnings(&mb_ctx.config_path).unwrap();
+        let t = reloaded
+            .hook_templates
+            .iter()
+            .find(|t| t.name == "invoke-claude-sam")
+            .expect("template still present after update");
+        assert_eq!(t.description, "rewritten-on-disk");
+        assert_eq!(t.cmd[0], "/usr/local/bin/claude");
+    }
+
+    #[tokio::test]
+    async fn template_delete_persists_to_disk() {
+        let tmp = TempDir::new().unwrap();
+        let (_s, mb_ctx) = contexts(&tmp);
+        let create = crate::send_protocol::TemplateCreateRequest {
+            payload: payload("invoke-foo-sam", "sam"),
+        };
+        assert!(matches!(
+            handle_template_create(&mb_ctx, &create, &Caller::internal_root()).await,
+            AckResponse::Ok
+        ));
+
+        let del = crate::send_protocol::TemplateDeleteRequest {
+            name: "invoke-foo-sam".into(),
+        };
+        let caller = Caller::with_username(1001, 1001, "sam");
+        assert!(matches!(
+            handle_template_delete(&mb_ctx, &del, &caller).await,
+            AckResponse::Ok
+        ));
+
+        let reloaded = Config::load_ignore_warnings(&mb_ctx.config_path).unwrap();
+        assert!(
+            !reloaded
+                .hook_templates
+                .iter()
+                .any(|t| t.name == "invoke-foo-sam"),
+            "deleted template must not reappear on reload"
+        );
+    }
+
+    /// Rename round-trip: `payload.name` differs from the `Template-Name`
+    /// header. The handler treats this as a rename — the old entry at the
+    /// existing position is replaced with the new payload, the old name
+    /// disappears, the new name takes its place.
+    #[tokio::test]
+    async fn template_update_renames_when_body_name_differs_from_header() {
+        let tmp = TempDir::new().unwrap();
+        let (_s, mb_ctx) = contexts(&tmp);
+        let create = crate::send_protocol::TemplateCreateRequest {
+            payload: payload("invoke-claude-sam", "sam"),
+        };
+        assert!(matches!(
+            handle_template_create(&mb_ctx, &create, &Caller::internal_root()).await,
+            AckResponse::Ok
+        ));
+
+        // Submit UPDATE with header = old name, body.name = new name.
+        let mut renamed = payload("invoke-claude-renamed-sam", "sam");
+        renamed.description = "renamed".into();
+        let update = crate::send_protocol::TemplateUpdateRequest {
+            name: "invoke-claude-sam".into(),
+            payload: renamed,
+        };
+        let caller = Caller::with_username(1001, 1001, "sam");
+        assert!(matches!(
+            handle_template_update(&mb_ctx, &update, &caller).await,
+            AckResponse::Ok
+        ));
+
+        let reloaded = Config::load_ignore_warnings(&mb_ctx.config_path).unwrap();
+        assert!(
+            !reloaded
+                .hook_templates
+                .iter()
+                .any(|t| t.name == "invoke-claude-sam"),
+            "old name must be gone after rename"
+        );
+        let t = reloaded
+            .hook_templates
+            .iter()
+            .find(|t| t.name == "invoke-claude-renamed-sam")
+            .expect("new name must be present after rename");
+        assert_eq!(t.description, "renamed");
+    }
+
+    // ---- Negative: reject paths must leave disk untouched --------------
+
+    /// Helper: read the raw on-disk `config.toml` bytes so tests can
+    /// assert byte-for-byte equality across a rejected operation.
+    fn read_config_bytes(mb_ctx: &MailboxContext) -> Vec<u8> {
+        std::fs::read(&mb_ctx.config_path).expect("config.toml must exist")
+    }
+
+    #[tokio::test]
+    async fn template_create_conflict_does_not_mutate_disk() {
+        let tmp = TempDir::new().unwrap();
+        let (_s, mb_ctx) = contexts(&tmp);
+        let before = read_config_bytes(&mb_ctx);
+
+        // `invoke-claude` is seeded by `base_config`, so this is a dup.
+        let req = crate::send_protocol::TemplateCreateRequest {
+            payload: payload("invoke-claude", "sam"),
+        };
+        match handle_template_create(&mb_ctx, &req, &Caller::internal_root()).await {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Conflict),
+            other => panic!("expected Err(ECONFLICT), got {other:?}"),
+        }
+
+        let after = read_config_bytes(&mb_ctx);
+        assert_eq!(before, after, "disk must be untouched on ECONFLICT reject");
+    }
+
+    #[tokio::test]
+    async fn template_update_missing_does_not_mutate_disk() {
+        let tmp = TempDir::new().unwrap();
+        let (_s, mb_ctx) = contexts(&tmp);
+        let before = read_config_bytes(&mb_ctx);
+
+        let req = crate::send_protocol::TemplateUpdateRequest {
+            name: "invoke-nope".into(),
+            payload: payload("invoke-nope", "sam"),
+        };
+        match handle_template_update(&mb_ctx, &req, &Caller::internal_root()).await {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Enoent),
+            other => panic!("expected Err(ENOENT), got {other:?}"),
+        }
+
+        let after = read_config_bytes(&mb_ctx);
+        assert_eq!(before, after, "disk must be untouched on ENOENT reject");
+    }
+
+    #[tokio::test]
+    async fn template_delete_missing_does_not_mutate_disk() {
+        let tmp = TempDir::new().unwrap();
+        let (_s, mb_ctx) = contexts(&tmp);
+        let before = read_config_bytes(&mb_ctx);
+
+        let del = crate::send_protocol::TemplateDeleteRequest {
+            name: "invoke-nope".into(),
+        };
+        match handle_template_delete(&mb_ctx, &del, &Caller::internal_root()).await {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Enoent),
+            other => panic!("expected Err(ENOENT), got {other:?}"),
+        }
+
+        let after = read_config_bytes(&mb_ctx);
+        assert_eq!(before, after, "disk must be untouched on ENOENT reject");
+    }
+
+    #[tokio::test]
+    async fn template_update_unauthorized_does_not_mutate_disk() {
+        let tmp = TempDir::new().unwrap();
+        let (_s, mb_ctx) = contexts(&tmp);
+        let create = crate::send_protocol::TemplateCreateRequest {
+            payload: payload("invoke-foo-sam", "sam"),
+        };
+        assert!(matches!(
+            handle_template_create(&mb_ctx, &create, &Caller::internal_root()).await,
+            AckResponse::Ok
+        ));
+        let before = read_config_bytes(&mb_ctx);
+
+        let mut tampered = payload("invoke-foo-sam", "eve");
+        tampered.description = "hijacked".into();
+        let update = crate::send_protocol::TemplateUpdateRequest {
+            name: "invoke-foo-sam".into(),
+            payload: tampered,
+        };
+        let caller = Caller::with_username(1002, 1002, "eve");
+        match handle_template_update(&mb_ctx, &update, &caller).await {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Eaccess),
+            other => panic!("expected Err(EACCES), got {other:?}"),
+        }
+
+        let after = read_config_bytes(&mb_ctx);
+        assert_eq!(before, after, "disk must be untouched on EACCES reject");
+    }
+
+    #[tokio::test]
+    async fn template_create_validator_failure_does_not_mutate_disk() {
+        let tmp = TempDir::new().unwrap();
+        let (_s, mb_ctx) = contexts(&tmp);
+        let before = read_config_bytes(&mb_ctx);
+
+        // Same scenario as `template_create_rejects_when_validator_fails`:
+        // the parse-time shape check passes (the param is referenced in
+        // argv) but the on-config validator rejects because the declared
+        // param collides with the builtin `{mailbox}`.
+        let mut bad = payload("invoke-bad-sam", "sam");
+        bad.cmd = vec!["/usr/bin/echo".into(), "{event}".into(), "{mailbox}".into()];
+        bad.params = vec!["mailbox".into()];
+
+        let req = crate::send_protocol::TemplateCreateRequest { payload: bad };
+        match handle_template_create(&mb_ctx, &req, &Caller::internal_root()).await {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Validation),
+            other => panic!("expected Err(VALIDATION), got {other:?}"),
+        }
+
+        let after = read_config_bytes(&mb_ctx);
+        assert_eq!(
+            before, after,
+            "disk must be untouched on validator-failure reject"
         );
     }
 

--- a/src/hook_handler.rs
+++ b/src/hook_handler.rs
@@ -32,13 +32,15 @@
 use std::collections::BTreeMap;
 
 use crate::config::{
-    Config, HookTemplate, OrphanSkipContext, validate_hooks, validate_single_hook,
+    Config, HookTemplate, OrphanSkipContext, RESERVED_RUN_AS_CATCHALL, RESERVED_RUN_AS_ROOT,
+    validate_hook_templates, validate_hooks, validate_single_hook,
 };
 use crate::hook::{Hook, HookEvent, HookOrigin, effective_hook_name, is_valid_hook_name};
 use crate::hook_substitute::{BuiltinContext, substitute_argv};
 use crate::mailbox_handler::{CONFIG_WRITE_LOCK, MailboxContext, write_config_atomic};
 use crate::send_protocol::{
     AckResponse, ErrCode, HookCreateRequest, HookDeleteRequest, HookTemplateCreateBody,
+    TemplateCreateRequest, TemplateDeleteRequest, TemplateUpdateRequest,
 };
 use crate::state_handler::StateContext;
 use crate::uds_authz::{Caller, LogDecision, enforce_mailbox_owner_or_root, log_decision};
@@ -413,6 +415,296 @@ pub async fn handle_hook_delete(
         };
     }
 
+    mb_ctx.config_handle.store(new_config);
+    AckResponse::Ok
+}
+
+/// Handle an `AIMX/1 TEMPLATE-CREATE` request. The caller's username
+/// (from `SO_PEERCRED`) must equal the submitted `run_as`, or be root
+/// (logged as `root_bypass`). Atomic write-through: validate + stage a
+/// new `Config`, write-temp-then-rename `config.toml`, then swap the
+/// in-memory handle. Duplicate-name submissions return `ECONFLICT`.
+pub async fn handle_template_create(
+    mb_ctx: &MailboxContext,
+    req: &TemplateCreateRequest,
+    caller: &Caller,
+) -> AckResponse {
+    if let Err(reply) = enforce_run_as_matches_caller(
+        "TEMPLATE-CREATE",
+        caller,
+        &req.payload.run_as,
+        Some(&req.payload.name),
+    ) {
+        return reply;
+    }
+
+    let _config_guard = CONFIG_WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let current = mb_ctx.config_handle.load();
+    if current
+        .hook_templates
+        .iter()
+        .any(|t| t.name == req.payload.name)
+    {
+        return AckResponse::Err {
+            code: ErrCode::Conflict,
+            reason: format!("template '{}' already exists", req.payload.name),
+        };
+    }
+
+    let template: HookTemplate = req.payload.clone().into_hook_template();
+    let mut new_config: Config = (*current).clone();
+    new_config.hook_templates.push(template);
+
+    if let Err(reason) = validate_hook_templates(&new_config.hook_templates) {
+        return AckResponse::Err {
+            code: ErrCode::Validation,
+            reason,
+        };
+    }
+
+    // Re-run the hook invariant pass: if an existing hook binds this
+    // template, adding it via UDS must not create an invariant violation.
+    // This mirrors the path `Config::load` takes.
+    if let Err(reason) = validate_hooks(&new_config, &OrphanSkipContext::strict()) {
+        return AckResponse::Err {
+            code: ErrCode::Validation,
+            reason,
+        };
+    }
+
+    commit_config(mb_ctx, new_config)
+}
+
+/// Handle an `AIMX/1 TEMPLATE-UPDATE` request. Replaces an existing
+/// template (located via the `Template-Name:` header) with the submitted
+/// payload. Authz rule matches CREATE: the caller's username must equal
+/// the submitted `run_as`, or be root.
+pub async fn handle_template_update(
+    mb_ctx: &MailboxContext,
+    req: &TemplateUpdateRequest,
+    caller: &Caller,
+) -> AckResponse {
+    if let Err(reply) = enforce_run_as_matches_caller(
+        "TEMPLATE-UPDATE",
+        caller,
+        &req.payload.run_as,
+        Some(&req.name),
+    ) {
+        return reply;
+    }
+
+    // When the header name differs from the body name we treat the
+    // submission as a rename: remove the old entry, insert the new. The
+    // load-time validator catches duplicate-name collisions below.
+    let _config_guard = CONFIG_WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let current = mb_ctx.config_handle.load();
+    let Some(existing_idx) = current
+        .hook_templates
+        .iter()
+        .position(|t| t.name == req.name)
+    else {
+        return AckResponse::Err {
+            code: ErrCode::Enoent,
+            reason: format!("template '{}' does not exist", req.name),
+        };
+    };
+
+    let existing = &current.hook_templates[existing_idx];
+
+    // Authz check against the *existing* run_as so a caller cannot sneak
+    // a template from someone else into their name. Root bypass above
+    // already cleared them; non-root callers land here only if they own
+    // the submitted `run_as`, which must also match the on-disk one.
+    if !caller.is_root() {
+        let caller_name = caller.username().unwrap_or("");
+        if existing.run_as != caller_name {
+            log_decision(
+                "TEMPLATE-UPDATE",
+                caller,
+                Some(&req.name),
+                LogDecision::Reject,
+                Some("existing template run_as mismatch"),
+            );
+            return AckResponse::Err {
+                code: ErrCode::Eaccess,
+                reason: format!(
+                    "caller '{caller_name}' is not authorized to update template '{}' (run_as: '{}')",
+                    req.name, existing.run_as
+                ),
+            };
+        }
+    }
+
+    let template: HookTemplate = req.payload.clone().into_hook_template();
+    let mut new_config: Config = (*current).clone();
+    new_config.hook_templates[existing_idx] = template;
+
+    if let Err(reason) = validate_hook_templates(&new_config.hook_templates) {
+        return AckResponse::Err {
+            code: ErrCode::Validation,
+            reason,
+        };
+    }
+
+    if let Err(reason) = validate_hooks(&new_config, &OrphanSkipContext::strict()) {
+        return AckResponse::Err {
+            code: ErrCode::Validation,
+            reason,
+        };
+    }
+
+    commit_config(mb_ctx, new_config)
+}
+
+/// Handle an `AIMX/1 TEMPLATE-DELETE` request. Removes the template
+/// addressed by `Template-Name:`. Authz rule: caller's username must
+/// equal the template's `run_as`, or be root.
+pub async fn handle_template_delete(
+    mb_ctx: &MailboxContext,
+    req: &TemplateDeleteRequest,
+    caller: &Caller,
+) -> AckResponse {
+    let _config_guard = CONFIG_WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let current = mb_ctx.config_handle.load();
+    let Some(existing_idx) = current
+        .hook_templates
+        .iter()
+        .position(|t| t.name == req.name)
+    else {
+        log_decision(
+            "TEMPLATE-DELETE",
+            caller,
+            Some(&req.name),
+            LogDecision::Reject,
+            Some("template not found"),
+        );
+        return AckResponse::Err {
+            code: ErrCode::Enoent,
+            reason: format!("template '{}' does not exist", req.name),
+        };
+    };
+
+    let existing = &current.hook_templates[existing_idx];
+    if let Err(reply) =
+        enforce_run_as_matches_caller("TEMPLATE-DELETE", caller, &existing.run_as, Some(&req.name))
+    {
+        return reply;
+    }
+
+    let mut new_config: Config = (*current).clone();
+    new_config.hook_templates.remove(existing_idx);
+
+    // Re-run validation. A template removed while a hook still binds to
+    // it would leave the config in an inconsistent state; the hook
+    // validator catches this and returns the fix hint.
+    if let Err(reason) = validate_hooks(&new_config, &OrphanSkipContext::strict()) {
+        return AckResponse::Err {
+            code: ErrCode::Validation,
+            reason,
+        };
+    }
+
+    commit_config(mb_ctx, new_config)
+}
+
+/// PRD §6.5 authz rule for TEMPLATE-*: the submitted / existing `run_as`
+/// must equal the caller's resolved username, or the caller must be
+/// root (logged as `root_bypass`). Reserved names (`root` /
+/// `aimx-catchall`) are rejected at parse time; they should never
+/// arrive here, but if they do we reject with `EACCES` for safety.
+fn enforce_run_as_matches_caller(
+    verb: &'static str,
+    caller: &Caller,
+    submitted_run_as: &str,
+    template_name: Option<&str>,
+) -> Result<(), AckResponse> {
+    if caller.is_root() {
+        log_decision(verb, caller, template_name, LogDecision::RootBypass, None);
+        return Ok(());
+    }
+
+    if submitted_run_as == RESERVED_RUN_AS_ROOT || submitted_run_as == RESERVED_RUN_AS_CATCHALL {
+        log_decision(
+            verb,
+            caller,
+            template_name,
+            LogDecision::Reject,
+            Some("reserved run_as"),
+        );
+        return Err(AckResponse::Err {
+            code: ErrCode::Eaccess,
+            reason: format!(
+                "run_as '{submitted_run_as}' is reserved and can only be set via \
+                 direct config edit"
+            ),
+        });
+    }
+
+    let caller_name = match caller.username() {
+        Some(n) => n,
+        None => {
+            log_decision(
+                verb,
+                caller,
+                template_name,
+                LogDecision::Reject,
+                Some("caller username unresolved"),
+            );
+            return Err(AckResponse::Err {
+                code: ErrCode::Eaccess,
+                reason: format!(
+                    "caller uid {} has no resolvable username; cannot authorize \
+                     template action",
+                    caller.uid
+                ),
+            });
+        }
+    };
+
+    if caller_name != submitted_run_as {
+        log_decision(
+            verb,
+            caller,
+            template_name,
+            LogDecision::Reject,
+            Some("caller != run_as"),
+        );
+        return Err(AckResponse::Err {
+            code: ErrCode::Eaccess,
+            reason: format!(
+                "caller '{caller_name}' is not authorized to manage template with \
+                 run_as '{submitted_run_as}'"
+            ),
+        });
+    }
+
+    log_decision(verb, caller, template_name, LogDecision::Accept, None);
+    Ok(())
+}
+
+/// Finalize a pending `Config` mutation: atomically rewrite `config.toml`
+/// (disk rename first) and swap the in-memory handle. A failure during
+/// rename leaves the handle untouched so the daemon continues against
+/// the pre-call snapshot. A swap cannot fail in the present
+/// implementation (the handle's `store` is infallible), but the
+/// semantics documented in Sprint 5 require a loud failure path here
+/// should it ever become fallible — keep the panic-free surface.
+fn commit_config(mb_ctx: &MailboxContext, new_config: Config) -> AckResponse {
+    if let Err(e) = write_config_atomic(&mb_ctx.config_path, &new_config) {
+        return AckResponse::Err {
+            code: ErrCode::Io,
+            reason: format!("failed to write {}: {e}", mb_ctx.config_path.display()),
+        };
+    }
     mb_ctx.config_handle.store(new_config);
     AckResponse::Ok
 }
@@ -997,6 +1289,341 @@ mod tests {
             AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Validation),
             other => panic!("expected Err(VALIDATION), got {other:?}"),
         }
+    }
+
+    // ---- TEMPLATE-CREATE / UPDATE / DELETE -------------------------
+
+    use crate::send_protocol::UdsTemplatePayload;
+
+    fn payload(name: &str, run_as: &str) -> UdsTemplatePayload {
+        UdsTemplatePayload {
+            name: name.to_string(),
+            description: "test".into(),
+            cmd: vec!["/usr/bin/echo".into(), "{prompt}".into()],
+            params: vec!["prompt".into()],
+            stdin: crate::config::HookTemplateStdin::Email,
+            run_as: run_as.to_string(),
+            timeout_secs: 60,
+            allowed_events: vec![HookEvent::OnReceive, HookEvent::AfterSend],
+        }
+    }
+
+    #[tokio::test]
+    async fn template_create_root_bypass_succeeds() {
+        let tmp = TempDir::new().unwrap();
+        let (_s, mb_ctx) = contexts(&tmp);
+        let req = crate::send_protocol::TemplateCreateRequest {
+            payload: payload("invoke-foo-sam", "sam"),
+        };
+        match handle_template_create(&mb_ctx, &req, &Caller::internal_root()).await {
+            AckResponse::Ok => {}
+            other => panic!("expected Ok, got {other:?}"),
+        }
+        let live = mb_ctx.config_handle.load();
+        assert!(
+            live.hook_templates
+                .iter()
+                .any(|t| t.name == "invoke-foo-sam")
+        );
+    }
+
+    #[tokio::test]
+    async fn template_create_requires_caller_matches_run_as() {
+        let tmp = TempDir::new().unwrap();
+        let (_s, mb_ctx) = contexts(&tmp);
+        let req = crate::send_protocol::TemplateCreateRequest {
+            payload: payload("invoke-foo-sam", "sam"),
+        };
+        let caller = Caller::with_username(1001, 1001, "eve");
+        match handle_template_create(&mb_ctx, &req, &caller).await {
+            AckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Eaccess);
+                assert!(reason.contains("eve"), "{reason}");
+            }
+            other => panic!("expected Err(EACCES), got {other:?}"),
+        }
+        let live = mb_ctx.config_handle.load();
+        assert!(
+            !live
+                .hook_templates
+                .iter()
+                .any(|t| t.name == "invoke-foo-sam")
+        );
+    }
+
+    #[tokio::test]
+    async fn template_create_accepts_matching_caller() {
+        let tmp = TempDir::new().unwrap();
+        let (_s, mb_ctx) = contexts(&tmp);
+        let req = crate::send_protocol::TemplateCreateRequest {
+            payload: payload("invoke-foo-sam", "sam"),
+        };
+        let caller = Caller::with_username(1001, 1001, "sam");
+        assert!(matches!(
+            handle_template_create(&mb_ctx, &req, &caller).await,
+            AckResponse::Ok
+        ));
+    }
+
+    #[tokio::test]
+    async fn template_create_duplicate_name_is_conflict() {
+        let tmp = TempDir::new().unwrap();
+        let (_s, mb_ctx) = contexts(&tmp);
+        let req = crate::send_protocol::TemplateCreateRequest {
+            payload: payload("invoke-claude", "sam"),
+        };
+        // `base_config` already ships `invoke-claude`, so this is a dup.
+        match handle_template_create(&mb_ctx, &req, &Caller::internal_root()).await {
+            AckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Conflict);
+                assert!(reason.contains("invoke-claude"), "{reason}");
+            }
+            other => panic!("expected Err(ECONFLICT), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn template_update_missing_name_returns_enoent() {
+        let tmp = TempDir::new().unwrap();
+        let (_s, mb_ctx) = contexts(&tmp);
+        let req = crate::send_protocol::TemplateUpdateRequest {
+            name: "invoke-nope".into(),
+            payload: payload("invoke-nope", "sam"),
+        };
+        match handle_template_update(&mb_ctx, &req, &Caller::internal_root()).await {
+            AckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Enoent);
+                assert!(reason.contains("invoke-nope"), "{reason}");
+            }
+            other => panic!("expected Err(ENOENT), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn template_update_replaces_existing() {
+        let tmp = TempDir::new().unwrap();
+        let (_s, mb_ctx) = contexts(&tmp);
+        // Seed a template owned by `sam` so the non-root caller path
+        // can be exercised.
+        let create = crate::send_protocol::TemplateCreateRequest {
+            payload: payload("invoke-claude-sam", "sam"),
+        };
+        assert!(matches!(
+            handle_template_create(&mb_ctx, &create, &Caller::internal_root()).await,
+            AckResponse::Ok
+        ));
+
+        let mut new_payload = payload("invoke-claude-sam", "sam");
+        new_payload.description = "rewritten".into();
+        new_payload.cmd = vec!["/usr/local/bin/claude".into(), "{prompt}".into()];
+        let update = crate::send_protocol::TemplateUpdateRequest {
+            name: "invoke-claude-sam".into(),
+            payload: new_payload,
+        };
+        let caller = Caller::with_username(1001, 1001, "sam");
+        assert!(matches!(
+            handle_template_update(&mb_ctx, &update, &caller).await,
+            AckResponse::Ok
+        ));
+
+        let live = mb_ctx.config_handle.load();
+        let t = live
+            .hook_templates
+            .iter()
+            .find(|t| t.name == "invoke-claude-sam")
+            .unwrap();
+        assert_eq!(t.description, "rewritten");
+        assert_eq!(t.cmd[0], "/usr/local/bin/claude");
+    }
+
+    #[tokio::test]
+    async fn template_update_rejects_non_owner_caller() {
+        let tmp = TempDir::new().unwrap();
+        let (_s, mb_ctx) = contexts(&tmp);
+        let create = crate::send_protocol::TemplateCreateRequest {
+            payload: payload("invoke-claude-sam", "sam"),
+        };
+        assert!(matches!(
+            handle_template_create(&mb_ctx, &create, &Caller::internal_root()).await,
+            AckResponse::Ok
+        ));
+
+        let mut tampered = payload("invoke-claude-sam", "eve");
+        tampered.description = "hijacked".into();
+        let update = crate::send_protocol::TemplateUpdateRequest {
+            name: "invoke-claude-sam".into(),
+            payload: tampered,
+        };
+        let caller = Caller::with_username(1002, 1002, "eve");
+        match handle_template_update(&mb_ctx, &update, &caller).await {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Eaccess),
+            other => panic!("expected Err(EACCES), got {other:?}"),
+        }
+
+        let live = mb_ctx.config_handle.load();
+        let t = live
+            .hook_templates
+            .iter()
+            .find(|t| t.name == "invoke-claude-sam")
+            .unwrap();
+        assert_ne!(t.description, "hijacked");
+    }
+
+    #[tokio::test]
+    async fn template_delete_removes_template() {
+        let tmp = TempDir::new().unwrap();
+        let (_s, mb_ctx) = contexts(&tmp);
+        let create = crate::send_protocol::TemplateCreateRequest {
+            payload: payload("invoke-foo-sam", "sam"),
+        };
+        assert!(matches!(
+            handle_template_create(&mb_ctx, &create, &Caller::internal_root()).await,
+            AckResponse::Ok
+        ));
+
+        let del = crate::send_protocol::TemplateDeleteRequest {
+            name: "invoke-foo-sam".into(),
+        };
+        let caller = Caller::with_username(1001, 1001, "sam");
+        assert!(matches!(
+            handle_template_delete(&mb_ctx, &del, &caller).await,
+            AckResponse::Ok
+        ));
+
+        let live = mb_ctx.config_handle.load();
+        assert!(
+            !live
+                .hook_templates
+                .iter()
+                .any(|t| t.name == "invoke-foo-sam")
+        );
+    }
+
+    #[tokio::test]
+    async fn template_delete_missing_returns_enoent() {
+        let tmp = TempDir::new().unwrap();
+        let (_s, mb_ctx) = contexts(&tmp);
+        let del = crate::send_protocol::TemplateDeleteRequest {
+            name: "invoke-nope".into(),
+        };
+        match handle_template_delete(&mb_ctx, &del, &Caller::internal_root()).await {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Enoent),
+            other => panic!("expected Err(ENOENT), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn template_delete_non_owner_is_eaccess() {
+        let tmp = TempDir::new().unwrap();
+        let (_s, mb_ctx) = contexts(&tmp);
+        let create = crate::send_protocol::TemplateCreateRequest {
+            payload: payload("invoke-foo-sam", "sam"),
+        };
+        assert!(matches!(
+            handle_template_create(&mb_ctx, &create, &Caller::internal_root()).await,
+            AckResponse::Ok
+        ));
+
+        let del = crate::send_protocol::TemplateDeleteRequest {
+            name: "invoke-foo-sam".into(),
+        };
+        let caller = Caller::with_username(1002, 1002, "eve");
+        match handle_template_delete(&mb_ctx, &del, &caller).await {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Eaccess),
+            other => panic!("expected Err(EACCES), got {other:?}"),
+        }
+
+        let live = mb_ctx.config_handle.load();
+        assert!(
+            live.hook_templates
+                .iter()
+                .any(|t| t.name == "invoke-foo-sam")
+        );
+    }
+
+    #[tokio::test]
+    async fn template_create_rejects_when_validator_fails() {
+        // Invariant: validate_hook_templates runs on the full templates
+        // vec before any disk write. Seed the payload with a name that
+        // collides with a reserved-name rule caught only by the
+        // load-time validator (e.g. a duplicate name). Duplicate-name
+        // rejection lands as ECONFLICT earlier, so we use a payload
+        // that slips past parse-time shape checks but fails the deeper
+        // validator — here, a param that references an unknown
+        // placeholder.
+        let tmp = TempDir::new().unwrap();
+        let (_s, mb_ctx) = contexts(&tmp);
+
+        // Build manually to bypass UdsTemplatePayload::validate shape
+        // rule that every declared param must appear in cmd. The deeper
+        // validator still catches the mismatch.
+        let mut bad = payload("invoke-bad-sam", "sam");
+        bad.cmd = vec!["/usr/bin/echo".into(), "{unknown}".into()];
+        bad.params = vec!["prompt".into()];
+        // Skip the parse-time validate() (which would reject "unused
+        // param"); call the handler with this payload directly.
+        // Instead we exercise the on-config validator by using a
+        // scenario it catches but the parser allows.
+        // One such case: `allowed_events = []` — parse-time validate
+        // rejects it too. Instead, construct a scenario where the
+        // parser passes (param is referenced) but the on-config
+        // validator fails (declared param collides with a builtin).
+        bad.cmd = vec!["/usr/bin/echo".into(), "{event}".into(), "{mailbox}".into()];
+        bad.params = vec!["mailbox".into()];
+
+        let req = crate::send_protocol::TemplateCreateRequest { payload: bad };
+        match handle_template_create(&mb_ctx, &req, &Caller::internal_root()).await {
+            AckResponse::Err { code, reason: _ } => assert_eq!(code, ErrCode::Validation),
+            other => panic!("expected Err(VALIDATION), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn template_delete_rejects_when_hook_still_bound() {
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+        // Wire a hook against the seeded invoke-claude template so
+        // deletion leaves a dangling hook — the validator must reject.
+        let req = HookCreateRequest {
+            mailbox: "alice".into(),
+            event: "on_receive".into(),
+            template: "invoke-claude".into(),
+            name: Some("bound_hook".into()),
+            body: body(&[("prompt", "hi")]),
+        };
+        assert!(matches!(
+            handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await,
+            AckResponse::Ok
+        ));
+
+        let del = crate::send_protocol::TemplateDeleteRequest {
+            name: "invoke-claude".into(),
+        };
+        match handle_template_delete(&mb_ctx, &del, &Caller::internal_root()).await {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Validation),
+            other => panic!("expected Err(VALIDATION), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn template_create_persists_to_disk() {
+        let tmp = TempDir::new().unwrap();
+        let (_s, mb_ctx) = contexts(&tmp);
+        let req = crate::send_protocol::TemplateCreateRequest {
+            payload: payload("invoke-foo-sam", "sam"),
+        };
+        assert!(matches!(
+            handle_template_create(&mb_ctx, &req, &Caller::internal_root()).await,
+            AckResponse::Ok
+        ));
+
+        let reloaded = Config::load_ignore_warnings(&mb_ctx.config_path).unwrap();
+        assert!(
+            reloaded
+                .hook_templates
+                .iter()
+                .any(|t| t.name == "invoke-foo-sam")
+        );
     }
 
     #[tokio::test(flavor = "multi_thread", worker_threads = 4)]

--- a/src/send_protocol.rs
+++ b/src/send_protocol.rs
@@ -46,6 +46,25 @@
 //!   Content-Length: 0\n
 //!   \n
 //!
+//! Client → Server (TEMPLATE-CREATE):
+//!   AIMX/1 TEMPLATE-CREATE\n
+//!   Content-Length: <n>\n
+//!   \n
+//!   <n bytes of TOML: UdsTemplatePayload fields>
+//!
+//! Client → Server (TEMPLATE-UPDATE):
+//!   AIMX/1 TEMPLATE-UPDATE\n
+//!   Template-Name: <name>\n
+//!   Content-Length: <n>\n
+//!   \n
+//!   <n bytes of TOML: UdsTemplatePayload fields>
+//!
+//! Client → Server (TEMPLATE-DELETE):
+//!   AIMX/1 TEMPLATE-DELETE\n
+//!   Template-Name: <name>\n
+//!   Content-Length: 0\n
+//!   \n
+//!
 //! Server → Client:
 //!   AIMX/1 OK [<message-id>]\n
 //! or
@@ -209,14 +228,176 @@ pub struct HookDeleteRequest {
     pub name: String,
 }
 
-/// One decoded `AIMX/1` request, tagged by verb.
+/// Safe, UDS-exposed subset of [`crate::config::HookTemplate`] used by
+/// `TEMPLATE-CREATE` and `TEMPLATE-UPDATE` (Sprint 5 §6.6). Every field
+/// is whitelisted; anything else in the submitted body is rejected by
+/// `deny_unknown_fields` with the offending key named in the TOML parser
+/// error (propagated to the caller as `MALFORMED <reason>`).
+///
+/// Reserved `run_as` values (`"root"`, `"aimx-catchall"`) are rejected
+/// at parse time so they cannot land via UDS even if the body is
+/// otherwise shape-correct. That check plus the `cmd[0]` placeholder
+/// rejection mirror the load-time guarantees of
+/// [`crate::config::validate_hook_templates`] — §6.6 says the UDS
+/// "never accepts raw `cmd` or `run_as = root` / `aimx-catchall`".
+#[derive(Debug, Clone, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct UdsTemplatePayload {
+    pub name: String,
+    #[serde(default)]
+    pub description: String,
+    pub cmd: Vec<String>,
+    #[serde(default)]
+    pub params: Vec<String>,
+    #[serde(default)]
+    pub stdin: crate::config::HookTemplateStdin,
+    pub run_as: String,
+    #[serde(default = "default_uds_template_timeout_secs")]
+    pub timeout_secs: u32,
+    #[serde(default = "default_uds_template_allowed_events")]
+    pub allowed_events: Vec<crate::hook::HookEvent>,
+}
+
+fn default_uds_template_timeout_secs() -> u32 {
+    60
+}
+
+fn default_uds_template_allowed_events() -> Vec<crate::hook::HookEvent> {
+    vec![
+        crate::hook::HookEvent::OnReceive,
+        crate::hook::HookEvent::AfterSend,
+    ]
+}
+
+impl UdsTemplatePayload {
+    /// Light-weight, shape-only validation the parser runs before handing
+    /// the request to the verb dispatcher. Every rule here mirrors a
+    /// subset of [`crate::config::validate_hook_templates`] so the final
+    /// on-config validator is the single source of truth; the parser
+    /// catches the obvious bad-shape cases early so the handler doesn't
+    /// have to hunt them down and so the error name landing on the wire
+    /// is precise.
+    ///
+    /// Per PRD §6.6:
+    /// - `cmd` must be non-empty
+    /// - `cmd[0]` must not contain a `{placeholder}`
+    /// - `run_as` must not be the reserved `root` / `aimx-catchall`
+    ///   (those templates can only be authored by an explicit root edit
+    ///   of `config.toml`)
+    /// - `timeout_secs` must be within `[1, HOOK_TEMPLATE_TIMEOUT_SECS_MAX]`
+    /// - every declared `params` entry must be referenced somewhere in
+    ///   `cmd` (any slot after `cmd[0]`)
+    pub fn validate(&self) -> Result<(), String> {
+        if !crate::config::is_valid_template_name_str(&self.name) {
+            return Err(format!(
+                "invalid template name '{}': must match [a-z0-9-]+",
+                self.name
+            ));
+        }
+        if self.cmd.is_empty() {
+            return Err("cmd is empty; must be a non-empty argv".into());
+        }
+        if crate::config::cmd_zero_contains_placeholder(&self.cmd[0]) {
+            return Err(format!(
+                "cmd[0] '{}' contains a placeholder; the binary path must be a literal",
+                self.cmd[0]
+            ));
+        }
+        if self.run_as == crate::config::RESERVED_RUN_AS_ROOT
+            || self.run_as == crate::config::RESERVED_RUN_AS_CATCHALL
+        {
+            return Err(format!(
+                "run_as '{}' can only be set via direct config edit",
+                self.run_as
+            ));
+        }
+        if self.timeout_secs == 0
+            || self.timeout_secs > crate::config::HOOK_TEMPLATE_TIMEOUT_SECS_MAX
+        {
+            return Err(format!(
+                "timeout_secs = {} is out of range [1, {}]",
+                self.timeout_secs,
+                crate::config::HOOK_TEMPLATE_TIMEOUT_SECS_MAX
+            ));
+        }
+        if self.allowed_events.is_empty() {
+            return Err("allowed_events is empty: at least one event must be listed".into());
+        }
+        // Every declared param must appear somewhere in argv past cmd[0].
+        // Full placeholder validity (charset, unknown references, etc.)
+        // is left to `validate_hook_templates`; this catches the common
+        // "declared but unused" case at the parser so the error names
+        // the offending param.
+        for p in &self.params {
+            let referenced = self.cmd.iter().skip(1).any(|slot| {
+                let needle = format!("{{{p}}}");
+                slot.contains(&needle)
+            });
+            if !referenced {
+                return Err(format!(
+                    "param '{p}' is declared but never referenced in cmd"
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    /// Convert to a full [`crate::config::HookTemplate`] after validation
+    /// has succeeded. The handler runs the load-time validator on the
+    /// resulting config before persisting.
+    pub fn into_hook_template(self) -> crate::config::HookTemplate {
+        crate::config::HookTemplate {
+            name: self.name,
+            description: self.description,
+            cmd: self.cmd,
+            params: self.params,
+            stdin: self.stdin,
+            run_as: self.run_as,
+            timeout_secs: self.timeout_secs,
+            allowed_events: self.allowed_events,
+        }
+    }
+}
+
+/// Decoded `AIMX/1 TEMPLATE-CREATE` request. Body is a TOML fragment
+/// deserialized into [`UdsTemplatePayload`]; the `name` travels inside
+/// the body so the parser can return a precise error when the operator
+/// mis-spells it.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TemplateCreateRequest {
+    pub payload: UdsTemplatePayload,
+}
+
+/// Decoded `AIMX/1 TEMPLATE-UPDATE` request. Carries a `Template-Name:`
+/// header identifying the template to replace plus a TOML body with the
+/// new fields. The handler validates that the header matches
+/// `payload.name`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TemplateUpdateRequest {
+    pub name: String,
+    pub payload: UdsTemplatePayload,
+}
+
+/// Decoded `AIMX/1 TEMPLATE-DELETE` request. `Template-Name:` header,
+/// empty body. The handler enforces the authz rule that
+/// `caller.username == template.run_as` (or root bypass) before
+/// deleting.
 #[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TemplateDeleteRequest {
+    pub name: String,
+}
+
+/// One decoded `AIMX/1` request, tagged by verb.
+#[derive(Debug, Clone, PartialEq)]
 pub enum Request {
     Send(SendRequest),
     Mark(MarkRequest),
     MailboxCrud(MailboxCrudRequest),
     HookCreate(HookCreateRequest),
     HookDelete(HookDeleteRequest),
+    TemplateCreate(TemplateCreateRequest),
+    TemplateUpdate(TemplateUpdateRequest),
+    TemplateDelete(TemplateDeleteRequest),
 }
 
 /// Error codes reported on the wire in `AIMX/1 ERR <code> <reason>`.
@@ -416,6 +597,15 @@ where
         "HOOK-DELETE" => parse_hook_delete_headers(reader)
             .await
             .map(Request::HookDelete),
+        "TEMPLATE-CREATE" => parse_template_create_headers_and_body(reader, max_body)
+            .await
+            .map(Request::TemplateCreate),
+        "TEMPLATE-UPDATE" => parse_template_update_headers_and_body(reader, max_body)
+            .await
+            .map(Request::TemplateUpdate),
+        "TEMPLATE-DELETE" => parse_template_delete_headers(reader)
+            .await
+            .map(Request::TemplateDelete),
         other => Err(ParseError::UnknownVerb(other.to_string())),
     }
 }
@@ -442,6 +632,11 @@ where
         Request::HookCreate(_) | Request::HookDelete(_) => Err(ParseError::Malformed(
             "expected SEND verb, got HOOK-*".to_string(),
         )),
+        Request::TemplateCreate(_) | Request::TemplateUpdate(_) | Request::TemplateDelete(_) => {
+            Err(ParseError::Malformed(
+                "expected SEND verb, got TEMPLATE-*".to_string(),
+            ))
+        }
     }
 }
 
@@ -904,6 +1099,218 @@ where
     Ok(HookDeleteRequest { name })
 }
 
+async fn parse_template_create_headers_and_body<R>(
+    reader: &mut R,
+    max_body: usize,
+) -> Result<TemplateCreateRequest, ParseError>
+where
+    R: AsyncRead + Unpin,
+{
+    let body =
+        read_template_headers_and_body(reader, max_body, /* expect_name_header */ false)
+            .await?
+            .body;
+    let payload = parse_template_payload(&body)?;
+    Ok(TemplateCreateRequest { payload })
+}
+
+async fn parse_template_update_headers_and_body<R>(
+    reader: &mut R,
+    max_body: usize,
+) -> Result<TemplateUpdateRequest, ParseError>
+where
+    R: AsyncRead + Unpin,
+{
+    let parsed = read_template_headers_and_body(reader, max_body, true).await?;
+    let name = parsed
+        .template_name
+        .ok_or_else(|| ParseError::Malformed("missing required header: Template-Name".into()))?;
+    let payload = parse_template_payload(&parsed.body)?;
+    Ok(TemplateUpdateRequest { name, payload })
+}
+
+async fn parse_template_delete_headers<R>(
+    reader: &mut R,
+) -> Result<TemplateDeleteRequest, ParseError>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut template_name: Option<String> = None;
+    let mut content_length: Option<usize> = None;
+
+    loop {
+        let line = read_line(reader)
+            .await?
+            .ok_or_else(|| ParseError::Malformed("unexpected EOF in headers".into()))?;
+        let line = line.trim_end_matches('\r');
+        if line.is_empty() {
+            break;
+        }
+
+        let (n, v) = line
+            .split_once(':')
+            .ok_or_else(|| ParseError::Malformed(format!("invalid header line: {line:?}")))?;
+
+        if !n.is_ascii() {
+            return Err(ParseError::Malformed(format!(
+                "non-ascii header name: {n:?}"
+            )));
+        }
+        let header_name = n.trim().to_ascii_lowercase();
+        let value = v.trim().to_string();
+
+        match header_name.as_str() {
+            "template-name" => {
+                if template_name.is_some() {
+                    return Err(ParseError::Malformed(
+                        "duplicate Template-Name header".into(),
+                    ));
+                }
+                if value.is_empty() {
+                    return Err(ParseError::Malformed("empty Template-Name value".into()));
+                }
+                template_name = Some(value);
+            }
+            "content-length" => {
+                if content_length.is_some() {
+                    return Err(ParseError::Malformed(
+                        "duplicate Content-Length header".into(),
+                    ));
+                }
+                let n: usize = value.parse().map_err(|_| {
+                    ParseError::Malformed(format!("non-integer Content-Length: {value:?}"))
+                })?;
+                if n != 0 {
+                    return Err(ParseError::Malformed(format!(
+                        "TEMPLATE-DELETE must have Content-Length: 0, got {n}"
+                    )));
+                }
+                content_length = Some(n);
+            }
+            _ => {
+                // Unknown headers are ignored.
+            }
+        }
+    }
+
+    let name = template_name
+        .ok_or_else(|| ParseError::Malformed("missing required header: Template-Name".into()))?;
+    let _ = content_length;
+    Ok(TemplateDeleteRequest { name })
+}
+
+/// Shared header/body reader for `TEMPLATE-CREATE` and `TEMPLATE-UPDATE`.
+/// `expect_name_header` selects whether `Template-Name:` is parsed (UPDATE
+/// requires it; CREATE carries the name in the body). Content-Length is
+/// required in both cases.
+struct TemplateHeadersAndBody {
+    body: Vec<u8>,
+    template_name: Option<String>,
+}
+
+async fn read_template_headers_and_body<R>(
+    reader: &mut R,
+    max_body: usize,
+    expect_name_header: bool,
+) -> Result<TemplateHeadersAndBody, ParseError>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut template_name: Option<String> = None;
+    let mut content_length: Option<usize> = None;
+
+    loop {
+        let line = read_line(reader)
+            .await?
+            .ok_or_else(|| ParseError::Malformed("unexpected EOF in headers".into()))?;
+        let line = line.trim_end_matches('\r');
+        if line.is_empty() {
+            break;
+        }
+
+        let (n, v) = line
+            .split_once(':')
+            .ok_or_else(|| ParseError::Malformed(format!("invalid header line: {line:?}")))?;
+
+        if !n.is_ascii() {
+            return Err(ParseError::Malformed(format!(
+                "non-ascii header name: {n:?}"
+            )));
+        }
+        let header_name = n.trim().to_ascii_lowercase();
+        let value = v.trim().to_string();
+
+        match header_name.as_str() {
+            "template-name" => {
+                if !expect_name_header {
+                    // Ignore on CREATE; the name of record is the body's
+                    // `name` field. Do not reject, so future clients that
+                    // set it redundantly keep working.
+                    continue;
+                }
+                if template_name.is_some() {
+                    return Err(ParseError::Malformed(
+                        "duplicate Template-Name header".into(),
+                    ));
+                }
+                if value.is_empty() {
+                    return Err(ParseError::Malformed("empty Template-Name value".into()));
+                }
+                template_name = Some(value);
+            }
+            "content-length" => {
+                if content_length.is_some() {
+                    return Err(ParseError::Malformed(
+                        "duplicate Content-Length header".into(),
+                    ));
+                }
+                let n: usize = value.parse().map_err(|_| {
+                    ParseError::Malformed(format!("non-integer Content-Length: {value:?}"))
+                })?;
+                if n > max_body {
+                    return Err(ParseError::Malformed(format!(
+                        "Content-Length {n} exceeds cap {max_body}"
+                    )));
+                }
+                content_length = Some(n);
+            }
+            _ => {
+                // Unknown headers are ignored.
+            }
+        }
+    }
+
+    let content_length = content_length
+        .ok_or_else(|| ParseError::Malformed("missing required header: Content-Length".into()))?;
+
+    let mut body = vec![0u8; content_length];
+    reader.read_exact(&mut body).await.map_err(|e| {
+        if e.kind() == std::io::ErrorKind::UnexpectedEof {
+            ParseError::Malformed(format!("body truncated: expected {content_length} bytes"))
+        } else {
+            ParseError::Io(e.to_string())
+        }
+    })?;
+
+    Ok(TemplateHeadersAndBody {
+        body,
+        template_name,
+    })
+}
+
+/// Parse the TOML body into a `UdsTemplatePayload` and run the
+/// parse-time shape check. Rejections surface as `ParseError::Malformed`
+/// so the dispatcher can uniformly map them to `ERR MALFORMED <reason>`
+/// on the wire before the handler runs any authz logic (PRD §6.6).
+fn parse_template_payload(body: &[u8]) -> Result<UdsTemplatePayload, ParseError> {
+    let text = std::str::from_utf8(body)
+        .map_err(|_| ParseError::Malformed("TEMPLATE body is not valid UTF-8".into()))?;
+    let payload: UdsTemplatePayload = toml::from_str(text)
+        .map_err(|e| ParseError::Malformed(format!("malformed TEMPLATE body: {e}")))?;
+    payload.validate().map_err(ParseError::Malformed)?;
+    Ok(payload)
+}
+
 /// Read a single `\n`-terminated line from `reader`, returning it without the
 /// trailing `\n`. Returns `Ok(None)` when the stream ends cleanly before any
 /// byte arrives. Enforces [`MAX_HEADER_LINE`] to bound memory on garbage
@@ -1112,6 +1519,77 @@ where
 {
     let header = format!(
         "AIMX/1 HOOK-DELETE\nHook-Name: {}\nContent-Length: 0\n\n",
+        sanitize_inline(&request.name),
+    );
+    writer.write_all(header.as_bytes()).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Render a `UdsTemplatePayload` as a TOML body suitable for wire
+/// submission. Separate helper so client code and tests share one
+/// serialization.
+// Consumed by Sprint 6 client code and by the tests below. `pub` so the
+// future CLI can import it; `#[allow(dead_code)]` silences the binary's
+// dead-code lint until the wiring lands.
+#[allow(dead_code)]
+pub fn render_template_payload(payload: &UdsTemplatePayload) -> Result<String, std::io::Error> {
+    toml::to_string_pretty(payload)
+        .map_err(|e| std::io::Error::other(format!("toml serialize: {e}")))
+}
+
+/// Write an `AIMX/1 TEMPLATE-CREATE` request frame. Body is the payload
+/// serialized as TOML.
+#[allow(dead_code)]
+pub async fn write_template_create_request<W>(
+    writer: &mut W,
+    request: &TemplateCreateRequest,
+) -> Result<(), std::io::Error>
+where
+    W: AsyncWrite + Unpin,
+{
+    let body = render_template_payload(&request.payload)?;
+    let header = format!("AIMX/1 TEMPLATE-CREATE\nContent-Length: {}\n\n", body.len());
+    writer.write_all(header.as_bytes()).await?;
+    writer.write_all(body.as_bytes()).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Write an `AIMX/1 TEMPLATE-UPDATE` request frame. Header carries the
+/// `Template-Name:` of the template to replace; body is the new payload.
+#[allow(dead_code)]
+pub async fn write_template_update_request<W>(
+    writer: &mut W,
+    request: &TemplateUpdateRequest,
+) -> Result<(), std::io::Error>
+where
+    W: AsyncWrite + Unpin,
+{
+    let body = render_template_payload(&request.payload)?;
+    let header = format!(
+        "AIMX/1 TEMPLATE-UPDATE\nTemplate-Name: {}\nContent-Length: {}\n\n",
+        sanitize_inline(&request.name),
+        body.len()
+    );
+    writer.write_all(header.as_bytes()).await?;
+    writer.write_all(body.as_bytes()).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Write an `AIMX/1 TEMPLATE-DELETE` request frame. Empty body; the
+/// `Template-Name:` header identifies the target.
+#[allow(dead_code)]
+pub async fn write_template_delete_request<W>(
+    writer: &mut W,
+    request: &TemplateDeleteRequest,
+) -> Result<(), std::io::Error>
+where
+    W: AsyncWrite + Unpin,
+{
+    let header = format!(
+        "AIMX/1 TEMPLATE-DELETE\nTemplate-Name: {}\nContent-Length: 0\n\n",
         sanitize_inline(&request.name),
     );
     writer.write_all(header.as_bytes()).await?;
@@ -2107,6 +2585,302 @@ mod tests {
         match parsed {
             Request::HookCreate(r) => assert_eq!(r.body, body),
             other => panic!("expected HookCreate, got {other:?}"),
+        }
+    }
+
+    // ----- TEMPLATE-CREATE / UPDATE / DELETE verbs --------------------
+
+    fn example_payload(name: &str, run_as: &str) -> UdsTemplatePayload {
+        UdsTemplatePayload {
+            name: name.to_string(),
+            description: "example".into(),
+            cmd: vec!["/usr/bin/echo".into(), "{prompt}".into()],
+            params: vec!["prompt".into()],
+            stdin: crate::config::HookTemplateStdin::Email,
+            run_as: run_as.to_string(),
+            timeout_secs: 60,
+            allowed_events: vec![
+                crate::hook::HookEvent::OnReceive,
+                crate::hook::HookEvent::AfterSend,
+            ],
+        }
+    }
+
+    #[tokio::test]
+    async fn template_create_roundtrip() {
+        let req = TemplateCreateRequest {
+            payload: example_payload("invoke-claude-sam", "sam"),
+        };
+        let (mut client, mut server) = duplex(4096);
+        let w = {
+            let req = req.clone();
+            tokio::spawn(async move {
+                write_template_create_request(&mut client, &req)
+                    .await
+                    .unwrap();
+            })
+        };
+        let parsed = parse_request(&mut server).await.unwrap();
+        w.await.unwrap();
+        match parsed {
+            Request::TemplateCreate(r) => {
+                assert_eq!(r.payload.name, "invoke-claude-sam");
+                assert_eq!(r.payload.run_as, "sam");
+                assert_eq!(r.payload.cmd, vec!["/usr/bin/echo", "{prompt}"]);
+            }
+            other => panic!("expected TemplateCreate, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn template_update_roundtrip_carries_name_header() {
+        let req = TemplateUpdateRequest {
+            name: "invoke-claude-sam".into(),
+            payload: example_payload("invoke-claude-sam", "sam"),
+        };
+        let (mut client, mut server) = duplex(4096);
+        let w = {
+            let req = req.clone();
+            tokio::spawn(async move {
+                write_template_update_request(&mut client, &req)
+                    .await
+                    .unwrap();
+            })
+        };
+        let parsed = parse_request(&mut server).await.unwrap();
+        w.await.unwrap();
+        match parsed {
+            Request::TemplateUpdate(r) => {
+                assert_eq!(r.name, "invoke-claude-sam");
+                assert_eq!(r.payload.name, "invoke-claude-sam");
+            }
+            other => panic!("expected TemplateUpdate, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn template_delete_roundtrip() {
+        let req = TemplateDeleteRequest {
+            name: "invoke-claude-sam".into(),
+        };
+        let (mut client, mut server) = duplex(1024);
+        let w = {
+            let req = req.clone();
+            tokio::spawn(async move {
+                write_template_delete_request(&mut client, &req)
+                    .await
+                    .unwrap();
+            })
+        };
+        let parsed = parse_request(&mut server).await.unwrap();
+        w.await.unwrap();
+        match parsed {
+            Request::TemplateDelete(r) => assert_eq!(r.name, "invoke-claude-sam"),
+            other => panic!("expected TemplateDelete, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn template_create_rejects_reserved_run_as_root() {
+        let body = toml::to_string_pretty(&example_payload("invoke-x", "root")).unwrap();
+        let input = format!(
+            "AIMX/1 TEMPLATE-CREATE\nContent-Length: {}\n\n{body}",
+            body.len()
+        );
+        let err = parse_any_from_bytes(input.as_bytes()).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => {
+                assert!(m.contains("run_as 'root'"), "{m}");
+                assert!(m.contains("direct config edit"), "{m}");
+            }
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn template_create_rejects_reserved_run_as_catchall() {
+        let body = toml::to_string_pretty(&example_payload("invoke-x", "aimx-catchall")).unwrap();
+        let input = format!(
+            "AIMX/1 TEMPLATE-CREATE\nContent-Length: {}\n\n{body}",
+            body.len()
+        );
+        let err = parse_any_from_bytes(input.as_bytes()).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => {
+                assert!(m.contains("aimx-catchall"), "{m}");
+            }
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn template_create_rejects_placeholder_in_cmd0() {
+        let mut payload = example_payload("invoke-x", "sam");
+        payload.cmd = vec!["{binary}".into(), "{prompt}".into()];
+        let body = toml::to_string_pretty(&payload).unwrap();
+        let input = format!(
+            "AIMX/1 TEMPLATE-CREATE\nContent-Length: {}\n\n{body}",
+            body.len()
+        );
+        let err = parse_any_from_bytes(input.as_bytes()).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("placeholder"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn template_create_rejects_empty_cmd() {
+        let mut payload = example_payload("invoke-x", "sam");
+        payload.cmd = vec![];
+        payload.params = vec![];
+        let body = toml::to_string_pretty(&payload).unwrap();
+        let input = format!(
+            "AIMX/1 TEMPLATE-CREATE\nContent-Length: {}\n\n{body}",
+            body.len()
+        );
+        let err = parse_any_from_bytes(input.as_bytes()).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("cmd is empty"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn template_create_rejects_out_of_range_timeout() {
+        let mut payload = example_payload("invoke-x", "sam");
+        payload.timeout_secs = 0;
+        let body = toml::to_string_pretty(&payload).unwrap();
+        let input = format!(
+            "AIMX/1 TEMPLATE-CREATE\nContent-Length: {}\n\n{body}",
+            body.len()
+        );
+        let err = parse_any_from_bytes(input.as_bytes()).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("timeout_secs"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn template_create_rejects_unreferenced_param() {
+        let mut payload = example_payload("invoke-x", "sam");
+        payload.params = vec!["prompt".into(), "unused".into()];
+        let body = toml::to_string_pretty(&payload).unwrap();
+        let input = format!(
+            "AIMX/1 TEMPLATE-CREATE\nContent-Length: {}\n\n{body}",
+            body.len()
+        );
+        let err = parse_any_from_bytes(input.as_bytes()).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => {
+                assert!(m.contains("unused"), "{m}");
+                assert!(m.contains("never referenced"), "{m}");
+            }
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn template_create_rejects_unknown_field_in_body() {
+        // `deny_unknown_fields` guarantees any stray key is named in the
+        // TOML deserializer error. `dangerously_support_untrusted` is
+        // the canonical "smuggled in a disallowed property" case.
+        let body = r#"
+name = "invoke-x"
+cmd = ["/usr/bin/echo"]
+run_as = "sam"
+dangerously_support_untrusted = true
+"#;
+        let input = format!(
+            "AIMX/1 TEMPLATE-CREATE\nContent-Length: {}\n\n{body}",
+            body.len()
+        );
+        let err = parse_any_from_bytes(input.as_bytes()).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(
+                m.contains("dangerously_support_untrusted") || m.contains("unknown field"),
+                "{m}"
+            ),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn template_update_missing_name_header_is_malformed() {
+        let body = toml::to_string_pretty(&example_payload("invoke-x", "sam")).unwrap();
+        let input = format!(
+            "AIMX/1 TEMPLATE-UPDATE\nContent-Length: {}\n\n{body}",
+            body.len()
+        );
+        let err = parse_any_from_bytes(input.as_bytes()).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("Template-Name"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn template_delete_missing_name_header_is_malformed() {
+        let input = b"AIMX/1 TEMPLATE-DELETE\nContent-Length: 0\n\n";
+        let err = parse_any_from_bytes(input).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("Template-Name"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn template_delete_empty_name_header_is_malformed() {
+        let input = b"AIMX/1 TEMPLATE-DELETE\nTemplate-Name: \nContent-Length: 0\n\n";
+        let err = parse_any_from_bytes(input).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("empty Template-Name"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn template_delete_nonzero_content_length_is_malformed() {
+        let input = b"AIMX/1 TEMPLATE-DELETE\nTemplate-Name: x\nContent-Length: 5\n\nhello";
+        let err = parse_any_from_bytes(input).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("Content-Length: 0"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn template_create_verb_selection_in_wire_format() {
+        let req = TemplateCreateRequest {
+            payload: example_payload("invoke-claude-sam", "sam"),
+        };
+        let (mut client, mut server) = duplex(4096);
+        write_template_create_request(&mut client, &req)
+            .await
+            .unwrap();
+        drop(client);
+        let mut buf = Vec::new();
+        tokio::io::AsyncReadExt::read_to_end(&mut server, &mut buf)
+            .await
+            .unwrap();
+        assert!(buf.starts_with(b"AIMX/1 TEMPLATE-CREATE"));
+    }
+
+    #[tokio::test]
+    async fn template_body_invalid_template_name_is_malformed() {
+        let mut payload = example_payload("Invoke-Bad", "sam");
+        payload.params = vec![];
+        payload.cmd = vec!["/usr/bin/echo".into()];
+        let body = toml::to_string_pretty(&payload).unwrap();
+        let input = format!(
+            "AIMX/1 TEMPLATE-CREATE\nContent-Length: {}\n\n{body}",
+            body.len()
+        );
+        let err = parse_any_from_bytes(input.as_bytes()).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => assert!(m.contains("invalid template name"), "{m}"),
+            other => panic!("expected Malformed, got {other:?}"),
         }
     }
 }

--- a/src/send_protocol.rs
+++ b/src/send_protocol.rs
@@ -369,9 +369,20 @@ pub struct TemplateCreateRequest {
 }
 
 /// Decoded `AIMX/1 TEMPLATE-UPDATE` request. Carries a `Template-Name:`
-/// header identifying the template to replace plus a TOML body with the
-/// new fields. The handler validates that the header matches
-/// `payload.name`.
+/// header identifying the *existing* template to replace plus a TOML
+/// body describing its new fields.
+///
+/// `name` (from the header) and `payload.name` (from the body) are
+/// independent:
+/// - When they match, the handler performs an in-place update.
+/// - When they differ, the handler performs a rename — the entry at the
+///   position of the existing template is replaced with the new payload,
+///   whose `name` becomes the canonical identifier. `validate_hook_templates`
+///   catches any duplicate-name collision that this would introduce.
+///
+/// Both values are independently charset-validated (`[a-z0-9-]+`) at
+/// parse time, so a header or body name that fails the rule is rejected
+/// as `MALFORMED` before any handler dispatch.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TemplateUpdateRequest {
     pub name: String,
@@ -1169,6 +1180,11 @@ where
                 if value.is_empty() {
                     return Err(ParseError::Malformed("empty Template-Name value".into()));
                 }
+                if !crate::config::is_valid_template_name_str(&value) {
+                    return Err(ParseError::Malformed(format!(
+                        "invalid Template-Name '{value}': must match [a-z0-9-]+"
+                    )));
+                }
                 template_name = Some(value);
             }
             "content-length" => {
@@ -1255,6 +1271,11 @@ where
                 }
                 if value.is_empty() {
                     return Err(ParseError::Malformed("empty Template-Name value".into()));
+                }
+                if !crate::config::is_valid_template_name_str(&value) {
+                    return Err(ParseError::Malformed(format!(
+                        "invalid Template-Name '{value}': must match [a-z0-9-]+"
+                    )));
                 }
                 template_name = Some(value);
             }
@@ -2865,6 +2886,41 @@ dangerously_support_untrusted = true
             .await
             .unwrap();
         assert!(buf.starts_with(b"AIMX/1 TEMPLATE-CREATE"));
+    }
+
+    #[tokio::test]
+    async fn template_update_invalid_template_name_header_is_malformed() {
+        // The header carries the identifier of the existing template and
+        // must pass the same `[a-z0-9-]+` charset check used by
+        // `derive_template_name`. An out-of-charset header would fall
+        // through to ENOENT on lookup; rejecting it at parse time is the
+        // tidier thing to do.
+        let body = toml::to_string_pretty(&example_payload("invoke-x", "sam")).unwrap();
+        let input = format!(
+            "AIMX/1 TEMPLATE-UPDATE\nTemplate-Name: Invoke_Bad\nContent-Length: {}\n\n{body}",
+            body.len()
+        );
+        let err = parse_any_from_bytes(input.as_bytes()).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => {
+                assert!(m.contains("invalid Template-Name"), "{m}");
+                assert!(m.contains("Invoke_Bad"), "{m}");
+            }
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn template_delete_invalid_template_name_header_is_malformed() {
+        let input = b"AIMX/1 TEMPLATE-DELETE\nTemplate-Name: Invoke_Bad\nContent-Length: 0\n\n";
+        let err = parse_any_from_bytes(input).await.unwrap_err();
+        match err {
+            ParseError::Malformed(m) => {
+                assert!(m.contains("invalid Template-Name"), "{m}");
+                assert!(m.contains("Invoke_Bad"), "{m}");
+            }
+            other => panic!("expected Malformed, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -865,6 +865,24 @@ async fn handle_uds_connection_with_timeout(
                 ),
                 false,
             ),
+            Ok(Ok(Request::TemplateCreate(req))) => (
+                Reply::Ack(
+                    crate::hook_handler::handle_template_create(&mb_ctx, &req, &caller).await,
+                ),
+                false,
+            ),
+            Ok(Ok(Request::TemplateUpdate(req))) => (
+                Reply::Ack(
+                    crate::hook_handler::handle_template_update(&mb_ctx, &req, &caller).await,
+                ),
+                false,
+            ),
+            Ok(Ok(Request::TemplateDelete(req))) => (
+                Reply::Ack(
+                    crate::hook_handler::handle_template_delete(&mb_ctx, &req, &caller).await,
+                ),
+                false,
+            ),
             Ok(Err(ParseError::ClosedBeforeRequest)) => {
                 return;
             }

--- a/src/uds_authz.rs
+++ b/src/uds_authz.rs
@@ -93,6 +93,17 @@ impl Caller {
         Self::new(0, 0, None)
     }
 
+    /// Construct a caller with a pre-populated username cache. Tests
+    /// across the crate (not just `uds_authz`) use this to synthesize a
+    /// peer whose `getpwuid` lookup resolves to a known name without
+    /// touching the host's user database.
+    #[cfg(test)]
+    pub fn with_username(uid: u32, gid: u32, username: &str) -> Self {
+        let c = Self::new(uid, gid, None);
+        let _ = c.username_cache.set(Some(username.to_string()));
+        c
+    }
+
     /// Lazily resolve the caller's username via `getpwuid(3)`. Root is
     /// always `Some("root")`. Unknown uids return `None`.
     pub fn username(&self) -> Option<&str> {


### PR DESCRIPTION
## Summary
- Adds three new `AIMX/1` verbs (`TEMPLATE-CREATE`, `TEMPLATE-UPDATE`, `TEMPLATE-DELETE`) so unprivileged callers can register, revise, and remove hook templates bound to their own Linux user, with caller-uid = `run_as` enforcement (PRD §6.5). Reserved `run_as` values (`root`, `aimx-catchall`) and raw `cmd` fields are rejected at parse time — the UDS remains a narrow attack surface.
- Introduces `UdsTemplatePayload` as the whitelisted TOML shape and `derive_template_name` (pure helper) that produces the canonical `invoke-<agent>-<username>` name used by Sprint 6's `aimx agent-setup`.
- Handlers go through `validate_hook_templates` + `validate_hooks` before the atomic write-temp-then-rename + `ConfigHandle::store` swap, mirroring the existing MAILBOX-CRUD and HOOK-CRUD paths.

## Stories
- **S5-1 — Wire protocol.** New request variants, parser dispatch for all three verbs, shape-level body validation, round-trip write helpers, and 16 tests covering rejection paths (reserved `run_as`, placeholder in `cmd[0]`, empty argv, out-of-range `timeout_secs`, unknown fields, missing `Template-Name` header, nonzero body on DELETE, etc.).
- **S5-2 — Handlers.** `handle_template_create`, `handle_template_update`, `handle_template_delete` with caller-uid enforcement, root bypass logging, `ECONFLICT` on duplicate CREATE, `ENOENT` on missing UPDATE/DELETE, validator rejection returning the `VALIDATION` reason, and 14 tests.
- **S5-3 — `derive_template_name`.** Pure helper in `agent_setup.rs` with `TemplateNameError` enum; rejects empty components, uppercase, underscore, non-ASCII. 7 unit tests.
- **S5-4 — `UdsTemplatePayload`.** `#[serde(deny_unknown_fields)]` whitelist with explicit per-field validation per PRD §6.6. Submissions carrying unknown or disallowed fields return `MALFORMED` with the offending field named.

## Acceptance criteria
All AC checkboxes from S5-1 through S5-4 are satisfied:
- [x] Three new verbs in `Request` with parse + serialize tests
- [x] Parser rejects reserved `run_as` with `EINVAL` before handler dispatch
- [x] `cmd[0]` placeholder rejection reuses `validate_hook_templates` rule
- [x] Round-trip happy-path for each verb, reserved-name rejection, malformed-body rejection covered
- [x] Three handler functions with authz + atomic rewrite
- [x] Non-root mismatch returns `EACCES`, root logs `root_bypass`
- [x] `validate_hook_templates` runs before disk write; rejection returns `EINVAL`
- [x] Disk rename first, then in-memory swap
- [x] Duplicate on CREATE → `ECONFLICT`; missing on UPDATE/DELETE → `ENOENT`
- [x] `derive_template_name` pure function with rejection axes covered
- [x] `UdsTemplatePayload` whitelist rejects unknown fields with offending key named
- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean

## Deferred
Client-side CLI wiring (`aimx hooks template-create/update/delete`) is explicitly out of scope per S5 — it lands alongside `agent-setup` in Sprint 6. The daemon verbs are exercisable today via raw UDS frames.

## Test plan
- [x] `cargo test` — 1146 unit + 92 integration tests pass
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `services/verifier` crate still compiles