### PR TITLE
[Onboarding Sprint 3] Install script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,18 +231,19 @@ jobs:
             apt-get install -y --no-install-recommends curl ca-certificates tar dash >/dev/null
             mkdir -p /tmp/aimx-down
             # Lay down a fake "newer" aimx (reports a tag newer than the fixture).
-            cat > /tmp/aimx-down/aimx <<EOF
-          #!/bin/sh
-          echo "aimx 9.9.9 (deadbeef)"
-          EOF
+            # Use printf (not HEREDOC) so YAML indentation does not leak into
+            # the file or stop the HEREDOC terminator from matching at column 0.
+            printf "%s\n" "#!/bin/sh" "echo \"aimx 9.9.9 (deadbeef)\"" > /tmp/aimx-down/aimx
             chmod 0755 /tmp/aimx-down/aimx
             # install.sh must refuse to overwrite with the older fixture tag,
             # even under --force, and emit the "aimx upgrade ... --force" hint.
             if dash install.sh --tag v0.0.0-fixture --force \
-                --target x86_64-unknown-linux-gnu --to /tmp/aimx-down 2>&1 | tee /tmp/down.log; then
+                --target x86_64-unknown-linux-gnu --to /tmp/aimx-down >/tmp/down.log 2>&1; then
+              cat /tmp/down.log
               echo "expected downgrade refusal to exit non-zero" >&2
               exit 1
             fi
+            cat /tmp/down.log
             grep -q "aimx upgrade --version" /tmp/down.log
             grep -q -- "--force" /tmp/down.log
           '

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,60 @@ jobs:
             exit 1
           fi
 
+      - name: Same-version re-install refused without --force, accepted with --force
+        run: |
+          docker run --rm -v "${PWD}:/src" -w /src debian:stable-slim sh -eu -c '
+            apt-get update >/dev/null
+            apt-get install -y --no-install-recommends curl ca-certificates tar dash >/dev/null
+            mkdir -p /tmp/aimx-same
+            # First install the fixture release.
+            dash install.sh --tag v0.0.0-fixture \
+              --target x86_64-unknown-linux-gnu --to /tmp/aimx-same
+            # Re-run without --force — must exit 0 with "already installed" and not rewrite.
+            _before="$(stat -c %Y /tmp/aimx-same/aimx)"
+            sleep 1
+            dash install.sh --tag v0.0.0-fixture \
+              --target x86_64-unknown-linux-gnu --to /tmp/aimx-same 2>&1 | tee /tmp/same.log
+            grep -q "already installed" /tmp/same.log
+            _after="$(stat -c %Y /tmp/aimx-same/aimx)"
+            if [ "${_before}" != "${_after}" ]; then
+              echo "same-version re-install should not rewrite binary without --force" >&2
+              exit 1
+            fi
+            # Now re-run with --force — must rewrite the binary.
+            sleep 1
+            dash install.sh --tag v0.0.0-fixture --force \
+              --target x86_64-unknown-linux-gnu --to /tmp/aimx-same
+            _forced="$(stat -c %Y /tmp/aimx-same/aimx)"
+            if [ "${_after}" = "${_forced}" ]; then
+              echo "--force same-version re-install should rewrite binary" >&2
+              exit 1
+            fi
+          '
+
+      - name: Downgrade refusal points at aimx upgrade --force
+        run: |
+          docker run --rm -v "${PWD}:/src" -w /src debian:stable-slim sh -eu -c '
+            apt-get update >/dev/null
+            apt-get install -y --no-install-recommends curl ca-certificates tar dash >/dev/null
+            mkdir -p /tmp/aimx-down
+            # Lay down a fake "newer" aimx (reports a tag newer than the fixture).
+            cat > /tmp/aimx-down/aimx <<EOF
+          #!/bin/sh
+          echo "aimx 9.9.9 (deadbeef)"
+          EOF
+            chmod 0755 /tmp/aimx-down/aimx
+            # install.sh must refuse to overwrite with the older fixture tag,
+            # even under --force, and emit the "aimx upgrade ... --force" hint.
+            if dash install.sh --tag v0.0.0-fixture --force \
+                --target x86_64-unknown-linux-gnu --to /tmp/aimx-down 2>&1 | tee /tmp/down.log; then
+              echo "expected downgrade refusal to exit non-zero" >&2
+              exit 1
+            fi
+            grep -q "aimx upgrade --version" /tmp/down.log
+            grep -q -- "--force" /tmp/down.log
+          '
+
   verifier-tests:
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,24 +199,40 @@ jobs:
             apt-get update >/dev/null
             apt-get install -y --no-install-recommends curl ca-certificates tar dash >/dev/null
             mkdir -p /tmp/aimx-same
-            # First install the fixture release.
-            dash install.sh --tag v0.0.0-fixture \
-              --target x86_64-unknown-linux-gnu --to /tmp/aimx-same
-            # Re-run without --force — must exit 0 with "already installed" and not rewrite.
+            # Lay down a stub aimx that self-reports the fixture tag, so the
+            # same-version short-circuit in install.sh fires without relying
+            # on the fixture tarballs self-reporting (they predate Sprint 2
+            # build.rs metadata). Use printf (not HEREDOC) so YAML indentation
+            # does not leak into the file.
+            printf "%s\n" "#!/bin/sh" "echo \"aimx v0.0.0-fixture (stubshad) x86_64-unknown-linux-gnu built 2026-04-23\"" > /tmp/aimx-same/aimx
+            chmod 0755 /tmp/aimx-same/aimx
             _before="$(stat -c %Y /tmp/aimx-same/aimx)"
             sleep 1
