### PR TITLE
[Sprint 7.5] Non-blocking cleanup from Sprints 1-3 reviews

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2",
+ "syn",
  "tempfile",
  "tokio",
  "tokio-rustls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,3 +58,8 @@ sha2 = "0.10"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
 tracing-test = "0.2"
 serial_test = "3"
+# Dev-only: structural AST walk for the Sprint 3 legacy-template-phase
+# regression guard in `src/setup.rs` tests. Replaces a brittle
+# `include_str!` + substring grep with a proper syn visitor that matches
+# on `ItemFn` signatures rather than source text.
+syn = { version = "2", features = ["full", "visit"] }

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -14,3 +14,4 @@
 - [CLI Reference](cli.md)
 - [Troubleshooting](troubleshooting.md)
 - [FAQ](faq.md)
+- [Release Notes](release-notes.md)

--- a/book/release-notes.md
+++ b/book/release-notes.md
@@ -1,0 +1,14 @@
+# Release Notes
+
+Version-by-version changelog of operator-visible behavior changes. Use this as the canonical source for "what changed" between aimx releases; individual book chapters describe the current behavior only.
+
+## v1 (pre-launch)
+
+### Behavioral shifts
+
+- **`aimx mailboxes create <name>` without `--owner` now prompts interactively** (agent-integration Sprint 3). Previously this command hard-errored with a `useradd` hint when the local-part of the address did not resolve to an existing Linux user. The new behavior:
+  - On a TTY with `AIMX_NONINTERACTIVE` unset: the command prompts for the Linux user that should own the mailbox, re-prompts up to five times if the entered username does not resolve via `getpwnam`, and finally errors with an actionable `useradd` hint if every attempt fails.
+  - With `AIMX_NONINTERACTIVE=1`: the command errors immediately (exit 1) with the same hint whenever the local-part default does not resolve. Scripted installers should set this variable so the command never blocks.
+  - With a piped / closed stdin AND `AIMX_NONINTERACTIVE` unset: the prompt loop burns its five attempts (each `read_line` returns EOF immediately) before erroring. Still fails fast, just noisier than the non-interactive path. Set `AIMX_NONINTERACTIVE=1` whenever you pipe input to avoid the extra output.
+
+- **`aimx setup` drops the `--non-interactive` flag** (agent-integration Sprint 7.5). The legacy hook-template checkbox phase was removed in Sprint 3 so the flag no longer gated any interactive prompt. Scripts that passed `--non-interactive` must drop the argument; the `AIMX_NONINTERACTIVE=1` environment variable remains the canonical way to force non-interactive behavior for helpers that still support it (today: `aimx mailboxes create`).

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -62,14 +62,6 @@ pub enum Command {
         /// Override the verify service host (e.g. https://verify.example.com)
         #[arg(long)]
         verify_host: Option<String>,
-
-        /// Skip interactive prompts (e.g. the hook-template checkbox).
-        /// Useful for CI and scripted installs where no TTY is attached.
-        /// When set, no hook templates are installed; operators can enable
-        /// templates later by re-running `aimx setup` on a real terminal
-        /// or hand-editing `/etc/aimx/config.toml`.
-        #[arg(long)]
-        non_interactive: bool,
     },
 
     /// Uninstall the aimx daemon service (config and data are retained)

--- a/src/config.rs
+++ b/src/config.rs
@@ -518,6 +518,76 @@ impl ConfigResolved {
     }
 }
 
+/// Typed variants returned by [`check_hook_owner_invariant`] when the
+/// hook/mailbox owner invariant fails. Lets callers (doctor findings,
+/// UDS `HOOK-CREATE` response frames) discriminate by variant instead of
+/// string-matching on the rendered message. The `Display` impl produces
+/// the same user-facing text the old `Result<(), String>` shape did, so
+/// existing tests and error-message assertions keep working.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum HookOwnerInvariantError {
+    /// Hook is attached to a catchall mailbox but `run_as` is neither
+    /// `aimx-catchall` nor `root`.
+    CatchallRunAsMismatch {
+        mailbox: String,
+        hook_label: String,
+        run_as: String,
+    },
+    /// Hook is attached to a non-catchall mailbox and its effective
+    /// `run_as` does not equal the mailbox `owner` (and is not `root`).
+    OwnerMismatch {
+        mailbox: String,
+        hook_label: String,
+        run_as: String,
+        owner: String,
+    },
+}
+
+impl std::fmt::Display for HookOwnerInvariantError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HookOwnerInvariantError::CatchallRunAsMismatch {
+                mailbox,
+                hook_label,
+                run_as,
+            } => write!(
+                f,
+                "hook '{hook_label}' on catchall mailbox '{mailbox}' has \
+                 run_as='{run_as}'; catchall hooks must use run_as='{catchall}' or \
+                 run_as='{root}' (PRD §6.3)",
+                catchall = RESERVED_RUN_AS_CATCHALL,
+                root = RESERVED_RUN_AS_ROOT,
+            ),
+            HookOwnerInvariantError::OwnerMismatch {
+                mailbox,
+                hook_label,
+                run_as,
+                owner,
+            } => {
+                // When the mailbox owner is already `root` the fallback hint
+                // (`or run_as='root'`) would duplicate the primary suggestion,
+                // so drop the `or` clause for that one case.
+                let fix_suggestion = if owner == RESERVED_RUN_AS_ROOT {
+                    format!("set run_as='{RESERVED_RUN_AS_ROOT}'")
+                } else {
+                    format!(
+                        "set run_as='{owner}' or run_as='{root}'",
+                        root = RESERVED_RUN_AS_ROOT,
+                    )
+                };
+                write!(
+                    f,
+                    "hook '{hook_label}' on mailbox '{mailbox}' has run_as='{run_as}' \
+                     but the mailbox is owned by '{owner}'; fix: {fix_suggestion} so the \
+                     hook can read this mailbox's files (PRD §6.3)"
+                )
+            }
+        }
+    }
+}
+
+impl std::error::Error for HookOwnerInvariantError {}
+
 /// Hook/mailbox owner invariant (PRD §6.3): for every hook on a mailbox
 /// the hook's `run_as` must equal the mailbox's `owner` OR be `root`.
 /// Catchall relaxes the equality: `run_as` may be `aimx-catchall` or
