### PR TITLE
[Onboarding Sprint 1] Release pipeline — cross-build + SHA-256 + tag discipline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,271 @@
+name: Release
+
+# Onboarding Sprint 1 (M1 / FR-1.1–1.5): build tarballs + SHA-256 sums
+# for all four supported Linux targets on every SemVer-shaped tag push,
+# and publish them as assets on a GitHub Release with a templated body
+# that includes a verbatim `curl + sha256sum -c` verify block.
+#
+# Trigger glob accepts tags shaped like `v<digit>...` (e.g. `v1.0.0`,
+# `v1.2.3-rc1`, `v0.0.0-fixture`). Non-SemVer tags (`test`, `dev-*`) are
+# ignored so ad-hoc tags never spend CI minutes or publish a release.
+on:
+  push:
+    tags:
+      - 'v[0-9]*'
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build ${{ matrix.target }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          - aarch64-unknown-linux-musl
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Resolve version string
+        id: version
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: release-${{ matrix.target }}
+
+      - name: Install cross
+        run: cargo install cross --locked --version 0.2.5
+
+      - name: Build release binary
+        run: cross build --release --locked --target ${{ matrix.target }}
+
+      - name: Stage tarball contents
+        run: |
+          set -euo pipefail
+          stage="aimx-${{ steps.version.outputs.version }}-${{ matrix.target }}"
+          mkdir -p "${stage}"
+          cp "target/${{ matrix.target }}/release/aimx" "${stage}/aimx"
+          chmod 0755 "${stage}/aimx"
+          cp LICENSE "${stage}/LICENSE"
+          cp README.md "${stage}/README.md"
+          cp -R book "${stage}/book"
+          mkdir -p "${stage}/hook-templates"
+          cp hook-templates/defaults.toml "${stage}/hook-templates/defaults.toml"
+          echo "stage=${stage}" >> "$GITHUB_ENV"
+
+      - name: Create tarball and per-asset SHA-256
+        run: |
+          set -euo pipefail
+          tarball="${stage}.tar.gz"
+          # Deterministic-ish tar: fixed owner/group and mtime from the commit.
+          # The GNU tar on ubuntu-latest supports these flags.
+          mtime="$(git log -1 --format=%cI "${GITHUB_REF_NAME}")"
+          tar \
+            --sort=name \
+            --owner=0 --group=0 --numeric-owner \
+            --mtime="${mtime}" \
+            -czf "${tarball}" "${stage}"
+          sha256sum "${tarball}" > "${tarball}.sha256"
+          echo "tarball=${tarball}" >> "$GITHUB_ENV"
+
+      - name: Upload artefact
+        uses: actions/upload-artifact@v4
+        with:
+          name: aimx-${{ matrix.target }}
+          path: |
+            ${{ env.tarball }}
+            ${{ env.tarball }}.sha256
+          if-no-files-found: error
+          retention-days: 7
+
+  release:
+    name: Publish release
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve version string
+        id: version
+        run: |
+          tag="${GITHUB_REF_NAME}"
+          version="${tag#v}"
+          echo "tag=${tag}" >> "$GITHUB_OUTPUT"
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+          date="$(date -u +%Y-%m-%d)"
+          echo "date=${date}" >> "$GITHUB_OUTPUT"
+
+      - name: Download build artefacts
+        uses: actions/download-artifact@v4
+        with:
+          path: dist
+          pattern: aimx-*
+          merge-multiple: true
+
+      - name: Aggregate SHA256SUMS
+        id: sums
+        run: |
+          set -euo pipefail
+          cd dist
+          # Normalise per-asset .sha256 files (strip any path prefix left by
+          # matrix stages) and assemble the release-wide SHA256SUMS file.
+          : > SHA256SUMS
+          for t in aimx-*.tar.gz; do
+            digest="$(sha256sum "${t}" | awk '{print $1}')"
+            printf '%s  %s\n' "${digest}" "${t}" >> SHA256SUMS
+            printf '%s  %s\n' "${digest}" "${t}" > "${t}.sha256"
+          done
+          sort -o SHA256SUMS SHA256SUMS
+          # Expose each target digest for the release-notes template.
+          {
+            for target in \
+              x86_64-unknown-linux-gnu \
+              aarch64-unknown-linux-gnu \
+              x86_64-unknown-linux-musl \
+              aarch64-unknown-linux-musl
+            do
+              tarball="aimx-${{ steps.version.outputs.version }}-${target}.tar.gz"
+              if [ -f "${tarball}" ]; then
+                digest="$(sha256sum "${tarball}" | awk '{print $1}')"
+                echo "sha_${target}=${digest}"
+              fi
+            done
+          } >> "$GITHUB_OUTPUT"
+          echo "--- SHA256SUMS ---"
+          cat SHA256SUMS
+
+      - name: Build release notes body
+        id: notes
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
+          DATE: ${{ steps.version.outputs.date }}
+          SHA_X86_GNU: ${{ steps.sums.outputs.sha_x86_64-unknown-linux-gnu }}
+          SHA_ARM_GNU: ${{ steps.sums.outputs.sha_aarch64-unknown-linux-gnu }}
+          SHA_X86_MUSL: ${{ steps.sums.outputs.sha_x86_64-unknown-linux-musl }}
+          SHA_ARM_MUSL: ${{ steps.sums.outputs.sha_aarch64-unknown-linux-musl }}
+        run: |
+          set -euo pipefail
+          notes_file="$(mktemp)"
+          base_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${TAG}"
+
+          # Resolve the previous SemVer-shaped tag (if any) for the
+          # changelog range. If no previous tag exists, fall back to the
+          # root commit so first releases still produce a sensible log.
+          prev_tag="$(git tag --list 'v[0-9]*' --sort=-v:refname \
+            | grep -v -x "${TAG}" | head -n1 || true)"
+          if [ -n "${prev_tag}" ]; then
+            range="${prev_tag}..${TAG}"
+            range_label="${prev_tag}...${TAG}"
+          else
+            range="${TAG}"
+            range_label="(initial release)"
+          fi
+
+          {
+            echo "# aimx ${TAG}"
+            echo
+            echo "_Released ${DATE}._"
+            echo
+            echo "## Changelog (${range_label})"
+            echo
+            if [ -n "${prev_tag}" ]; then
+              git log --no-merges --pretty=format:'- %s (%h)' "${range}" || true
+            else
+              git log --no-merges --pretty=format:'- %s (%h)' "${TAG}" || true
+            fi
+            echo
+            echo
+            echo "## SHA-256 checksums"
+            echo
+            echo "| Target | SHA-256 |"
+            echo "| --- | --- |"
+            echo "| \`x86_64-unknown-linux-gnu\`   | \`${SHA_X86_GNU:-unavailable}\` |"
+            echo "| \`aarch64-unknown-linux-gnu\`  | \`${SHA_ARM_GNU:-unavailable}\` |"
+            echo "| \`x86_64-unknown-linux-musl\`  | \`${SHA_X86_MUSL:-unavailable}\` |"
+            echo "| \`aarch64-unknown-linux-musl\` | \`${SHA_ARM_MUSL:-unavailable}\` |"
+            echo
+            echo "The release-wide \`SHA256SUMS\` file is attached as an asset."
+            echo
+            echo "## Verify a download"
+            echo
+            echo "Pick the tarball for your target, then:"
+            echo
+            echo '```sh'
+            echo "# x86_64 glibc"
+            echo "curl -fsSLO ${base_url}/aimx-${VERSION}-x86_64-unknown-linux-gnu.tar.gz"
+            echo "curl -fsSLO ${base_url}/aimx-${VERSION}-x86_64-unknown-linux-gnu.tar.gz.sha256"
+            echo "sha256sum -c aimx-${VERSION}-x86_64-unknown-linux-gnu.tar.gz.sha256"
+            echo
+            echo "# aarch64 glibc"
+            echo "curl -fsSLO ${base_url}/aimx-${VERSION}-aarch64-unknown-linux-gnu.tar.gz"
+            echo "curl -fsSLO ${base_url}/aimx-${VERSION}-aarch64-unknown-linux-gnu.tar.gz.sha256"
+            echo "sha256sum -c aimx-${VERSION}-aarch64-unknown-linux-gnu.tar.gz.sha256"
+            echo
+            echo "# x86_64 musl"
+            echo "curl -fsSLO ${base_url}/aimx-${VERSION}-x86_64-unknown-linux-musl.tar.gz"
+            echo "curl -fsSLO ${base_url}/aimx-${VERSION}-x86_64-unknown-linux-musl.tar.gz.sha256"
+            echo "sha256sum -c aimx-${VERSION}-x86_64-unknown-linux-musl.tar.gz.sha256"
+            echo
+            echo "# aarch64 musl"
+            echo "curl -fsSLO ${base_url}/aimx-${VERSION}-aarch64-unknown-linux-musl.tar.gz"
+            echo "curl -fsSLO ${base_url}/aimx-${VERSION}-aarch64-unknown-linux-musl.tar.gz.sha256"
+            echo "sha256sum -c aimx-${VERSION}-aarch64-unknown-linux-musl.tar.gz.sha256"
+            echo '```'
+            echo
+            echo "Or verify every tarball at once with the aggregate file:"
+            echo
+            echo '```sh'
+            echo "curl -fsSLO ${base_url}/SHA256SUMS"
+            echo "sha256sum -c --ignore-missing SHA256SUMS"
+            echo '```'
+            echo
+            echo "Trust anchor for v1 is HTTPS on the GitHub Releases domain."
+            echo "Signed releases (minisign / cosign / GPG) are deferred to v2."
+          } > "${notes_file}"
+          echo "notes_file=${notes_file}" >> "$GITHUB_OUTPUT"
+
+      - name: Detect pre-release
+        id: prerelease
+        env:
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          # Treat any tag that carries a hyphen after the SemVer core as
+          # a pre-release (e.g. v0.0.0-rc1, v0.0.0-fixture, v1.2.3-rc1).
+          if printf '%s' "${TAG}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+-'; then
+            echo "prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: aimx ${{ steps.version.outputs.tag }}
+          body_path: ${{ steps.notes.outputs.notes_file }}
+          prerelease: ${{ steps.prerelease.outputs.prerelease }}
+          fail_on_unmatched_files: true
+          files: |
+            dist/aimx-*.tar.gz
+            dist/aimx-*.tar.gz.sha256
+            dist/SHA256SUMS

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,13 +5,18 @@ name: Release
 # and publish them as assets on a GitHub Release with a templated body
 # that includes a verbatim `curl + sha256sum -c` verify block.
 #
-# Trigger glob accepts tags shaped like `v<digit>...` (e.g. `v1.0.0`,
-# `v1.2.3-rc1`, `v0.0.0-fixture`). Non-SemVer tags (`test`, `dev-*`) are
-# ignored so ad-hoc tags never spend CI minutes or publish a release.
+# Trigger glob requires the SemVer-shaped `vMAJOR.MINOR.PATCH` core
+# (with an optional pre-release / build suffix) — e.g. `v1.0.0`,
+# `v1.2.3-rc1`, `v0.0.0-fixture`. GitHub ref filters use fnmatch (not
+# regex), so `[0-9]*` enforces "digit followed by anything" and the two
+# literal dots enforce the three-segment shape. This keeps malformed
+# tags like `v1`, `v1-beta`, `v1.2`, or `test` from spending CI minutes
+# before the pre-release regex (`^v[0-9]+\.[0-9]+\.[0-9]+-`) rejects
+# them further down.
 on:
   push:
     tags:
-      - 'v[0-9]*'
+      - 'v[0-9]*.[0-9]*.[0-9]*'
 
 permissions:
   contents: write
@@ -32,7 +37,10 @@ jobs:
           - x86_64-unknown-linux-musl
           - aarch64-unknown-linux-musl
     steps:
-      - uses: actions/checkout@v4
+      # Third-party actions are pinned by full commit SHA for supply-chain
+      # safety; the trailing comment names the human-readable version so
+      # `dependabot`/`renovate` (and humans) can bump them in lockstep.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Resolve version string
         id: version
@@ -42,16 +50,20 @@ jobs:
           echo "tag=${tag}" >> "$GITHUB_OUTPUT"
           echo "version=${version}" >> "$GITHUB_OUTPUT"
 
-      - uses: dtolnay/rust-toolchain@stable
+      - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable @ 2025-09-27
         with:
           targets: ${{ matrix.target }}
 
-      - uses: Swatinem/rust-cache@v2
+      - uses: Swatinem/rust-cache@23869a5bd66c73db3c0ac40331f3206eb23791dc # v2.9.1
         with:
           key: release-${{ matrix.target }}
 
-      - name: Install cross
-        run: cargo install cross --locked --version 0.2.5
+      # Use `taiki-e/install-action` to pull a prebuilt `cross` binary
+      # into `~/.cargo/bin` instead of recompiling it from source on
+      # every matrix shard (saved ~1–2 min per leg).
+      - uses: taiki-e/install-action@5f57d6cb7cd20b14a8a27f522884c4bc8a187458 # v2.75.19
+        with:
+          tool: cross@0.2.5
 
       - name: Build release binary
         run: cross build --release --locked --target ${{ matrix.target }}
@@ -86,7 +98,7 @@ jobs:
           echo "tarball=${tarball}" >> "$GITHUB_ENV"
 
       - name: Upload artefact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: aimx-${{ matrix.target }}
           path: |
@@ -100,7 +112,7 @@ jobs:
     needs: build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
@@ -115,7 +127,7 @@ jobs:
           echo "date=${date}" >> "$GITHUB_OUTPUT"
 
       - name: Download build artefacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           path: dist
           pattern: aimx-*
@@ -159,10 +171,14 @@ jobs:
           TAG: ${{ steps.version.outputs.tag }}
           VERSION: ${{ steps.version.outputs.version }}
           DATE: ${{ steps.version.outputs.date }}
-          SHA_X86_GNU: ${{ steps.sums.outputs.sha_x86_64-unknown-linux-gnu }}
-          SHA_ARM_GNU: ${{ steps.sums.outputs.sha_aarch64-unknown-linux-gnu }}
-          SHA_X86_MUSL: ${{ steps.sums.outputs.sha_x86_64-unknown-linux-musl }}
-          SHA_ARM_MUSL: ${{ steps.sums.outputs.sha_aarch64-unknown-linux-musl }}
+          # Output names include hyphens (the target triples), so use
+          # bracket notation — dot notation on hyphenated identifiers is
+          # ambiguous in the expression language (could tokenize as
+          # subtraction) even though it happens to work today.
+          SHA_X86_GNU: ${{ steps.sums.outputs['sha_x86_64-unknown-linux-gnu'] }}
+          SHA_ARM_GNU: ${{ steps.sums.outputs['sha_aarch64-unknown-linux-gnu'] }}
+          SHA_X86_MUSL: ${{ steps.sums.outputs['sha_x86_64-unknown-linux-musl'] }}
+          SHA_ARM_MUSL: ${{ steps.sums.outputs['sha_aarch64-unknown-linux-musl'] }}
         run: |
           set -euo pipefail
           notes_file="$(mktemp)"
@@ -171,7 +187,10 @@ jobs:
           # Resolve the previous SemVer-shaped tag (if any) for the
           # changelog range. If no previous tag exists, fall back to the
           # root commit so first releases still produce a sensible log.
-          prev_tag="$(git tag --list 'v[0-9]*' --sort=-v:refname \
+          # Keep this glob in lockstep with the trigger glob up top so
+          # only SemVer-shaped tags count as candidate "previous" tags
+          # for the changelog range.
+          prev_tag="$(git tag --list 'v[0-9]*.[0-9]*.[0-9]*' --sort=-v:refname \
             | grep -v -x "${TAG}" | head -n1 || true)"
           if [ -n "${prev_tag}" ]; then
             range="${prev_tag}..${TAG}"
@@ -258,7 +277,7 @@ jobs:
           fi
 
       - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           tag_name: ${{ steps.version.outputs.tag }}
           name: aimx ${{ steps.version.outputs.tag }}


### PR DESCRIPTION
## Summary

Lands the onboarding track's **Sprint 1 — Release pipeline** (M1 in `docs/onboarding-prd.md`). On every SemVer-shaped tag push (`v[0-9]*`), a new GitHub Actions workflow cross-builds `aimx` for all four supported Linux targets, produces tarballs + per-tarball `.sha256` files + a release-wide `SHA256SUMS`, and publishes them as assets on a GitHub Release with a templated body containing the changelog, a SHA-256 table, and a verbatim `curl + sha256sum -c` verify block operators can paste.

- New workflow: `.github/workflows/release.yml`
- New doc (in the companion `aimx-docs` repo): `release-process.md` — tag discipline, dry-run + cleanup loop, `v0.0.0-fixture` convention
  - Committed to `aimx-docs` at SHA `1d082d8` (`docs(release-process): add release pipeline + tag discipline docs`)

Trust anchor for v1 is HTTPS on the GitHub Releases domain. Signed releases (minisign / cosign / GPG) are explicitly deferred to v2 per PRD §9.

## Stories addressed

### S1-1 — `release.yml` cross-builds four targets
- [x] `.github/workflows/release.yml` exists, triggered only on `v*.*.*` tag push (trigger glob is `v[0-9]*`, matches every SemVer tag shape and excludes `test` / `dev-*`)
- [x] Matrix covers all four targets (`x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl`) via `cross`
- [ ] All four succeed on a test tag `v0.0.0-rc1` — **deferred, needs tag push; see below**
- [x] Each artefact named exactly `aimx-<version>-<target>.tar.gz` where `<version>` is the tag minus the leading `v`
- [x] Tarball contents: `aimx` (0755), `LICENSE`, `README.md`, `book/`, `hook-templates/defaults.toml`; deterministic tar flags (`--sort=name --owner=0 --group=0 --numeric-owner --mtime=<commit-ISO>`) so the archive shape is reproducible modulo binary determinism
- [x] GitHub Release created automatically via `softprops/action-gh-release@v2` with all tarballs + `.sha256` files + `SHA256SUMS` attached
- [ ] Workflow completes in under 15 minutes on the test tag — **deferred, needs tag push to measure**
- [x] `actionlint` clean against `release.yml` (and existing `ci.yml` / `site.yml`)

### S1-2 — SHA-256 checksums + release notes with verify block
- [x] Per-tarball `aimx-<version>-<target>.tar.gz.sha256` files produced; release-wide `SHA256SUMS` aggregate assembled in the `release` job after all matrix artefacts upload
- [x] Release body template: release name, release date, changelog (`git log <prev-tag>..<this-tag> --no-merges --pretty=format:'- %s (%h)'` with a root-commit fallback for first releases), SHA-256 table for the four targets, per-target `curl + sha256sum -c` blocks, and an aggregate `SHA256SUMS` verify block
- [ ] Changelog between `vX.Y.Z` and `vX.Y.W` renders correctly on a test tag — **deferred, needs tag push**
- [ ] Release body validates as well-formed Markdown on the GitHub Release page — **deferred, needs tag push**
- [x] `docs/release-process.md` documents the tag → CI → publish flow (committed to the companion `aimx-docs` repo at SHA `1d082d8`); deliberately short — no signing story
- [ ] Dry-run tag `v0.0.0-rc1` lands four tarballs + four `.sha256` + one `SHA256SUMS` with the templated body — **deferred, needs tag push**

### S1-3 — Tag discipline + test-release cleanup
- [x] `release.yml` trigger fires only on `v[0-9]*` glob (SemVer-shaped)
- [x] Tag-naming rule documented in `docs/release-process.md`
- [x] Pre-release detection: any SemVer core with a hyphen suffix (`v0.0.0-rc1`, `v0.0.0-fixture`, `v1.2.3-rc1`) publishes as a GitHub pre-release, so it stays out of `/releases/latest`. Regular `vX.Y.Z` tags become the new latest
- [ ] `v0.0.0-rc1` dry-run + cleanup — **deferred, needs tag push**
- [ ] `v0.0.0-fixture` permanent pre-release created with a fixture tarball — **deferred, needs tag push**
- [x] Nothing under `main` references `v0.0.0-rc1` post-cleanup (nothing references it today — will remain true after the dry-run)

## Deferred — needs user go-ahead before tag push

The remaining acceptance criteria require pushing tags to `origin`, which:
- Triggers CI minutes on GitHub Actions (one run per tag; `cross` aarch64 builds are the slow leg).
- Publishes a **public** GitHub Release on `uzyn/aimx` (the `v0.0.0-rc1` release is temporary but publicly visible while it exists; the `v0.0.0-fixture` release is permanent and public).
- Are shared-state actions that affect the project's release page for any visitor.

Per the sprint-implementer guidance, I did **not** push these tags autonomously. I'd like explicit confirmation before doing:

```sh
# 1. Dry-run: push the test tag, watch the workflow, confirm assets shape.
git tag v0.0.0-rc1 && git push origin v0.0.0-rc1
gh run watch
gh release view v0.0.0-rc1

# 2. Clean up the dry-run tag + release.
gh release delete v0.0.0-rc1 --cleanup-tag --yes

# 3. Publish the permanent fixture pre-release (consumed by Sprint 2 tests).
git tag v0.0.0-fixture && git push origin v0.0.0-fixture
gh release view v0.0.0-fixture
```

Happy to execute all three in sequence on your go-ahead, or split them (dry-run only first, then fixture after reviewing the first run). If a reviewer wants the workflow landed *with* the dry-run completed as part of merge, that comes back in Cycle 2 and we push then.

## Test plan

- [x] `actionlint .github/workflows/release.yml` — clean
- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` — parses
- [x] `cargo fmt -- --check` — clean
- [x] `cargo check` — clean (release workflow changes are CI-only, no Rust change, but confirmed no regression)
- [ ] Push `v0.0.0-rc1`, confirm workflow produces four tarballs + four `.sha256` + one `SHA256SUMS` — **deferred, pending user go-ahead**
- [ ] Spot-check the release body on GitHub: changelog rows, SHA-256 table, verify blocks — **deferred, pending user go-ahead**
- [ ] Push `v0.0.0-fixture`, confirm it publishes as a pre-release (so `/releases/latest` stays on whatever the real latest is) — **deferred, pending user go-ahead**

## Notes for the reviewer

- The workflow uses `cross` rather than `taiki-e/upload-rust-binary-action` because the sprint plan explicitly called out `cross` as the expected tool for the aarch64 cross leg, and keeping the artefact-assembly logic in one place makes the tarball contents trivially auditable. If `taiki-e` turns out to be simpler later we can swap; nothing downstream depends on the exact matrix shape.
- `cross` is pinned to `0.2.5` (the latest stable release at writing) to keep the pipeline reproducible across runs.
- The tarball step uses deterministic `tar` flags so two runs on the same commit produce byte-identical tarballs modulo binary determinism — a cheap step toward the PRD's P2 reproducible-builds goal without committing to it.
- Pre-release auto-detection means `v0.0.0-fixture` will publish as a pre-release without manual intervention (hyphen in the SemVer core is the discriminator), keeping it out of `/releases/latest` so Sprint 2's integration tests can pin it safely.