-            dash install.sh --tag v0.0.0-fixture \
-              --target x86_64-unknown-linux-gnu --to /tmp/aimx-same 2>&1 | tee /tmp/same.log
+            # Without --force: installed == target short-circuits. Exit 0,
+            # log "already installed", binary untouched.
+            if ! dash install.sh --tag v0.0.0-fixture \
+                --target x86_64-unknown-linux-gnu --to /tmp/aimx-same >/tmp/same.log 2>&1; then
+              cat /tmp/same.log
+              echo "expected same-version no-force install to exit 0" >&2
+              exit 1
+            fi
+            cat /tmp/same.log
             grep -q "already installed" /tmp/same.log
             _after="$(stat -c %Y /tmp/aimx-same/aimx)"
             if [ "${_before}" != "${_after}" ]; then
               echo "same-version re-install should not rewrite binary without --force" >&2
               exit 1
             fi
-            # Now re-run with --force — must rewrite the binary.
+            # With --force: install.sh proceeds through the upgrade path and
+            # swaps the stub for the real fixture binary. mtime must change.
             sleep 1
-            dash install.sh --tag v0.0.0-fixture --force \
-              --target x86_64-unknown-linux-gnu --to /tmp/aimx-same
+            if ! dash install.sh --tag v0.0.0-fixture --force \
+                --target x86_64-unknown-linux-gnu --to /tmp/aimx-same >/tmp/same-force.log 2>&1; then
+              cat /tmp/same-force.log
+              echo "expected same-version --force install to exit 0" >&2
+              exit 1
+            fi
+            cat /tmp/same-force.log
             _forced="$(stat -c %Y /tmp/aimx-same/aimx)"
             if [ "${_after}" = "${_forced}" ]; then
               echo "--force same-version re-install should rewrite binary" >&2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,89 @@ jobs:
         run: |
           sudo -E env "PATH=$PATH" AIMX_INTEGRATION_SUDO=1 cargo test --test e2e_agent_flow -- --ignored
 
+  # Onboarding Sprint 3 (S3-3): lint + exercise `install.sh` under dash
+  # (debian:stable-slim) and busybox sh (alpine:latest). The happy-path
+  # runs fetch the real `v0.0.0-fixture` GitHub Release — that tag is
+  # permanent per Sprint 1.3 tag discipline, carries all four target
+  # tarballs, and exercises the exact curl-to-shell flow operators hit.
+  #
+  # No checksum-verification test path here: `install.sh` v1 does not
+  # verify SHA-256 (PRD FR-2.4 — trust anchor is HTTPS). Skeptical
+  # operators verify manually via the release-notes `sha256sum -c`
+  # block (FR-1.4).
+  install-sh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install shellcheck
+        run: sudo apt-get update && sudo apt-get install -y shellcheck
+
+      - name: shellcheck install.sh
+        run: shellcheck install.sh
+
+      - name: POSIX parse via dash
+        run: dash -n install.sh
+
+      - name: POSIX parse via busybox sh
+        run: |
+          # busybox sh -n on the host if available; fall back to Docker.
+          if command -v busybox >/dev/null; then
+            busybox sh -n install.sh
+          else
+            docker run --rm -v "${PWD}:/src" -w /src busybox:stable sh -n install.sh
+          fi
+
+      - name: Help flag under dash
+        run: dash install.sh --help
+
+      - name: Dry-run under dash (fixture release, x86_64 gnu)
+        env:
+          AIMX_DRY_RUN: '1'
+        run: |
+          dash install.sh --tag v0.0.0-fixture \
+            --target x86_64-unknown-linux-gnu --to /tmp/aimx-dry
+
+      - name: Dry-run under dash (fixture release, aarch64 musl target override)
+        env:
+          AIMX_DRY_RUN: '1'
+        run: |
+          dash install.sh --tag v0.0.0-fixture \
+            --target aarch64-unknown-linux-musl --to /tmp/aimx-dry
+
+      - name: Fresh install under alpine:latest (busybox sh)
+        run: |
+          docker run --rm -v "${PWD}:/src" -w /src alpine:latest sh -eu -c '
+            apk add --no-cache curl tar >/dev/null
+            mkdir -p /tmp/aimx-alpine
+            # alpine is musl; let detection resolve target triple.
+            sh install.sh --tag v0.0.0-fixture --to /tmp/aimx-alpine
+            test -x /tmp/aimx-alpine/aimx
+            /tmp/aimx-alpine/aimx --version
+          '
+
+      - name: Fresh install under debian:stable-slim (dash as sh)
+        run: |
+          docker run --rm -v "${PWD}:/src" -w /src debian:stable-slim sh -eu -c '
+            apt-get update >/dev/null
+            apt-get install -y --no-install-recommends curl ca-certificates tar dash >/dev/null
+            mkdir -p /tmp/aimx-deb
+            # Run explicitly under dash for POSIX purity.
+            dash install.sh --tag v0.0.0-fixture \
+              --target x86_64-unknown-linux-gnu --to /tmp/aimx-deb
+            test -x /tmp/aimx-deb/aimx
+            /tmp/aimx-deb/aimx --version
+          '
+
+      - name: Unsupported-platform refusal is clean
+        run: |
+          # Force an unsupported target triple; install.sh must err
+          # before any download and exit non-zero.
+          if dash install.sh --target x86_64-unknown-linux-nosuch; then
+            echo "expected failure on unsupported target" >&2
+            exit 1
+          fi
+
   verifier-tests:
     runs-on: ubuntu-latest
     defaults:

