### PR TITLE
[Onboarding Sprint 4] aimx upgrade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,20 @@ jobs:
             mailbox_delete_force_without_yes_prompts_and_aborts_on_n \
             concurrent_mailbox_create_and_ingest_does_not_deadlock
 
+      # Sprint 4 review NB-1: drives `RealReleaseOps::fetch_asset`
+      # end-to-end against the live `v0.0.0-fixture` release. The
+      # non-root test in `tests/release_integration.rs` only asserts
+      # the root-check refusal; this sudo-gated step is what actually
+      # exercises the rustls + HTTPS production path in CI so a
+      # regression in `fetch_asset` or the rustls-provider install
+      # surfaces here.
+      - name: Run release end-to-end integration test (root)
+        run: |
+          sudo -E env "PATH=$PATH" AIMX_INTEGRATION_SUDO=1 \
+            cargo test --features integration --test release_integration -- \
+            --ignored --exact \
+            real_release_ops_end_to_end_against_fixture_as_root
+
       # Sprint 8 S8-4: end-to-end agent flow test. Creates a real
       # system user, runs `aimx setup`-style config + DKIM keys, then
       # `aimx agent-setup claude-code` with a fake `claude` binary,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -51,6 +51,7 @@ dependencies = [
  "clap",
  "colored",
  "dialoguer",
+ "flate2",
  "glob-match",
  "hickory-resolver 0.25.2",
  "html2text",
@@ -76,6 +77,7 @@ dependencies = [
  "serial_test",
  "sha2",
  "syn",
+ "tar",
  "tempfile",
  "tokio",
  "tokio-rustls",
@@ -713,6 +715,17 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
 
 [[package]]
 name = "find-msvc-tools"
@@ -1383,6 +1396,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1673,7 +1698,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1790,6 +1815,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "portable-atomic"
@@ -2015,6 +2046,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]
@@ -2532,6 +2572,17 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
+
+[[package]]
+name = "tar"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22692a6476a21fa75fdfc11d452fda482af402c008cdbaf3476414e122040973"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
 
 [[package]]
 name = "tempfile"
@@ -3373,6 +3424,16 @@ name = "writeable"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "yasna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,7 +70,6 @@ flate2 = { version = "1", default-features = false, features = ["rust_backend"] 
 tempfile = "3"
 
 [dev-dependencies]
-tempfile = "3"
 assert_cmd = "2"
 predicates = "3"
 wait-timeout = "0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,18 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter"] }
 dialoguer = { version = "0.11", default-features = false }
 ureq = { version = "3", default-features = false, features = ["rustls-no-provider", "rustls-webpki-roots", "gzip", "json"] }
+# `aimx upgrade` (Sprint 4) extracts release tarballs produced by
+# `.github/workflows/release.yml`. The shape is well-known (a flat
+# `aimx-<version>-<target>/` directory with the `aimx` binary), so the
+# upgrade path only needs gzip + basic tar extraction — no rollback,
+# no symlink handling. `tar` + `flate2` are the obvious minimal deps.
+tar = "0.4"
+flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
+# `aimx upgrade` stages the extracted tarball in a tempdir before
+# atomically swapping the binary into place. Pulled into runtime deps
+# (not just dev-deps) so `run_upgrade` can call `tempfile::tempdir`
+# directly rather than re-implementing tempdir cleanup by hand.
+tempfile = "3"
 
 [dev-dependencies]
 tempfile = "3"
@@ -86,3 +98,10 @@ serde_json = "1"
 # feature shape used by the main crate so we don't link a second
 # crypto backend.
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "std"] }
+# Dev-only: the Sprint 4 addendum test in
+# `tests/release_integration.rs` uses `libc::geteuid` to detect whether
+# the integration test is running as root; in that case it drives the
+# real `aimx upgrade --dry-run` path end-to-end against the fixture
+# release, exercising `RealReleaseOps::fetch_asset` with the full TLS
+# wiring (addresses the backlog item from the Sprint 2 review).
+libc = "0.2"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -206,6 +206,36 @@ pub enum Command {
         #[arg(long)]
         force: bool,
     },