@@ -531,7 +601,7 @@ pub fn check_hook_owner_invariant(
     mailbox_name: &str,
     mailbox: &MailboxConfig,
     hook: &Hook,
-) -> Result<(), String> {
+) -> Result<(), HookOwnerInvariantError> {
     let effective_run_as = resolve_effective_run_as(config, hook);
     let Some(run_as) = effective_run_as else {
         // No explicit run_as, no template to inherit from — a raw-cmd
@@ -545,43 +615,29 @@ pub fn check_hook_owner_invariant(
         return Ok(());
     }
 
+    let hook_label = hook.name.clone().unwrap_or_else(|| "<anonymous>".into());
+
     if mailbox.is_catchall(config) {
         if run_as == RESERVED_RUN_AS_CATCHALL {
             return Ok(());
         }
-        let hook_label = hook.name.clone().unwrap_or_else(|| "<anonymous>".into());
-        return Err(format!(
-            "hook '{hook_label}' on catchall mailbox '{mailbox_name}' has \
-             run_as='{run_as}'; catchall hooks must use run_as='{catchall}' or \
-             run_as='{root}' (PRD §6.3)",
-            catchall = RESERVED_RUN_AS_CATCHALL,
-            root = RESERVED_RUN_AS_ROOT,
-        ));
+        return Err(HookOwnerInvariantError::CatchallRunAsMismatch {
+            mailbox: mailbox_name.to_string(),
+            hook_label,
+            run_as,
+        });
     }
 
     if run_as == mailbox.owner {
         return Ok(());
     }
 
-    let hook_label = hook.name.clone().unwrap_or_else(|| "<anonymous>".into());
-    // When the mailbox owner is already `root` the fallback hint
-    // (`or run_as='root'`) would duplicate the primary suggestion, so
-    // drop the `or` clause for that one case.
-    let fix_suggestion = if mailbox.owner == RESERVED_RUN_AS_ROOT {
-        format!("set run_as='{RESERVED_RUN_AS_ROOT}'")
-    } else {
-        format!(
-            "set run_as='{owner}' or run_as='{root}'",
-            owner = mailbox.owner,
-            root = RESERVED_RUN_AS_ROOT,
-        )
-    };
-    Err(format!(
-        "hook '{hook_label}' on mailbox '{mailbox_name}' has run_as='{run_as}' \
-         but the mailbox is owned by '{owner}'; fix: {fix_suggestion} so the \
-         hook can read this mailbox's files (PRD §6.3)",
-        owner = mailbox.owner,
-    ))
+    Err(HookOwnerInvariantError::OwnerMismatch {
+        mailbox: mailbox_name.to_string(),
+        hook_label,
+        run_as,
+        owner: mailbox.owner.clone(),
+    })
 }
 
 /// Compute the effective `run_as` for a hook: explicit `hook.run_as`
@@ -833,8 +889,8 @@ pub(crate) fn validate_hooks(
                         reason: skip_reason,
                     });
                 }
-            } else {
-                check_hook_owner_invariant(config, mailbox_name, mb, hook)?;
+            } else if let Err(e) = check_hook_owner_invariant(config, mailbox_name, mb, hook) {
+                return Err(e.to_string());
             }
 
             let effective = hook_effective_name;
@@ -1336,12 +1392,24 @@ impl Config {
     /// Warnings are silently discarded — production callers that need
     /// to surface them (daemon startup, SIGHUP reload, doctor) must
     /// use [`Self::load`] directly.
+    ///
+    /// TODO(Sprint 7.5 S7.5-1 audit): when ingest / MCP / UDS paths start
+    /// consulting [`ConfigResolved`] directly (rather than relying on
+    /// `validate_hooks` + load-time rejection), the transitional
+    /// `*_ignore_warnings` helpers should either be pruned from the
+    /// callers that newly need the warning stream, or reserved for test-
+    /// only call sites. Today every caller audited in Sprint 7.5 either
+    /// re-parses after a write (where warnings are redundant), is a
+    /// pre-serve one-shot CLI (mailbox CRUD, portcheck, main's best-
+    /// effort peek), or is a test fixture. Keep the helpers until a new
+    /// production path arrives that genuinely needs warnings suppressed.
     pub fn load_ignore_warnings(path: &Path) -> Result<Self, Box<dyn std::error::Error>> {
         Self::load(path).map(|(cfg, _)| cfg)
     }
 
     /// Companion to [`Self::load_ignore_warnings`] for the resolved
-    /// config path.
+    /// config path. See the audit TODO on
+    /// [`Self::load_ignore_warnings`] for the remaining-caller story.
     pub fn load_resolved_ignore_warnings() -> Result<Self, Box<dyn std::error::Error>> {
         Self::load_resolved().map(|(cfg, _)| cfg)
     }
@@ -3467,10 +3535,19 @@ allow_root_catchall = true
         let h = hook_for_invariant(Some("bob"));
         let err = check_hook_owner_invariant(&cfg, "alice", &mb, &h).unwrap_err();
         assert!(
-            err.contains("run_as='bob'") && err.contains("owned by 'alice'"),
-            "message must name both run_as and owner: {err}"
+            matches!(
+                err,
+                HookOwnerInvariantError::OwnerMismatch { ref run_as, ref owner, .. }
+                    if run_as == "bob" && owner == "alice"
+            ),
+            "expected OwnerMismatch with run_as=bob owner=alice, got {err:?}"
         );
-        assert!(err.contains("set run_as="), "{err}");
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("run_as='bob'") && rendered.contains("owned by 'alice'"),
+            "message must name both run_as and owner: {rendered}"
+        );
+        assert!(rendered.contains("set run_as="), "{rendered}");
     }
 
     #[test]