--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -7,12 +7,14 @@ on:
       - 'website/**'
       - 'book/**'
       - 'etc/aimx-pigeon.svg'
+      - 'install.sh'
       - '.github/workflows/site.yml'
   pull_request:
     paths:
       - 'website/**'
       - 'book/**'
       - 'etc/aimx-pigeon.svg'
+      - 'install.sh'
       - '.github/workflows/site.yml'
   workflow_dispatch:
 
@@ -43,6 +45,11 @@ jobs:
           test -f website/dist/book/faq.html
           test -f website/dist/book/security.html
           test -f website/dist/assets/aimx-pigeon.svg
+          test -f website/dist/install.sh
+          # Verify install.sh is syntactically valid POSIX sh before
+          # publishing to aimx.email — site build is the last gate.
+          sh -n website/dist/install.sh
+          head -1 website/dist/install.sh | grep -q '^#!/bin/sh'
 
       - name: Add CNAME for custom domain
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/install.sh
+++ b/install.sh
@@ -291,8 +291,8 @@ compare_tags() {
         printf 'equal'
         return 0
     fi
-    # Lexicographic tiebreaker via sort; POSIX `sort` supports -C (silent
-    # order check; exit 0 iff already sorted). First line is the "smaller".
+    # Lexicographic tiebreaker: feed both pre-release strings through
+    # `LC_ALL=C sort` and take the first line — that is the "smaller" one.
     _first="$(printf '%s\n%s\n' "${_a_pre}" "${_b_pre}" | LC_ALL=C sort | head -n1)"
     if [ "${_first}" = "${_a_pre}" ]; then
         printf 'older'
@@ -454,7 +454,7 @@ main() {
     # Print the three facts operators want to see before any download.
     say "target:  ${TARGET}"
     say "tarball: ${_url}"
-    say "install: ${_install_path}"
+    say "install path: ${_install_path}"
 
     # Upgrade-vs-fresh decision (FR-2.5). Only matters when a binary is
     # already present at ${_install_path}.

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,581 @@
+#!/bin/sh
+# aimx install script — POSIX sh (dash / busybox compatible).
+#
+# Usage:
+#   curl -fsSL https://aimx.email/install.sh | sh
+#   curl -fsSL https://aimx.email/install.sh | sh -s -- --tag v1.2.3
+#
+# Modelled on `just.systems/install.sh` — `say` / `err` / `need` / `download`
+# helper idioms, no bashisms, HTTPS-only trust anchor. Implements PRD
+# onboarding FR-2.1–2.9 (see docs/onboarding-prd.md).
+
+set -eu
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+GITHUB_REPO="uzyn/aimx"
+GITHUB_API="https://api.github.com/repos/${GITHUB_REPO}/releases"
+GITHUB_DL="https://github.com/${GITHUB_REPO}/releases/download"
+DEFAULT_PREFIX="/usr/local/bin"
+UNSUPPORTED_DOC="https://aimx.email/book/installation.html#unsupported-platforms"
+
+# ---------------------------------------------------------------------------
+# Helpers (say / err / need / download)
+# ---------------------------------------------------------------------------
+
+say() {
+    printf 'install: %s\n' "$1" >&2
+}
+
+verbose() {
+    if [ "${AIMX_VERBOSE:-0}" = "1" ]; then
+        printf 'install: %s\n' "$1" >&2
+    fi
+}
+
+err() {
+    printf 'install: error: %s\n' "$1" >&2
+    cleanup
+    exit 1
+}
+
+need() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        err "required command not found: $1"
+    fi
+}
+
+# Create temp dir and arm cleanup trap. Safe on every exit path.
+_td=""
+cleanup() {
+    if [ -n "${_td}" ] && [ -d "${_td}" ]; then
+        rm -rf "${_td}"
+        _td=""
+    fi
+}
+
+# download <url> <path>
+#   Prefers curl; falls back to wget. Refuses non-HTTPS URLs. Honors
+#   GITHUB_TOKEN for api.github.com calls so rate-limited CI runs succeed.
+download() {
+    _url="$1"
+    _dst="$2"
+    case "${_url}" in
+        https://*) : ;;
+        *) err "refusing non-HTTPS URL: ${_url}" ;;
+    esac
+    _auth_hdr=""
+    case "${_url}" in
+        https://api.github.com/*)
+            if [ -n "${GITHUB_TOKEN:-}" ]; then
+                _auth_hdr="Authorization: Bearer ${GITHUB_TOKEN}"
+            fi
+            ;;
+    esac
+    verbose "GET ${_url}"
+    if command -v curl >/dev/null 2>&1; then
+        if [ -n "${_auth_hdr}" ]; then
+            curl --proto '=https' --tlsv1.2 -fsSL -H "${_auth_hdr}" \
+                -o "${_dst}" "${_url}"
+        else
+            curl --proto '=https' --tlsv1.2 -fsSL -o "${_dst}" "${_url}"
+        fi
+    elif command -v wget >/dev/null 2>&1; then
+        if [ -n "${_auth_hdr}" ]; then
+            wget --https-only -q --header="${_auth_hdr}" \
+                -O "${_dst}" "${_url}"
+        else
+            wget --https-only -q -O "${_dst}" "${_url}"
+        fi
+    else
+        err "need curl or wget on PATH"
+    fi
+}
+
+help() {
+    cat <<'EOF'
+aimx install script
+
+USAGE:
+    install.sh [FLAGS]
+
+FLAGS:
+    -h, --help               Print this help and exit
+        --tag <VERSION>      Install a specific release tag (e.g. v1.2.3);
+                             overrides AIMX_VERSION env var
+        --target <TRIPLE>    Override target auto-detection
+                             (x86_64-unknown-linux-gnu,
+                              aarch64-unknown-linux-gnu,
+                              x86_64-unknown-linux-musl,
+                              aarch64-unknown-linux-musl)
+        --to <DIR>           Install binary into DIR (default /usr/local/bin);
+                             overrides AIMX_PREFIX env var
+        --force              Re-install even if target version already present
+
+ENVIRONMENT:
+    AIMX_VERSION             Release tag to install (e.g. v1.2.3)
+    AIMX_PREFIX              Install directory (default /usr/local/bin)
+    AIMX_DRY_RUN=1           Print every step without downloading or installing
+    AIMX_VERBOSE=1           Trace HTTP requests and filesystem actions
+    GITHUB_TOKEN             Token for rate-limited GitHub API calls
+
+EXAMPLES:
+    # Latest stable into /usr/local/bin
+    curl -fsSL https://aimx.email/install.sh | sh
+
+    # Pin a specific tag
+    curl -fsSL https://aimx.email/install.sh | sh -s -- --tag v1.2.3
+
+    # Dry-run: see what would happen without installing
+    curl -fsSL https://aimx.email/install.sh | AIMX_DRY_RUN=1 sh
+
+Trust anchor is HTTPS on the GitHub Releases domain. No signature or
+checksum verification in this script; skeptical operators can verify
+manually via the 'curl + sha256sum -c' block in the release notes.
+EOF
+}
+
+# ---------------------------------------------------------------------------
+# Platform detection
+# ---------------------------------------------------------------------------
+
+detect_os() {
+    _os="$(uname -s)"
+    case "${_os}" in
+        Linux) printf 'linux' ;;
+        *)
+            err "aimx is Linux-only; detected ${_os}. See ${UNSUPPORTED_DOC}"
+            ;;
+    esac
+}
+
+detect_arch() {
+    _arch="$(uname -m)"
+    case "${_arch}" in
+        x86_64 | amd64) printf 'x86_64' ;;
+        aarch64 | arm64) printf 'aarch64' ;;
+        *)
+            err "unsupported CPU architecture: ${_arch}. See ${UNSUPPORTED_DOC}"
+            ;;
+    esac
+}
+
+detect_libc() {
+    # Presence of a musl dynamic loader under /lib/ld-musl-* signals musl.
+    # Otherwise assume glibc — aimx only ships gnu + musl Linux builds.
+    for _musl in /lib/ld-musl-* /lib64/ld-musl-*; do
+        if [ -e "${_musl}" ]; then
+            printf 'musl'
+            return 0
+        fi
+    done
+    printf 'gnu'
+}
+
+compose_target() {
+    _arch="$1"
+    _libc="$2"
+    printf '%s-unknown-linux-%s' "${_arch}" "${_libc}"
+}
+
+# ---------------------------------------------------------------------------
+# Version resolution
+# ---------------------------------------------------------------------------
+
+# resolve_latest_tag
+#   Fetch https://api.github.com/repos/uzyn/aimx/releases/latest, pluck the
+#   "tag_name" value with grep + sed. Deliberately does NOT use jq — matches
+#   the just.systems installer.
+resolve_latest_tag() {
+    _body="${_td}/release.json"
+    download "${GITHUB_API}/latest" "${_body}"
+    _tag="$(grep -m1 '"tag_name":' "${_body}" \
+        | sed -E 's/.*"tag_name":[[:space:]]*"([^"]+)".*/\1/')"
+    if [ -z "${_tag}" ]; then
+        err "could not parse tag_name from GitHub latest-release response"
+    fi
+    printf '%s' "${_tag}"
+}
+
+# Strip the leading "v" from a tag (v1.2.3 -> 1.2.3) since tarball asset
+# names embed the bare version per release.yml (FR-1.2).
+tag_to_version() {
+    printf '%s' "$1" | sed 's/^v//'
+}
+
+# ---------------------------------------------------------------------------
+# Running-binary version parsing (upgrade path)
+# ---------------------------------------------------------------------------
+
+# parse_installed_tag <bin-path>
+#   Runs <bin-path> --version and extracts the second whitespace-separated
+#   token, matching the Sprint 2 format:
+#     aimx <tag> (<git-sha>) <target-triple> built <date>
+#   Returns empty string on any failure.
+parse_installed_tag() {
+    _bin="$1"
+    if [ ! -x "${_bin}" ]; then
+        return 0
+    fi
+    # Capture stdout only; a binary that aborts on --version prints nothing
+    # here and we treat that as "unknown version" (falls through to install).
+    _out="$("${_bin}" --version 2>/dev/null || true)"
+    if [ -z "${_out}" ]; then
+        return 0
+    fi
+    # Expect the literal "aimx" prefix. If not, treat as unknown.
+    case "${_out}" in
+        aimx\ *) : ;;
+        *) return 0 ;;
+    esac
+    # Second whitespace-separated token is the tag.
+    printf '%s' "${_out}" | awk '{print $2}'
+}
+
+# Compare two SemVer-ish tags. Prints "older" / "equal" / "newer" describing
+# the relationship of $1 relative to $2 (i.e. is $1 older/equal/newer than
+# $2?). Strips the leading "v" and compares dot-separated numeric segments
+# pairwise; any pre-release suffix (-rc1, -fixture) is compared
+# lexicographically *only* as a tiebreaker (pre-release < release per
+# SemVer). Good enough for the install-script upgrade heuristic; the real
+# Sprint 4 `aimx upgrade` uses a proper crate.
+compare_tags() {
+    _a="$(tag_to_version "$1")"
+    _b="$(tag_to_version "$2")"
+
+    _a_core="$(printf '%s' "${_a}" | sed 's/[-+].*//')"
+    _b_core="$(printf '%s' "${_b}" | sed 's/[-+].*//')"
+    _a_pre="$(printf '%s' "${_a}" | sed -n 's/^[^-]*-\(.*\)$/\1/p')"
+    _b_pre="$(printf '%s' "${_b}" | sed -n 's/^[^-]*-\(.*\)$/\1/p')"
+
+    # Pad to three segments.
+    _a1="$(printf '%s' "${_a_core}" | cut -d. -f1)"
+    _a2="$(printf '%s' "${_a_core}" | cut -d. -f2)"
+    _a3="$(printf '%s' "${_a_core}" | cut -d. -f3)"
+    _b1="$(printf '%s' "${_b_core}" | cut -d. -f1)"
+    _b2="$(printf '%s' "${_b_core}" | cut -d. -f2)"
+    _b3="$(printf '%s' "${_b_core}" | cut -d. -f3)"
+    : "${_a1:=0}" "${_a2:=0}" "${_a3:=0}"
+    : "${_b1:=0}" "${_b2:=0}" "${_b3:=0}"
+
+    for _pair in "${_a1} ${_b1}" "${_a2} ${_b2}" "${_a3} ${_b3}"; do
+        # shellcheck disable=SC2086
+        set -- ${_pair}
+        if [ "$1" -lt "$2" ]; then
+            printf 'older'
+            return 0
+        fi
+        if [ "$1" -gt "$2" ]; then
+            printf 'newer'
+            return 0
+        fi
+    done
+
+    # Cores equal. Apply pre-release tiebreaker: no-pre > has-pre; if both
+    # have pre, compare strings.
+    if [ -z "${_a_pre}" ] && [ -z "${_b_pre}" ]; then
+        printf 'equal'
+        return 0
+    fi
+    if [ -z "${_a_pre}" ] && [ -n "${_b_pre}" ]; then
+        printf 'newer'
+        return 0
+    fi
+    if [ -n "${_a_pre}" ] && [ -z "${_b_pre}" ]; then
+        printf 'older'
+        return 0
+    fi
+    if [ "${_a_pre}" = "${_b_pre}" ]; then
+        printf 'equal'
+        return 0
+    fi
+    # Lexicographic tiebreaker via sort; POSIX `sort` supports -C (silent
+    # order check; exit 0 iff already sorted). First line is the "smaller".
+    _first="$(printf '%s\n%s\n' "${_a_pre}" "${_b_pre}" | LC_ALL=C sort | head -n1)"
+    if [ "${_first}" = "${_a_pre}" ]; then
+        printf 'older'
+    else
+        printf 'newer'
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Service control (upgrade path)
+# ---------------------------------------------------------------------------
+
+stop_service() {
+    if command -v systemctl >/dev/null 2>&1; then
+        if systemctl is-active --quiet aimx 2>/dev/null; then
+            verbose "systemctl stop aimx"
+            systemctl stop aimx || err "systemctl stop aimx failed"
+            printf 'systemd'
+            return 0
+        fi
+        return 0
+    fi
+    if command -v rc-service >/dev/null 2>&1; then
+        verbose "rc-service aimx stop"
+        rc-service aimx stop 2>/dev/null || true
+        printf 'openrc'
+        return 0
+    fi
+    say "warning: no systemd or OpenRC detected; skipping service stop"
+    printf 'unknown'
+}
+
+start_service() {
+    _init="$1"
+    case "${_init}" in
+        systemd)
+            verbose "systemctl start aimx"
+            systemctl start aimx
+            ;;
+        openrc)
+            verbose "rc-service aimx start"
+            rc-service aimx start
+            ;;
+        unknown)
+            say "warning: unrecognized init system; not starting aimx.service"
+            ;;
+    esac
+}
+
+# ---------------------------------------------------------------------------
+# Install / upgrade
+# ---------------------------------------------------------------------------
+
+TAG=""
+TARGET=""
+PREFIX=""
+FORCE=0
+DRY_RUN="${AIMX_DRY_RUN:-0}"
+
+parse_args() {
+    while [ "$#" -gt 0 ]; do
+        case "$1" in
+            -h | --help)
+                help
+                exit 0
+                ;;
+            --tag)
+                [ "$#" -ge 2 ] || err "--tag requires a value"
+                TAG="$2"
+                shift 2
+                ;;
+            --tag=*)
+                TAG="${1#--tag=}"
+                shift
+                ;;
+            --target)
+                [ "$#" -ge 2 ] || err "--target requires a value"
+                TARGET="$2"
+                shift 2
+                ;;
+            --target=*)
+                TARGET="${1#--target=}"
+                shift
+                ;;
+            --to)
+                [ "$#" -ge 2 ] || err "--to requires a value"
+                PREFIX="$2"
+                shift 2
+                ;;
+            --to=*)
+                PREFIX="${1#--to=}"
+                shift
+                ;;
+            --force)
+                FORCE=1
+                shift
+                ;;
+            *)
+                err "unknown argument: $1 (try --help)"
+                ;;
+        esac
+    done
+}
+
+main() {
+    parse_args "$@"
+
+    # Env-var defaults (flags already win).
+    if [ -z "${TAG}" ] && [ -n "${AIMX_VERSION:-}" ]; then
+        TAG="${AIMX_VERSION}"
+    fi
+    if [ -z "${PREFIX}" ] && [ -n "${AIMX_PREFIX:-}" ]; then
+        PREFIX="${AIMX_PREFIX}"
+    fi
+    if [ -z "${PREFIX}" ]; then
+        PREFIX="${DEFAULT_PREFIX}"
+    fi
+
+    # Platform detection.
+    detect_os >/dev/null
+    if [ -z "${TARGET}" ]; then
+        _arch="$(detect_arch)"
+        _libc="$(detect_libc)"
+        TARGET="$(compose_target "${_arch}" "${_libc}")"
+    fi
+    case "${TARGET}" in
+        x86_64-unknown-linux-gnu | aarch64-unknown-linux-gnu \
+            | x86_64-unknown-linux-musl | aarch64-unknown-linux-musl) : ;;
+        *)
+            err "unsupported target triple: ${TARGET}. See ${UNSUPPORTED_DOC}"
+            ;;
+    esac
+
+    need uname
+    need tar
+    need mkdir
+    need rm
+    need install
+    need awk
+    need sed
+    need grep
+
+    # Temp dir for downloads.
+    _td="$(mktemp -d 2>/dev/null || mktemp -d -t aimx-install)"
+    [ -d "${_td}" ] || err "mktemp failed"
+    trap cleanup EXIT INT TERM
+
+    # Resolve tag.
+    if [ -z "${TAG}" ]; then
+        say "resolving latest release from ${GITHUB_API}/latest"
+        TAG="$(resolve_latest_tag)"
+    fi
+    _version="$(tag_to_version "${TAG}")"
+
+    _asset="aimx-${_version}-${TARGET}.tar.gz"
+    _url="${GITHUB_DL}/${TAG}/${_asset}"
+    _install_path="${PREFIX}/aimx"
+
+    # Print the three facts operators want to see before any download.
+    say "target:  ${TARGET}"
+    say "tarball: ${_url}"
+    say "install: ${_install_path}"
+
+    # Upgrade-vs-fresh decision (FR-2.5). Only matters when a binary is
+    # already present at ${_install_path}.
+    _installed_tag=""
+    _is_upgrade=0
+    if [ -x "${_install_path}" ]; then
+        _installed_tag="$(parse_installed_tag "${_install_path}")"
+        if [ -n "${_installed_tag}" ]; then
+            _cmp="$(compare_tags "${_installed_tag}" "${TAG}")"
+            case "${_cmp}" in
+                equal)
+                    if [ "${FORCE}" -ne 1 ]; then
+                        say "aimx ${_installed_tag} is already installed (pass --force to re-install)"
+                        exit 0
+                    fi
+                    say "re-installing ${TAG} (--force)"
+                    _is_upgrade=1
+                    ;;
+                newer)
+                    err "installed ${_installed_tag} is newer than target ${TAG}; run 'aimx upgrade --version ${TAG} --force' to downgrade explicitly"
+                    ;;
+                older)
+                    say "upgrading ${_installed_tag} -> ${TAG}"
+                    _is_upgrade=1
+                    ;;
+            esac
+        else
+            # Binary present but --version unparseable. Treat as upgrade
+            # so the service-aware swap path runs.
+            say "existing binary at ${_install_path} did not report a parseable version; proceeding as upgrade"
+            _is_upgrade=1
+        fi
+    fi
+
+    if [ "${DRY_RUN}" = "1" ]; then
+        say "dry-run: would download ${_url}"
+        say "dry-run: would extract tarball under ${_td}"
+        if [ "${_is_upgrade}" -eq 1 ]; then
+            say "dry-run: would stop aimx.service, swap binary, restart"
+        else
+            say "dry-run: would install to ${_install_path}"
+        fi
+        say "dry-run: no filesystem changes made"
+        exit 0
+    fi
+
+    # For the upgrade path and writes to system dirs, enforce root.
+    _euid="$(id -u 2>/dev/null || echo 0)"
+    if [ "${_is_upgrade}" -eq 1 ] && [ "${_euid}" -ne 0 ]; then
+        err "upgrade path needs root to stop aimx.service and write to ${PREFIX}; re-run with sudo"
+    fi
+    if [ ! -d "${PREFIX}" ]; then
+        # Try to create it. If we can't, surface a clear error.
+        if ! mkdir -p "${PREFIX}" 2>/dev/null; then
+            err "install prefix ${PREFIX} does not exist and cannot be created (re-run with sudo, or use --to)"
+        fi
+    fi
+    if [ ! -w "${PREFIX}" ]; then
+        err "install prefix ${PREFIX} is not writable (re-run with sudo, or use --to)"
+    fi
+
+    # Download + extract.
+    _tarball="${_td}/${_asset}"
+    say "downloading ${_asset}"
+    download "${_url}" "${_tarball}"
+    verbose "extracting ${_tarball}"
+    (cd "${_td}" && tar -xzf "${_asset}") || err "tar extract failed"
+    _staged="${_td}/aimx-${_version}-${TARGET}/aimx"
+    if [ ! -x "${_staged}" ]; then
+        err "extracted tarball missing executable aimx at expected path"
+    fi
+
+    if [ "${_is_upgrade}" -eq 1 ]; then
+        _init="$(stop_service)"
+        _prev="${_install_path}.prev"
+
+        # Preserve the existing binary at .prev.
+        if [ -f "${_install_path}" ]; then
+            if ! mv -f "${_install_path}" "${_prev}"; then
+                say "✗ failed to preserve ${_install_path} as ${_prev}"
+                start_service "${_init}"
+                err "aborting upgrade; previous binary still in place"
+            fi
+        fi
+
+        # Install new binary.
+        if ! install -m 0755 "${_staged}" "${_install_path}"; then
+            # Rollback.
+            say "✗ install failed; rolling back"
+            if [ -f "${_prev}" ]; then
+                mv -f "${_prev}" "${_install_path}" || true
+            fi
+            start_service "${_init}"
+            err "upgrade failed at install step; service restored"
+        fi
+
+        # Start service.
+        if ! start_service "${_init}"; then
+            say "✗ service start failed; rolling back"
+            if [ -f "${_prev}" ]; then
+                mv -f "${_prev}" "${_install_path}" || true
+                start_service "${_init}" || true
+            fi
+            err "upgrade failed at start step; service restored if possible"
+        fi
+
+        if [ -n "${_installed_tag}" ]; then
+            say "aimx ${_installed_tag} -> ${TAG}. Service restarted."
+        else
+            say "aimx installed at ${TAG}. Service restarted."
+        fi
+        say "upgrade complete. Run 'aimx doctor' for health."
+        exit 0
+    fi
+
+    # Fresh install.
+    install -m 0755 "${_staged}" "${_install_path}" \
+        || err "install failed writing ${_install_path}"
+
+    say "✓ aimx ${TAG} installed to ${_install_path}"
+    say "→ next: sudo aimx setup"
+}
+
+main "$@"

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,5 +1,6 @@
-DIST   := dist
-PIGEON := ../etc/aimx-pigeon.svg
+DIST    := dist
+PIGEON  := ../etc/aimx-pigeon.svg
+INSTALL := ../install.sh
 
 .PHONY: build serve clean
 
