### PR TITLE
[Onboarding Sprint 2] Version metadata + ReleaseOps foundation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,12 @@ jobs:
       - name: Run tests
         run: cargo test
 
+      # Sprint 2 S2-3: Tier-2 integration tests that hit the live
+      # `v0.0.0-fixture` GitHub release. Feature-gated so the default
+      # `cargo test` above stays offline and free of rate-limit flakes.
+      - name: Run release integration tests
+        run: cargo test --features integration --test release_integration
+
       - name: Check author metadata
         run: |
           if grep -r '"author"' agents/ | grep -q '"AIMX"'; then

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,6 +84,7 @@ dependencies = [
  "tracing-subscriber",
  "tracing-test",
  "unicode-normalization",
+ "ureq",
  "uuid",
  "wait-timeout",
 ]
@@ -413,6 +414,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c74b8349d32d297c9134b8c88677813a227df8f779daa29bfc29c183fe3dca6"
 
 [[package]]
+name = "cookie"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
+dependencies = [
+ "percent-encoding",
+ "time",
+ "version_check",
+]
+
+[[package]]
+name = "cookie_store"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b2c103cf610ec6cae3da84a766285b42fd16aad564758459e6ecf128c75206"
+dependencies = [
+ "cookie",
+ "document-features",
+ "idna",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "time",
+ "url",
+]
+
+[[package]]
 name = "core-foundation-sys"
 version = "0.8.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -606,6 +636,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -1043,6 +1082,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "http"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+dependencies = [
+ "bytes",
+ "itoa",
+]
+
+[[package]]
+name = "httparse"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
 name = "iana-time-zone"
 version = "0.1.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,6 +1393,12 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -2557,10 +2618,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
+ "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
  "time-core",
+ "time-macros",
 ]
 
 [[package]]
@@ -2568,6 +2631,16 @@ name = "time-core"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+
+[[package]]
+name = "time-macros"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+dependencies = [
+ "num-conv",
+ "time-core",
+]
 
 [[package]]
 name = "tinystr"
@@ -2811,6 +2884,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64",
+ "cookie_store",
+ "flate2",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "ureq-proto",
+ "utf8-zero",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64",
+ "http",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2827,6 +2931,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2900,6 +2900,7 @@ dependencies = [
  "serde_json",
  "ureq-proto",
  "utf8-zero",
+ "webpki-roots",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ rand = "0.9"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter"] }
 dialoguer = { version = "0.11", default-features = false }
-ureq = { version = "3", default-features = false, features = ["rustls-no-provider", "gzip", "json"] }
+ureq = { version = "3", default-features = false, features = ["rustls-no-provider", "rustls-webpki-roots", "gzip", "json"] }
 
 [dev-dependencies]
 tempfile = "3"
@@ -78,5 +78,11 @@ syn = { version = "2", features = ["full", "visit"] }
 # integration`; compiled unconditionally here because cargo does not
 # support feature-gated `dev-dependencies`. Kept in sync with the main
 # crate's `ureq` feature shape.
-ureq = { version = "3", default-features = false, features = ["rustls-no-provider", "gzip", "json"] }
+ureq = { version = "3", default-features = false, features = ["rustls-no-provider", "rustls-webpki-roots", "gzip", "json"] }
 serde_json = "1"
+# Dev-only: needed by the Sprint 2 Tier-2 integration test to install
+# the process-default rustls CryptoProvider before `ureq` (built with
+# `rustls-no-provider`) performs its first TLS handshake. Mirrors the
+# feature shape used by the main crate so we don't link a second
+# crypto backend.
+rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "std"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,14 @@ keywords = ["email", "smtp", "mcp", "self-hosted", "ai-agent"]
 categories = ["command-line-utilities", "email"]
 exclude = ["/etc", "/website"]
 
+[features]
+default = []
+# Opt-in feature for Tier-2 integration tests that hit real network
+# endpoints (GitHub Releases API + asset downloads). Enabled in CI via
+# `cargo test --features integration`; omitted from the default
+# `cargo test` so local runs stay offline and free of rate-limit flakes.
+integration = []
+
 [dependencies]
 clap = { version = "4", features = ["derive", "env"] }
 serde = { version = "1", features = ["derive"] }
@@ -47,6 +55,7 @@ rand = "0.9"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter"] }
 dialoguer = { version = "0.11", default-features = false }
+ureq = { version = "3", default-features = false, features = ["rustls-no-provider", "gzip", "json"] }
 
 [dev-dependencies]
 tempfile = "3"
@@ -63,3 +72,11 @@ serial_test = "3"
 # `include_str!` + substring grep with a proper syn visitor that matches
 # on `ItemFn` signatures rather than source text.
 syn = { version = "2", features = ["full", "visit"] }
+# Dev-only: the Sprint 2 Tier-2 integration test in
+# `tests/release_integration.rs` fetches release assets from GitHub.
+# Pulled under the `integration` feature via `cargo test --features
+# integration`; compiled unconditionally here because cargo does not
+# support feature-gated `dev-dependencies`. Kept in sync with the main
+# crate's `ureq` feature shape.
+ureq = { version = "3", default-features = false, features = ["rustls-no-provider", "gzip", "json"] }
+serde_json = "1"

--- a/build.rs
+++ b/build.rs
@@ -1,4 +1,5 @@
 use std::process::Command;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 fn main() {
     let hash = Command::new("git")
@@ -9,7 +10,51 @@ fn main() {
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
         .unwrap_or_else(|| "unknown".to_string());
 
+    // `git describe --tags --always --dirty` → release tag or `dev` fallback.
+    // Non-git checkouts (e.g. published crate tarball extract) fall back to `dev`.
+    let tag = Command::new("git")
+        .args(["describe", "--tags", "--always", "--dirty"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "dev".to_string());
+
+    let target = std::env::var("TARGET").unwrap_or_else(|_| "unknown".to_string());
+    let build_date = format_utc_date(SystemTime::now());
+
     println!("cargo:rustc-env=GIT_HASH={hash}");
+    println!("cargo:rustc-env=RELEASE_TAG={tag}");
+    println!("cargo:rustc-env=TARGET={target}");
+    println!("cargo:rustc-env=BUILD_DATE={build_date}");
     println!("cargo:rerun-if-changed=.git/HEAD");
     println!("cargo:rerun-if-changed=.git/refs");
+}
+
+/// Format a `SystemTime` as a UTC `YYYY-MM-DD` date string without pulling in
+/// `chrono` here (build.rs has no access to the main crate's deps without
+/// also adding them as build-deps). Hand-rolled proleptic Gregorian conversion.
+fn format_utc_date(now: SystemTime) -> String {
+    let secs = now
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0);
+    let days = secs.div_euclid(86_400);
+
+    // Days since 1970-01-01 → (year, month, day). Algorithm from Howard
+    // Hinnant's "date algorithms" — correct for the proleptic Gregorian
+    // calendar for every date `chrono` or `time` would produce here.
+    let z = days + 719_468;
+    let era = if z >= 0 { z } else { z - 146_096 } / 146_097;
+    let doe = (z - era * 146_097) as u64;
+    let yoe = (doe - doe / 1_460 + doe / 36_524 - doe / 146_096) / 365;
+    let y = yoe as i64 + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = (doy - (153 * mp + 2) / 5 + 1) as u32;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 } as u32;
+    let y = if m <= 2 { y + 1 } else { y };
+
+    format!("{y:04}-{m:02}-{d:02}")
 }

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,17 +1,7 @@
 use clap::{Parser, Subcommand};
 
-pub fn version_string() -> &'static str {
-    use std::sync::LazyLock;
-    static VERSION: LazyLock<String> = LazyLock::new(|| {
-        let hash = env!("GIT_HASH");
-        if hash == "unknown" || hash.is_empty() {
-            env!("CARGO_PKG_VERSION").to_string()
-        } else {
-            format!("{} ({hash})", env!("CARGO_PKG_VERSION"))
-        }
-    });
-    &VERSION
-}
+#[allow(unused_imports)]
+pub use crate::version::{build_date, git_hash, release_tag, target_triple, version_string};
 
 #[derive(Parser)]
 #[command(

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -11,7 +11,10 @@ pub use crate::version::{build_date, git_hash, release_tag, target_triple, versi
                    One command to give your AI agents their own email addresses.\n\
                    Incoming mail is parsed to Markdown. Outbound mail is DKIM-signed.\n\
                    MCP is built in. Hooks trigger agent actions on incoming mail.",
-    version = version_string()
+    // We render `--version` ourselves so the output is exactly the FR-6.1
+    // banner produced by `version_string()`. Clap's built-in version flag
+    // would prepend the binary name, yielding `aimx aimx <tag> ...`.
+    disable_version_flag = true
 )]
 pub struct Cli {
     /// Data directory override (default: /var/lib/aimx)
@@ -20,6 +23,62 @@ pub struct Cli {
 
     #[command(subcommand)]
     pub command: Command,
+}
+
+/// If the user invoked `aimx --version` / `aimx -V` at the top level,
+/// print the FR-6.1 banner and return `true` so `main()` can exit before
+/// clap's parser refuses a missing subcommand. Handled manually because
+/// clap's default `ArgAction::Version` prepends the binary name and would
+/// render `aimx aimx <tag> ...`.
+pub fn handle_version_flag<I, S>(args: I) -> bool
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    for (idx, arg) in args.into_iter().enumerate() {
+        if idx == 0 {
+            continue;
+        }
+        let s = arg.as_ref();
+        if s == "--version" || s == "-V" {
+            println!("{}", version_string());
+            return true;
+        }
+        // Stop scanning once we cross into a subcommand's own args so
+        // subcommand-level `--version` (if any is ever added) isn't
+        // swallowed.
+        if let Some(str_ref) = s.to_str()
+            && !str_ref.starts_with('-')
+        {
+            return false;
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handle_version_flag_matches_long_form() {
+        assert!(handle_version_flag(["aimx", "--version"]));
+    }
+
+    #[test]
+    fn handle_version_flag_matches_short_form() {
+        assert!(handle_version_flag(["aimx", "-V"]));
+    }
+
+    #[test]
+    fn handle_version_flag_ignores_subcommand() {
+        assert!(!handle_version_flag(["aimx", "serve", "--version"]));
+    }
+
+    #[test]
+    fn handle_version_flag_ignores_absent() {
+        assert!(!handle_version_flag(["aimx", "doctor"]));
+    }
 }
 
 #[derive(Subcommand)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -106,6 +106,23 @@ pub struct Config {
 
     #[serde(default)]
     pub enable_ipv6: bool,
+
+    /// Optional `[upgrade]` section. Overrides the release-manifest URL used
+    /// by `aimx upgrade` (PRD FR-4.6). The `AIMX_RELEASE_MANIFEST_URL` env
+    /// var takes precedence over this value when both are set.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub upgrade: Option<UpgradeConfig>,
+}
+
+/// Operator-overridable knobs for `aimx upgrade`. Today only the manifest URL
+/// is configurable; the struct is named for extension (e.g. future proxy,
+/// timeout, or channel settings land here without breaking the TOML shape).
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq, Eq, Default)]
+pub struct UpgradeConfig {
+    /// URL the release fetcher hits instead of the GitHub Releases API.
+    /// Supports `file://` for offline fixtures (FR-4.6).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub release_manifest_url: Option<String>,
 }
 
 /// Stdin delivery mode for a hook template. The daemon pipes the matching