@@ -3504,8 +3581,17 @@ allow_root_catchall = true
         let h = hook_for_invariant(Some("alice"));
         let err = check_hook_owner_invariant(&cfg, "catchall", &mb, &h).unwrap_err();
         assert!(
-            err.contains("aimx-catchall") && err.contains("catchall"),
-            "catchall error must name the expected run_as: {err}"
+            matches!(
+                err,
+                HookOwnerInvariantError::CatchallRunAsMismatch { ref run_as, .. }
+                    if run_as == "alice"
+            ),
+            "expected CatchallRunAsMismatch, got {err:?}"
+        );
+        let rendered = err.to_string();
+        assert!(
+            rendered.contains("aimx-catchall") && rendered.contains("catchall"),
+            "catchall error must name the expected run_as: {rendered}"
         );
     }
 
@@ -3515,7 +3601,16 @@ allow_root_catchall = true
         let mb = mailbox_for_invariant("alice@test.com", "alice");
         let h = hook_for_invariant(Some("aimx-catchall"));
         let err = check_hook_owner_invariant(&cfg, "alice", &mb, &h).unwrap_err();
-        assert!(err.contains("run_as='aimx-catchall'"), "{err}");
+        assert!(
+            matches!(
+                err,
+                HookOwnerInvariantError::OwnerMismatch { ref run_as, .. }
+                    if run_as == "aimx-catchall"
+            ),
+            "expected OwnerMismatch with run_as=aimx-catchall, got {err:?}"
+        );
+        let rendered = err.to_string();
+        assert!(rendered.contains("run_as='aimx-catchall'"), "{rendered}");
     }
 
     #[test]
@@ -3752,7 +3847,9 @@ owner = "ghost-user"
         let cfg = invariant_config("test.com");
         let mb = mailbox_for_invariant("alice@test.com", "root");
         let h = hook_for_invariant(Some("nobody"));
-        let err = check_hook_owner_invariant(&cfg, "alice", &mb, &h).unwrap_err();
+        let err = check_hook_owner_invariant(&cfg, "alice", &mb, &h)
+            .unwrap_err()
+            .to_string();
         assert!(
             err.contains("set run_as='root'"),
             "message must suggest run_as=root: {err}"
@@ -3770,7 +3867,9 @@ owner = "ghost-user"
         let cfg = invariant_config("test.com");
         let mb = mailbox_for_invariant("alice@test.com", "alice");
         let h = hook_for_invariant(Some("nobody"));
-        let err = check_hook_owner_invariant(&cfg, "alice", &mb, &h).unwrap_err();
+        let err = check_hook_owner_invariant(&cfg, "alice", &mb, &h)
+            .unwrap_err()
+            .to_string();
         assert!(err.contains("set run_as='alice'"), "{err}");
         assert!(err.contains("or run_as='root'"), "{err}");
     }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,6 +1,6 @@
 use crate::config::{
-    Config, LoadWarning, MailboxConfig, RESERVED_RUN_AS_CATCHALL, RESERVED_RUN_AS_ROOT,
-    check_hook_owner_invariant, is_reserved_run_as,
+    Config, HookOwnerInvariantError, LoadWarning, MailboxConfig, RESERVED_RUN_AS_CATCHALL,
+    RESERVED_RUN_AS_ROOT, check_hook_owner_invariant, is_reserved_run_as,
 };
 use crate::frontmatter::InboundFrontmatter;
 use crate::hook::effective_hook_name;