+
+    /// Fetch the latest release and swap the installed binary. Requires root.
+    ///
+    /// Compares the running tag to the release manifest and, if a newer
+    /// version exists, downloads the target-matching tarball, stops the
+    /// `aimx.service`, atomically swaps the binary (preserving the old
+    /// one at `<install_path>.prev`), and restarts the service. Any
+    /// failure between stop and final start rolls back to the previous
+    /// binary. Never runs the setup wizard, never prompts.
+    Upgrade(UpgradeArgs),
+}
+
+#[derive(clap::Args, Clone, Debug)]
+pub struct UpgradeArgs {
+    /// Print what would happen (current → target version, tarball URL,
+    /// install path, action list) without touching the service or
+    /// writing to `/usr/local/bin`. Exits 0 on "would proceed" and on
+    /// "already up to date"; non-zero only on download failure.
+    #[arg(long)]
+    pub dry_run: bool,
+
+    /// Target a specific release tag (downgrade path). When omitted,
+    /// `aimx upgrade` resolves the latest release from the manifest.
+    #[arg(long, value_name = "TAG")]
+    pub version: Option<String>,
+
+    /// Re-install the current tag (useful for repair) or the specified
+    /// `--version` tag. Bypasses the up-to-date short-circuit.
+    #[arg(long)]
+    pub force: bool,
 }
 
 #[derive(clap::Args, Clone)]

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1866,6 +1866,12 @@ mod tests {
         fn restart_service(&self, _service: &str) -> Result<(), Box<dyn std::error::Error>> {
             unreachable!("gather_status must not touch restart_service")
         }
+        fn stop_service(&self, _service: &str) -> Result<(), Box<dyn std::error::Error>> {
+            unreachable!("gather_status must not touch stop_service")
+        }
+        fn start_service(&self, _service: &str) -> Result<(), Box<dyn std::error::Error>> {
+            unreachable!("gather_status must not touch start_service")
+        }
         fn is_service_running(&self, service: &str) -> bool {
             assert_eq!(service, "aimx", "status must query the aimx service");
             self.running

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -112,6 +112,12 @@ mod tests {
         fn restart_service(&self, _service: &str) -> Result<(), Box<dyn std::error::Error>> {
             unreachable!("logs::run must not touch restart_service")
         }
+        fn stop_service(&self, _service: &str) -> Result<(), Box<dyn std::error::Error>> {
+            unreachable!("logs::run must not touch stop_service")
+        }
+        fn start_service(&self, _service: &str) -> Result<(), Box<dyn std::error::Error>> {
+            unreachable!("logs::run must not touch start_service")
+        }
         fn is_service_running(&self, _service: &str) -> bool {
             unreachable!("logs::run must not touch is_service_running")
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,6 +41,7 @@ mod uds_authz;
 // item still surfaces.
 mod release;
 mod uninstall;
+mod upgrade;
 mod user_resolver;
 mod version;
 
@@ -116,6 +117,20 @@ fn dispatch(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         // `aimx logs` is a thin wrapper around journalctl; it does not
         // read config.toml.
         Command::Logs { lines, follow } => logs::run(lines, follow),
+        // `aimx upgrade` reads the release-manifest URL from Config
+        // (optional `[upgrade] release_manifest_url`) but tolerates a
+        // missing / unloadable config — a freshly-installed machine
+        // that never ran `aimx setup` should still be able to upgrade.
+        Command::Upgrade(args) => {
+            let config = config::Config::load_resolved_ignore_warnings().ok();
+            let manifest_url = config
+                .as_ref()
+                .and_then(|c| c.upgrade.as_ref())
+                .and_then(|u| u.release_manifest_url.clone());
+            let release = release::RealReleaseOps::new(manifest_url);
+            let sys = setup::RealSystemOps;
+            upgrade::run(args, &release, &sys)
+        }
         // Everything else loads Config once here and takes it by value.
         // For long-lived processes (`aimx serve`, `aimx doctor`) we log
         // startup warnings via `tracing` so orphan mailboxes / templates
@@ -170,7 +185,8 @@ fn dispatch_with_config(
         | Command::Send(_)
         | Command::Logs { .. }
         | Command::AgentSetup { .. }
-        | Command::AgentCleanup { .. } => unreachable!("handled by dispatch"),
+        | Command::AgentCleanup { .. }
+        | Command::Upgrade(_) => unreachable!("handled by dispatch"),
     }
 }
 

--- a/src/portcheck.rs
+++ b/src/portcheck.rs
@@ -274,6 +274,12 @@ mod tests {
         fn restart_service(&self, _service: &str) -> Result<(), Box<dyn std::error::Error>> {
             Ok(())
         }
+        fn stop_service(&self, _service: &str) -> Result<(), Box<dyn std::error::Error>> {
+            unreachable!("portcheck::run must not touch stop_service")
+        }
+        fn start_service(&self, _service: &str) -> Result<(), Box<dyn std::error::Error>> {
+            unreachable!("portcheck::run must not touch start_service")
+        }
         fn is_service_running(&self, _service: &str) -> bool {
             false
         }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1050,6 +1050,62 @@ pub mod service {
         }
     }
 
+    /// Pure dispatch table for `stop_service`: returns the `(program,
+    /// args)` the real implementation will invoke. Split out so the
+    /// systemd-vs-OpenRC routing can be unit-tested without shelling out.
+    /// Used by `aimx upgrade` (Sprint 4) to express the strict stop →
+    /// swap → start sequence that `restart_service` alone can't.
+    pub fn stop_service_command(
+        init: &InitSystem,
+        service: &str,
+    ) -> Option<(&'static str, Vec<String>)> {
+        match init {
+            InitSystem::Systemd => Some((
+                "sudo",
+                vec![
+                    "systemctl".to_string(),
+                    "stop".to_string(),
+                    service.to_string(),
+                ],
+            )),
+            InitSystem::OpenRC => Some((
+                "sudo",
+                vec![
+                    "rc-service".to_string(),
+                    service.to_string(),
+                    "stop".to_string(),
+                ],
+            )),
+            InitSystem::Unknown => None,
+        }
+    }
+
+    /// Pure dispatch table for `start_service`: the `stop` complement.
+    pub fn start_service_command(
+        init: &InitSystem,
+        service: &str,
+    ) -> Option<(&'static str, Vec<String>)> {
+        match init {
+            InitSystem::Systemd => Some((
+                "sudo",
+                vec![
+                    "systemctl".to_string(),
+                    "start".to_string(),
+                    service.to_string(),
+                ],
+            )),
+            InitSystem::OpenRC => Some((
+                "sudo",
+                vec![
+                    "rc-service".to_string(),
+                    service.to_string(),
+                    "start".to_string(),
+                ],
+            )),
+            InitSystem::Unknown => None,
+        }
+    }
+
     /// Pure dispatch table for `is_service_running`: returns the `(program,
     /// args)` to probe the service's running state.
     pub fn is_service_running_command(
@@ -1403,6 +1459,44 @@ mod tests {
     #[test]
     fn restart_service_unknown_init_returns_none() {
         assert!(restart_service_command(&InitSystem::Unknown, "aimx").is_none());
+    }
+
+    #[test]
+    fn stop_service_systemd_dispatch() {
+        let (prog, args) = stop_service_command(&InitSystem::Systemd, "aimx").unwrap();
+        assert_eq!(prog, "sudo");
+        assert_eq!(args, vec!["systemctl", "stop", "aimx"]);
+    }
+
+    #[test]
+    fn stop_service_openrc_dispatch() {
+        let (prog, args) = stop_service_command(&InitSystem::OpenRC, "aimx").unwrap();
+        assert_eq!(prog, "sudo");
+        assert_eq!(args, vec!["rc-service", "aimx", "stop"]);
+    }
+
+    #[test]
+    fn stop_service_unknown_init_returns_none() {
+        assert!(stop_service_command(&InitSystem::Unknown, "aimx").is_none());
+    }
+
+    #[test]
+    fn start_service_systemd_dispatch() {
+        let (prog, args) = start_service_command(&InitSystem::Systemd, "aimx").unwrap();
+        assert_eq!(prog, "sudo");
+        assert_eq!(args, vec!["systemctl", "start", "aimx"]);
+    }
+
+    #[test]
+    fn start_service_openrc_dispatch() {
+        let (prog, args) = start_service_command(&InitSystem::OpenRC, "aimx").unwrap();
+        assert_eq!(prog, "sudo");
+        assert_eq!(args, vec!["rc-service", "aimx", "start"]);
+    }
+
+    #[test]
+    fn start_service_unknown_init_returns_none() {
+        assert!(start_service_command(&InitSystem::Unknown, "aimx").is_none());
     }
 
     #[test]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -24,18 +24,17 @@ pub trait SystemOps {
     /// shutdown and startup. Idempotent w.r.t. the real init system:
     /// a stop call on an already-stopped service is not an error.
     ///
-    /// Default impl panics — unrelated mocks in the tree don't need to
-    /// implement this. The Sprint 4 `aimx upgrade` path uses
-    /// [`MockSystemOps`] in `setup::tests` which overrides it.
-    fn stop_service(&self, _service: &str) -> Result<(), Box<dyn std::error::Error>> {
-        Err("stop_service not implemented for this SystemOps impl".into())
-    }
+    /// Required trait method — every `SystemOps` impl must provide it.
+    /// Test mocks in modules that never reach the upgrade path
+    /// (`doctor.rs`, `logs.rs`, `portcheck.rs`, `uninstall.rs`) are
+    /// expected to `unreachable!()` here; a future sprint that teaches
+    /// those modules to stop/start the service will then surface a
+    /// clear panic rather than a silent `Err` string.
+    fn stop_service(&self, service: &str) -> Result<(), Box<dyn std::error::Error>>;
     /// Complement of `stop_service`. Not idempotent — starting an
     /// already-started service surfaces as an error from both systemd
-    /// and OpenRC.
-    fn start_service(&self, _service: &str) -> Result<(), Box<dyn std::error::Error>> {
-        Err("start_service not implemented for this SystemOps impl".into())
-    }
+    /// and OpenRC. Required trait method; see `stop_service` above.
+    fn start_service(&self, service: &str) -> Result<(), Box<dyn std::error::Error>>;
     fn is_service_running(&self, service: &str) -> bool;
     fn generate_tls_cert(
         &self,
@@ -2216,10 +2215,18 @@ pub(crate) mod tests {
         /// If set, `stop_service` returns an error. Used to exercise the
         /// "stop failed, nothing to roll back" branch.
         pub(crate) stop_service_fails: bool,
-        /// If set, `start_service` returns an error. Used to exercise
-        /// both the normal start-failure rollback path and the
-        /// rollback-failed-to-start path.
+        /// If set (sticky), every `start_service` call returns an error.
+        /// Used to exercise the "start failed, rollback's own start
+        /// also fails" path that yields `UpgradeError::RollbackFailed`.
         pub(crate) start_service_fails: bool,
+        /// Number of upcoming `start_service` calls that must fail
+        /// before subsequent calls succeed. Takes precedence over
+        /// `start_service_fails` when non-zero. Set to `1` to drive the
+        /// canonical `RolledBack { failed_step: StartService }` path:
+        /// the upgrade's `start_service` call fails, rollback's own
+        /// `start_service` call succeeds, and the service is left
+        /// running on the previous binary.
+        pub(crate) start_service_failures_remaining: std::cell::Cell<u32>,
     }
 
     impl Default for MockSystemOps {
@@ -2242,6 +2249,7 @@ pub(crate) mod tests {
                 override_aimx_binary_path: None,
                 stop_service_fails: false,
                 start_service_fails: false,
+                start_service_failures_remaining: std::cell::Cell::new(0),
             }
         }
     }
@@ -2271,6 +2279,11 @@ pub(crate) mod tests {
         }
         fn start_service(&self, service: &str) -> Result<(), Box<dyn std::error::Error>> {
             self.started_services.borrow_mut().push(service.to_string());
+            let remaining = self.start_service_failures_remaining.get();
+            if remaining > 0 {
+                self.start_service_failures_remaining.set(remaining - 1);
+                return Err("mock start failure (scheduled)".into());
+            }
             if self.start_service_fails {
                 return Err("mock start failure".into());
             }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -18,6 +18,24 @@ pub trait SystemOps {
     fn write_file(&self, path: &Path, content: &str) -> Result<(), Box<dyn std::error::Error>>;
     fn file_exists(&self, path: &Path) -> bool;
     fn restart_service(&self, service: &str) -> Result<(), Box<dyn std::error::Error>>;
+    /// Stop the service. `aimx upgrade` requires this split
+    /// (stop → swap → start) because `restart_service` alone can't
+    /// express a pause window where the binary swap happens between
+    /// shutdown and startup. Idempotent w.r.t. the real init system:
+    /// a stop call on an already-stopped service is not an error.
+    ///
+    /// Default impl panics — unrelated mocks in the tree don't need to
+    /// implement this. The Sprint 4 `aimx upgrade` path uses
+    /// [`MockSystemOps`] in `setup::tests` which overrides it.
+    fn stop_service(&self, _service: &str) -> Result<(), Box<dyn std::error::Error>> {
+        Err("stop_service not implemented for this SystemOps impl".into())
+    }
+    /// Complement of `stop_service`. Not idempotent — starting an
+    /// already-started service surfaces as an error from both systemd
+    /// and OpenRC.
+    fn start_service(&self, _service: &str) -> Result<(), Box<dyn std::error::Error>> {
+        Err("start_service not implemented for this SystemOps impl".into())
+    }
     fn is_service_running(&self, service: &str) -> bool;
     fn generate_tls_cert(
         &self,
@@ -304,6 +322,34 @@ impl SystemOps for RealSystemOps {
         let status = std::process::Command::new(program).args(&args).status()?;
         if !status.success() {
             return Err(format!("Failed to restart {service}").into());
+        }
+        Ok(())
+    }
+
+    fn stop_service(&self, service: &str) -> Result<(), Box<dyn std::error::Error>> {
+        use crate::serve::service::{detect_init_system, stop_service_command};
+
+        let init = detect_init_system();
+        let (program, args) = stop_service_command(&init, service).ok_or_else(|| {
+            format!("Could not detect init system (systemd or OpenRC) to stop {service}.")
+        })?;
+        let status = std::process::Command::new(program).args(&args).status()?;
+        if !status.success() {
+            return Err(format!("Failed to stop {service}").into());
+        }
+        Ok(())
+    }
+
+    fn start_service(&self, service: &str) -> Result<(), Box<dyn std::error::Error>> {
+        use crate::serve::service::{detect_init_system, start_service_command};
+
+        let init = detect_init_system();
+        let (program, args) = start_service_command(&init, service).ok_or_else(|| {
+            format!("Could not detect init system (systemd or OpenRC) to start {service}.")
+        })?;
+        let status = std::process::Command::new(program).args(&args).status()?;
+        if !status.success() {
+            return Err(format!("Failed to start {service}").into());
         }
         Ok(())
     }
@@ -2071,7 +2117,7 @@ fn run_port25_preflight(net: &dyn NetworkOps) -> Result<(), Box<dyn std::error::
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
     use crate::mailbox;
     use std::cell::RefCell;
@@ -2134,29 +2180,46 @@ mod tests {
         }
     }
 
-    struct MockSystemOps {
-        written_files: RefCell<HashMap<PathBuf, String>>,
-        existing_files: HashMap<PathBuf, String>,
-        restarted_services: RefCell<Vec<String>>,
-        service_file_installed: RefCell<bool>,
-        is_root: bool,
-        port25_status: Port25Status,
-        service_running: bool,
-        service_ready: bool,
-        wait_for_ready_calls: RefCell<u32>,
+    pub(crate) struct MockSystemOps {
+        pub(crate) written_files: RefCell<HashMap<PathBuf, String>>,
+        pub(crate) existing_files: HashMap<PathBuf, String>,
+        pub(crate) restarted_services: RefCell<Vec<String>>,
+        /// Ordered list of services passed to `stop_service`. Used by
+        /// the Sprint 4 `aimx upgrade` tests to assert the stop → swap
+        /// → start sequence.
+        pub(crate) stopped_services: RefCell<Vec<String>>,
+        /// Ordered list of services passed to `start_service`.
+        pub(crate) started_services: RefCell<Vec<String>>,
+        pub(crate) service_file_installed: RefCell<bool>,
+        pub(crate) is_root: bool,
+        pub(crate) port25_status: Port25Status,
+        pub(crate) service_running: bool,
+        pub(crate) service_ready: bool,
+        pub(crate) wait_for_ready_calls: RefCell<u32>,
         /// Set of existing users (for `user_exists`) — mutable to simulate
         /// a `create_system_user` call creating the user.
-        existing_users: RefCell<std::collections::HashSet<String>>,
+        pub(crate) existing_users: RefCell<std::collections::HashSet<String>>,
         /// Ordered list of `(user, home)` pairs passed to
         /// `create_system_user`. Sprint 3 renames the helper's caller
         /// from `ensure_hook_user` to `ensure_catchall_user`; tests
         /// assert both the user name AND its home-dir arg.
-        created_users: RefCell<Vec<(String, PathBuf)>>,
+        pub(crate) created_users: RefCell<Vec<(String, PathBuf)>>,
         /// Ordered list of `(path, owner, group, mode)` tuples passed to
         /// `ensure_owned_directory`. Sprint 3 replaces the recursive
         /// `chown_group_readable` with a single-path, explicit-mode
         /// helper scoped to the `aimx-catchall` home dir.
-        owned_dirs: RefCell<Vec<(PathBuf, String, String, u32)>>,
+        pub(crate) owned_dirs: RefCell<Vec<(PathBuf, String, String, u32)>>,
+        /// Override for [`SystemOps::get_aimx_binary_path`] so the Sprint 4
+        /// `aimx upgrade` tests can route the swap through a tempdir
+        /// instead of the real `/usr/local/bin/aimx`.
+        pub(crate) override_aimx_binary_path: Option<PathBuf>,
+        /// If set, `stop_service` returns an error. Used to exercise the
+        /// "stop failed, nothing to roll back" branch.
+        pub(crate) stop_service_fails: bool,
+        /// If set, `start_service` returns an error. Used to exercise
+        /// both the normal start-failure rollback path and the
+        /// rollback-failed-to-start path.
+        pub(crate) start_service_fails: bool,
     }
 
     impl Default for MockSystemOps {
@@ -2165,6 +2228,8 @@ mod tests {
                 written_files: RefCell::new(HashMap::new()),
                 existing_files: HashMap::new(),
                 restarted_services: RefCell::new(vec![]),
+                stopped_services: RefCell::new(vec![]),
+                started_services: RefCell::new(vec![]),
                 service_file_installed: RefCell::new(false),
                 is_root: true,
                 port25_status: Port25Status::Free,
@@ -2174,6 +2239,9 @@ mod tests {
                 existing_users: RefCell::new(std::collections::HashSet::new()),
                 created_users: RefCell::new(vec![]),
                 owned_dirs: RefCell::new(vec![]),
+                override_aimx_binary_path: None,
+                stop_service_fails: false,
+                start_service_fails: false,
             }
         }
     }
@@ -2194,6 +2262,20 @@ mod tests {
                 .push(service.to_string());
             Ok(())
         }
+        fn stop_service(&self, service: &str) -> Result<(), Box<dyn std::error::Error>> {
+            self.stopped_services.borrow_mut().push(service.to_string());
+            if self.stop_service_fails {
+                return Err("mock stop failure".into());
+            }
+            Ok(())
+        }
+        fn start_service(&self, service: &str) -> Result<(), Box<dyn std::error::Error>> {
+            self.started_services.borrow_mut().push(service.to_string());
+            if self.start_service_fails {
+                return Err("mock start failure".into());
+            }
+            Ok(())
+        }
         fn is_service_running(&self, _service: &str) -> bool {
             self.service_running
         }
@@ -2205,7 +2287,10 @@ mod tests {
             Ok(())
         }
         fn get_aimx_binary_path(&self) -> Result<PathBuf, Box<dyn std::error::Error>> {
-            Ok(PathBuf::from("/usr/local/bin/aimx"))
+            Ok(self
+                .override_aimx_binary_path
+                .clone()
+                .unwrap_or_else(|| PathBuf::from("/usr/local/bin/aimx")))
         }
         fn check_root(&self) -> bool {
             self.is_root

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -83,6 +83,12 @@ mod tests {
         fn restart_service(&self, _s: &str) -> Result<(), Box<dyn std::error::Error>> {
             Ok(())
         }
+        fn stop_service(&self, _s: &str) -> Result<(), Box<dyn std::error::Error>> {
+            unreachable!("uninstall::run must not touch stop_service")
+        }
+        fn start_service(&self, _s: &str) -> Result<(), Box<dyn std::error::Error>> {
+            unreachable!("uninstall::run must not touch start_service")
+        }
         fn is_service_running(&self, _s: &str) -> bool {
             false
         }

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -1,0 +1,1081 @@
+//! `aimx upgrade` — single-verb binary self-update (PRD §6.4, FR-4.1–4.6).
+//!
+//! # Flow (happy path)
+//!
+//! 1. Root check (FR-4.1).
+//! 2. Resolve the target manifest: `--version <tag>` → `release_by_tag`,
+//!    else `latest_release`. Compare its tag against
+//!    [`crate::version::release_tag`]. Equal and no `--force` → print
+//!    "up to date" and exit.
+//! 3. Resolve the install path from `/proc/self/exe` (handles
+//!    `AIMX_PREFIX=/opt/aimx` installs) and look up the target-specific
+//!    tarball asset in the manifest using [`crate::version::target_triple`].
+//! 4. Fetch the tarball bytes (HTTPS-only; trust anchor is the GitHub
+//!    Releases domain per PRD §7).
+//! 5. Dry-run short-circuit: if `--dry-run`, print the preview and exit.
+//! 6. Extract the tarball into a fresh `tempfile::tempdir`; verify it
+//!    contains an executable `aimx-<version>-<target>/aimx`.
+//! 7. Stop the service; atomically swap the binary (preserving the old
+//!    one at `<install_path>.prev`); start the service; poll port 25
+//!    for readiness.
+//! 8. On any step failure between stop and the final start-ready poll,
+//!    roll back by restoring `.prev` and starting the service again,
+//!    then return [`UpgradeError::RolledBack`].
+//!
+//! # Trust model
+//!
+//! No checksum or signature verification on the default path (PRD §9).
+//! HTTPS on the GitHub Releases domain is the v1 trust anchor.
+//! [`crate::release::verify_sha256`] remains available for operator-run
+//! `sha256sum -c` workflows against the published `SHA256SUMS` asset.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use crate::cli::UpgradeArgs;
+use crate::release::{ReleaseError, ReleaseManifest, ReleaseOps};
+use crate::setup::SystemOps;
+use crate::term;
+use crate::version;
+
+/// Service name the upgrade flow drives. Matches `install_service_file`
+/// in `src/setup.rs`.
+pub const SERVICE_NAME: &str = "aimx";
+
+/// Named steps of the upgrade flow. [`UpgradeReport`] records each
+/// step the real flow executed so tests can assert the full sequence
+/// and [`UpgradeError::RolledBack`] can name the failing one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum UpgradeStep {
+    ResolveManifest,
+    CompareTag,
+    FetchTarball,
+    ExtractTarball,
+    StopService,
+    PreserveOldBinary,
+    InstallNewBinary,
+    StartService,
+    WaitForReady,
+}
+
+impl std::fmt::Display for UpgradeStep {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::ResolveManifest => "resolve manifest",
+            Self::CompareTag => "compare tag",
+            Self::FetchTarball => "fetch tarball",
+            Self::ExtractTarball => "extract tarball",
+            Self::StopService => "stop service",
+            Self::PreserveOldBinary => "preserve old binary",
+            Self::InstallNewBinary => "install new binary",
+            Self::StartService => "start service",
+            Self::WaitForReady => "wait for service ready",
+        };
+        f.write_str(s)
+    }
+}
+
+/// Outcome of a successful / dry-run / up-to-date invocation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome {
+    /// Running tag already matches the target tag and `--force` was not
+    /// set. No fetches, no writes.
+    UpToDate,
+    /// `--dry-run` exercised resolve + fetch, then stopped.
+    DryRun,
+    /// Full swap completed; service restarted.
+    Upgraded,
+}
+
+/// What the upgrade run did, in order, for testability.
+#[derive(Debug, Default, Clone)]
+pub struct UpgradeReport {
+    pub steps: Vec<UpgradeStep>,
+    pub current_tag: String,
+    pub target_tag: String,
+    pub tarball_url: Option<String>,
+    pub install_path: Option<PathBuf>,
+    pub outcome: Option<Outcome>,
+}
+
+impl UpgradeReport {
+    fn record(&mut self, step: UpgradeStep) {
+        self.steps.push(step);
+    }
+}
+
+#[derive(Debug)]
+#[allow(clippy::enum_variant_names)]
+pub enum UpgradeError {
+    /// Invoked by a non-root user.
+    NotRoot,
+    /// Release manifest / tarball fetch / parse failure (pre-swap).
+    /// Surfaces the underlying [`ReleaseError`] so operators see the
+    /// HTTP status or transport cause directly.
+    Release(ReleaseError),
+    /// Filesystem or process error that did not reach the stop-service
+    /// step. Nothing to roll back. Tarball-shape mismatches land here
+    /// with [`UpgradeStep::ExtractTarball`].
+    PreSwap { step: UpgradeStep, cause: String },
+    /// Failure after `stop_service` succeeded. The service was restored
+    /// onto the previous binary (best effort) before this error was
+    /// returned. Tests assert on the failed step; the CLI renders it
+    /// as `✗ <step>: <cause>` + a rollback hint line.
+    RolledBack {
+        failed_step: UpgradeStep,
+        cause: String,
+        previous_tag: String,
+    },
+    /// The rollback itself failed — service may be in an indeterminate
+    /// state. Operator must intervene.
+    RollbackFailed {
+        original_step: UpgradeStep,
+        original_cause: String,
+        rollback_step: UpgradeStep,
+        rollback_cause: String,
+    },
+}
+
+impl std::fmt::Display for UpgradeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::NotRoot => write!(f, "aimx upgrade requires root"),
+            Self::Release(e) => write!(f, "{e}"),
+            Self::PreSwap { step, cause } => write!(f, "{step}: {cause}"),
+            Self::RolledBack {
+                failed_step,
+                cause,
+                previous_tag,
+            } => write!(f, "{failed_step}: {cause}; rolled back to {previous_tag}"),
+            Self::RollbackFailed {
+                original_step,
+                original_cause,
+                rollback_step,
+                rollback_cause,
+            } => write!(
+                f,
+                "{original_step}: {original_cause}; rollback failed at {rollback_step}: {rollback_cause}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for UpgradeError {}
+
+impl From<ReleaseError> for UpgradeError {
+    fn from(e: ReleaseError) -> Self {
+        UpgradeError::Release(e)
+    }
+}
+
+/// Entry point for the `aimx upgrade` subcommand wired up in `main.rs`.
+/// Prints progress / result lines to stdout via [`term`] helpers and
+/// returns a boxed error so the existing `dispatch` loop surfaces it
+/// uniformly with every other subcommand.
+pub fn run(
+    args: UpgradeArgs,
+    release: &dyn ReleaseOps,
+    sys: &dyn SystemOps,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let report = run_upgrade(&args, release, sys).map_err(render_error)?;
+    print_result(&report);
+    Ok(())
+}
+
+fn render_error(e: UpgradeError) -> Box<dyn std::error::Error> {
+    if let UpgradeError::RolledBack {
+        failed_step,
+        cause,
+        previous_tag,
+    } = &e
+    {
+        eprintln!("{} {failed_step}: {cause}", term::error("✗"));
+        eprintln!("→ rolled back to {previous_tag}; check logs with 'aimx logs'",);
+    }
+    Box::new(e)
+}
+
+fn print_result(report: &UpgradeReport) {
+    match report.outcome {
+        Some(Outcome::UpToDate) => {
+            println!(
+                "{} aimx {} is up to date.",
+                term::success("✓"),
+                term::highlight(&report.current_tag)
+            );
+        }
+        Some(Outcome::DryRun) => {
+            // Dry-run preview lines are already printed by run_upgrade.
+        }
+        Some(Outcome::Upgraded) => {
+            println!(
+                "{} aimx {} → {}. Service restarted.",
+                term::success("✓"),
+                term::highlight(&report.current_tag),
+                term::highlight(&report.target_tag)
+            );
+        }
+        None => {}
+    }
+}
+
+/// Core upgrade flow. Pure enough to unit-test with [`MockReleaseOps`]
+/// + `MockSystemOps`; prints operator-facing progress via [`term`].
+pub fn run_upgrade(
+    args: &UpgradeArgs,
+    release: &dyn ReleaseOps,
+    sys: &dyn SystemOps,
+) -> Result<UpgradeReport, UpgradeError> {
+    let mut report = UpgradeReport {
+        current_tag: version::release_tag().to_string(),
+        ..Default::default()
+    };
+
+    if !sys.check_root() {
+        return Err(UpgradeError::NotRoot);
+    }
+
+    // Step 1: resolve the target manifest.
+    report.record(UpgradeStep::ResolveManifest);
+    let manifest = match args.version.as_deref() {
+        Some(tag) => release.release_by_tag(tag)?,
+        None => release.latest_release()?,
+    };
+    report.target_tag = manifest.tag.clone();
+
+    // Step 2: compare tags.
+    report.record(UpgradeStep::CompareTag);
+    if !args.force && manifest.tag == report.current_tag {
+        report.outcome = Some(Outcome::UpToDate);
+        return Ok(report);
+    }
+
+    // Step 3: resolve the binary path + the matching tarball asset URL.
+    let install_path = resolve_install_path(sys)?;
+    report.install_path = Some(install_path.clone());
+    let target = version::target_triple();
+    let tarball_name = tarball_filename(&manifest.tag, target);
+    let tarball_url = manifest
+        .asset_url(&tarball_name)
+        .map_err(UpgradeError::Release)?
+        .to_string();
+    report.tarball_url = Some(tarball_url.clone());
+
+    // Step 4: fetch the tarball bytes.
+    report.record(UpgradeStep::FetchTarball);
+    let tarball_bytes = release.fetch_asset(&tarball_url)?;
+
+    // Dry-run stops here with an operator-facing preview.
+    if args.dry_run {
+        print_dry_run_preview(&report, &manifest, &tarball_url, &install_path);
+        report.outcome = Some(Outcome::DryRun);
+        return Ok(report);
+    }
+
+    // Step 5: extract to a temp dir and locate the staged binary.
+    report.record(UpgradeStep::ExtractTarball);
+    let extract_dir = tempfile::tempdir().map_err(|e| UpgradeError::PreSwap {
+        step: UpgradeStep::ExtractTarball,
+        cause: format!("create tempdir: {e}"),
+    })?;
+    let staged = extract_tarball(&tarball_bytes, extract_dir.path(), &manifest.tag, target)
+        .map_err(|cause| UpgradeError::PreSwap {
+            step: UpgradeStep::ExtractTarball,
+            cause,
+        })?;
+
+    // Step 6: stop → swap → start, with rollback.
+    report.record(UpgradeStep::StopService);
+    sys.stop_service(SERVICE_NAME)
+        .map_err(|e| UpgradeError::PreSwap {
+            step: UpgradeStep::StopService,
+            cause: e.to_string(),
+        })?;
+
+    // From here on, any failure must attempt rollback.
+    let prev_path = prev_path(&install_path);
+
+    // Preserve old binary at <install_path>.prev. `rename` is atomic on
+    // the same filesystem; tempdir is under /tmp which may not be the
+    // same fs as /usr/local/bin, so we stage via a sibling rename.
+    if let Err(e) = preserve_previous_binary(&install_path, &prev_path) {
+        return attempt_rollback(
+            sys,
+            &install_path,
+            &prev_path,
+            UpgradeStep::PreserveOldBinary,
+            e,
+            &report.current_tag,
+        );
+    }
+    report.record(UpgradeStep::PreserveOldBinary);
+
+    if let Err(e) = install_binary_result(&staged, &install_path) {
+        return attempt_rollback(
+            sys,
+            &install_path,
+            &prev_path,
+            UpgradeStep::InstallNewBinary,
+            e,
+            &report.current_tag,
+        );
+    }
+    report.record(UpgradeStep::InstallNewBinary);
+
+    if let Err(e) = sys.start_service(SERVICE_NAME) {
+        return attempt_rollback(
+            sys,
+            &install_path,
+            &prev_path,
+            UpgradeStep::StartService,
+            e.to_string(),
+            &report.current_tag,
+        );
+    }
+    report.record(UpgradeStep::StartService);
+
+    if !sys.wait_for_service_ready() {
+        return attempt_rollback(
+            sys,
+            &install_path,
+            &prev_path,
+            UpgradeStep::WaitForReady,
+            "service did not reach ready state within timeout".to_string(),
+            &report.current_tag,
+        );
+    }
+    report.record(UpgradeStep::WaitForReady);
+
+    report.outcome = Some(Outcome::Upgraded);
+    Ok(report)
+}
+
+/// Derive the upgrade target path from `/proc/self/exe`. `AIMX_PREFIX`
+/// installs (e.g. `/opt/aimx/bin/aimx`) resolve here correctly without
+/// a hardcoded fallback. Canonicalisation resolves `aimx → aimx.prev`
+/// symlinks or a future `/usr/local/bin/aimx → /opt/aimx/bin/aimx`
+/// redirection so the upgrade swaps the real file rather than the link.
+pub fn resolve_install_path(sys: &dyn SystemOps) -> Result<PathBuf, UpgradeError> {
+    let raw = sys
+        .get_aimx_binary_path()
+        .map_err(|e| UpgradeError::PreSwap {
+            step: UpgradeStep::ResolveManifest,
+            cause: format!("resolve current executable: {e}"),
+        })?;
+    // If the binary is a symlink (rare; install.sh uses `install -m`
+    // which writes a real file), follow it so we swap the target.
+    let canonical = std::fs::canonicalize(&raw).unwrap_or(raw);
+    Ok(canonical)
+}
+
+/// Standard tarball filename per PRD FR-1.2: `aimx-<version>-<target>.tar.gz`.
+/// The leading `v` is stripped from the tag — `v1.2.3` → version `1.2.3` —
+/// matching `.github/workflows/release.yml`.
+pub fn tarball_filename(tag: &str, target: &str) -> String {
+    let version = tag.strip_prefix('v').unwrap_or(tag);
+    format!("aimx-{version}-{target}.tar.gz")
+}
+
+/// Expected directory inside the tarball (flat layout produced by the
+/// release pipeline). Kept as a separate helper for testability.
+pub fn tarball_inner_dir(tag: &str, target: &str) -> String {
+    let version = tag.strip_prefix('v').unwrap_or(tag);
+    format!("aimx-{version}-{target}")
+}
+
+fn prev_path(install_path: &Path) -> PathBuf {
+    let mut s = install_path.as_os_str().to_os_string();
+    s.push(".prev");
+    PathBuf::from(s)
+}
+
+/// Extract `bytes` (a gzipped tar) into `dest_dir` and return the path
+/// to the staged `aimx` binary inside `aimx-<version>-<target>/`.
+/// Returns a [`String`] error message so the caller can wrap it in a
+/// [`UpgradeError::PreSwap`] / [`UpgradeError::InvalidTarball`].
+pub fn extract_tarball(
+    bytes: &[u8],
+    dest_dir: &Path,
+    tag: &str,
+    target: &str,
+) -> Result<PathBuf, String> {
+    let decoder = flate2::read::GzDecoder::new(bytes);
+    let mut archive = tar::Archive::new(decoder);
+    archive
+        .unpack(dest_dir)
+        .map_err(|e| format!("tar extract: {e}"))?;
+
+    let inner = dest_dir.join(tarball_inner_dir(tag, target));
+    let staged = inner.join("aimx");
+    if !staged.exists() {
+        return Err(format!(
+            "tarball missing executable at {}/aimx",
+            inner.display()
+        ));
+    }
+
+    // Verify the staged binary is readable + non-empty. We don't try to
+    // execute it here — that would bypass the swap-then-start rollback
+    // guarantees below.
+    let meta = fs::metadata(&staged).map_err(|e| format!("stat staged binary: {e}"))?;
+    if !meta.is_file() || meta.len() == 0 {
+        return Err("staged binary is empty or not a regular file".to_string());
+    }
+    Ok(staged)
+}
+
+/// Move the currently-installed binary to `<install_path>.prev`. Uses
+/// `rename` for atomicity on the same filesystem. If the install path
+/// does not exist (fresh install on a path-not-yet-written machine),
+/// returns `Ok(())` — there is nothing to preserve.
+fn preserve_previous_binary(install_path: &Path, prev_path: &Path) -> Result<(), String> {
+    if !install_path.exists() {
+        return Ok(());
+    }
+    // Remove any stale .prev from a prior upgrade before renaming.
+    if prev_path.exists() {
+        fs::remove_file(prev_path)
+            .map_err(|e| format!("remove stale {}: {e}", prev_path.display()))?;
+    }
+    fs::rename(install_path, prev_path).map_err(|e| {
+        format!(
+            "rename {} → {}: {e}",
+            install_path.display(),
+            prev_path.display()
+        )
+    })
+}
+
+/// Install the staged binary at `install_path` with mode `0755`. Uses a
+/// sibling temp file + `rename` so a crash mid-write leaves either the
+/// previous binary (in `.prev`) or the new one — never a partial write.
+fn install_binary(staged: &Path, install_path: &Path) -> String {
+    // Copy staged → sibling of install_path so the rename is same-fs.
+    let parent = match install_path.parent() {
+        Some(p) => p,
+        None => {
+            return format!(
+                "install path {} has no parent directory",
+                install_path.display()
+            );
+        }
+    };
+    let tmp = parent.join(".aimx.upgrade.tmp");
+    if let Err(e) = fs::copy(staged, &tmp) {
+        return format!("copy staged → {}: {e}", tmp.display());
+    }
+    if let Err(e) = set_executable(&tmp) {
+        let _ = fs::remove_file(&tmp);
+        return format!("chmod 0755 {}: {e}", tmp.display());
+    }
+    if let Err(e) = fs::rename(&tmp, install_path) {
+        let _ = fs::remove_file(&tmp);
+        return format!("rename {} → {}: {e}", tmp.display(), install_path.display());
+    }
+    String::new()
+}
+
+/// Wrapper that turns [`install_binary`]'s `String` (empty = OK) into
+/// a `Result`. The empty-string convention lets the caller keep the
+/// rollback branches flat.
+fn install_binary_result(staged: &Path, install_path: &Path) -> Result<(), String> {
+    let err = install_binary(staged, install_path);
+    if err.is_empty() { Ok(()) } else { Err(err) }
+}
+
+#[cfg(unix)]
+fn set_executable(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    let mut perms = fs::metadata(path)?.permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms)
+}
+
+#[cfg(not(unix))]
+fn set_executable(_path: &Path) -> std::io::Result<()> {
+    Ok(())
+}
+
+/// Attempt to restore `<install_path>.prev` → `<install_path>` and
+/// start the service back up. Always returns `Err` — either the
+/// rollback succeeded (→ [`UpgradeError::RolledBack`]) or it didn't
+/// (→ [`UpgradeError::RollbackFailed`]).
+fn attempt_rollback(
+    sys: &dyn SystemOps,
+    install_path: &Path,
+    prev_path: &Path,
+    failed_step: UpgradeStep,
+    cause: String,
+    previous_tag: &str,
+) -> Result<UpgradeReport, UpgradeError> {
+    // If .prev exists, try to restore it. A .prev may not exist if
+    // preservation itself failed or we never got that far — in that
+    // case we just attempt to start the service on whatever is there.
+    if prev_path.exists() {
+        // Drop any partially-installed new binary so the rename can
+        // land on a clean slot.
+        if install_path.exists()
+            && let Err(e) = fs::remove_file(install_path)
+        {
+            return Err(UpgradeError::RollbackFailed {
+                original_step: failed_step,
+                original_cause: cause,
+                rollback_step: UpgradeStep::PreserveOldBinary,
+                rollback_cause: format!("remove {}: {e}", install_path.display()),
+            });
+        }
+        if let Err(e) = fs::rename(prev_path, install_path) {
+            return Err(UpgradeError::RollbackFailed {
+                original_step: failed_step,
+                original_cause: cause,
+                rollback_step: UpgradeStep::PreserveOldBinary,
+                rollback_cause: format!(
+                    "rename {} → {}: {e}",
+                    prev_path.display(),
+                    install_path.display()
+                ),
+            });
+        }
+    }
+
+    // Best-effort start. `RolledBack` is the success case for the
+    // rollback itself — the operator's service is running again, just
+    // on the old binary.
+    if let Err(e) = sys.start_service(SERVICE_NAME) {
+        return Err(UpgradeError::RollbackFailed {
+            original_step: failed_step,
+            original_cause: cause,
+            rollback_step: UpgradeStep::StartService,
+            rollback_cause: e.to_string(),
+        });
+    }
+
+    Err(UpgradeError::RolledBack {
+        failed_step,
+        cause,
+        previous_tag: previous_tag.to_string(),
+    })
+}
+
+/// Print the dry-run preview (FR-4.2). The exact wording is matched by
+/// the integration tests, so changes here must sync with those.
+fn print_dry_run_preview(
+    report: &UpgradeReport,
+    manifest: &ReleaseManifest,
+    tarball_url: &str,
+    install_path: &Path,
+) {
+    println!("{}", term::header("aimx upgrade (dry-run)"));
+    println!("  current: {}", term::highlight(&report.current_tag));
+    println!("  target:  {}", term::highlight(&manifest.tag));
+    println!("  tarball: {tarball_url}");
+    println!("  install path: {}", install_path.display());
+    println!("  actions (would run): stop {SERVICE_NAME} → swap binary → start {SERVICE_NAME}");
+    println!(
+        "{}",
+        term::dim("(dry-run: no service or filesystem changes)")
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Hooks used by unit tests in tests/ (re-exported through a test-only
+// wrapper so tests can call install_binary_result without duplicating the
+// rename machinery).
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(dead_code)]
+pub(crate) fn test_install_binary(staged: &Path, install_path: &Path) -> Result<(), String> {
+    install_binary_result(staged, install_path)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+#[allow(clippy::field_reassign_with_default)]
+mod tests {
+    use super::*;
+    use crate::cli::UpgradeArgs;
+    use crate::release::ReleaseManifest;
+    use crate::release::mock::MockReleaseOps;
+    use crate::setup::tests::MockSystemOps;
+    use std::io::Write;
+    use tempfile::TempDir;
+
+    fn current_target() -> &'static str {
+        version::target_triple()
+    }
+
+    fn make_manifest(tag: &str, asset_names: &[&str]) -> ReleaseManifest {
+        let asset_urls = asset_names
+            .iter()
+            .map(|n| ((*n).to_string(), format!("https://example.invalid/{n}")))
+            .collect();
+        ReleaseManifest {
+            tag: tag.to_string(),
+            published_at: "2026-04-20T00:00:00Z".to_string(),
+            asset_urls,
+        }
+    }
+
+    /// Build a minimal well-formed `aimx-<version>-<target>/aimx` tarball
+    /// (a placeholder binary) as gzipped bytes.
+    fn make_tarball(tag: &str, target: &str, body: &[u8]) -> Vec<u8> {
+        let version = tag.strip_prefix('v').unwrap_or(tag);
+        let inner = format!("aimx-{version}-{target}");
+        let mut gz = flate2::write::GzEncoder::new(Vec::new(), flate2::Compression::default());
+        {
+            let mut builder = tar::Builder::new(&mut gz);
+            let mut header = tar::Header::new_gnu();
+            header.set_path(format!("{inner}/aimx")).unwrap();
+            header.set_size(body.len() as u64);
+            header.set_mode(0o755);
+            header.set_cksum();
+            builder.append(&header, body).unwrap();
+            builder.finish().unwrap();
+        }
+        gz.finish().unwrap()
+    }
+
+    fn args_default() -> UpgradeArgs {
+        UpgradeArgs {
+            dry_run: false,
+            version: None,
+            force: false,
+        }
+    }
+
+    fn write_fake_binary(dir: &Path) -> PathBuf {
+        let path = dir.join("aimx");
+        let mut f = std::fs::File::create(&path).unwrap();
+        f.write_all(b"#!/bin/sh\nexit 0\n").unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let mut p = std::fs::metadata(&path).unwrap().permissions();
+            p.set_mode(0o755);
+            std::fs::set_permissions(&path, p).unwrap();
+        }
+        path
+    }
+
+    fn seed_install_path(sys: &mut MockSystemOps, install_path: PathBuf) {
+        sys.override_aimx_binary_path = Some(install_path);
+    }
+
+    #[test]
+    fn up_to_date_short_circuits_without_fetches() {
+        let mut sys = MockSystemOps::default();
+        let tmp = TempDir::new().unwrap();
+        let install = write_fake_binary(tmp.path());
+        seed_install_path(&mut sys, install);
+
+        let release = MockReleaseOps::default();
+        release.push_latest(Ok(make_manifest(
+            version::release_tag(),
+            &[&tarball_filename(version::release_tag(), current_target())],
+        )));
+
+        let report = run_upgrade(&args_default(), &release, &sys).unwrap();
+        assert_eq!(report.outcome, Some(Outcome::UpToDate));
+        // No fetch step should appear.
+        assert!(!report.steps.contains(&UpgradeStep::FetchTarball));
+        // No file writes.
+        assert!(sys.restarted_services.borrow().is_empty());
+        assert!(sys.stopped_services.borrow().is_empty());
+    }
+
+    #[test]
+    fn not_root_refuses() {
+        let mut sys = MockSystemOps::default();
+        sys.is_root = false;
+        let release = MockReleaseOps::default();
+        let err = run_upgrade(&args_default(), &release, &sys).unwrap_err();
+        assert!(matches!(err, UpgradeError::NotRoot));
+    }
+
+    #[test]
+    fn happy_path_stop_swap_start_sequence() {
+        let mut sys = MockSystemOps::default();
+        let tmp = TempDir::new().unwrap();
+        let install = write_fake_binary(tmp.path());
+        seed_install_path(&mut sys, install.clone());
+
+        let tag = "v9.9.9-test";
+        let target = current_target();
+        let asset = tarball_filename(tag, target);
+        let bytes = make_tarball(tag, target, b"fake aimx binary");
+        let release = MockReleaseOps::default();
+        release.push_latest(Ok(make_manifest(tag, &[&asset])));
+        release.push_asset(Ok(bytes));
+
+        let report = run_upgrade(&args_default(), &release, &sys).unwrap();
+        assert_eq!(report.outcome, Some(Outcome::Upgraded));
+
+        // Every step recorded in order.
+        assert_eq!(
+            report.steps,
+            vec![
+                UpgradeStep::ResolveManifest,
+                UpgradeStep::CompareTag,
+                UpgradeStep::FetchTarball,
+                UpgradeStep::ExtractTarball,
+                UpgradeStep::StopService,
+                UpgradeStep::PreserveOldBinary,
+                UpgradeStep::InstallNewBinary,
+                UpgradeStep::StartService,
+                UpgradeStep::WaitForReady,
+            ]
+        );
+
+        // Service calls in order: stop then start (never restart).
+        assert_eq!(&*sys.stopped_services.borrow(), &[SERVICE_NAME.to_string()]);
+        assert_eq!(&*sys.started_services.borrow(), &[SERVICE_NAME.to_string()]);
+
+        // Binary at install_path is the new one.
+        let installed = std::fs::read(&install).unwrap();
+        assert_eq!(installed, b"fake aimx binary");
+        // .prev exists and holds the original placeholder body.
+        let prev = prev_path(&install);
+        assert!(prev.exists(), ".prev must be preserved after upgrade");
+        let prev_bytes = std::fs::read(&prev).unwrap();
+        assert!(prev_bytes.starts_with(b"#!/bin/sh"));
+    }
+
+    #[test]
+    fn dry_run_fetches_but_does_not_swap() {
+        let mut sys = MockSystemOps::default();
+        let tmp = TempDir::new().unwrap();
+        let install = write_fake_binary(tmp.path());
+        seed_install_path(&mut sys, install.clone());
+
+        let tag = "v9.9.9-dryrun";
+        let target = current_target();
+        let asset = tarball_filename(tag, target);
+        let bytes = make_tarball(tag, target, b"dryrun body");
+        let release = MockReleaseOps::default();
+        release.push_latest(Ok(make_manifest(tag, &[&asset])));
+        release.push_asset(Ok(bytes));
+
+        let mut args = args_default();
+        args.dry_run = true;
+        let report = run_upgrade(&args, &release, &sys).unwrap();
+
+        assert_eq!(report.outcome, Some(Outcome::DryRun));
+        assert!(report.steps.contains(&UpgradeStep::FetchTarball));
+        assert!(!report.steps.contains(&UpgradeStep::StopService));
+        assert!(!report.steps.contains(&UpgradeStep::InstallNewBinary));
+        assert!(sys.stopped_services.borrow().is_empty());
+        assert!(sys.started_services.borrow().is_empty());
+
+        // Binary untouched.
+        let installed = std::fs::read(&install).unwrap();
+        assert!(installed.starts_with(b"#!/bin/sh"));
+        let prev = prev_path(&install);
+        assert!(!prev.exists(), "dry-run must not create a .prev file");
+    }
+
+    #[test]
+    fn dry_run_with_download_failure_returns_release_error() {
+        let mut sys = MockSystemOps::default();
+        let tmp = TempDir::new().unwrap();
+        let install = write_fake_binary(tmp.path());
+        seed_install_path(&mut sys, install);
+
+        let tag = "v9.9.9-fail";
+        let target = current_target();
+        let asset = tarball_filename(tag, target);
+        let release = MockReleaseOps::default();
+        release.push_latest(Ok(make_manifest(tag, &[&asset])));
+        release.push_asset(Err(ReleaseError::Transport("simulated".to_string())));
+
+        let mut args = args_default();
+        args.dry_run = true;
+        let err = run_upgrade(&args, &release, &sys).unwrap_err();
+        assert!(matches!(err, UpgradeError::Release(_)));
+    }
+
+    #[test]
+    fn version_flag_uses_release_by_tag_and_skips_up_to_date() {
+        let mut sys = MockSystemOps::default();
+        let tmp = TempDir::new().unwrap();
+        let install = write_fake_binary(tmp.path());
+        seed_install_path(&mut sys, install.clone());
+
+        let tag = version::release_tag();
+        let target = current_target();
+        let asset = tarball_filename(tag, target);
+        let bytes = make_tarball(tag, target, b"pinned body");
+        let release = MockReleaseOps::default();
+        release.push_by_tag(Ok(make_manifest(tag, &[&asset])));
+        release.push_asset(Ok(bytes));
+
+        // With --version equal to current tag *and* --force, we must
+        // re-install rather than short-circuit. This is the FR-4.4
+        // same-tag + --force test (PRD §11 resolved open question).
+        let args = UpgradeArgs {
+            dry_run: false,
+            version: Some(tag.to_string()),
+            force: true,
+        };
+        let report = run_upgrade(&args, &release, &sys).unwrap();
+        assert_eq!(report.outcome, Some(Outcome::Upgraded));
+        assert_eq!(&*sys.stopped_services.borrow(), &[SERVICE_NAME.to_string()]);
+    }
+
+    #[test]
+    fn force_same_tag_without_version_flag_still_reinstalls() {
+        let mut sys = MockSystemOps::default();
+        let tmp = TempDir::new().unwrap();
+        let install = write_fake_binary(tmp.path());
+        seed_install_path(&mut sys, install);
+
+        let tag = version::release_tag();
+        let target = current_target();
+        let asset = tarball_filename(tag, target);
+        let bytes = make_tarball(tag, target, b"reinstalled body");
+        let release = MockReleaseOps::default();
+        release.push_latest(Ok(make_manifest(tag, &[&asset])));
+        release.push_asset(Ok(bytes));
+
+        let args = UpgradeArgs {
+            dry_run: false,
+            version: None,
+            force: true,
+        };
+        let report = run_upgrade(&args, &release, &sys).unwrap();
+        assert_eq!(report.outcome, Some(Outcome::Upgraded));
+    }
+
+    #[test]
+    fn dry_run_composes_with_version_and_force() {
+        let mut sys = MockSystemOps::default();
+        let tmp = TempDir::new().unwrap();
+        let install = write_fake_binary(tmp.path());
+        seed_install_path(&mut sys, install);
+
+        let tag = "v1.2.3";
+        let target = current_target();
+        let asset = tarball_filename(tag, target);
+        let bytes = make_tarball(tag, target, b"hello");
+        let release = MockReleaseOps::default();
+        release.push_by_tag(Ok(make_manifest(tag, &[&asset])));
+        release.push_asset(Ok(bytes));
+
+        let args = UpgradeArgs {
+            dry_run: true,
+            version: Some(tag.to_string()),
+            force: true,
+        };
+        let report = run_upgrade(&args, &release, &sys).unwrap();
+        assert_eq!(report.outcome, Some(Outcome::DryRun));
+        assert_eq!(report.target_tag, tag);
+    }
+
+    #[test]
+    fn unknown_tag_surfaces_release_error() {
+        let mut sys = MockSystemOps::default();
+        let tmp = TempDir::new().unwrap();
+        let install = write_fake_binary(tmp.path());
+        seed_install_path(&mut sys, install);
+
+        let release = MockReleaseOps::default();
+        release.push_by_tag(Err(ReleaseError::Http {
+            status: 404,
+            body: "Not Found".to_string(),
+        }));
+
+        let args = UpgradeArgs {
+            dry_run: false,
+            version: Some("v0.0.0-does-not-exist".to_string()),
+            force: false,
+        };
+        let err = run_upgrade(&args, &release, &sys).unwrap_err();
+        match err {
+            UpgradeError::Release(ReleaseError::Http { status, .. }) => {
+                assert_eq!(status, 404);
+            }
+            other => panic!("expected Release(Http{{404}}), got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn missing_tarball_asset_errors_before_swap() {
+        let mut sys = MockSystemOps::default();
+        let tmp = TempDir::new().unwrap();
+        let install = write_fake_binary(tmp.path());
+        seed_install_path(&mut sys, install.clone());
+
+        // Manifest that has no matching-target asset.
+        let release = MockReleaseOps::default();
+        release.push_latest(Ok(make_manifest(
+            "v9.9.9-missing",
+            &["aimx-9.9.9-missing-SHA256SUMS"],
+        )));
+
+        let err = run_upgrade(&args_default(), &release, &sys).unwrap_err();
+        assert!(matches!(
+            err,
+            UpgradeError::Release(ReleaseError::AssetNotFound(_))
+        ));
+        // Nothing was touched.
+        assert!(sys.stopped_services.borrow().is_empty());
+        let prev = prev_path(&install);
+        assert!(!prev.exists());
+    }
+
+    #[test]
+    fn rollback_fires_on_start_failure() {
+        let mut sys = MockSystemOps::default();
+        sys.start_service_fails = true;
+        let tmp = TempDir::new().unwrap();
+        let install = write_fake_binary(tmp.path());
+        seed_install_path(&mut sys, install.clone());
+
+        let tag = "v9.9.9-rollback";
+        let target = current_target();
+        let asset = tarball_filename(tag, target);
+        let bytes = make_tarball(tag, target, b"new but service wont start");
+        let release = MockReleaseOps::default();
+        release.push_latest(Ok(make_manifest(tag, &[&asset])));
+        release.push_asset(Ok(bytes));
+
+        // Every invocation of `start_service` fails — so rollback's own
+        // `start_service` call fails too, yielding `RollbackFailed`.
+        let err = run_upgrade(&args_default(), &release, &sys).unwrap_err();
+        match &err {
+            UpgradeError::RollbackFailed {
+                original_step,
+                rollback_step,
+                ..
+            } => {
+                assert_eq!(*original_step, UpgradeStep::StartService);
+                assert_eq!(*rollback_step, UpgradeStep::StartService);
+            }
+            other => panic!("expected RollbackFailed, got {other:?}"),
+        }
+
+        // But the binary was restored.
+        let installed = std::fs::read(&install).unwrap();
+        assert!(installed.starts_with(b"#!/bin/sh"));
+    }
+
+    #[test]
+    fn rollback_fires_on_stop_failure_without_modifying_binary() {
+        let mut sys = MockSystemOps::default();
+        sys.stop_service_fails = true;
+        let tmp = TempDir::new().unwrap();
+        let install = write_fake_binary(tmp.path());
+        seed_install_path(&mut sys, install.clone());
+
+        let tag = "v9.9.9-stopfail";
+        let target = current_target();
+        let asset = tarball_filename(tag, target);
+        let bytes = make_tarball(tag, target, b"wont even start");
+        let release = MockReleaseOps::default();
+        release.push_latest(Ok(make_manifest(tag, &[&asset])));
+        release.push_asset(Ok(bytes));
+
+        let err = run_upgrade(&args_default(), &release, &sys).unwrap_err();
+        // Stop failed, so we are in PreSwap — nothing to roll back.
+        match err {
+            UpgradeError::PreSwap { step, .. } => assert_eq!(step, UpgradeStep::StopService),
+            other => panic!("expected PreSwap(StopService), got {other:?}"),
+        }
+        // Binary is unchanged (stop-service failed before swap).
+        let installed = std::fs::read(&install).unwrap();
+        assert!(installed.starts_with(b"#!/bin/sh"));
+        let prev = prev_path(&install);
+        assert!(!prev.exists());
+    }
+
+    #[test]
+    fn rollback_fires_on_wait_for_ready_timeout() {
+        let mut sys = MockSystemOps::default();
+        sys.service_ready = false;
+        let tmp = TempDir::new().unwrap();
+        let install = write_fake_binary(tmp.path());
+        seed_install_path(&mut sys, install.clone());
+
+        let tag = "v9.9.9-waitfail";
+        let target = current_target();
+        let asset = tarball_filename(tag, target);
+        let bytes = make_tarball(tag, target, b"started but never ready");
+        let release = MockReleaseOps::default();
+        release.push_latest(Ok(make_manifest(tag, &[&asset])));
+        release.push_asset(Ok(bytes));
+
+        let err = run_upgrade(&args_default(), &release, &sys).unwrap_err();
+        match err {
+            UpgradeError::RolledBack { failed_step, .. } => {
+                assert_eq!(failed_step, UpgradeStep::WaitForReady);
+            }
+            other => panic!("expected RolledBack(WaitForReady), got {other:?}"),
+        }
+        // Binary reverted.
+        let installed = std::fs::read(&install).unwrap();
+        assert!(installed.starts_with(b"#!/bin/sh"));
+    }
+
+    #[test]
+    fn extract_tarball_rejects_malformed_payload() {
+        let tmp = TempDir::new().unwrap();
+        let err =
+            extract_tarball(b"not a tarball", tmp.path(), "v1.0.0", current_target()).unwrap_err();
+        assert!(err.contains("tar extract"));
+    }
+
+    #[test]
+    fn tarball_filename_strips_leading_v() {
+        assert_eq!(
+            tarball_filename("v1.2.3", "x86_64-unknown-linux-gnu"),
+            "aimx-1.2.3-x86_64-unknown-linux-gnu.tar.gz"
+        );
+        // Tags without the leading v are taken verbatim.
+        assert_eq!(
+            tarball_filename("1.2.3", "aarch64-unknown-linux-musl"),
+            "aimx-1.2.3-aarch64-unknown-linux-musl.tar.gz"
+        );
+    }
+
+    #[test]
+    fn prev_path_appends_suffix() {
+        assert_eq!(
+            prev_path(Path::new("/usr/local/bin/aimx")),
+            PathBuf::from("/usr/local/bin/aimx.prev")
+        );
+        assert_eq!(
+            prev_path(Path::new("/opt/aimx/bin/aimx")),
+            PathBuf::from("/opt/aimx/bin/aimx.prev")
+        );
+    }
+
+    #[test]
+    fn stale_prev_overwritten_by_new_upgrade() {
+        let mut sys = MockSystemOps::default();
+        let tmp = TempDir::new().unwrap();
+        let install = write_fake_binary(tmp.path());
+        // Plant an existing .prev from a fictional earlier upgrade.
+        let prev = prev_path(&install);
+        std::fs::write(&prev, b"old prev body").unwrap();
+        seed_install_path(&mut sys, install.clone());
+
+        let tag = "v9.9.9-overwrite";
+        let target = current_target();
+        let asset = tarball_filename(tag, target);
+        let bytes = make_tarball(tag, target, b"new body");
+        let release = MockReleaseOps::default();
+        release.push_latest(Ok(make_manifest(tag, &[&asset])));
+        release.push_asset(Ok(bytes));
+
+        run_upgrade(&args_default(), &release, &sys).unwrap();
+
+        // .prev now holds the prior-generation binary (the one at
+        // `install` before this run), not the old pre-planted body.
+        let prev_bytes = std::fs::read(&prev).unwrap();
+        assert!(prev_bytes.starts_with(b"#!/bin/sh"));
+        assert_ne!(prev_bytes, b"old prev body");
+    }
+}

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -425,17 +425,16 @@ pub fn extract_tarball(
 }
 
 /// Move the currently-installed binary to `<install_path>.prev`. Uses
-/// `rename` for atomicity on the same filesystem. If the install path
-/// does not exist (fresh install on a path-not-yet-written machine),
-/// returns `Ok(())` — there is nothing to preserve.
+/// `rename` for atomicity on the same filesystem — `fs::rename` on Unix
+/// overwrites the destination atomically, so we rely on that instead of
+/// pre-deleting a stale `.prev`. If the rename fails for an unrelated
+/// reason (cross-filesystem, ENOSPC, etc.), the previous cycle's `.prev`
+/// is preserved untouched. If the install path does not exist (fresh
+/// install on a path-not-yet-written machine), returns `Ok(())` — there
+/// is nothing to preserve.
 fn preserve_previous_binary(install_path: &Path, prev_path: &Path) -> Result<(), String> {
     if !install_path.exists() {
         return Ok(());
-    }
-    // Remove any stale .prev from a prior upgrade before renaming.
-    if prev_path.exists() {
-        fs::remove_file(prev_path)
-            .map_err(|e| format!("remove stale {}: {e}", prev_path.display()))?;
     }
     fs::rename(install_path, prev_path).map_err(|e| {
         format!(
@@ -1017,6 +1016,13 @@ mod tests {
         // Binary reverted.
         let installed = std::fs::read(&install).unwrap();
         assert!(installed.starts_with(b"#!/bin/sh"));
+        // Service came back up on the old binary: one start call for
+        // the upgrade, one start call for rollback.
+        assert_eq!(
+            sys.started_services.borrow().len(),
+            2,
+            "expected start_service called twice (upgrade + rollback)"
+        );
     }
 
     #[test]
@@ -1049,6 +1055,172 @@ mod tests {
         assert_eq!(
             prev_path(Path::new("/opt/aimx/bin/aimx")),
             PathBuf::from("/opt/aimx/bin/aimx.prev")
+        );
+    }
+
+    /// N2 regression guard: feed `run_upgrade` a malformed tarball and
+    /// assert the PreSwap(ExtractTarball) outcome — the service is never
+    /// stopped and `.prev` is never created. Closes the S4-3 AC
+    /// "Rollback fires on tarball-extraction failure" at the `run_upgrade`
+    /// level (the in-helper test only covered `extract_tarball` directly).
+    #[test]
+    fn run_upgrade_malformed_tarball_returns_preswap_extract_error() {
+        let mut sys = MockSystemOps::default();
+        let tmp = TempDir::new().unwrap();
+        let install = write_fake_binary(tmp.path());
+        seed_install_path(&mut sys, install.clone());
+
+        let tag = "v9.9.9-malformed";
+        let target = current_target();
+        let asset = tarball_filename(tag, target);
+        // Not a gzipped tar — `extract_tarball` must reject this.
+        let garbage = b"not a tarball at all".to_vec();
+        let release = MockReleaseOps::default();
+        release.push_latest(Ok(make_manifest(tag, &[&asset])));
+        release.push_asset(Ok(garbage));
+
+        let err = run_upgrade(&args_default(), &release, &sys).unwrap_err();
+        match &err {
+            UpgradeError::PreSwap { step, .. } => {
+                assert_eq!(*step, UpgradeStep::ExtractTarball);
+            }
+            other => panic!("expected PreSwap(ExtractTarball), got {other:?}"),
+        }
+
+        // Service was never touched — pre-swap means no rollback was
+        // needed, so stop/start must have zero calls.
+        assert!(
+            sys.stopped_services.borrow().is_empty(),
+            "stop_service must not run on extract-tarball failure"
+        );
+        assert!(
+            sys.started_services.borrow().is_empty(),
+            "start_service must not run on extract-tarball failure"
+        );
+        // Binary untouched and `.prev` never created.
+        let installed = std::fs::read(&install).unwrap();
+        assert!(installed.starts_with(b"#!/bin/sh"));
+        let prev = prev_path(&install);
+        assert!(!prev.exists(), ".prev must not exist after pre-swap abort");
+    }
+
+    /// N3 regression guard: make the `install_binary` step fail and
+    /// assert `RolledBack { failed_step: InstallNewBinary }` with the
+    /// `.prev` body restored onto `install_path`. Forces the failure by
+    /// planting a *directory* at the sibling temp-file path
+    /// (`<parent>/.aimx.upgrade.tmp`) that `install_binary` uses as its
+    /// staging target: `fs::copy` refuses to overwrite a directory, so
+    /// the install fails cleanly at the copy step. `preserve_previous_binary`
+    /// runs before that and succeeds — putting us squarely in the
+    /// post-stop / post-preserve rollback branch.
+    #[test]
+    fn run_upgrade_install_binary_failure_rolls_back_to_prev() {
+        let mut sys = MockSystemOps::default();
+        let tmp = TempDir::new().unwrap();
+        let install_dir = tmp.path().join("bin");
+        std::fs::create_dir(&install_dir).unwrap();
+        let install = write_fake_binary(&install_dir);
+        seed_install_path(&mut sys, install.clone());
+
+        // Plant a directory where `install_binary` expects to write a
+        // sibling temp file. `fs::copy(staged, &tmp)` fails with
+        // "Is a directory" on Linux, deterministically driving the
+        // InstallNewBinary branch of `attempt_rollback`.
+        let blocker = install_dir.join(".aimx.upgrade.tmp");
+        std::fs::create_dir(&blocker).unwrap();
+
+        let tag = "v9.9.9-installfail";
+        let target = current_target();
+        let asset = tarball_filename(tag, target);
+        let bytes = make_tarball(tag, target, b"would-be new body");
+        let release = MockReleaseOps::default();
+        release.push_latest(Ok(make_manifest(tag, &[&asset])));
+        release.push_asset(Ok(bytes));
+
+        let err = run_upgrade(&args_default(), &release, &sys).unwrap_err();
+
+        match &err {
+            UpgradeError::RolledBack { failed_step, .. } => {
+                assert_eq!(
+                    *failed_step,
+                    UpgradeStep::InstallNewBinary,
+                    "expected RolledBack at InstallNewBinary, got {failed_step:?}"
+                );
+            }
+            other => panic!("expected RolledBack(InstallNewBinary), got {other:?}"),
+        }
+
+        // `.prev` was restored back onto `install_path` — the running
+        // binary is the original.
+        let installed = std::fs::read(&install).unwrap();
+        assert!(
+            installed.starts_with(b"#!/bin/sh"),
+            "install path should hold the original binary after rollback"
+        );
+        // Rollback fired a start_service (the upgrade never got there).
+        assert_eq!(
+            sys.started_services.borrow().len(),
+            1,
+            "rollback should have called start_service exactly once"
+        );
+        // Service was stopped once (before the failed install).
+        assert_eq!(
+            sys.stopped_services.borrow().len(),
+            1,
+            "stop_service should have run before install failed"
+        );
+    }
+
+    /// N4 regression guard: the canonical `RolledBack { failed_step:
+    /// StartService }` outcome. The upgrade's `start_service` fails
+    /// once, rollback's own `start_service` succeeds, and the service
+    /// is left running on the previous binary. Requires the fail-once
+    /// knob on `MockSystemOps` (`start_service_failures_remaining`) —
+    /// the sticky `start_service_fails` bool would fail rollback's
+    /// start too and yield `RollbackFailed` instead.
+    #[test]
+    fn rollback_succeeds_when_start_fails_once() {
+        let mut sys = MockSystemOps::default();
+        // Fail the upgrade's start, then allow rollback's start to succeed.
+        sys.start_service_failures_remaining.set(1);
+        let tmp = TempDir::new().unwrap();
+        let install = write_fake_binary(tmp.path());
+        seed_install_path(&mut sys, install.clone());
+
+        let tag = "v9.9.9-startfailonce";
+        let target = current_target();
+        let asset = tarball_filename(tag, target);
+        let bytes = make_tarball(tag, target, b"new body (start fails once)");
+        let release = MockReleaseOps::default();
+        release.push_latest(Ok(make_manifest(tag, &[&asset])));
+        release.push_asset(Ok(bytes));
+
+        let err = run_upgrade(&args_default(), &release, &sys).unwrap_err();
+        match &err {
+            UpgradeError::RolledBack {
+                failed_step,
+                previous_tag,
+                ..
+            } => {
+                assert_eq!(*failed_step, UpgradeStep::StartService);
+                assert_eq!(previous_tag, version::release_tag());
+            }
+            other => panic!("expected RolledBack(StartService), got {other:?}"),
+        }
+
+        // Binary restored to the original.
+        let installed = std::fs::read(&install).unwrap();
+        assert!(installed.starts_with(b"#!/bin/sh"));
+        // Two start_service calls: one failed, one succeeded.
+        assert_eq!(
+            sys.started_services.borrow().len(),
+            2,
+            "expected start_service called twice (upgrade + rollback)"
+        );
+        assert_eq!(
+            sys.start_service_failures_remaining.get(),
+            0,
+            "fail-once counter should be drained"
         );
     }
 

--- a/tests/release_integration.rs
+++ b/tests/release_integration.rs
@@ -188,6 +188,122 @@ fn fixture_release_tarball_sha256_matches() {
     );
 }
 
+/// Sprint 4 S4-1 / S4-3 addendum (backlog item from Sprint 2 review):
+/// exercise the **production** `RealReleaseOps` path end-to-end with the
+/// real rustls wiring, against the live `v0.0.0-fixture` release. The
+/// earlier test in this file hand-rolls a bare `ureq::Agent` and only
+/// covers `parse_release_json` / `verify_sha256` indirectly; this test
+/// goes through `RealReleaseOps::latest_release_url` override
+/// resolution, `RealReleaseOps::fetch_asset` (which owns the rustls
+/// provider install + HTTPS-only enforcement), and `verify_sha256`.
+#[test]
+fn real_release_ops_end_to_end_against_fixture() {
+    // SAFETY: pointing at the tag URL lets us exercise `latest_release`
+    // without depending on whichever release is `latest` on GitHub at
+    // test time.
+    unsafe {
+        std::env::set_var("AIMX_RELEASE_MANIFEST_URL", FIXTURE_RELEASE_URL);
+    }
+
+    // Use the compiled binary's library crate via `assert_cmd` to
+    // discover the running target triple — mirrors the earlier test.
+    use std::process::Command;
+    let out = Command::new(assert_cmd::cargo::cargo_bin("aimx"))
+        .arg("--version")
+        .output()
+        .expect("run aimx --version");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let line = stdout.lines().next().unwrap();
+    let target = line
+        .split(") ")
+        .nth(1)
+        .and_then(|s| s.split(" built ").next())
+        .expect("target in --version");
+
+    let tarball_name = format!("aimx-0.0.0-fixture-{target}.tar.gz");
+    let expected = expected_sums();
+    let expected_sha = match expected.get(tarball_name.as_str()) {
+        Some(s) => *s,
+        None => {
+            eprintln!("skipping — target {target:?} is not a fixture-release target");
+            unsafe {
+                std::env::remove_var("AIMX_RELEASE_MANIFEST_URL");
+            }
+            return;
+        }
+    };
+
+    // Install the rustls provider explicitly so when we construct
+    // RealReleaseOps below via the `aimx` binary's crate, its internal
+    // `install_rustls_provider` idempotently finds the slot taken.
+    rustls::crypto::aws_lc_rs::default_provider()
+        .install_default()
+        .ok();
+
+    // Spawn a tiny helper: use `aimx upgrade --dry-run --version
+    // v0.0.0-fixture` which walks the exact production path —
+    // `RealReleaseOps::release_by_tag` → `fetch_asset` against a real
+    // HTTPS URL — and prints the asset URL it would install.
+    //
+    // Dry-run exits 0 and never touches the service or filesystem,
+    // making this safe to run in CI even as a non-root test runner.
+    // The dry-run refuses under a non-root uid though, so we fall
+    // back to a subprocess only if the test is actually running as
+    // root; otherwise we assert the refusal message to prove the
+    // verb is wired.
+    let euid = unsafe { libc::geteuid() };
+    if euid != 0 {
+        let out = Command::new(assert_cmd::cargo::cargo_bin("aimx"))
+            .args(["upgrade", "--dry-run", "--version", "v0.0.0-fixture"])
+            .output()
+            .expect("run aimx upgrade --dry-run");
+        // Non-root should hit the root check before any network I/O.
+        let combined = format!(
+            "{}{}",
+            String::from_utf8_lossy(&out.stdout),
+            String::from_utf8_lossy(&out.stderr)
+        );
+        assert!(
+            combined.contains("aimx upgrade requires root"),
+            "expected root-check refusal, got: {combined}"
+        );
+        unsafe {
+            std::env::remove_var("AIMX_RELEASE_MANIFEST_URL");
+        }
+        return;
+    }
+
+    // Running as root: exercise the real end-to-end dry-run which
+    // drives `RealReleaseOps::fetch_asset` against the fixture tarball.
+    let out = Command::new(assert_cmd::cargo::cargo_bin("aimx"))
+        .args(["upgrade", "--dry-run", "--version", "v0.0.0-fixture"])
+        .env("AIMX_RELEASE_MANIFEST_URL", FIXTURE_RELEASE_URL)
+        .output()
+        .expect("run aimx upgrade --dry-run (root)");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(out.status.success(), "dry-run failed: {combined}");
+    assert!(
+        combined.contains("v0.0.0-fixture"),
+        "expected target tag in dry-run output: {combined}"
+    );
+    assert!(
+        combined.contains(&tarball_name),
+        "expected tarball name {tarball_name} in dry-run output: {combined}"
+    );
+    // Expected SHA only asserted for the side-effect of using it —
+    // the dry-run downloads but does not checksum, so we leave the
+    // checksum to the other test.
+    let _ = expected_sha;
+
+    unsafe {
+        std::env::remove_var("AIMX_RELEASE_MANIFEST_URL");
+    }
+}
+
 fn hex(bytes: &[u8]) -> String {
     const H: &[u8; 16] = b"0123456789abcdef";
     let mut out = String::with_capacity(bytes.len() * 2);

--- a/tests/release_integration.rs
+++ b/tests/release_integration.rs
@@ -318,9 +318,18 @@ fn real_release_ops_end_to_end_against_fixture_as_root() {
     // → `fetch_asset` over real HTTPS — via `aimx upgrade --dry-run`.
     // The dry-run exits cleanly after the fetch without touching the
     // service or filesystem, so this is safe to run under sudo in CI.
+    //
+    // Point the env override at the canonical `/releases/latest` URL
+    // rather than the per-tag URL — `RealReleaseOps::release_by_tag_url`
+    // runs `rewrite_to_tag` on the override, which maps `.../latest`
+    // to `.../tags/<tag>`. Passing the per-tag URL directly would
+    // double-append `/tags/<tag>` and 404.
     let out = Command::new(assert_cmd::cargo::cargo_bin("aimx"))
         .args(["upgrade", "--dry-run", "--version", "v0.0.0-fixture"])
-        .env("AIMX_RELEASE_MANIFEST_URL", FIXTURE_RELEASE_URL)
+        .env(
+            "AIMX_RELEASE_MANIFEST_URL",
+            "https://api.github.com/repos/uzyn/aimx/releases/latest",
+        )
         .output()
         .expect("run aimx upgrade --dry-run (root)");
     let combined = format!(

--- a/tests/release_integration.rs
+++ b/tests/release_integration.rs
@@ -189,25 +189,104 @@ fn fixture_release_tarball_sha256_matches() {
 }
 
 /// Sprint 4 S4-1 / S4-3 addendum (backlog item from Sprint 2 review):
-/// exercise the **production** `RealReleaseOps` path end-to-end with the
-/// real rustls wiring, against the live `v0.0.0-fixture` release. The
-/// earlier test in this file hand-rolls a bare `ureq::Agent` and only
-/// covers `parse_release_json` / `verify_sha256` indirectly; this test
-/// goes through `RealReleaseOps::latest_release_url` override
-/// resolution, `RealReleaseOps::fetch_asset` (which owns the rustls
-/// provider install + HTTPS-only enforcement), and `verify_sha256`.
+/// wire-through check for the `aimx upgrade` verb.
+///
+/// Asserts that running `aimx upgrade --dry-run --version v0.0.0-fixture`
+/// as a non-root user hits the root check and exits with the expected
+/// refusal message — proving the verb is plumbed through `cli.rs` /
+/// `main.rs` / `upgrade::run` without actually making any network calls.
+///
+/// **This test does NOT drive `RealReleaseOps::fetch_asset` end-to-end.**
+/// The full production HTTPS path is exercised by
+/// `real_release_ops_end_to_end_against_fixture_as_root`, which is
+/// `#[ignore]`-gated and run under sudo in the `integration-isolation`
+/// CI job. Without that sudo step the production-path-with-TLS gap
+/// remains open in CI.
 #[test]
-fn real_release_ops_end_to_end_against_fixture() {
+fn real_release_ops_wireup_non_root_refuses() {
+    use std::process::Command;
+
     // SAFETY: pointing at the tag URL lets us exercise `latest_release`
     // without depending on whichever release is `latest` on GitHub at
-    // test time.
+    // test time. Not strictly needed for the non-root refusal branch,
+    // but kept for symmetry with the root path.
     unsafe {
         std::env::set_var("AIMX_RELEASE_MANIFEST_URL", FIXTURE_RELEASE_URL);
     }
 
-    // Use the compiled binary's library crate via `assert_cmd` to
-    // discover the running target triple — mirrors the earlier test.
+    // This test is only valid when running non-root. Under sudo, the
+    // sibling `real_release_ops_end_to_end_against_fixture_as_root`
+    // test drives the full HTTPS path instead.
+    let euid = unsafe { libc::geteuid() };
+    if euid == 0 {
+        eprintln!(
+            "skipping — running as root; the sibling #[ignore]-gated test \
+             covers the root path under the `integration-isolation` CI job"
+        );
+        unsafe {
+            std::env::remove_var("AIMX_RELEASE_MANIFEST_URL");
+        }
+        return;
+    }
+
+    let out = Command::new(assert_cmd::cargo::cargo_bin("aimx"))
+        .args(["upgrade", "--dry-run", "--version", "v0.0.0-fixture"])
+        .output()
+        .expect("run aimx upgrade --dry-run");
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        combined.contains("aimx upgrade requires root"),
+        "expected root-check refusal, got: {combined}"
+    );
+    unsafe {
+        std::env::remove_var("AIMX_RELEASE_MANIFEST_URL");
+    }
+}
+
+/// Sprint 4 review NB-1: drives the **production** `RealReleaseOps`
+/// path end-to-end against the live `v0.0.0-fixture` release. Runs
+/// `aimx upgrade --dry-run --version v0.0.0-fixture` as root —
+/// `--dry-run` stops after `fetch_asset` and never touches the
+/// filesystem or the service, so the test is safe under sudo.
+///
+/// Gated by `#[ignore]` + `AIMX_INTEGRATION_SUDO=1` so a casual
+/// `cargo test --features integration` does not shell out under root.
+/// The `.github/workflows/ci.yml` `integration-isolation` job runs
+/// this test under sudo via:
+///
+/// ```text
+/// sudo -E env "PATH=$PATH" AIMX_INTEGRATION_SUDO=1 \
+///   cargo test --features integration --test release_integration \
+///   -- --ignored --exact \
+///   real_release_ops_end_to_end_against_fixture_as_root
+/// ```
+///
+/// which is the sibling pattern to the `isolation` / `uds_authz` /
+/// MAILBOX-CRUD sudo-gated tests already in that job.
+#[test]
+#[ignore = "requires root + AIMX_INTEGRATION_SUDO=1; run in CI under sudo"]
+fn real_release_ops_end_to_end_against_fixture_as_root() {
     use std::process::Command;
+
+    let euid = unsafe { libc::geteuid() };
+    assert_eq!(
+        euid, 0,
+        "this test must run as root so `aimx upgrade` passes the root \
+         check and exercises RealReleaseOps::fetch_asset against the \
+         fixture release; re-run under sudo with AIMX_INTEGRATION_SUDO=1"
+    );
+    assert_eq!(
+        std::env::var("AIMX_INTEGRATION_SUDO").ok().as_deref(),
+        Some("1"),
+        "AIMX_INTEGRATION_SUDO=1 must be set to opt into network + root \
+         integration tests"
+    );
+
+    // Discover the running target triple.
     let out = Command::new(assert_cmd::cargo::cargo_bin("aimx"))
         .arg("--version")
         .output()
@@ -222,59 +301,23 @@ fn real_release_ops_end_to_end_against_fixture() {
 
     let tarball_name = format!("aimx-0.0.0-fixture-{target}.tar.gz");
     let expected = expected_sums();
-    let expected_sha = match expected.get(tarball_name.as_str()) {
-        Some(s) => *s,
-        None => {
-            eprintln!("skipping — target {target:?} is not a fixture-release target");
-            unsafe {
-                std::env::remove_var("AIMX_RELEASE_MANIFEST_URL");
-            }
-            return;
-        }
-    };
+    if !expected.contains_key(tarball_name.as_str()) {
+        eprintln!("skipping — target {target:?} is not a fixture-release target");
+        return;
+    }
 
-    // Install the rustls provider explicitly so when we construct
-    // RealReleaseOps below via the `aimx` binary's crate, its internal
+    // Install the rustls provider explicitly so when the spawned `aimx`
+    // subprocess constructs `RealReleaseOps`, its internal
     // `install_rustls_provider` idempotently finds the slot taken.
+    // (Belt-and-braces — the subprocess has its own provider init.)
     rustls::crypto::aws_lc_rs::default_provider()
         .install_default()
         .ok();
 
-    // Spawn a tiny helper: use `aimx upgrade --dry-run --version
-    // v0.0.0-fixture` which walks the exact production path —
-    // `RealReleaseOps::release_by_tag` → `fetch_asset` against a real
-    // HTTPS URL — and prints the asset URL it would install.
-    //
-    // Dry-run exits 0 and never touches the service or filesystem,
-    // making this safe to run in CI even as a non-root test runner.
-    // The dry-run refuses under a non-root uid though, so we fall
-    // back to a subprocess only if the test is actually running as
-    // root; otherwise we assert the refusal message to prove the
-    // verb is wired.
-    let euid = unsafe { libc::geteuid() };
-    if euid != 0 {
-        let out = Command::new(assert_cmd::cargo::cargo_bin("aimx"))
-            .args(["upgrade", "--dry-run", "--version", "v0.0.0-fixture"])
-            .output()
-            .expect("run aimx upgrade --dry-run");
-        // Non-root should hit the root check before any network I/O.
-        let combined = format!(
-            "{}{}",
-            String::from_utf8_lossy(&out.stdout),
-            String::from_utf8_lossy(&out.stderr)
-        );
-        assert!(
-            combined.contains("aimx upgrade requires root"),
-            "expected root-check refusal, got: {combined}"
-        );
-        unsafe {
-            std::env::remove_var("AIMX_RELEASE_MANIFEST_URL");
-        }
-        return;
-    }
-
-    // Running as root: exercise the real end-to-end dry-run which
-    // drives `RealReleaseOps::fetch_asset` against the fixture tarball.
+    // Drive the exact production path — `RealReleaseOps::release_by_tag`
+    // → `fetch_asset` over real HTTPS — via `aimx upgrade --dry-run`.
+    // The dry-run exits cleanly after the fetch without touching the
+    // service or filesystem, so this is safe to run under sudo in CI.
     let out = Command::new(assert_cmd::cargo::cargo_bin("aimx"))
         .args(["upgrade", "--dry-run", "--version", "v0.0.0-fixture"])
         .env("AIMX_RELEASE_MANIFEST_URL", FIXTURE_RELEASE_URL)
@@ -294,14 +337,6 @@ fn real_release_ops_end_to_end_against_fixture() {
         combined.contains(&tarball_name),
         "expected tarball name {tarball_name} in dry-run output: {combined}"
     );
-    // Expected SHA only asserted for the side-effect of using it —
-    // the dry-run downloads but does not checksum, so we leave the
-    // checksum to the other test.
-    let _ = expected_sha;
-
-    unsafe {
-        std::env::remove_var("AIMX_RELEASE_MANIFEST_URL");
-    }
 }
 
 fn hex(bytes: &[u8]) -> String {


### PR DESCRIPTION
## Summary

Ships `aimx upgrade` per PRD §6.4 — a single-verb, non-interactive,
self-updating binary flow with `--dry-run` / `--version` / `--force`,
rollback-safe on any step failure. No wizard re-run, no prompts, no
signing (HTTPS on GitHub Releases is the v1 trust anchor per §9).

## Per-story AC status

### S4-1 — happy path: check → fetch → verify → swap → restart
- [x] `src/upgrade.rs` created; `aimx upgrade` wired through `src/cli.rs` and `src/main.rs`
- [x] Root check: non-root invocation fails with `aimx upgrade requires root`
- [x] Happy path end-to-end test via `MockReleaseOps` + `MockSystemOps`; every step recorded in `UpgradeReport` and asserted in order
- [x] `/proc/self/exe`-derived target path (not hardcoded `/usr/local/bin/aimx`) — `AIMX_PREFIX` installs respected
- [x] Up-to-date short-circuit: prints `aimx v<x> is up to date.`, no fetches, no writes
- [x] `SystemOps::stop_service` + `SystemOps::start_service` added as first-class **required** methods with systemd + OpenRC dispatch tables in `src/serve.rs` (post-review NB-5: removed `Err("not implemented")` defaults; all four in-tree mocks now provide explicit `unreachable!()` overrides)
- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean

### S4-2 — `--dry-run`, `--version`, `--force` flags
- [x] `--dry-run` prints current → target, tarball URL, install path, action list; never touches the service or `/usr/local/bin/`
- [x] `--dry-run` on download failure exits non-zero with the specific `ReleaseError` (test: `dry_run_with_download_failure_returns_release_error`)
- [x] `--version <tag>` fetches that tag; unknown tag returns a `ReleaseError::Http { status: 404, .. }` (test: `unknown_tag_surfaces_release_error`)
- [x] `--force` re-installs the current tag; with `--version`, the specified tag
- [x] Same-tag `--force` test re-installs (closes PRD §11 `CARGO_PKG_VERSION` collision question) — test: `version_flag_uses_release_by_tag_and_skips_up_to_date`
- [x] `--dry-run --version v<x> --force` composes correctly (test: `dry_run_composes_with_version_and_force`)
- [x] Help text matches FR-4.2 / FR-4.4 phrasing
- [x] Unit tests cover every flag combination via `MockReleaseOps`

### S4-3 — rollback on step failure + `aimx.prev` preservation
- [x] Rollback fires on `systemctl stop` failure (PreSwap — nothing to roll back since swap hadn't started)
- [x] Rollback fires on extraction failure — **new** test `run_upgrade_malformed_tarball_returns_preswap_extract_error` drives `run_upgrade` with a garbage tarball and asserts `PreSwap { step: ExtractTarball }` plus that `stop_service` never ran
- [x] Rollback fires on binary-install failure — **new** test `run_upgrade_install_binary_failure_rolls_back_to_prev` plants a directory at the staging `.aimx.upgrade.tmp` sibling path so `fs::copy` fails; asserts `RolledBack { failed_step: InstallNewBinary }` and that `.prev` was restored onto `install_path`
- [x] Rollback fires on `systemctl start` failure — **new** test `rollback_succeeds_when_start_fails_once` exercises the canonical `RolledBack { failed_step: StartService }` path via the new `start_service_failures_remaining` fail-once counter on `MockSystemOps` (the sticky `start_service_fails` bool still covers the `RollbackFailed` path in `rollback_fires_on_start_failure`)
- [x] Rollback fires on `wait_for_service_ready` timeout; now also asserts `started_services.len() == 2` to prove the rollback restarted the service on the old binary
- [x] Rollback restores `aimx.prev` atomically; service is running on the previous binary when `RolledBack` is returned
- [x] `UpgradeError::RolledBack { failed_step, cause, previous_tag }` rendered by the CLI as `✗ <step>: <cause>` + `→ rolled back to v<previous>; check logs with 'aimx logs'`
- [x] `aimx.prev` exists after a successful upgrade and is overwritten (not deleted) on the next upgrade (test: `stale_prev_overwritten_by_new_upgrade`). Post-review NB-7: `preserve_previous_binary` now relies on `fs::rename`'s Unix atomic-overwrite semantics instead of pre-deleting `.prev`, so a rename failure leaves the previous cycle's `.prev` intact.
- [x] Integration tests simulate failure at every rollback-relevant step via `stop_service_fails` / `start_service_fails` / `start_service_failures_remaining` / `service_ready` mock knobs
- [ ] Manual smoke test on a VPS (corrupt-tarball/kill-network) — deferred to operator-run smoke pass; all failure paths are unit-tested
- [x] `cargo test`, clippy, fmt clean

### Sprint 2 backlog item — exercise production `RealReleaseOps::fetch_asset` path end-to-end

- [x] `tests/release_integration.rs` now splits the coverage:
  - `real_release_ops_wireup_non_root_refuses` — runs under the default `cargo test --features integration` in the `core-tests` CI job and proves the verb is plumbed through CLI dispatch (root-check refusal branch).
  - `real_release_ops_end_to_end_against_fixture_as_root` — `#[ignore]` + `AIMX_INTEGRATION_SUDO=1` gated; drives `aimx upgrade --dry-run --version v0.0.0-fixture` through the production `RealReleaseOps::release_by_tag` → `fetch_asset` → real HTTPS + rustls path against the live fixture release. Runs in the `integration-isolation` CI job under sudo, matching the pattern already used for `isolation` / `uds_authz` / MAILBOX-CRUD integration tests.

## Test plan

- [x] `cargo test` — 1269 unit tests + 95 integration pass (was 1266 + 95; +3 new tests for N2/N3/N4)
- [x] `cargo test --features integration --test release_integration` — 2 tests pass (fixture SHA match + non-root wire-up), 1 ignored (root-gated end-to-end, run via the new sudo step)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo clippy --all-targets --features integration -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [ ] Manual smoke test on a real VPS (deferred to operator-run release-prep pass)

## Notes

- `tar` + `flate2` + `tempfile` promoted from dev-deps (or newly added) so the upgrade path can stage + extract without re-implementing tarball parsing or tempdir cleanup. `flate2` uses the pure-Rust `rust_backend` to stay consistent with the existing no-extra-C-deps posture. Post-review NB-6: the duplicate `tempfile = "3"` line under `[dev-dependencies]` was dropped (the `[dependencies]` entry covers test code too).
- `SystemOps::stop_service` / `start_service` are now **required** trait methods with no default impl. The four in-tree mocks in `doctor.rs`, `logs.rs`, `portcheck.rs`, `uninstall.rs` provide explicit `unreachable!()` overrides so a future sprint that teaches any of those modules to stop/start the service gets a clear panic at the mock instead of the old `Err("not implemented")` string.
- `MockSystemOps` grew a new `start_service_failures_remaining: Cell<u32>` knob so tests can fail the upgrade's `start_service` exactly once and let rollback's own `start_service` succeed — the canonical `RolledBack { failed_step: StartService }` path that the old sticky bool could not express.
- `MockSystemOps` bumped to `pub(crate)` with pub fields so `upgrade::tests` can drive it from its own module while keeping it `#[cfg(test)]`-gated.