@@ -9,6 +10,12 @@ build:
 	mkdir -p $(DIST)/assets
 	cp -R public/. $(DIST)/
 	cp $(PIGEON) $(DIST)/assets/aimx-pigeon.svg
+	# Publish the installer at https://aimx.email/install.sh so the
+	# curl-to-shell one-liner (PRD FR-2.8) has a canonical URL. GitHub
+	# Pages serves files under their on-disk extension; `.sh` resolves
+	# to `application/x-sh` by default, which is correct for
+	# `curl | sh`.
+	cp $(INSTALL) $(DIST)/install.sh
 
 serve: build
 	@echo ""

--- a/website/public/index.html
+++ b/website/public/index.html
@@ -421,12 +421,10 @@ footer a:hover {
 
     <section class="block fade d6">
       <h2 class="section-label">Quick start</h2>
-<pre class="code">git clone https://github.com/uzyn/aimx.git &amp;&amp; cd aimx
-cargo build --release
-sudo cp target/release/aimx /usr/local/bin/
+<pre class="code">curl -fsSL https://aimx.email/install.sh | sh
 sudo aimx setup</pre>
       <p class="prose" style="margin-top: 1.1em;">
-        You need sudo — port 25 is privileged. A VPS with port 25 open (inbound and outbound) and a domain you control are the only requirements.
+        You need sudo — port 25 is privileged. A VPS with port 25 open (inbound and outbound) and a domain you control are the only requirements. Want to see the script before running it? <a href="/install.sh">Read <code>install.sh</code></a>.
       </p>
     </section>
 


### PR DESCRIPTION
## Summary

Ships `install.sh` at the repo root — POSIX `sh` (dash + busybox compatible), modelled on [`just.systems/install.sh`](https://just.systems/install.sh). Operators run `curl -fsSL https://aimx.email/install.sh | sh` and get a binary at `/usr/local/bin/aimx` with no Rust toolchain required. Re-runs on a box with an older binary perform the stop/swap/start upgrade dance without invoking the setup wizard. Trust anchor for v1 is HTTPS on the GitHub Releases domain — no checksum or signature verification in the script itself (PRD FR-2.4 / §9 Out of Scope).

- **S3-1** — fresh-install path: platform detection (Linux-only, x86_64/aarch64 × gnu/musl), `--tag` / `--target` / `--to` / `--force` flags, `AIMX_VERSION` / `AIMX_PREFIX` / `AIMX_DRY_RUN` / `GITHUB_TOKEN` env vars, `say` / `err` / `need` / `download` / `help` helper idioms, pre-download target+URL+path print, trap-based `$TMPDIR` cleanup on every exit path, HTTPS-enforced `download` helper.
- **S3-2** — upgrade path: parses installed `--version` (Sprint 2 format), SemVer-ish comparison, equal = short-circuit (bypass with `--force`), installed-newer = refuse with explicit `aimx upgrade … --force` hint, installed-older = stop service → swap → start, rollback on any failure, `aimx.prev` preserved. Requires root for the upgrade branch; refuses clearly otherwise. Systemd and OpenRC both detected.
- **S3-3** — CI + hosting: new `install-sh` CI job runs `shellcheck`, `dash -n`, `busybox sh -n`, a `--help` parse, dry-runs under dash, and full fresh installs under `alpine:latest` (busybox sh, musl) and `debian:stable-slim` (dash) against the real `v0.0.0-fixture` release. `website/Makefile` copies `install.sh` into `dist/`, and `site.yml` triggers on `install.sh` changes + verifies the deployed copy parses as `sh -n`. Landing page's Quick Start swapped to `curl … | sh` with a link to read the raw script first.

## Per-story AC status

### S3-1 — `install.sh` fresh-install path

- [x] `install.sh` at repo root; passes `shellcheck` with no warnings
- [x] Helper fns `say`, `err`, `need`, `download`, `help` all exist; `just`-shaped
- [x] Refuses non-Linux with a single `err` + non-zero exit; message names the OS and links `book/installation.html#unsupported-platforms`
- [x] `download` refuses non-HTTPS URLs with a clear error
- [x] Target-triple composition correct for all four supported combinations (exercised via the Docker matrix — S3-3)
- [x] Pre-download output: target triple, tarball URL, and install path printed to stderr via `say`
- [x] Fresh install lands a runnable `aimx` at `/usr/local/bin/aimx`; `aimx --version` reports the correct tag + target (verified locally against `v0.0.0-fixture`; CI repeats this under alpine + debian)
- [x] Success banner: `✓ aimx <tag> installed to <path>` + `→ sudo aimx setup`; does not auto-run the wizard
- [x] Flags work: `--help`, `--tag`, `--target`, `--to`, `--force` (also `--tag=…` / `--target=…` / `--to=…` shapes)
- [x] Env vars work: `AIMX_VERSION`, `AIMX_PREFIX`, `AIMX_DRY_RUN=1`, `GITHUB_TOKEN`, `AIMX_VERBOSE=1`
- [x] `AIMX_DRY_RUN=1` prints every step to stderr without downloading or installing anything; exits 0
- [x] Temp-dir cleanup on every exit path (trap `EXIT INT TERM`; verified via before/after `/tmp` count)

### S3-2 — `install.sh` upgrade path

- [x] Detects existing binary; parses version via `<installed> --version` (second whitespace token of the Sprint 2 format)
- [x] Same-version install: "already installed" + exits 0 unless `--force`
- [x] Downgrade refused with the explicit `aimx upgrade --version … --force` hint (verified locally: installing `v0.0.0-fixture` over a `0.1.0`-reporting binary refuses correctly)
- [ ] Upgrade happy path on a live VPS fixture — deferred to Sprint 3 live-validation (same pattern as Sprint 1.1). CI exercises the fresh-install half end-to-end; the stop/swap/start upgrade sequence requires a real `systemctl`-managed aimx.service, which the Docker matrix does not model.
- [x] Systemd + OpenRC both supported: detected via `command -v systemctl` / `command -v rc-service`; unknown init systems warn and skip service restart
- [x] Rollback on failure between stop and start (implemented — tested by code review; live smoke defers to Sprint 3 validation)
- [x] Non-root upgrade refused clearly (root required for service stop + write to `/usr/local/bin/`)
- [x] Temp-dir cleanup holds on the upgrade path (same trap)

### S3-3 — `install.sh` CI + aimx.email hosting

- [x] `.github/workflows/ci.yml` gained an `install-sh` job running `shellcheck install.sh` + dash + busybox parse + container installs under `alpine:latest` and `debian:stable-slim`
- [x] Five of the six requested test paths exercised (two shells × three scenarios — see **Deferred** below for the sixth)
- [x] `site.yml` publishes `install.sh` to `https://aimx.email/install.sh`; the Makefile copies it into `dist/`. GitHub Pages' default `.sh` handling serves `application/x-sh`; the AC's `Content-Type: text/x-sh; charset=utf-8` is not directly configurable on Pages (AC names this limitation explicitly). File lands at the canonical path.
- [ ] Manual end-to-end VPS smoke test (real x86_64 + aarch64 hardware) deferred to Sprint 3 live-validation (`docs/onboarding-smoke-results.md` will be authored then, mirroring the Sprint 1.1 pattern)
- [x] Landing page links the raw script (Quick Start section; "Read `install.sh`" link)

## Deferred

- **SHA-256 fail-path test in CI.** The sprint AC listed a "checksum-fail" scenario; PRD FR-2.4 (authoritative) explicitly says no checksum verification in `install.sh` v1. The script has nothing to fail, so there is no path to exercise. If the next sprint adds checksum support, add the test with it.
- **Live VPS smoke test** (S3-2 upgrade happy-path on real systemd + S3-3 manual x86_64 + aarch64 VPS runs). Same pattern as Sprint 1.1 — hardware-gated, done by a human, results logged under `docs/onboarding-smoke-results.md`.
- **`Content-Type: text/x-sh; charset=utf-8` header** on the served `install.sh`. GitHub Pages serves `.sh` as `application/x-sh` by default; Pages does not expose the header config surface to flip it. The file lands at the canonical URL, which is what matters for `curl | sh`. Noted in the S3-3 AC row.

## Test plan

- [x] `shellcheck install.sh` clean
- [x] `dash -n install.sh` and `busybox sh -n install.sh` clean
- [x] `actionlint .github/workflows/*.yml` clean
- [x] `cargo fmt -- --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test` all green (no Rust surface changed, nothing should regress)
- [x] Manual smoke: `AIMX_DRY_RUN=1 install.sh --tag v0.0.0-fixture --to /tmp/aimx-dry` prints target + URL + path without writing
- [x] Manual smoke: real fresh install from `v0.0.0-fixture` to `/tmp/aimx-dry` — binary lands, `--version` runs
- [x] Manual smoke: re-run over installed `0.1.0` with `--tag v0.0.0-fixture` refuses as downgrade with the explicit hint
- [ ] CI run on the PR (the new `install-sh` job will exercise the alpine + debian containers against `v0.0.0-fixture`)
- [ ] Live VPS test on x86_64 + aarch64 Debian/Ubuntu (post-merge, human-executed, logged to `docs/onboarding-smoke-results.md`)