@@ -1310,18 +1310,30 @@ pub fn check_hook_invariants(config: &Config) -> Vec<DoctorFinding> {
     let mut out = Vec::new();
     for (mailbox_name, mb) in &config.mailboxes {
         for hook in &mb.hooks {
-            if let Err(reason) = check_hook_owner_invariant(config, mailbox_name, mb, hook) {
+            if let Err(err) = check_hook_owner_invariant(config, mailbox_name, mb, hook) {
                 let hook_name = effective_hook_name(hook);
+                // Variant-specific fix text: the catchall case has a
+                // different remediation (use `aimx-catchall` or `root`)
+                // from the plain owner-mismatch case.
+                let fix = match &err {
+                    HookOwnerInvariantError::CatchallRunAsMismatch { .. } => format!(
+                        "set run_as='{RESERVED_RUN_AS_CATCHALL}' or \
+                         run_as='{RESERVED_RUN_AS_ROOT}' on the catchall \
+                         hook in config.toml"
+                    ),
+                    HookOwnerInvariantError::OwnerMismatch { .. } => {
+                        "align the hook's run_as with the mailbox owner \
+                         (or set run_as='root') in config.toml"
+                            .to_string()
+                    }
+                };
                 out.push(
                     DoctorFinding::new(
                         "HOOK-INVARIANT",
                         FindingSeverity::Fail,
-                        format!("hook '{hook_name}' on mailbox '{mailbox_name}': {reason}"),
+                        format!("hook '{hook_name}' on mailbox '{mailbox_name}': {err}"),
                     )
-                    .with_fix(
-                        "align the hook's run_as with the mailbox owner (or set \
-                         run_as='root') in config.toml",
-                    ),
+                    .with_fix(fix),
                 );
             }
         }

--- a/src/mailbox_handler.rs
+++ b/src/mailbox_handler.rs
@@ -162,6 +162,19 @@ fn resolve_owner_ids(owner: &str) -> Result<(u32, u32), String> {
     Ok((uid, gid))
 }
 
+// Sprint 7.5 S7.5-5 re-evaluation: Sprint 2 review proposed collapsing
+// the repeated `AckResponse::Err { code: ErrCode::Io, reason: format!(...) }`
+// pattern inside `handle_create` into a small `io_err(path, op, e)`
+// helper. A second pass after three more sprints of on-disk evidence
+// confirms the original decision: the six Io-error sites carry four
+// distinct operation verbs (`failed to create`, `failed to chown`,
+// `failed to write`, `stat … failed`) and two of them include
+// site-specific guidance (the chown site names the syscall, the rename
+// site names the config path). A shared helper would either force the
+// verbs into a uniform template (losing the distinct framing the
+// messages currently carry) or accept a `&str` verb argument that
+// reintroduces the same `format!` chain at every call site. Deferred
+// indefinitely; the spelled-out pattern stays more scannable.
 fn handle_create(
     state_ctx: &StateContext,
     mb_ctx: &MailboxContext,
@@ -1086,18 +1099,18 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_rollback_on_chown_failure_removes_only_self_created_dirs() {
-        // Sprint 2 S2-1: when the post-create chown fails the handler
-        // must roll back the directories IT created in this call, but
-        // must NOT remove directories that pre-existed. We simulate
-        // this by pre-creating `inbox/alice` (so the rollback must
-        // preserve it) while letting the handler create `sent/alice`
-        // fresh (so the rollback must remove it on chown failure).
+    async fn create_conflict_on_preexisting_dir_with_wrong_owner_preserves_operator_data() {
+        // Sprint 7.5 S7.5-2: this test pins the `Conflict` short-circuit
+        // in `check_preexisting_dirs`, NOT the chown-failure rollback
+        // path. By pre-creating `inbox/alice` owned by the current uid
+        // while asking the handler to chown for `nobody` (uid 65534),
+        // the preexistence check refuses with `Conflict` BEFORE any
+        // chown is attempted. The rollback invariant we pin here is:
+        // operator-created artifacts survive, no config stanza is
+        // written, and the handler-created sibling dir does not linger.
         //
-        // chown failure is triggered by resolving the owner to uid
-        // 65534 (nobody) on a non-root CI runner: `chown(nobody)` as
-        // unprivileged fails with EPERM, landing us in the rollback
-        // branch. Root runners skip the test since the chown succeeds.
+        // The chown-failure rollback branch is exercised separately by
+        // `create_rollback_on_chown_failure_removes_only_self_created_dirs`.
         let is_root = unsafe { libc::geteuid() == 0 };
         if is_root {
             return;
@@ -1118,8 +1131,6 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let (state_ctx, mb_ctx) = contexts(&tmp);
 
-        // Pre-create ONLY `inbox/alice` so the rollback must preserve
-        // it. `sent/alice` does not exist and is created by the handler.
         let inbox = tmp.path().join("inbox").join("alice");
         let sent = tmp.path().join("sent").join("alice");
         std::fs::create_dir_all(&inbox).unwrap();
@@ -1135,14 +1146,11 @@ mod tests {
         };
         match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, .. } => {
-                // Either Conflict (pre-existing dir owner mismatch) or
-                // Io (chown failed). Both are valid outcomes for the
-                // rollback invariant we're asserting — the stanza must
-                // not be in the in-memory config, and operator-created
-                // artifacts must survive.
-                assert!(
-                    matches!(code, ErrCode::Io | ErrCode::Conflict),
-                    "expected Io or Conflict, got {code:?}"
+                assert_eq!(
+                    code,
+                    ErrCode::Conflict,
+                    "pre-existing dir with wrong owner must short-circuit with Conflict, \
+                     got {code:?}"
                 );
             }
             other => panic!("expected Err, got {other:?}"),
@@ -1157,12 +1165,86 @@ mod tests {
             inbox.is_dir(),
             "pre-existing inbox dir must survive rollback"
         );
-        // The handler-created sent dir was either never created (early
-        // Conflict return) or rolled back on chown failure. Either way,
-        // it must not exist now.
+        // Sent dir was never created (early Conflict return from the
+        // preexistence check on inbox).
         assert!(
             !sent.exists(),
-            "handler-created sent dir must not survive after failure"
+            "handler must not create the sent dir when inbox pre-exists with wrong owner"
+        );
+        // Config stanza did not get written.
+        assert!(!mb_ctx.config_handle.load().mailboxes.contains_key("alice"));
+    }
+
+    #[tokio::test]
+    async fn create_rollback_on_chown_failure_removes_only_self_created_dirs() {
+        // Sprint 2 S2-1 / Sprint 7.5 S7.5-2: when the post-create chown
+        // fails the handler must roll back the directories IT created
+        // in this call. To deterministically hit the chown-failure
+        // branch (NOT the preexistence Conflict short-circuit), we
+        // leave both `inbox/alice` and `sent/alice` absent so the
+        // handler creates them fresh, then resolve the owner to uid
+        // 65534 (nobody) so the subsequent `libc::chown` syscall fails
+        // with EPERM on an unprivileged CI runner.
+        //
+        // Root runners skip the test since the chown syscall succeeds
+        // and we can't provoke the failure without elevated privilege
+        // tricks we don't want in the test suite.
+        let is_root = unsafe { libc::geteuid() == 0 };
+        if is_root {
+            return;
+        }
+        fn nobody(name: &str) -> Option<crate::user_resolver::ResolvedUser> {
+            if name == "nobody" {
+                Some(crate::user_resolver::ResolvedUser {
+                    name: "nobody".into(),
+                    uid: 65534,
+                    gid: 65534,
+                })
+            } else {
+                None
+            }
+        }
+        let _r = crate::user_resolver::set_test_resolver(nobody);
+
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+
+        let inbox = tmp.path().join("inbox").join("alice");
+        let sent = tmp.path().join("sent").join("alice");
+        // Neither dir pre-exists. The handler creates both fresh, then
+        // the chown for `nobody` fails (EPERM under unprivileged euid),
+        // and rollback removes both self-created dirs.
+        assert!(!inbox.exists());
+        assert!(!sent.exists());
+
+        let req = MailboxCrudRequest {
+            name: "alice".into(),
+            create: true,
+            owner: Some("nobody".into()),
+        };
+        match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
+            AckResponse::Err { code, reason } => {
+                assert_eq!(
+                    code,
+                    ErrCode::Io,
+                    "chown failure must surface as Io, got {code:?}: {reason}"
+                );
+                assert!(
+                    reason.contains("failed to chown"),
+                    "reason must name the chown op: {reason}"
+                );
+            }
+            other => panic!("expected Err, got {other:?}"),
+        }
+
+        // Both handler-created dirs were rolled back.
+        assert!(
+            !inbox.exists(),
+            "handler-created inbox dir must not survive chown failure"
+        );
+        assert!(
+            !sent.exists(),
+            "handler-created sent dir must not survive chown failure"
         );
         // Config stanza did not get written.
         assert!(!mb_ctx.config_handle.load().mailboxes.contains_key("alice"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -54,17 +54,10 @@ fn dispatch(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         Command::Setup {
             domain,
             verify_host,
-            non_interactive,
         } => {
             let sys = setup::RealSystemOps;
             let net = build_network_ops(verify_host.as_deref())?;
-            setup::run_setup(
-                domain.as_deref(),
-                cli.data_dir.as_deref(),
-                non_interactive,
-                &sys,
-                &net,
-            )
+            setup::run_setup(domain.as_deref(), cli.data_dir.as_deref(), &sys, &net)
         }
         // Uninstall also runs pre-config: config may be missing or unreadable.
         Command::Uninstall { yes } => {

--- a/src/ownership.rs
+++ b/src/ownership.rs
@@ -43,6 +43,33 @@ use crate::config::MailboxConfig;
 /// pattern. Every daemon-side writer that lands a file in a mailbox tree
 /// must call it immediately after the `fs::write` / `fs::create_dir*` /
 /// `rename(2)` that publishes the file.
+///
+/// ### Two-syscall shape (Sprint 7.5 S7.5-5 revisit)
+///
+/// POSIX has no atomic "change owner and mode in one call" primitive —
+/// `chown(2)` and `chmod(2)` are necessarily distinct syscalls. The
+/// order here is chown-then-chmod because:
+///
+/// 1. `chown` on Linux clears the setuid/setgid bits on success
+///    (POSIX `chown(2)`, "CLEARING OF SET-USER-ID AND SET-GROUP-ID
+///    BITS"), so calling it after `chmod` would silently discard the
+///    mode we just set. chown-first avoids that race entirely.
+/// 2. A partial failure (chown succeeds, chmod fails) is an EPERM /
+///    ENOSPC / ENOENT edge case that in practice only fires when the
+///    caller lacks privileges to chown at all — in which case we never
+///    reach the chmod step anyway. `aimx serve` always runs as root,
+///    where both syscalls succeed or both fail together for the same
+///    underlying reason (ENOSPC, ENOENT, EROFS).
+///
+/// Callers therefore get one of:
+/// - `Ok(())` — file has BOTH the requested owner and mode.
+/// - `Err(_)` — file's final state is undefined and the caller should
+///   roll back (`mailbox_handler::rollback_self_created_dirs`,
+///   ingest's temp-unlink-on-error path).
+///
+/// The test suite pins the post-condition end-to-end (stat the file,
+/// check `mode() & 0o777 == mode` and `uid() == expected_uid`) rather
+/// than trying to assert each syscall's contribution separately.
 pub fn chown_as_owner(path: &Path, mailbox: &MailboxConfig, mode: u32) -> io::Result<()> {
     let uid = mailbox
         .owner_uid()

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1690,6 +1690,20 @@ pub fn prompt_mailbox_owner(
     address: &str,
     sys: &dyn SystemOps,
 ) -> Result<String, Box<dyn std::error::Error>> {
+    let stdin = io::stdin();
+    let mut reader = stdin.lock();
+    prompt_mailbox_owner_with_reader(address, sys, &mut reader)
+}
+
+/// Inner prompt helper that reads from an injectable `BufRead`. The
+/// public [`prompt_mailbox_owner`] wraps this with a `stdin().lock()`
+/// reader in production; tests drive the re-prompt / 5-failure branches
+/// with scripted `Cursor<&[u8]>` input.
+pub(crate) fn prompt_mailbox_owner_with_reader(
+    address: &str,
+    sys: &dyn SystemOps,
+    reader: &mut dyn io::BufRead,
+) -> Result<String, Box<dyn std::error::Error>> {
     let local_part = address.split('@').next().unwrap_or("").trim().to_string();
     let default_candidate = if local_part.is_empty() {
         None
@@ -1711,8 +1725,6 @@ pub fn prompt_mailbox_owner(
         });
     }
 
-    let stdin = io::stdin();
-    let mut reader = stdin.lock();
     for attempt in 0..MAX_OWNER_PROMPT_ATTEMPTS {
         match &default_candidate {
             Some(def) => print!("Which Linux user should own `{address}`? [{def}]: "),
@@ -1790,7 +1802,6 @@ pub(crate) fn detect_server_ipv6(enable_ipv6: bool, ipv6: Option<Ipv6Addr>) -> O
 pub fn run_setup(
     domain: Option<&str>,
     data_dir: Option<&Path>,
-    non_interactive: bool,
     sys: &dyn SystemOps,
     net: &dyn NetworkOps,
 ) -> Result<(), Box<dyn std::error::Error>> {
@@ -1886,11 +1897,6 @@ pub fn run_setup(
     // domain changes). Must happen before the aimx.service install at the end,
     // because the daemon refuses to start without a loadable config and DKIM key.
     finalize_setup(data_dir, &domain, &dkim_selector, trust_defaults)?;
-
-    // Silence the `non_interactive` unused-var warning until a future
-    // sprint reintroduces an interactive prompt phase. Kept on the
-    // signature so callers don't have to change when that lands.
-    let _ = non_interactive;
 
     // Step 4b: Create `aimx-catchall` service user (PRD §6.4, S3-1) —
     // but only when the operator's configured mailboxes include a
@@ -2433,38 +2439,143 @@ owner = "aimx-catchall"
         );
     }
 
+    #[test]
+    fn prompt_mailbox_owner_reprompts_until_valid_user_entered() {
+        // Sprint 7.5 S7.5-3: exercise the re-prompt loop with a scripted
+        // stdin. Two bad entries (users that don't exist) followed by a
+        // good one — the helper must re-prompt after each bad entry and
+        // return the good entry without burning the full 5-attempt
+        // budget. Mock `SystemOps` reports only "carol" as a real user.
+        use crate::user_resolver::{ResolvedUser, set_test_resolver};
+        fn empty_resolver(_name: &str) -> Option<ResolvedUser> {
+            None
+        }
+        let _r = set_test_resolver(empty_resolver);
+        let _g = NONINT_ENV_SERIALIZE
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        unsafe { std::env::remove_var(super::NONINTERACTIVE_ENV) };
+
+        let sys = MockSystemOps::default();
+        sys.existing_users.borrow_mut().insert("carol".into());
+
+        // Three lines, one per `read_line` call. The first two are
+        // rejected by the `user_exists` mock, the third succeeds.
+        let scripted = b"alice\nbob\ncarol\n";
+        let mut cursor = std::io::Cursor::new(&scripted[..]);
+        let owner =
+            super::prompt_mailbox_owner_with_reader("team@example.com", &sys, &mut cursor).unwrap();
+        assert_eq!(owner, "carol");
+    }
+
+    #[test]
+    fn prompt_mailbox_owner_errors_after_five_rejected_attempts() {
+        // Sprint 7.5 S7.5-3: when every scripted attempt is a bad user,
+        // the helper must give up after `MAX_OWNER_PROMPT_ATTEMPTS` and
+        // return the documented useradd error.
+        use crate::user_resolver::{ResolvedUser, set_test_resolver};
+        fn empty_resolver(_name: &str) -> Option<ResolvedUser> {
+            None
+        }
+        let _r = set_test_resolver(empty_resolver);
+        let _g = NONINT_ENV_SERIALIZE
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        unsafe { std::env::remove_var(super::NONINTERACTIVE_ENV) };
+
+        // `existing_users` stays empty — nothing the operator types can
+        // resolve, so every attempt re-prompts.
+        let sys = MockSystemOps::default();
+
+        let scripted = b"a\nb\nc\nd\ne\n";
+        let mut cursor = std::io::Cursor::new(&scripted[..]);
+        let err = super::prompt_mailbox_owner_with_reader("ghost@example.com", &sys, &mut cursor)
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("5 attempts") && err.contains("useradd"),
+            "after 5 failures the error must name the ceiling and point at useradd: {err}"
+        );
+    }
+
     // ----- Sprint 3 S3-3: legacy-template-phase removal regression ------
 
     #[test]
     fn legacy_template_phase_is_absent_from_setup() {
-        // Regression guard: the Sprint 3 grep-based AC checks that
-        // setup no longer carries the legacy hook-template wiring.
-        // The check targets pub(crate)-fn definitions only — rendering
-        // the needles with a runtime-built string keeps this test's
-        // own body from tripping its own assertion when it loads its
-        // own source.
+        // Regression guard: the Sprint 3 interactive-checkbox phase
+        // and the `aimx-hook` group plumbing must stay gone. This
+        // check uses a structural `syn` walk over the parsed AST of
+        // `src/setup.rs` rather than a substring grep over the source,
+        // so future string literals and comments that happen to mention
+        // the retired names cannot trip the assertion (Sprint 7.5
+        // S7.5-4 — replaced the Sprint 3 `include_str!` + grep).
+        use syn::visit::Visit;
+
         let source = include_str!("setup.rs");
-        let fn_kw = "pub(crate) fn ";
-        let retired = [
+        let parsed = syn::parse_file(source).expect("src/setup.rs must parse as a Rust file");
+
+        // Retired helpers: any function or method with one of these
+        // identifiers is a regression regardless of visibility, since
+        // the whole point is that the legacy template-checkbox phase
+        // no longer exists anywhere in the module.
+        const RETIRED: &[&str] = &[
             "apply_selected_templates",
             "current_hook_templates",
             "ensure_hook_user",
             "chown_datadir_for_hook_user",
         ];
-        for name in retired {
-            let needle = format!("{fn_kw}{name}");
-            assert!(
-                !source.contains(&needle),
-                "{needle} must stay retired — agent-setup owns template wiring now"
-            );
+        // Any `configure_hook_*` helper was the heart of the old
+        // interactive checkbox flow. Match on the prefix so future
+        // `configure_hook_foo` rebirths surface here.
+        const BANNED_PREFIX: &str = "configure_hook";
+
+        struct Walker {
+            found_retired: Vec<&'static str>,
+            found_banned: Vec<String>,
         }
-        // Separately assert no `configure_hook_*` helper exists (the
-        // interactive-checkbox phase is gone). Target the `pub(crate)`
-        // signature specifically so the test's own body doesn't match.
-        let banned_prefix = format!("{fn_kw}configure_hook");
+        impl<'ast> Visit<'ast> for Walker {
+            fn visit_item_fn(&mut self, f: &'ast syn::ItemFn) {
+                self.record(f.sig.ident.to_string());
+                syn::visit::visit_item_fn(self, f);
+            }
+            fn visit_impl_item_fn(&mut self, f: &'ast syn::ImplItemFn) {
+                self.record(f.sig.ident.to_string());
+                syn::visit::visit_impl_item_fn(self, f);
+            }
+            fn visit_trait_item_fn(&mut self, f: &'ast syn::TraitItemFn) {
+                self.record(f.sig.ident.to_string());
+                syn::visit::visit_trait_item_fn(self, f);
+            }
+        }
+        impl Walker {
+            fn record(&mut self, name: String) {
+                for retired in RETIRED {
+                    if name == *retired {
+                        self.found_retired.push(retired);
+                    }
+                }
+                if name.starts_with(BANNED_PREFIX) {
+                    self.found_banned.push(name);
+                }
+            }
+        }
+
+        let mut walker = Walker {
+            found_retired: Vec::new(),
+            found_banned: Vec::new(),
+        };
+        walker.visit_file(&parsed);
+
         assert!(
-            !source.contains(&banned_prefix),
-            "{banned_prefix}* helpers were removed in Sprint 3 S3-3"
+            walker.found_retired.is_empty(),
+            "retired helper(s) resurfaced — agent-setup owns template wiring now: {:?}",
+            walker.found_retired
+        );
+        assert!(
+            walker.found_banned.is_empty(),
+            "`{BANNED_PREFIX}*` helper(s) were removed in Sprint 3 S3-3 and must \
+             not come back: {:?}",
+            walker.found_banned
         );
     }
 
@@ -3087,7 +3198,7 @@ owner = "aimx-catchall"
             ..Default::default()
         };
 
-        let _ = run_setup(Some("example.com"), Some(tmp.path()), true, &sys, &net);
+        let _ = run_setup(Some("example.com"), Some(tmp.path()), &sys, &net);
 
         assert!(
             !*sys.service_file_installed.borrow(),
@@ -3111,7 +3222,7 @@ owner = "aimx-catchall"
             ..Default::default()
         };
 
-        let result = run_setup(Some("example.com"), Some(tmp.path()), true, &sys, &net);
+        let result = run_setup(Some("example.com"), Some(tmp.path()), &sys, &net);
 
         let err = result.expect_err("preflight failure must bubble up");
         assert!(
@@ -3144,7 +3255,7 @@ owner = "aimx-catchall"
             ..Default::default()
         };
 
-        let result = run_setup(Some("example.com"), Some(tmp.path()), true, &sys, &net);
+        let result = run_setup(Some("example.com"), Some(tmp.path()), &sys, &net);
         let err = result.expect_err("preflight failure must bubble up");
         assert!(
             err.to_string().contains("Port 25 checks failed"),
@@ -3237,7 +3348,7 @@ owner = "aimx-catchall"
             ..Default::default()
         };
 
-        let _ = run_setup(Some("example.com"), Some(tmp.path()), true, &sys, &net);
+        let _ = run_setup(Some("example.com"), Some(tmp.path()), &sys, &net);
 
         assert!(
             !*sys.service_file_installed.borrow(),
@@ -3433,7 +3544,7 @@ owner = "aimx-catchall"
             ..Default::default()
         };
         let net = MockNetworkOps::default();
-        let result = run_setup(Some("example.com"), None, true, &sys, &net);
+        let result = run_setup(Some("example.com"), None, &sys, &net);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -3451,7 +3562,7 @@ owner = "aimx-catchall"
             ..Default::default()
         };
         let net = MockNetworkOps::default();
-        let result = run_setup(Some("example.com"), Some(tmp.path()), true, &sys, &net);
+        let result = run_setup(Some("example.com"), Some(tmp.path()), &sys, &net);
         assert!(result.is_err());
         let err = result.unwrap_err().to_string();
         assert!(
@@ -3858,7 +3969,7 @@ owner = "aimx-catchall"
             inbound_port25: false,
             ..Default::default()
         };
-        let result = run_setup(Some("example.com"), Some(tmp.path()), true, &sys, &net);
+        let result = run_setup(Some("example.com"), Some(tmp.path()), &sys, &net);
         // Should progress past domain prompt and fail on port 25 check
         assert!(result.is_err());
         assert!(

--- a/src/user_resolver.rs
+++ b/src/user_resolver.rs
@@ -13,7 +13,6 @@
 //! present-but-orphan user from an outright lookup error.
 
 use std::ffi::CString;
-use std::sync::RwLock;
 
 /// A resolved Linux user. `name` echoes the input for convenience so
 /// callers can use the resolved value in error messages without cloning
@@ -121,13 +120,6 @@ pub(crate) fn set_test_resolver(
 ) -> test_resolver::ResolverOverride {
     test_resolver::ResolverOverride::set(f)
 }
-
-// Shared RwLock scaffold so a future, non-test-gated hot-swap (e.g.,
-// SIGHUP re-resolves cached uids) can drop in without API churn. Today
-// the RwLock is unused in production — the direct `libc::getpwnam` path
-// is cheap enough that we don't need a cache.
-#[allow(dead_code)]
-static _RESOLVER_SCAFFOLD: RwLock<()> = RwLock::new(());
 
 #[cfg(test)]
 mod tests {


### PR DESCRIPTION
## Summary

Triaged accumulated non-blocking review-backlog items from Sprints 1-3 into a single cleanup pass so that release prep in Sprint 8 ships with a clean slate.

Stories implemented: **S7.5-1 through S7.5-5**.

### S7.5-1 — Sprint 1 config-layer cleanup
- Delete `user_resolver::_RESOLVER_SCAFFOLD` dead-code scaffold (speculative SIGHUP-cache that never materialized).
- Convert `check_hook_owner_invariant` from `Result<(), String>` to a structured `HookOwnerInvariantError` enum (`CatchallRunAsMismatch`, `OwnerMismatch`) implementing `Display` + `Error`. Doctor's `check_hook_invariants` now picks per-variant fix guidance. Display preserves the existing user-facing text so existing error-message assertions keep working.
- Audit `load_ignore_warnings` / `load_resolved_ignore_warnings` call sites: all remaining callers are post-write re-parses, pre-serve CLI one-shots, or test fixtures. Added a TODO doc-comment pointing at the audit.

### S7.5-2 — Sprint 2 chown-rollback test coverage
- Split the old combined test into two deterministic tests:
  - `create_conflict_on_preexisting_dir_with_wrong_owner_preserves_operator_data` pins the `Conflict` short-circuit branch (pre-existing dir with wrong owner).
  - `create_rollback_on_chown_failure_removes_only_self_created_dirs` now pre-creates nothing so the handler lands in the chown-failure rollback branch (deterministic EPERM under unprivileged euid).
- Each test asserts its exact `ErrCode` rather than accepting `Io | Conflict`.

### S7.5-3 — Sprint 3 interactive-prompt cleanup
- Refactor `prompt_mailbox_owner` to expose an inner `prompt_mailbox_owner_with_reader(&mut dyn BufRead)` seam.
- Add scripted-stdin tests: `prompt_mailbox_owner_reprompts_until_valid_user_entered` (2 bad, 1 good) and `prompt_mailbox_owner_errors_after_five_rejected_attempts` (5 bad).
- Drop `non_interactive: bool` from `run_setup`'s signature and the CLI `--non-interactive` flag. The legacy hook-template checkbox phase it gated was removed in Sprint 3; `AIMX_NONINTERACTIVE=1` remains the canonical scripted-install env var.

### S7.5-4 — Sprint 3 release notes + test-guard hardening
- Add `book/release-notes.md` and wire into `SUMMARY.md`. Captures the `aimx mailboxes create` behavioral shift (TTY-now-prompts) from Sprint 3 and the `--non-interactive` drop from S7.5-3.
- Replace `legacy_template_phase_is_absent_from_setup`'s `include_str!` + substring-grep with a structural `syn::visit::Visit` walk over `ItemFn` / `ImplItemFn` / `TraitItemFn` identifiers. Future string literals and comments can no longer trip the assertion.

### S7.5-5 — Sprint 1 + 2 minor helper cleanups
- Document `chown_as_owner`'s two-syscall shape explicitly (POSIX has no atomic `chown+chmod`; chown-first avoids setuid/setgid bit clearing after mode is set). Deferral is now a conscious decision rather than a note-to-self.
- Document the `io_err` helper deferral in `mailbox_handler::handle_create`: six call sites with four distinct verbs would collapse awkwardly into a shared helper; spelled-out pattern stays more scannable.

## Notes on dependencies

- Added `syn = { version = "2", features = ["full", "visit"] }` as a **dev-dependency** only (already transitive via `proc-macro2` / build tooling; now explicit for the regression-guard test). Does not land in the release binary.

## Test plan

- [x] `cargo test` — 1209 unit + 94 integration tests pass, 0 failures
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `services/verifier`: `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` — all clean
- [x] New tests: `prompt_mailbox_owner_reprompts_until_valid_user_entered`, `prompt_mailbox_owner_errors_after_five_rejected_attempts`, `create_conflict_on_preexisting_dir_with_wrong_owner_preserves_operator_data`, `create_rollback_on_chown_failure_removes_only_self_created_dirs` — all pass
- [x] Rewritten `legacy_template_phase_is_absent_from_setup` (syn walk) — passes