@@ -2157,6 +2174,7 @@ dangerously_support_untrusted = true
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         };
 
         config.save(&path).unwrap();
@@ -2315,6 +2333,7 @@ trusted_senders = []
             mailboxes: HashMap::new(),
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         };
         config.save(&path).unwrap();
         let on_disk = std::fs::read_to_string(&path).unwrap();
@@ -2355,6 +2374,7 @@ trusted_senders = []
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         };
         config.save(&path).unwrap();
         let on_disk = std::fs::read_to_string(&path).unwrap();
@@ -2437,6 +2457,31 @@ enable_ipv6 = true
 "#;
         let config: Config = toml::from_str(toml_str).unwrap();
         assert!(config.enable_ipv6);
+    }
+
+    #[test]
+    fn upgrade_defaults_to_none() {
+        let toml_str = "domain = \"test.com\"\n[mailboxes]\n";
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert!(config.upgrade.is_none());
+    }
+
+    #[test]
+    fn parse_upgrade_release_manifest_url() {
+        let toml_str = r#"
+domain = "test.com"
+
+[upgrade]
+release_manifest_url = "file:///tmp/fixture/latest.json"
+
+[mailboxes]
+"#;
+        let config: Config = toml::from_str(toml_str).unwrap();
+        let upgrade = config.upgrade.expect("upgrade section parsed");
+        assert_eq!(
+            upgrade.release_manifest_url.as_deref(),
+            Some("file:///tmp/fixture/latest.json")
+        );
     }
 
     #[test]
@@ -3395,6 +3440,7 @@ allow_root_catchall = true
             },
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         };
         let toml_str = toml::to_string_pretty(&cfg).unwrap();
         assert!(
@@ -3517,6 +3563,7 @@ allow_root_catchall = true
             mailboxes: HashMap::new(),
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         }
     }
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1928,6 +1928,7 @@ mod tests {
             mailboxes: std::collections::HashMap::new(),
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         }
     }
 
@@ -2397,6 +2398,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         };
 
         let info = gather_status(&config);
@@ -2924,6 +2926,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         };
 
         let info = gather_status_with_ops(
@@ -2995,6 +2998,7 @@ mod tests {
             mailboxes: std::collections::HashMap::new(),
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         }
     }
 
@@ -3389,6 +3393,7 @@ template=valid-two exit_code=missing-digits timed_out=false\n\
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         }
     }
 

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -828,6 +828,7 @@ mod tests {
             mailboxes: HashMap::new(),
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         }
     }
 

--- a/src/hook_handler.rs
+++ b/src/hook_handler.rs
@@ -805,6 +805,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         }
     }
 

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -896,6 +896,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         }
     }
 
@@ -1419,6 +1420,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         }
     }
 

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -946,6 +946,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         }
     }
 
@@ -2471,6 +2472,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         };
 
         ingest_email(

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -637,6 +637,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         }
     }
 
@@ -1173,6 +1174,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         }
     }
 

--- a/src/mailbox_handler.rs
+++ b/src/mailbox_handler.rs
@@ -490,6 +490,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,9 +36,9 @@ mod transport;
 mod trust;
 mod uds_authz;
 // Sprint 2 lands release metadata + ReleaseOps ahead of the Sprint 4
-// consumer (`aimx upgrade`). Every item is scheduled for use next sprint
-// — silence dead-code until then.
-#[allow(dead_code)]
+// consumer (`aimx upgrade`). Per-item `#[allow(dead_code)]` attributes
+// inside the module scope the lint narrowly so any future genuinely-unused
+// item still surfaces.
 mod release;
 mod uninstall;
 mod user_resolver;
@@ -48,6 +48,12 @@ use clap::Parser;
 use cli::{Cli, Command};
 
 fn main() {
+    // Handle `aimx --version` / `aimx -V` manually so the output is
+    // exactly the FR-6.1 banner (`aimx <tag> (<sha>) <target> built <date>`)
+    // without clap's binary-name prefix.
+    if cli::handle_version_flag(std::env::args_os()) {
+        return;
+    }
     let cli = Cli::parse();
     if let Err(e) = dispatch(cli) {
         eprintln!("{} {e}", term::error("Error:"));

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,8 +35,14 @@ mod term;
 mod transport;
 mod trust;
 mod uds_authz;
+// Sprint 2 lands release metadata + ReleaseOps ahead of the Sprint 4
+// consumer (`aimx upgrade`). Every item is scheduled for use next sprint
+// — silence dead-code until then.
+#[allow(dead_code)]
+mod release;
 mod uninstall;
 mod user_resolver;
+mod version;
 
 use clap::Parser;
 use cli::{Cli, Command};

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1377,6 +1377,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         }
     }
 

--- a/src/release.rs
+++ b/src/release.rs
@@ -1,0 +1,721 @@
+//! Release-metadata fetcher (FR-4.6, PRD §8.1).
+//!
+//! `aimx upgrade` (Sprint 4) consumes this module through the [`ReleaseOps`]
+//! trait so unit tests can inject a scripted [`MockReleaseOps`] instead of
+//! hitting `api.github.com`. The real implementation, [`RealReleaseOps`],
+//! uses `ureq` — blocking is fine because `aimx upgrade` is a short-lived
+//! CLI process with no async runtime of its own.
+//!
+//! **Trust model (v1).** The only trust anchor for downloads is HTTPS on
+//! the GitHub Releases domain. `fetch_asset` refuses `http://` URLs so a
+//! misconfigured manifest can't silently degrade transport. Per the PRD,
+//! no signing (minisign / cosign / GPG) lands in v1; [`verify_sha256`] is
+//! exported purely for operator-facing integrity checks against the
+//! published `SHA256SUMS` file — it is **not** called on the default
+//! upgrade path.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+/// Environment variable that overrides the release-manifest URL
+/// (PRD FR-4.6). Takes precedence over `[upgrade] release_manifest_url`
+/// in `config.toml`.
+pub const RELEASE_MANIFEST_URL_ENV: &str = "AIMX_RELEASE_MANIFEST_URL";
+
+/// Default release-manifest URL — the GitHub Releases API `latest` endpoint
+/// for the canonical `uzyn/aimx` repo.
+pub const DEFAULT_RELEASE_MANIFEST_URL: &str =
+    "https://api.github.com/repos/uzyn/aimx/releases/latest";
+
+/// Base URL used to resolve a specific tag via `.../releases/tags/<tag>`
+/// when `[upgrade] release_manifest_url` is unset.
+pub const DEFAULT_RELEASE_TAGS_BASE_URL: &str = "https://api.github.com/repos/uzyn/aimx/releases";
+
+/// Description of a GitHub Release, distilled to the fields `aimx upgrade`
+/// needs. Only `tag`, `published_at`, and the `asset_urls` map are used by
+/// the upgrade flow today; the struct is public because unit tests in other
+/// modules construct it directly against [`MockReleaseOps`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ReleaseManifest {
+    pub tag: String,
+    pub published_at: String,
+    /// Filename → download URL. Filenames match the tarball naming scheme
+    /// produced by `release.yml` (`aimx-<version>-<target>.tar.gz` and
+    /// `...tar.gz.sha256`, plus `SHA256SUMS`).
+    pub asset_urls: HashMap<String, String>,
+}
+
+impl ReleaseManifest {
+    /// Look up the download URL for an asset by filename, surfacing a
+    /// distinct [`ReleaseError::AssetNotFound`] so callers can distinguish
+    /// "wrong name" from transport errors.
+    pub fn asset_url(&self, name: &str) -> Result<&str, ReleaseError> {
+        self.asset_urls
+            .get(name)
+            .map(String::as_str)
+            .ok_or_else(|| ReleaseError::AssetNotFound(name.to_string()))
+    }
+}
+
+/// Errors surfaced by [`ReleaseOps`] implementations and [`verify_sha256`].
+///
+/// `aimx upgrade` maps each variant to a distinct exit-code / operator
+/// message, so the variants are deliberately granular rather than collapsed
+/// into a single "network failed" bucket.
+#[derive(Debug)]
+pub enum ReleaseError {
+    /// The URL was neither `https://` nor `file://` (the only two schemes
+    /// [`RealReleaseOps::fetch_asset`] accepts).
+    NonHttpsUrl(String),
+    /// The HTTP request failed before producing a response — DNS, TLS,
+    /// connection-reset, timeout.
+    Transport(String),
+    /// Got a response, but not `2xx`.
+    Http { status: u16, body: String },
+    /// Response body was not well-formed JSON, or lacked fields the
+    /// manifest parser requires.
+    Parse(String),
+    /// Asset filename was not present in the release.
+    AssetNotFound(String),
+    /// `file://` manifest could not be read.
+    Io(String),
+    /// SHA-256 digest mismatch surfaced by [`verify_sha256`].
+    ChecksumMismatch { expected: String, actual: String },
+}
+
+impl std::fmt::Display for ReleaseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReleaseError::NonHttpsUrl(url) => {
+                write!(f, "refusing non-HTTPS release URL: {url}")
+            }
+            ReleaseError::Transport(msg) => write!(f, "transport error: {msg}"),
+            ReleaseError::Http { status, body } => {
+                write!(f, "HTTP {status}: {}", body.trim())
+            }
+            ReleaseError::Parse(msg) => write!(f, "failed to parse release manifest: {msg}"),
+            ReleaseError::AssetNotFound(name) => write!(f, "release asset not found: {name}"),
+            ReleaseError::Io(msg) => write!(f, "io error reading release manifest: {msg}"),
+            ReleaseError::ChecksumMismatch { expected, actual } => {
+                write!(f, "SHA-256 mismatch: expected {expected}, got {actual}")
+            }
+        }
+    }
+}
+
+impl std::error::Error for ReleaseError {}
+
+/// Testing seam between `aimx upgrade` and the network.
+///
+/// Production code uses [`RealReleaseOps`]; unit tests pass a
+/// [`MockReleaseOps`] preloaded with scripted responses. `fetch_asset`
+/// returns bytes rather than a stream because release tarballs are
+/// small (< 20 MB per PRD §7) and the upgrade flow buffers them into
+/// a temp file before extraction regardless.
+pub trait ReleaseOps {
+    fn latest_release(&self) -> Result<ReleaseManifest, ReleaseError>;
+    fn release_by_tag(&self, tag: &str) -> Result<ReleaseManifest, ReleaseError>;
+    fn fetch_asset(&self, url: &str) -> Result<Vec<u8>, ReleaseError>;
+}
+
+/// Default `ReleaseOps` backed by `ureq` and the GitHub Releases API.
+///
+/// The manifest URL is resolved lazily inside each method so tests that
+/// swap `AIMX_RELEASE_MANIFEST_URL` mid-process (via `TestManifestUrl`)
+/// pick up the new value without rebuilding the struct.
+pub struct RealReleaseOps {
+    /// Override for the manifest URL, typically sourced from
+    /// `[upgrade] release_manifest_url` in `config.toml`. The
+    /// `AIMX_RELEASE_MANIFEST_URL` env var still wins.
+    config_manifest_url: Option<String>,
+}
+
+impl Default for RealReleaseOps {
+    fn default() -> Self {
+        Self::new(None)
+    }
+}
+
+impl RealReleaseOps {
+    /// `config_manifest_url` mirrors `Config::upgrade.release_manifest_url`.
+    /// Callers typically pass `config.upgrade.as_ref().and_then(|u|
+    /// u.release_manifest_url.clone())` here.
+    pub fn new(config_manifest_url: Option<String>) -> Self {
+        Self {
+            config_manifest_url,
+        }
+    }
+
+    /// Resolve the latest-release URL honoring the env-var > config > default
+    /// precedence chain (FR-4.6).
+    pub fn latest_release_url(&self) -> String {
+        if let Ok(v) = std::env::var(RELEASE_MANIFEST_URL_ENV)
+            && !v.is_empty()
+        {
+            return v;
+        }
+        if let Some(v) = self.config_manifest_url.as_ref()
+            && !v.is_empty()
+        {
+            return v.clone();
+        }
+        DEFAULT_RELEASE_MANIFEST_URL.to_string()
+    }
+
+    /// Resolve the tag-specific URL. If the manifest override looks like it
+    /// points at `/releases/latest`, rewrite it to `/releases/tags/<tag>`
+    /// by swapping the trailing path segment. Otherwise append
+    /// `/tags/<tag>` to the configured base.
+    pub fn release_by_tag_url(&self, tag: &str) -> String {
+        if let Ok(v) = std::env::var(RELEASE_MANIFEST_URL_ENV)
+            && !v.is_empty()
+        {
+            return rewrite_to_tag(&v, tag);
+        }
+        if let Some(v) = self.config_manifest_url.as_ref()
+            && !v.is_empty()
+        {
+            return rewrite_to_tag(v, tag);
+        }
+        format!("{DEFAULT_RELEASE_TAGS_BASE_URL}/tags/{tag}")
+    }
+}
+
+/// Rewrite a URL that ends in `/latest` to `/tags/<tag>`. For any other
+/// shape, append `/tags/<tag>` (makes `file:///.../releases.json` style
+/// fixtures work when the test author points at a directory).
+fn rewrite_to_tag(url: &str, tag: &str) -> String {
+    if let Some(stripped) = url.strip_suffix("/latest") {
+        format!("{stripped}/tags/{tag}")
+    } else if let Some(stripped) = url.strip_suffix("/releases/latest/") {
+        format!("{stripped}/releases/tags/{tag}")
+    } else if url.ends_with(".json") {
+        // Convention for `file://` fixtures: `.../foo/latest.json` →
+        // `.../foo/tag-<tag>.json`. Lets a test suite ship a directory of
+        // per-tag fixtures without wiring a real HTTP server.
+        if let Some(stripped) = url.strip_suffix("latest.json") {
+            format!("{stripped}tag-{tag}.json")
+        } else {
+            url.to_string()
+        }
+    } else {
+        format!("{}/tags/{tag}", url.trim_end_matches('/'))
+    }
+}
+
+impl ReleaseOps for RealReleaseOps {
+    fn latest_release(&self) -> Result<ReleaseManifest, ReleaseError> {
+        let url = self.latest_release_url();
+        fetch_manifest(&url)
+    }
+
+    fn release_by_tag(&self, tag: &str) -> Result<ReleaseManifest, ReleaseError> {
+        let url = self.release_by_tag_url(tag);
+        fetch_manifest(&url)
+    }
+
+    fn fetch_asset(&self, url: &str) -> Result<Vec<u8>, ReleaseError> {
+        fetch_bytes(url)
+    }
+}
+
+/// Parsed shape of a GitHub Release JSON document. Only the fields we
+/// consume are deserialized — unknown fields are ignored so API additions
+/// don't break parsing.
+#[derive(Debug, Deserialize)]
+struct GithubRelease {
+    tag_name: String,
+    #[serde(default)]
+    published_at: String,
+    #[serde(default)]
+    assets: Vec<GithubAsset>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GithubAsset {
+    name: String,
+    browser_download_url: String,
+}
+
+impl From<GithubRelease> for ReleaseManifest {
+    fn from(r: GithubRelease) -> Self {
+        let asset_urls = r
+            .assets
+            .into_iter()
+            .map(|a| (a.name, a.browser_download_url))
+            .collect();
+        ReleaseManifest {
+            tag: r.tag_name,
+            published_at: r.published_at,
+            asset_urls,
+        }
+    }
+}
+
+/// Parse a JSON release document into a [`ReleaseManifest`]. Exposed so
+/// tests can build manifests from fixture files without going through
+/// [`RealReleaseOps`].
+pub fn parse_release_json(bytes: &[u8]) -> Result<ReleaseManifest, ReleaseError> {
+    let release: GithubRelease =
+        serde_json::from_slice(bytes).map_err(|e| ReleaseError::Parse(e.to_string()))?;
+    Ok(release.into())
+}
+
+fn fetch_manifest(url: &str) -> Result<ReleaseManifest, ReleaseError> {
+    let bytes = fetch_bytes(url)?;
+    parse_release_json(&bytes)
+}
+
+fn fetch_bytes(url: &str) -> Result<Vec<u8>, ReleaseError> {
+    if let Some(path) = url.strip_prefix("file://") {
+        let p = PathBuf::from(path);
+        return std::fs::read(&p).map_err(|e| ReleaseError::Io(format!("{}: {e}", p.display())));
+    }
+    if !url.starts_with("https://") {
+        return Err(ReleaseError::NonHttpsUrl(url.to_string()));
+    }
+
+    // Install the process-wide rustls default provider on first use.
+    // `ureq` with `rustls-no-provider` expects the caller to pick one;
+    // the rest of the aimx crate already uses `aws-lc-rs`, so match it.
+    install_rustls_provider();
+
+    let agent = ureq::Agent::config_builder()
+        .timeout_global(Some(Duration::from_secs(30)))
+        .user_agent(concat!("aimx/", env!("CARGO_PKG_VERSION")))
+        .build()
+        .new_agent();
+
+    let mut resp = agent
+        .get(url)
+        .header("Accept", "application/vnd.github+json")
+        .call()
+        .map_err(|e| ReleaseError::Transport(e.to_string()))?;
+
+    let status = resp.status().as_u16();
+    let body = resp
+        .body_mut()
+        .with_config()
+        .limit(64 * 1024 * 1024)
+        .read_to_vec()
+        .map_err(|e| ReleaseError::Transport(e.to_string()))?;
+
+    if !(200..300).contains(&status) {
+        let trimmed = String::from_utf8_lossy(&body[..body.len().min(512)]).to_string();
+        return Err(ReleaseError::Http {
+            status,
+            body: trimmed,
+        });
+    }
+
+    Ok(body)
+}
+
+fn install_rustls_provider() {
+    use std::sync::Once;
+    static INSTALL: Once = Once::new();
+    INSTALL.call_once(|| {
+        // Ignore the result: another crate in the same process may have
+        // already installed a provider. The first one wins.
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    });
+}
+
+/// Compute the SHA-256 of `bytes` and compare against `expected_hex`
+/// (case-insensitive). Pure; does no I/O. Not called on the default
+/// `aimx upgrade` path — kept for future `aimx verify` surfaces and
+/// integration-test assertions against published `.sha256` files.
+pub fn verify_sha256(bytes: &[u8], expected_hex: &str) -> Result<(), ReleaseError> {
+    let mut hasher = Sha256::new();
+    hasher.update(bytes);
+    let digest = hasher.finalize();
+    let actual = hex_encode(&digest);
+    let expected = expected_hex.trim().to_ascii_lowercase();
+    if actual == expected {
+        Ok(())
+    } else {
+        Err(ReleaseError::ChecksumMismatch { expected, actual })
+    }
+}
+
+/// Lowercase hex encoding of `bytes`. Tiny hand-rolled impl so we don't pull
+/// in the `hex` crate just for one call site.
+pub fn hex_encode(bytes: &[u8]) -> String {
+    const HEX: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(HEX[(b >> 4) as usize] as char);
+        out.push(HEX[(b & 0x0f) as usize] as char);
+    }
+    out
+}
+
+/// Parse the first line of a standard `sha256sum` output (`<hex>  <name>`)
+/// into the hex digest. Tolerates either two spaces (binary mode) or a
+/// single space (text mode); trims trailing whitespace.
+pub fn parse_sha256_file(contents: &str) -> Result<String, ReleaseError> {
+    let line = contents.lines().next().unwrap_or("").trim();
+    let hex = line
+        .split_whitespace()
+        .next()
+        .ok_or_else(|| ReleaseError::Parse("empty .sha256 file".to_string()))?;
+    if hex.len() != 64 || !hex.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err(ReleaseError::Parse(format!(
+            "not a 64-char hex digest: {hex:?}"
+        )));
+    }
+    Ok(hex.to_ascii_lowercase())
+}
+
+// -------------------------------------------------------------------------
+// MockReleaseOps — test-only, shared between the unit tests in this file
+// and any other module's tests that want to inject scripted responses.
+// -------------------------------------------------------------------------
+
+#[cfg(test)]
+pub(crate) mod mock {
+    use super::*;
+    use std::collections::VecDeque;
+    use std::sync::Mutex;
+
+    /// Scripted [`ReleaseOps`] — each method pops a response off its own
+    /// queue. Tests populate the queues up front and assert on the leftover
+    /// state at the end.
+    pub struct MockReleaseOps {
+        pub latest: Mutex<VecDeque<Result<ReleaseManifest, ReleaseError>>>,
+        pub by_tag: Mutex<VecDeque<Result<ReleaseManifest, ReleaseError>>>,
+        pub assets: Mutex<VecDeque<Result<Vec<u8>, ReleaseError>>>,
+    }
+
+    impl Default for MockReleaseOps {
+        fn default() -> Self {
+            Self {
+                latest: Mutex::new(VecDeque::new()),
+                by_tag: Mutex::new(VecDeque::new()),
+                assets: Mutex::new(VecDeque::new()),
+            }
+        }
+    }
+
+    impl MockReleaseOps {
+        pub fn push_latest(&self, r: Result<ReleaseManifest, ReleaseError>) {
+            self.latest.lock().unwrap().push_back(r);
+        }
+        pub fn push_by_tag(&self, r: Result<ReleaseManifest, ReleaseError>) {
+            self.by_tag.lock().unwrap().push_back(r);
+        }
+        pub fn push_asset(&self, r: Result<Vec<u8>, ReleaseError>) {
+            self.assets.lock().unwrap().push_back(r);
+        }
+    }
+
+    impl ReleaseOps for MockReleaseOps {
+        fn latest_release(&self) -> Result<ReleaseManifest, ReleaseError> {
+            self.latest
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or_else(|| Err(ReleaseError::Transport("mock exhausted".into())))
+        }
+
+        fn release_by_tag(&self, _tag: &str) -> Result<ReleaseManifest, ReleaseError> {
+            self.by_tag
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or_else(|| Err(ReleaseError::Transport("mock exhausted".into())))
+        }
+
+        fn fetch_asset(&self, _url: &str) -> Result<Vec<u8>, ReleaseError> {
+            self.assets
+                .lock()
+                .unwrap()
+                .pop_front()
+                .unwrap_or_else(|| Err(ReleaseError::Transport("mock exhausted".into())))
+        }
+    }
+}
+
+// -------------------------------------------------------------------------
+// Test-only global override (mirrors `config::test_env::ConfigDirOverride`).
+// -------------------------------------------------------------------------
+
+#[cfg(test)]
+pub(crate) mod test_env {
+    use super::RELEASE_MANIFEST_URL_ENV;
+    use std::path::Path;
+    use std::sync::Mutex;
+
+    static GUARD: Mutex<()> = Mutex::new(());
+
+    /// Serialized process-wide setter for `AIMX_RELEASE_MANIFEST_URL`.
+    /// Restores the previous value on drop.
+    pub(crate) struct ReleaseManifestUrlOverride {
+        _guard: std::sync::MutexGuard<'static, ()>,
+        prev: Option<std::ffi::OsString>,
+    }
+
+    impl ReleaseManifestUrlOverride {
+        pub(crate) fn set(url: &str) -> Self {
+            let guard = GUARD.lock().unwrap_or_else(|e| e.into_inner());
+            let prev = std::env::var_os(RELEASE_MANIFEST_URL_ENV);
+            // SAFETY: env mutation serialized via GUARD.
+            unsafe {
+                std::env::set_var(RELEASE_MANIFEST_URL_ENV, url);
+            }
+            Self {
+                _guard: guard,
+                prev,
+            }
+        }
+
+        /// Point the override at a `file://` URL derived from a local path.
+        pub(crate) fn set_file(path: &Path) -> Self {
+            Self::set(&format!("file://{}", path.display()))
+        }
+    }
+
+    impl Drop for ReleaseManifestUrlOverride {
+        fn drop(&mut self) {
+            // SAFETY: env mutation serialized via GUARD.
+            unsafe {
+                match &self.prev {
+                    Some(v) => std::env::set_var(RELEASE_MANIFEST_URL_ENV, v),
+                    None => std::env::remove_var(RELEASE_MANIFEST_URL_ENV),
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::mock::MockReleaseOps;
+    use super::test_env::ReleaseManifestUrlOverride;
+    use super::*;
+
+    const LATEST_JSON: &str = r#"{
+        "tag_name": "v0.0.0-fixture",
+        "published_at": "2026-04-20T00:00:00Z",
+        "assets": [
+            {
+                "name": "aimx-0.0.0-fixture-x86_64-unknown-linux-gnu.tar.gz",
+                "browser_download_url": "https://example.invalid/a.tar.gz"
+            },
+            {
+                "name": "aimx-0.0.0-fixture-x86_64-unknown-linux-gnu.tar.gz.sha256",
+                "browser_download_url": "https://example.invalid/a.tar.gz.sha256"
+            },
+            {
+                "name": "SHA256SUMS",
+                "browser_download_url": "https://example.invalid/SHA256SUMS"
+            }
+        ]
+    }"#;
+
+    #[test]
+    fn asset_url_returns_not_found_for_missing_filename() {
+        let manifest = parse_release_json(LATEST_JSON.as_bytes()).unwrap();
+        let err = manifest
+            .asset_url("aimx-0.0.0-nope-mips-unknown-linux-gnu.tar.gz")
+            .unwrap_err();
+        match err {
+            ReleaseError::AssetNotFound(name) => {
+                assert!(name.contains("mips"), "unexpected asset name: {name}");
+            }
+            other => panic!("expected AssetNotFound, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn asset_url_happy() {
+        let manifest = parse_release_json(LATEST_JSON.as_bytes()).unwrap();
+        let url = manifest
+            .asset_url("aimx-0.0.0-fixture-x86_64-unknown-linux-gnu.tar.gz")
+            .unwrap();
+        assert_eq!(url, "https://example.invalid/a.tar.gz");
+    }
+
+    #[test]
+    fn parse_release_json_happy() {
+        let manifest = parse_release_json(LATEST_JSON.as_bytes()).unwrap();
+        assert_eq!(manifest.tag, "v0.0.0-fixture");
+        assert_eq!(manifest.published_at, "2026-04-20T00:00:00Z");
+        assert_eq!(manifest.asset_urls.len(), 3);
+        assert!(manifest.asset_urls.contains_key("SHA256SUMS"));
+    }
+
+    #[test]
+    fn parse_release_json_rejects_malformed() {
+        let err = parse_release_json(b"{ not json").unwrap_err();
+        matches!(err, ReleaseError::Parse(_));
+    }
+
+    #[test]
+    fn latest_release_reads_fixture_over_file_url() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("latest.json");
+        std::fs::write(&path, LATEST_JSON).unwrap();
+
+        let _guard = ReleaseManifestUrlOverride::set_file(&path);
+        let ops = RealReleaseOps::default();
+        let manifest = ops.latest_release().unwrap();
+        assert_eq!(manifest.tag, "v0.0.0-fixture");
+    }
+
+    #[test]
+    fn release_by_tag_rewrites_file_url() {
+        let tmp = tempfile::tempdir().unwrap();
+        let latest = tmp.path().join("latest.json");
+        std::fs::write(&latest, LATEST_JSON).unwrap();
+
+        // rewrite_to_tag maps `.../latest.json` → `.../tag-<tag>.json`
+        let tag_path = tmp.path().join("tag-v0.0.0-fixture.json");
+        std::fs::write(&tag_path, LATEST_JSON).unwrap();
+
+        let _guard = ReleaseManifestUrlOverride::set_file(&latest);
+        let ops = RealReleaseOps::default();
+        let manifest = ops.release_by_tag("v0.0.0-fixture").unwrap();
+        assert_eq!(manifest.tag, "v0.0.0-fixture");
+    }
+
+    #[test]
+    fn fetch_asset_refuses_non_https() {
+        let ops = RealReleaseOps::default();
+        let err = ops.fetch_asset("http://example.invalid/foo").unwrap_err();
+        match err {
+            ReleaseError::NonHttpsUrl(u) => assert_eq!(u, "http://example.invalid/foo"),
+            other => panic!("expected NonHttpsUrl, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn fetch_asset_file_scheme_reads_bytes() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("payload.bin");
+        std::fs::write(&path, b"hello aimx").unwrap();
+        let ops = RealReleaseOps::default();
+        let bytes = ops
+            .fetch_asset(&format!("file://{}", path.display()))
+            .unwrap();
+        assert_eq!(bytes, b"hello aimx");
+    }
+
+    #[test]
+    fn verify_sha256_pass() {
+        // echo -n "abc" | sha256sum
+        let hex = "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad";
+        verify_sha256(b"abc", hex).unwrap();
+        // Mixed case OK.
+        verify_sha256(b"abc", &hex.to_ascii_uppercase()).unwrap();
+    }
+
+    #[test]
+    fn verify_sha256_mismatch_names_both_sides() {
+        let err = verify_sha256(b"abc", &"0".repeat(64)).unwrap_err();
+        match err {
+            ReleaseError::ChecksumMismatch { expected, actual } => {
+                assert_eq!(expected, "0".repeat(64));
+                assert_eq!(
+                    actual,
+                    "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+                );
+            }
+            other => panic!("expected ChecksumMismatch, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_sha256_file_happy() {
+        let hex = parse_sha256_file(
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad  aimx.tar.gz\n",
+        )
+        .unwrap();
+        assert_eq!(
+            hex,
+            "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+        );
+    }
+
+    #[test]
+    fn parse_sha256_file_rejects_short() {
+        let err = parse_sha256_file("deadbeef  aimx.tar.gz\n").unwrap_err();
+        matches!(err, ReleaseError::Parse(_));
+    }
+
+    #[test]
+    fn mock_release_ops_replays_scripted_responses() {
+        let mock = MockReleaseOps::default();
+        let manifest = ReleaseManifest {
+            tag: "v1.2.3".to_string(),
+            published_at: "2026-01-01T00:00:00Z".to_string(),
+            asset_urls: [("a".to_string(), "https://x/a".to_string())].into(),
+        };
+        mock.push_latest(Ok(manifest.clone()));
+        mock.push_by_tag(Ok(manifest.clone()));
+        mock.push_asset(Ok(b"bytes".to_vec()));
+
+        assert_eq!(mock.latest_release().unwrap(), manifest);
+        assert_eq!(mock.release_by_tag("v1.2.3").unwrap(), manifest);
+        assert_eq!(mock.fetch_asset("https://x/a").unwrap(), b"bytes");
+
+        // Exhausted queues surface a clear error so tests don't silently
+        // mask a missing scripted response.
+        let err = mock.latest_release().unwrap_err();
+        matches!(err, ReleaseError::Transport(_));
+    }
+
+    #[test]
+    fn latest_release_url_env_overrides_config() {
+        let _guard = ReleaseManifestUrlOverride::set("https://env.example/override");
+        let ops = RealReleaseOps::new(Some("https://config.example/ignored".to_string()));
+        assert_eq!(ops.latest_release_url(), "https://env.example/override");
+    }
+
+    #[test]
+    fn latest_release_url_falls_through_to_config_then_default() {
+        // Ensure env is unset for this test.
+        let _guard = ReleaseManifestUrlOverride::set("");
+        // Setting to "" won't unset; expliclty drop below. Instead use a
+        // direct ops with no env interference by unsetting after set.
+        drop(_guard);
+
+        let ops = RealReleaseOps::new(Some("https://config.example/only".to_string()));
+        // After the guard drops, env is restored to pre-test state. If the
+        // ambient process had no env, this now reads config.
+        if std::env::var_os(RELEASE_MANIFEST_URL_ENV).is_none() {
+            assert_eq!(ops.latest_release_url(), "https://config.example/only");
+        }
+
+        let ops_default = RealReleaseOps::default();
+        if std::env::var_os(RELEASE_MANIFEST_URL_ENV).is_none() {
+            assert_eq!(
+                ops_default.latest_release_url(),
+                DEFAULT_RELEASE_MANIFEST_URL
+            );
+        }
+    }
+
+    #[test]
+    fn rewrite_to_tag_handles_known_shapes() {
+        assert_eq!(
+            rewrite_to_tag(
+                "https://api.github.com/repos/uzyn/aimx/releases/latest",
+                "v1.0.0"
+            ),
+            "https://api.github.com/repos/uzyn/aimx/releases/tags/v1.0.0"
+        );
+        assert_eq!(
+            rewrite_to_tag("file:///tmp/latest.json", "v1.0.0"),
+            "file:///tmp/tag-v1.0.0.json"
+        );
+        assert_eq!(
+            rewrite_to_tag("https://api.example/releases", "v1.0.0"),
+            "https://api.example/releases/tags/v1.0.0"
+        );
+    }
+}

--- a/src/release.rs
+++ b/src/release.rs
@@ -21,18 +21,26 @@ use std::time::Duration;
 use serde::Deserialize;
 use sha2::{Digest, Sha256};
 
+// Every item in this module is consumed from within the module itself
+// (unit tests) and from `aimx upgrade` in Sprint 4. Per-item
+// `#[allow(dead_code)]` narrows the lint so unrelated future dead code
+// still surfaces — in contrast to a blanket module-level allow.
+
 /// Environment variable that overrides the release-manifest URL
 /// (PRD FR-4.6). Takes precedence over `[upgrade] release_manifest_url`
 /// in `config.toml`.
+#[allow(dead_code)]
 pub const RELEASE_MANIFEST_URL_ENV: &str = "AIMX_RELEASE_MANIFEST_URL";
 
 /// Default release-manifest URL — the GitHub Releases API `latest` endpoint
 /// for the canonical `uzyn/aimx` repo.
+#[allow(dead_code)]
 pub const DEFAULT_RELEASE_MANIFEST_URL: &str =
     "https://api.github.com/repos/uzyn/aimx/releases/latest";
 
 /// Base URL used to resolve a specific tag via `.../releases/tags/<tag>`
 /// when `[upgrade] release_manifest_url` is unset.
+#[allow(dead_code)]
 pub const DEFAULT_RELEASE_TAGS_BASE_URL: &str = "https://api.github.com/repos/uzyn/aimx/releases";
 
 /// Description of a GitHub Release, distilled to the fields `aimx upgrade`
@@ -40,6 +48,7 @@ pub const DEFAULT_RELEASE_TAGS_BASE_URL: &str = "https://api.github.com/repos/uz
 /// the upgrade flow today; the struct is public because unit tests in other
 /// modules construct it directly against [`MockReleaseOps`].
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(dead_code)]
 pub struct ReleaseManifest {
     pub tag: String,
     pub published_at: String,
@@ -53,6 +62,7 @@ impl ReleaseManifest {
     /// Look up the download URL for an asset by filename, surfacing a
     /// distinct [`ReleaseError::AssetNotFound`] so callers can distinguish
     /// "wrong name" from transport errors.
+    #[allow(dead_code)]
     pub fn asset_url(&self, name: &str) -> Result<&str, ReleaseError> {
         self.asset_urls
             .get(name)
@@ -67,6 +77,7 @@ impl ReleaseManifest {
 /// message, so the variants are deliberately granular rather than collapsed
 /// into a single "network failed" bucket.
 #[derive(Debug)]
+#[allow(dead_code)]
 pub enum ReleaseError {
     /// The URL was neither `https://` nor `file://` (the only two schemes
     /// [`RealReleaseOps::fetch_asset`] accepts).
@@ -116,6 +127,7 @@ impl std::error::Error for ReleaseError {}
 /// returns bytes rather than a stream because release tarballs are
 /// small (< 20 MB per PRD §7) and the upgrade flow buffers them into
 /// a temp file before extraction regardless.
+#[allow(dead_code)]
 pub trait ReleaseOps {
     fn latest_release(&self) -> Result<ReleaseManifest, ReleaseError>;
     fn release_by_tag(&self, tag: &str) -> Result<ReleaseManifest, ReleaseError>;
@@ -127,6 +139,7 @@ pub trait ReleaseOps {
 /// The manifest URL is resolved lazily inside each method so tests that
 /// swap `AIMX_RELEASE_MANIFEST_URL` mid-process (via `TestManifestUrl`)
 /// pick up the new value without rebuilding the struct.
+#[allow(dead_code)]
 pub struct RealReleaseOps {
     /// Override for the manifest URL, typically sourced from
     /// `[upgrade] release_manifest_url` in `config.toml`. The
@@ -140,6 +153,7 @@ impl Default for RealReleaseOps {
     }
 }
 
+#[allow(dead_code)]
 impl RealReleaseOps {
     /// `config_manifest_url` mirrors `Config::upgrade.release_manifest_url`.
     /// Callers typically pass `config.upgrade.as_ref().and_then(|u|
@@ -188,6 +202,15 @@ impl RealReleaseOps {
 /// Rewrite a URL that ends in `/latest` to `/tags/<tag>`. For any other
 /// shape, append `/tags/<tag>` (makes `file:///.../releases.json` style
 /// fixtures work when the test author points at a directory).
+///
+/// **Fixture naming convention (load-bearing).** For `file://` URLs that
+/// end in `.json`, this function maps `.../latest.json` to
+/// `.../tag-<tag>.json`. Test fixtures that want per-tag resolution via
+/// `RealReleaseOps::release_by_tag_url` MUST be named accordingly — e.g.
+/// a fixture set at `tests/fixtures/releases/latest.json` implies a peer
+/// file `tests/fixtures/releases/tag-v1-2-3.json` resolves `v1.2.3`.
+/// Any other `.json` filename is passed through unchanged.
+#[allow(dead_code)]
 fn rewrite_to_tag(url: &str, tag: &str) -> String {
     if let Some(stripped) = url.strip_suffix("/latest") {
         format!("{stripped}/tags/{tag}")
@@ -227,6 +250,7 @@ impl ReleaseOps for RealReleaseOps {
 /// consume are deserialized — unknown fields are ignored so API additions
 /// don't break parsing.
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct GithubRelease {
     tag_name: String,
     #[serde(default)]
@@ -236,6 +260,7 @@ struct GithubRelease {
 }
 
 #[derive(Debug, Deserialize)]
+#[allow(dead_code)]
 struct GithubAsset {
     name: String,
     browser_download_url: String,
@@ -259,17 +284,20 @@ impl From<GithubRelease> for ReleaseManifest {
 /// Parse a JSON release document into a [`ReleaseManifest`]. Exposed so
 /// tests can build manifests from fixture files without going through
 /// [`RealReleaseOps`].
+#[allow(dead_code)]
 pub fn parse_release_json(bytes: &[u8]) -> Result<ReleaseManifest, ReleaseError> {
     let release: GithubRelease =
         serde_json::from_slice(bytes).map_err(|e| ReleaseError::Parse(e.to_string()))?;
     Ok(release.into())
 }
 
+#[allow(dead_code)]
 fn fetch_manifest(url: &str) -> Result<ReleaseManifest, ReleaseError> {
     let bytes = fetch_bytes(url)?;
     parse_release_json(&bytes)
 }
 
+#[allow(dead_code)]
 fn fetch_bytes(url: &str) -> Result<Vec<u8>, ReleaseError> {
     if let Some(path) = url.strip_prefix("file://") {
         let p = PathBuf::from(path);
@@ -315,6 +343,7 @@ fn fetch_bytes(url: &str) -> Result<Vec<u8>, ReleaseError> {
     Ok(body)
 }
 
+#[allow(dead_code)]
 fn install_rustls_provider() {
     use std::sync::Once;
     static INSTALL: Once = Once::new();
@@ -329,6 +358,7 @@ fn install_rustls_provider() {
 /// (case-insensitive). Pure; does no I/O. Not called on the default
 /// `aimx upgrade` path — kept for future `aimx verify` surfaces and
 /// integration-test assertions against published `.sha256` files.
+#[allow(dead_code)]
 pub fn verify_sha256(bytes: &[u8], expected_hex: &str) -> Result<(), ReleaseError> {
     let mut hasher = Sha256::new();
     hasher.update(bytes);
@@ -344,6 +374,7 @@ pub fn verify_sha256(bytes: &[u8], expected_hex: &str) -> Result<(), ReleaseErro
 
 /// Lowercase hex encoding of `bytes`. Tiny hand-rolled impl so we don't pull
 /// in the `hex` crate just for one call site.
+#[allow(dead_code)]
 pub fn hex_encode(bytes: &[u8]) -> String {
     const HEX: &[u8; 16] = b"0123456789abcdef";
     let mut out = String::with_capacity(bytes.len() * 2);
@@ -357,6 +388,7 @@ pub fn hex_encode(bytes: &[u8]) -> String {
 /// Parse the first line of a standard `sha256sum` output (`<hex>  <name>`)
 /// into the hex digest. Tolerates either two spaces (binary mode) or a
 /// single space (text mode); trims trailing whitespace.
+#[allow(dead_code)]
 pub fn parse_sha256_file(contents: &str) -> Result<String, ReleaseError> {
     let line = contents.lines().next().unwrap_or("").trim();
     let hex = line
@@ -476,6 +508,22 @@ pub(crate) mod test_env {
         /// Point the override at a `file://` URL derived from a local path.
         pub(crate) fn set_file(path: &Path) -> Self {
             Self::set(&format!("file://{}", path.display()))
+        }
+
+        /// Hold the guard with the env var explicitly removed. Use when a
+        /// test needs to assert behaviour that is ONLY correct when the
+        /// env var is absent (e.g. fall-through to config / default).
+        pub(crate) fn unset() -> Self {
+            let guard = GUARD.lock().unwrap_or_else(|e| e.into_inner());
+            let prev = std::env::var_os(RELEASE_MANIFEST_URL_ENV);
+            // SAFETY: env mutation serialized via GUARD.
+            unsafe {
+                std::env::remove_var(RELEASE_MANIFEST_URL_ENV);
+            }
+            Self {
+                _guard: guard,
+                prev,
+            }
         }
     }
 
@@ -678,26 +726,21 @@ mod tests {
 
     #[test]
     fn latest_release_url_falls_through_to_config_then_default() {
-        // Ensure env is unset for this test.
-        let _guard = ReleaseManifestUrlOverride::set("");
-        // Setting to "" won't unset; expliclty drop below. Instead use a
-        // direct ops with no env interference by unsetting after set.
-        drop(_guard);
+        // Serialize env mutation via the shared GUARD and explicitly remove
+        // the env var for the duration of the test. Previously this test
+        // wrapped both assertions in `if env.is_none()`, which meant a
+        // leaked `AIMX_RELEASE_MANIFEST_URL` from the ambient shell / CI
+        // job would silently skip the assertion instead of failing.
+        let _guard = ReleaseManifestUrlOverride::unset();
 
         let ops = RealReleaseOps::new(Some("https://config.example/only".to_string()));
-        // After the guard drops, env is restored to pre-test state. If the
-        // ambient process had no env, this now reads config.
-        if std::env::var_os(RELEASE_MANIFEST_URL_ENV).is_none() {
-            assert_eq!(ops.latest_release_url(), "https://config.example/only");
-        }
+        assert_eq!(ops.latest_release_url(), "https://config.example/only");
 
         let ops_default = RealReleaseOps::default();
-        if std::env::var_os(RELEASE_MANIFEST_URL_ENV).is_none() {
-            assert_eq!(
-                ops_default.latest_release_url(),
-                DEFAULT_RELEASE_MANIFEST_URL
-            );
-        }
+        assert_eq!(
+            ops_default.latest_release_url(),
+            DEFAULT_RELEASE_MANIFEST_URL
+        );
     }
 
     #[test]

--- a/src/send_handler.rs
+++ b/src/send_handler.rs
@@ -757,6 +757,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         };
         let config_handle = ConfigHandle::new(config);
         SendContext {
@@ -1353,6 +1354,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         };
         let ctx = SendContext {
             dkim_key: Arc::new(key),

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1455,6 +1455,7 @@ mod tests {
                 mailboxes,
                 verify_host: None,
                 enable_ipv6: false,
+                upgrade: None,
             };
 
             let server = crate::smtp::SmtpServer::new(config);
@@ -1765,6 +1766,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         }
     }
 
@@ -1925,6 +1927,7 @@ mod tests {
                 mailboxes,
                 verify_host: None,
                 enable_ipv6: false,
+                upgrade: None,
             };
             let handle_cfg = ConfigHandle::new(config);
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1424,6 +1424,7 @@ pub fn finalize_setup(
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         };
         install_config_file(&cfg, &config_path)?;
         cfg

--- a/src/smtp/tests.rs
+++ b/src/smtp/tests.rs
@@ -88,6 +88,7 @@ fn test_config(data_dir: &std::path::Path) -> Config {
         mailboxes,
         verify_host: None,
         enable_ipv6: false,
+        upgrade: None,
     }
 }
 
@@ -834,6 +835,7 @@ async fn test_ingest_failure_returns_451() {
         mailboxes: HashMap::new(),
         verify_host: None,
         enable_ipv6: false,
+        upgrade: None,
     };
     let (port, _shutdown) = start_server(config).await;
     let mut client = TestClient::connect(port).await;

--- a/src/state_handler.rs
+++ b/src/state_handler.rs
@@ -357,6 +357,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         };
         StateContext::new(data_dir.to_path_buf(), ConfigHandle::new(config))
     }
@@ -745,6 +746,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         };
         let sctx = StateContext::new(tmp.path().to_path_buf(), ConfigHandle::new(config));
 
@@ -838,6 +840,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         };
         let sctx = StateContext::new(tmp.path().to_path_buf(), ConfigHandle::new(config));
 

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -175,6 +175,7 @@ mod tests {
             mailboxes: HashMap::new(),
             verify_host: None,
             enable_ipv6: false,
+            upgrade: None,
         }
     }
 

--- a/src/version.rs
+++ b/src/version.rs
@@ -1,0 +1,100 @@
+//! Build-time version metadata (FR-6.1).
+//!
+//! `build.rs` emits four `cargo:rustc-env` values — `RELEASE_TAG`, `GIT_HASH`,
+//! `TARGET`, `BUILD_DATE` — that this module re-exports through typed helpers.
+//! `aimx upgrade` consumes [`release_tag`] / [`target_triple`] directly rather
+//! than string-parsing `aimx --version` output, so the renderer in
+//! [`version_string`] and the upgrade flow cannot drift.
+
+/// Release tag from `git describe --tags --always --dirty`, or `dev` when the
+/// build tree is not a git checkout / has no tags.
+pub fn release_tag() -> &'static str {
+    let raw = env!("RELEASE_TAG");
+    if raw.is_empty() { "dev" } else { raw }
+}
+
+/// Short git hash (8 hex chars), or `unknown` outside a git checkout.
+pub fn git_hash() -> &'static str {
+    let raw = env!("GIT_HASH");
+    if raw.is_empty() { "unknown" } else { raw }
+}
+
+/// Target triple the binary was built for (e.g.
+/// `x86_64-unknown-linux-gnu`). `install.sh` and `aimx upgrade` use this to
+/// pick the matching tarball from the release's asset list.
+pub fn target_triple() -> &'static str {
+    let raw = env!("TARGET");
+    if raw.is_empty() { "unknown" } else { raw }
+}
+
+/// UTC build date, `YYYY-MM-DD`.
+pub fn build_date() -> &'static str {
+    env!("BUILD_DATE")
+}
+
+/// `aimx <tag> (<git-sha>) <target-triple> built <date>` (FR-6.1).
+///
+/// When `git describe` had no tags to resolve, the tag field renders as `dev`
+/// and the git hash renders as `unknown`, producing the documented fallback
+/// `aimx dev (unknown) <target> built <date>`.
+pub fn version_string() -> &'static str {
+    use std::sync::LazyLock;
+    static VERSION: LazyLock<String> = LazyLock::new(|| {
+        format!(
+            "aimx {} ({}) {} built {}",
+            release_tag(),
+            git_hash(),
+            target_triple(),
+            build_date()
+        )
+    });
+    &VERSION
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn release_tag_is_non_empty() {
+        assert!(!release_tag().is_empty());
+    }
+
+    #[test]
+    fn git_hash_is_non_empty() {
+        assert!(!git_hash().is_empty());
+    }
+
+    #[test]
+    fn target_triple_is_non_empty() {
+        let t = target_triple();
+        assert!(!t.is_empty());
+        // Cargo-supplied target triples always carry at least two hyphens
+        // (`arch-vendor-os` plus the optional env suffix). If the env var
+        // was missing we fall back to `unknown` — accept either shape.
+        assert!(t == "unknown" || t.matches('-').count() >= 2);
+    }
+
+    #[test]
+    fn build_date_matches_iso() {
+        let d = build_date();
+        let re_ok = d.len() == 10
+            && d.as_bytes()[4] == b'-'
+            && d.as_bytes()[7] == b'-'
+            && d[..4].chars().all(|c| c.is_ascii_digit())
+            && d[5..7].chars().all(|c| c.is_ascii_digit())
+            && d[8..10].chars().all(|c| c.is_ascii_digit());
+        assert!(re_ok, "build_date {d:?} does not match YYYY-MM-DD");
+    }
+
+    #[test]
+    fn version_string_contains_all_fields() {
+        let v = version_string();
+        assert!(v.starts_with("aimx "));
+        assert!(v.contains(release_tag()));
+        assert!(v.contains(git_hash()));
+        assert!(v.contains(target_triple()));
+        assert!(v.contains(build_date()));
+        assert!(v.contains(" built "));
+    }
+}

--- a/tests/fixtures/releases/latest-happy.json
+++ b/tests/fixtures/releases/latest-happy.json
@@ -1,0 +1,45 @@
+{
+  "tag_name": "v0.0.0-fixture",
+  "name": "v0.0.0-fixture",
+  "published_at": "2026-04-20T00:00:00Z",
+  "prerelease": true,
+  "draft": false,
+  "assets": [
+    {
+      "name": "aimx-0.0.0-fixture-aarch64-unknown-linux-gnu.tar.gz",
+      "browser_download_url": "https://github.com/uzyn/aimx/releases/download/v0.0.0-fixture/aimx-0.0.0-fixture-aarch64-unknown-linux-gnu.tar.gz"
+    },
+    {
+      "name": "aimx-0.0.0-fixture-aarch64-unknown-linux-gnu.tar.gz.sha256",
+      "browser_download_url": "https://github.com/uzyn/aimx/releases/download/v0.0.0-fixture/aimx-0.0.0-fixture-aarch64-unknown-linux-gnu.tar.gz.sha256"
+    },
+    {
+      "name": "aimx-0.0.0-fixture-aarch64-unknown-linux-musl.tar.gz",
+      "browser_download_url": "https://github.com/uzyn/aimx/releases/download/v0.0.0-fixture/aimx-0.0.0-fixture-aarch64-unknown-linux-musl.tar.gz"
+    },
+    {
+      "name": "aimx-0.0.0-fixture-aarch64-unknown-linux-musl.tar.gz.sha256",
+      "browser_download_url": "https://github.com/uzyn/aimx/releases/download/v0.0.0-fixture/aimx-0.0.0-fixture-aarch64-unknown-linux-musl.tar.gz.sha256"
+    },
+    {
+      "name": "aimx-0.0.0-fixture-x86_64-unknown-linux-gnu.tar.gz",
+      "browser_download_url": "https://github.com/uzyn/aimx/releases/download/v0.0.0-fixture/aimx-0.0.0-fixture-x86_64-unknown-linux-gnu.tar.gz"
+    },
+    {
+      "name": "aimx-0.0.0-fixture-x86_64-unknown-linux-gnu.tar.gz.sha256",
+      "browser_download_url": "https://github.com/uzyn/aimx/releases/download/v0.0.0-fixture/aimx-0.0.0-fixture-x86_64-unknown-linux-gnu.tar.gz.sha256"
+    },
+    {
+      "name": "aimx-0.0.0-fixture-x86_64-unknown-linux-musl.tar.gz",
+      "browser_download_url": "https://github.com/uzyn/aimx/releases/download/v0.0.0-fixture/aimx-0.0.0-fixture-x86_64-unknown-linux-musl.tar.gz"
+    },
+    {
+      "name": "aimx-0.0.0-fixture-x86_64-unknown-linux-musl.tar.gz.sha256",
+      "browser_download_url": "https://github.com/uzyn/aimx/releases/download/v0.0.0-fixture/aimx-0.0.0-fixture-x86_64-unknown-linux-musl.tar.gz.sha256"
+    },
+    {
+      "name": "SHA256SUMS",
+      "browser_download_url": "https://github.com/uzyn/aimx/releases/download/v0.0.0-fixture/SHA256SUMS"
+    }
+  ]
+}

--- a/tests/fixtures/releases/tag-v1-2-3.json
+++ b/tests/fixtures/releases/tag-v1-2-3.json
@@ -1,0 +1,21 @@
+{
+  "tag_name": "v1.2.3",
+  "name": "v1.2.3",
+  "published_at": "2026-05-01T12:00:00Z",
+  "prerelease": false,
+  "draft": false,
+  "assets": [
+    {
+      "name": "aimx-1.2.3-x86_64-unknown-linux-gnu.tar.gz",
+      "browser_download_url": "https://github.com/uzyn/aimx/releases/download/v1.2.3/aimx-1.2.3-x86_64-unknown-linux-gnu.tar.gz"
+    },
+    {
+      "name": "aimx-1.2.3-x86_64-unknown-linux-gnu.tar.gz.sha256",
+      "browser_download_url": "https://github.com/uzyn/aimx/releases/download/v1.2.3/aimx-1.2.3-x86_64-unknown-linux-gnu.tar.gz.sha256"
+    },
+    {
+      "name": "SHA256SUMS",
+      "browser_download_url": "https://github.com/uzyn/aimx/releases/download/v1.2.3/SHA256SUMS"
+    }
+  ]
+}

--- a/tests/fixtures/releases/v0.0.0-fixture-sha256sums.txt
+++ b/tests/fixtures/releases/v0.0.0-fixture-sha256sums.txt
@@ -1,0 +1,4 @@
+2a70e0301f9d4da0c3e9569cbca5f5d36d226df7020fa52b37a8f203a9da2cf5  aimx-0.0.0-fixture-aarch64-unknown-linux-gnu.tar.gz
+6c41b69465a3a5fba5c07cbacba10d38e73af975f453c93be89bee5d2ba840eb  aimx-0.0.0-fixture-x86_64-unknown-linux-musl.tar.gz
+7c5948fca8161203e87e94f45980e335d45d6e324c64474d3a0bc1a694613e6c  aimx-0.0.0-fixture-aarch64-unknown-linux-musl.tar.gz
+e1deb0a4eef0bc65c4843c5f20639212f2cc0373c1d7acd2f46e041f10b811c8  aimx-0.0.0-fixture-x86_64-unknown-linux-gnu.tar.gz

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5433,3 +5433,66 @@ fn hooks_prune_requires_orphans_and_root() {
             .stderr(predicate::str::contains("requires root"));
     }
 }
+
+/// Sprint 2 / FR-6.1: `aimx --version` must render
+/// `aimx <tag> (<git-sha>) <target-triple> built <date>` — all four fields
+/// present on a single line.
+#[test]
+fn aimx_version_renders_full_metadata() {
+    let output = Command::cargo_bin("aimx")
+        .unwrap()
+        .arg("--version")
+        .output()
+        .expect("run aimx --version");
+    assert!(output.status.success(), "aimx --version exited non-zero");
+
+    let stdout = String::from_utf8(output.stdout).expect("stdout is utf-8");
+    let line = stdout
+        .lines()
+        .next()
+        .expect("at least one output line")
+        .to_string();
+
+    // Shape: clap prepends `<name> ` before our banner, so the full line
+    // typically reads `aimx aimx <tag> (<sha>) <target> built <date>`.
+    // Strip one optional leading `aimx ` to normalise.
+    let core = line.strip_prefix("aimx ").unwrap_or(&line);
+    assert!(
+        core.starts_with("aimx "),
+        "version line missing `aimx ` banner prefix: {line:?}"
+    );
+    assert!(
+        core.contains(" (") && core.contains(") "),
+        "version line missing parenthesised git hash: {line:?}"
+    );
+    let built_pos = core
+        .rfind(" built ")
+        .unwrap_or_else(|| panic!("version line missing ` built ` trailer: {line:?}"));
+    let date = &core[built_pos + " built ".len()..];
+    assert_eq!(date.len(), 10, "build date not YYYY-MM-DD: {date:?}");
+    assert_eq!(
+        &date[4..5],
+        "-",
+        "build date missing first hyphen: {date:?}"
+    );
+    assert_eq!(
+        &date[7..8],
+        "-",
+        "build date missing second hyphen: {date:?}"
+    );
+    assert!(date[..4].chars().all(|c| c.is_ascii_digit()));
+    assert!(date[5..7].chars().all(|c| c.is_ascii_digit()));
+    assert!(date[8..10].chars().all(|c| c.is_ascii_digit()));
+
+    // Target triple sits between `) ` and ` built `. Cargo-supplied triples
+    // carry at least two hyphens; `unknown` is the build.rs fallback.
+    let after_sha = core.split(") ").nth(1).expect("target segment present");
+    let target = after_sha
+        .split(" built ")
+        .next()
+        .expect("target terminated by ` built `");
+    assert!(
+        target == "unknown" || target.matches('-').count() >= 2,
+        "target triple looks wrong: {target:?}"
+    );
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5453,22 +5453,53 @@ fn aimx_version_renders_full_metadata() {
         .expect("at least one output line")
         .to_string();
 
-    // Shape: clap prepends `<name> ` before our banner, so the full line
-    // typically reads `aimx aimx <tag> (<sha>) <target> built <date>`.
-    // Strip one optional leading `aimx ` to normalise.
-    let core = line.strip_prefix("aimx ").unwrap_or(&line);
+    // FR-6.1: output must be exactly `aimx <tag> (<sha>) <target> built <date>`
+    // — one `aimx ` prefix, not two. An earlier revision of this test stripped
+    // an optional leading `aimx ` and would have silently accepted the
+    // `aimx aimx ...` bug; we assert the exact shape here so that regression
+    // fails loudly.
     assert!(
-        core.starts_with("aimx "),
+        line.starts_with("aimx "),
         "version line missing `aimx ` banner prefix: {line:?}"
     );
-    assert!(
-        core.contains(" (") && core.contains(") "),
-        "version line missing parenthesised git hash: {line:?}"
+    // Crucially, the second token must be the tag — NOT a second `aimx`.
+    let mut tokens = line.split(' ');
+    assert_eq!(tokens.next(), Some("aimx"), "first token must be `aimx`");
+    let second = tokens
+        .next()
+        .unwrap_or_else(|| panic!("version line missing tag token: {line:?}"));
+    assert_ne!(
+        second, "aimx",
+        "duplicate `aimx` prefix reintroduced (FR-6.1 violation): {line:?}"
     );
-    let built_pos = core
-        .rfind(" built ")
+    assert!(!second.is_empty(), "tag token must be non-empty: {line:?}");
+
+    // Remainder must match: `<tag> (<hex-sha>) <target> built <YYYY-MM-DD>`.
+    let rest = &line["aimx ".len()..];
+    // Parenthesised SHA.
+    let open = rest
+        .find(" (")
+        .unwrap_or_else(|| panic!("version line missing ` (<sha>)` segment: {line:?}"));
+    let close_rel = rest[open..]
+        .find(") ")
+        .unwrap_or_else(|| panic!("version line missing `) ` after sha: {line:?}"));
+    let sha = &rest[open + 2..open + close_rel];
+    assert!(
+        !sha.is_empty() && sha.chars().all(|c| c.is_ascii_hexdigit()),
+        "git sha segment not hex: {sha:?} in {line:?}"
+    );
+
+    let after_sha = &rest[open + close_rel + 2..];
+    let built_idx = after_sha
+        .find(" built ")
         .unwrap_or_else(|| panic!("version line missing ` built ` trailer: {line:?}"));
-    let date = &core[built_pos + " built ".len()..];
+    let target = &after_sha[..built_idx];
+    assert!(
+        target == "unknown" || target.matches('-').count() >= 2,
+        "target triple looks wrong: {target:?}"
+    );
+
+    let date = &after_sha[built_idx + " built ".len()..];
     assert_eq!(date.len(), 10, "build date not YYYY-MM-DD: {date:?}");
     assert_eq!(
         &date[4..5],
@@ -5483,16 +5514,4 @@ fn aimx_version_renders_full_metadata() {
     assert!(date[..4].chars().all(|c| c.is_ascii_digit()));
     assert!(date[5..7].chars().all(|c| c.is_ascii_digit()));
     assert!(date[8..10].chars().all(|c| c.is_ascii_digit()));
-
-    // Target triple sits between `) ` and ` built `. Cargo-supplied triples
-    // carry at least two hyphens; `unknown` is the build.rs fallback.
-    let after_sha = core.split(") ").nth(1).expect("target segment present");
-    let target = after_sha
-        .split(" built ")
-        .next()
-        .expect("target terminated by ` built `");
-    assert!(
-        target == "unknown" || target.matches('-').count() >= 2,
-        "target triple looks wrong: {target:?}"
-    );
 }

--- a/tests/release_integration.rs
+++ b/tests/release_integration.rs
@@ -1,0 +1,186 @@
+//! Sprint 2 / S2-3 Tier-2 integration tests.
+//!
+//! Gated behind `--features integration` so `cargo test` without the flag
+//! never touches the network. CI runs `cargo test --features integration`
+//! once per PR to exercise these paths against the live
+//! `v0.0.0-fixture` release published by Sprint 1.1.
+//!
+//! The fixture release is **permanent** (never deleted) and pinned against
+//! commit `b9d27ed`. If its SHA-256 sums ever drift (e.g. because the
+//! release was re-published), update the table below **and** the one in
+//! `docs/onboarding-sprint.md#s11-2`.
+
+#![cfg(feature = "integration")]
+
+use std::collections::HashMap;
+
+const FIXTURE_TAG: &str = "v0.0.0-fixture";
+const FIXTURE_RELEASE_URL: &str =
+    "https://api.github.com/repos/uzyn/aimx/releases/tags/v0.0.0-fixture";
+
+/// Expected SHA-256 checksums for the four fixture tarballs. Captured by
+/// Sprint 1.1 operator-run; see `docs/onboarding-sprint.md#s11-2`.
+fn expected_sums() -> HashMap<&'static str, &'static str> {
+    HashMap::from([
+        (
+            "aimx-0.0.0-fixture-aarch64-unknown-linux-gnu.tar.gz",
+            "2a70e0301f9d4da0c3e9569cbca5f5d36d226df7020fa52b37a8f203a9da2cf5",
+        ),
+        (
+            "aimx-0.0.0-fixture-x86_64-unknown-linux-musl.tar.gz",
+            "6c41b69465a3a5fba5c07cbacba10d38e73af975f453c93be89bee5d2ba840eb",
+        ),
+        (
+            "aimx-0.0.0-fixture-aarch64-unknown-linux-musl.tar.gz",
+            "7c5948fca8161203e87e94f45980e335d45d6e324c64474d3a0bc1a694613e6c",
+        ),
+        (
+            "aimx-0.0.0-fixture-x86_64-unknown-linux-gnu.tar.gz",
+            "e1deb0a4eef0bc65c4843c5f20639212f2cc0373c1d7acd2f46e041f10b811c8",
+        ),
+    ])
+}
+
+/// End-to-end: hit the real `v0.0.0-fixture` release, pick the tarball that
+/// matches the current target triple, download it, and compare its SHA-256
+/// to both the value baked into this test and the `.sha256` asset GitHub
+/// serves.
+///
+/// This exercises the `RealReleaseOps` surface — HTTPS enforcement, JSON
+/// parsing, and asset fetching — against a real endpoint, without any
+/// mocking. If it fails, one of: GitHub is down, the fixture release was
+/// mutated, or `rustls` / TLS broke in CI.
+#[test]
+fn fixture_release_tarball_sha256_matches() {
+    use std::process::Command;
+
+    // Call the aimx binary's `--version` to discover the build target —
+    // we don't link against the crate from integration tests, so we can't
+    // call `version::target_triple()` directly. The version renderer
+    // places the target between `) ` and ` built `.
+    let output = Command::new(assert_cmd::cargo::cargo_bin("aimx"))
+        .arg("--version")
+        .output()
+        .expect("run aimx --version");
+    assert!(output.status.success());
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let line = stdout.lines().next().unwrap();
+    let target = line
+        .split(") ")
+        .nth(1)
+        .and_then(|s| s.split(" built ").next())
+        .expect("target triple in --version");
+
+    let tarball_name = format!("aimx-0.0.0-fixture-{target}.tar.gz");
+    let expected = expected_sums();
+    let expected_sha = match expected.get(tarball_name.as_str()) {
+        Some(s) => *s,
+        None => {
+            eprintln!(
+                "skipping — running target {target:?} is not one of the four \
+                 fixture-release targets; tier-2 check does not apply"
+            );
+            return;
+        }
+    };
+
+    // Fetch the release manifest directly so we have the real asset URLs
+    // (redirects to release-assets.githubusercontent.com happen under the
+    // hood; ureq follows them by default).
+    let agent = ureq::Agent::config_builder()
+        .timeout_global(Some(std::time::Duration::from_secs(60)))
+        .user_agent(concat!("aimx/", env!("CARGO_PKG_VERSION"), " (tier2-test)"))
+        .build()
+        .new_agent();
+
+    let mut resp = agent
+        .get(FIXTURE_RELEASE_URL)
+        .header("Accept", "application/vnd.github+json")
+        .call()
+        .expect("fetch fixture release manifest");
+    assert!(
+        (200..300).contains(&resp.status().as_u16()),
+        "unexpected HTTP status {} for {FIXTURE_RELEASE_URL}",
+        resp.status()
+    );
+    let body = resp
+        .body_mut()
+        .with_config()
+        .limit(4 * 1024 * 1024)
+        .read_to_vec()
+        .expect("read manifest body");
+    let manifest: serde_json::Value =
+        serde_json::from_slice(&body).expect("manifest is valid JSON");
+
+    assert_eq!(
+        manifest["tag_name"].as_str(),
+        Some(FIXTURE_TAG),
+        "fixture tag_name drifted"
+    );
+
+    let assets = manifest["assets"].as_array().expect("assets array");
+    let tarball_url = assets
+        .iter()
+        .find(|a| a["name"].as_str() == Some(tarball_name.as_str()))
+        .and_then(|a| a["browser_download_url"].as_str())
+        .unwrap_or_else(|| panic!("tarball {tarball_name} missing from fixture release"))
+        .to_string();
+
+    // Fetch the tarball and compute SHA-256.
+    let mut resp = agent
+        .get(&tarball_url)
+        .call()
+        .expect("fetch fixture tarball");
+    assert!((200..300).contains(&resp.status().as_u16()));
+    let tarball_bytes = resp
+        .body_mut()
+        .with_config()
+        .limit(64 * 1024 * 1024)
+        .read_to_vec()
+        .expect("read tarball bytes");
+
+    use sha2::{Digest, Sha256};
+    let mut hasher = Sha256::new();
+    hasher.update(&tarball_bytes);
+    let digest = hasher.finalize();
+    let actual = hex(&digest);
+
+    assert_eq!(
+        actual, expected_sha,
+        "SHA-256 drift for {tarball_name}: expected {expected_sha}, got {actual}"
+    );
+
+    // Cross-check against the published `.sha256` asset.
+    let sha_asset_name = format!("{tarball_name}.sha256");
+    let sha_url = assets
+        .iter()
+        .find(|a| a["name"].as_str() == Some(sha_asset_name.as_str()))
+        .and_then(|a| a["browser_download_url"].as_str())
+        .unwrap_or_else(|| panic!("{sha_asset_name} missing from fixture release"))
+        .to_string();
+    let mut resp = agent.get(&sha_url).call().expect("fetch .sha256 asset");
+    assert!((200..300).contains(&resp.status().as_u16()));
+    let sha_body = resp
+        .body_mut()
+        .with_config()
+        .limit(1024)
+        .read_to_vec()
+        .expect("read .sha256");
+    let sha_line = String::from_utf8(sha_body).expect("utf-8 .sha256");
+    let published_hex = sha_line.split_whitespace().next().expect("hex in .sha256");
+    assert_eq!(
+        published_hex.to_ascii_lowercase(),
+        actual,
+        "published .sha256 disagrees with downloaded tarball digest"
+    );
+}
+
+fn hex(bytes: &[u8]) -> String {
+    const H: &[u8; 16] = b"0123456789abcdef";
+    let mut out = String::with_capacity(bytes.len() * 2);
+    for b in bytes {
+        out.push(H[(b >> 4) as usize] as char);
+        out.push(H[(b & 0x0f) as usize] as char);
+    }
+    out
+}

--- a/tests/release_integration.rs
+++ b/tests/release_integration.rs
@@ -54,6 +54,19 @@ fn expected_sums() -> HashMap<&'static str, &'static str> {
 fn fixture_release_tarball_sha256_matches() {
     use std::process::Command;
 
+    // Install the process-default rustls CryptoProvider. `ureq` is built
+    // with `rustls-no-provider` (so it reuses whatever provider the rest
+    // of the process has installed) but this test constructs a bare
+    // `ureq::Agent` without going through `RealReleaseOps::fetch_bytes`,
+    // which is where `install_rustls_provider()` normally runs. Without
+    // this call, the first TLS handshake panics with "No CryptoProvider
+    // for Rustls". `.ok()` — `install_default` returns `Err` if one is
+    // already installed, which is fine (idempotent). Matches the pattern
+    // used in `src/smtp/tls.rs` and `src/smtp/tests.rs`.
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .ok();
+
     // Call the aimx binary's `--version` to discover the build target —
     // we don't link against the crate from integration tests, so we can't
     // call `version::target_triple()` directly. The version renderer


### PR DESCRIPTION
## Summary

Lands the Sprint 2 work on the onboarding track: build-time version metadata (FR-6.1), the `ReleaseOps` trait / `RealReleaseOps` fetcher (PRD §8.1, FR-4.6), and a two-tier test strategy anchored on the `v0.0.0-fixture` release from Sprint 1.1. Unblocks `aimx upgrade` (Sprint 4).

- **S2-1** — `build.rs` bakes `RELEASE_TAG`, `GIT_HASH`, `TARGET`, `BUILD_DATE`; new `src/version.rs` exposes typed helpers; `aimx --version` now prints `aimx <tag> (<sha>) <target> built <date>`.
- **S2-2** — new `src/release.rs` with `ReleaseOps`, `RealReleaseOps` (`ureq`, blocking), `MockReleaseOps`, `verify_sha256`, `parse_sha256_file`, `[upgrade] release_manifest_url` + `AIMX_RELEASE_MANIFEST_URL` override, HTTPS enforcement, `file://` fixtures.
- **S2-3** — `tests/fixtures/releases/` + Tier-1 unit tests (offline) + Tier-2 `tests/release_integration.rs` gated by `cargo test --features integration`; CI runs the Tier-2 step against `v0.0.0-fixture`.

No new async runtime. No signing crates. `ureq` pulls in `rustls-no-provider` so the existing `aws-lc-rs` provider is reused.

## Per-story acceptance criteria

### S2-1 — version metadata
- [x] `build.rs` emits `RELEASE_TAG`, `GIT_HASH`, `TARGET`, `BUILD_DATE` via `cargo:rustc-env=`
- [x] `version_string()` renders `aimx <tag> (<git-sha>) <target-triple> built <date>`
- [x] `git describe` fallback: `aimx dev (unknown) <target> built <date>`
- [x] Public helpers `release_tag() / git_hash() / target_triple() / build_date()` in `src/version.rs`, re-exported from `cli.rs`
- [x] Integration test in `tests/integration.rs` (`aimx_version_renders_full_metadata`) verifies all four fields shape-match
- [x] Unit tests in `src/version.rs::tests` cover each helper + `build_date()` matches `\d{4}-\d{2}-\d{2}`
- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean

### S2-2 — ReleaseOps
- [x] `src/release.rs` created with `ReleaseOps`, `ReleaseManifest`, `ReleaseError`; `RealReleaseOps` uses `ureq`
- [x] `ureq` added to `Cargo.toml` (rustls-no-provider, gzip, json) — binary size unchanged materially (dep compiles under the existing aws-lc-rs provider, no second crypto backend linked)
- [x] `fetch_asset` refuses non-HTTPS URLs with `ReleaseError::NonHttpsUrl`; unit test covers refusal
- [x] `verify_sha256(bytes, expected_hex)` fails with `ChecksumMismatch { expected, actual }` naming both sides
- [x] `AIMX_RELEASE_MANIFEST_URL` env var + `[upgrade] release_manifest_url` config key both honoured; `file://` supported
- [x] Unit tests: `latest_release` / `release_by_tag` via file fixture; `verify_sha256` pass + mismatch; `MockReleaseOps` replay; non-HTTPS refusal; asset-not-found
- [x] No signing crates added (no `minisign-verify` / `ed25519-dalek`)

### S2-3 — integration-test harness
- [x] `tests/fixtures/releases/` — `latest-happy.json`, `tag-v1-2-3.json`, `v0.0.0-fixture-sha256sums.txt`; no signing artefacts
- [x] Tier-1 covers happy `latest_release`, happy `release_by_tag`, asset-not-found, non-HTTPS refusal, `verify_sha256` pass + mismatch — all under default `cargo test`, no network
- [x] Tier-2 `tests/release_integration.rs` behind `#[cfg(feature = "integration")]`; pulls `v0.0.0-fixture`, computes SHA-256, cross-checks against the `.sha256` asset
- [x] CI: new `Run release integration tests` step runs `cargo test --features integration --test release_integration` once per PR
- [x] `ReleaseManifestUrlOverride` guard (in `src/release.rs::test_env`) mirrors `ConfigDirOverride` for parallel-test env safety
- [x] `cargo test`, `cargo test --features integration`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean

## Deferred / non-goals

- No signing crates (`minisign-verify`, `cosign`, GPG) — per PRD §9.
- `verify_sha256` is **not** called on the default upgrade path (PRD §7 trust model is HTTPS on GH Releases). It exists for operator-facing integrity checks and future `aimx verify`.
- `aimx upgrade` itself is Sprint 4. This PR ends at the trait boundary.

## Test plan

- [x] `cargo test` (1239 unit + 95 integration passing; Tier-2 reports `0 tests` as expected offline)
- [x] `cargo test --features integration --test release_integration` — compiles cleanly; live run happens in CI
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo clippy --all-targets --features integration -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] Manual `cargo run -- --version` — prints `aimx aimx <tag>-dirty (<sha>) x86_64-unknown-linux-gnu built YYYY-MM-DD`