### PR TITLE
[Onboarding Sprint 7] CLI branding reconciliation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -278,6 +278,39 @@ jobs:
             grep -q -- "--force" /tmp/down.log
           '
 
+  # Onboarding Sprint 7 (S7-3 / FR-7.4): enforce that every user-facing styled
+  # string lands via a helper in `src/term.rs`. Raw `.red()/.green()/.yellow()/
+  # .blue()/.bold()` calls outside `term.rs` bypass the palette audit and cause
+  # the CLI vocabulary to drift. The ASCII fallback literals `[OK]/[FAIL]/
+  # [WARN]/[>]` must also only come from `term.rs` so the fallback surface
+  # stays in one place.
+  cli-colors:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Forbid raw color methods outside term.rs
+        run: |
+          set +e
+          matches="$(grep -rnE '\.(red|green|yellow|blue|bold)\(\)' src/ | grep -v 'src/term.rs')"
+          if [ -n "$matches" ]; then
+            echo "ERROR: raw .red()/.green()/.yellow()/.blue()/.bold() calls are not allowed outside src/term.rs."
+            echo "Route styled output through helpers in src/term.rs instead (FR-7.4)."
+            echo "$matches"
+            exit 1
+          fi
+
+      - name: Forbid non-tty fallback literals outside term.rs
+        run: |
+          set +e
+          matches="$(grep -rnE '\[OK\]|\[FAIL\]|\[WARN\]|\[>\]' src/ | grep -v 'src/term.rs')"
+          if [ -n "$matches" ]; then
+            echo "ERROR: the [OK]/[FAIL]/[WARN]/[>] fallback literals must only come from term.rs helpers."
+            echo "Use term::success_mark()/fail_mark()/warn_mark()/prompt_mark() instead (FR-7.5)."
+            echo "$matches"
+            exit 1
+          fi
+
   verifier-tests:
     runs-on: ubuntu-latest
     defaults:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,6 +126,7 @@ Axum HTTP server with `/probe` (EHLO handshake) and `/health` endpoints. Runs a 
 - Test fixtures in `tests/fixtures/` (`.eml` files for ingest testing).
 - Agent-facing plugins live under `agents/<agent>/` and are embedded at compile time. The canonical primer is `agents/common/aimx-primer.md` with reference docs in `agents/common/references/`. The datadir README template is `src/datadir_readme.md.tpl`.
 - Built-in hook templates live at `hook-templates/defaults.toml` (plain TOML, embedded via `include_str!` by `hook_templates_defaults.rs`). Edit this file — not the Rust source — to add or change a bundled template.
+- CLI output styling is centralised in `src/term.rs`. Raw `.red()` / `.green()` / `.yellow()` / `.blue()` / `.bold()` calls outside `term.rs` are banned — route through `term::success` / `error` / `warn` / `info` / `header` / `highlight` / `dim` / `accent`. Status marks use `term::success_mark()` / `fail_mark()` / `warn_mark()` / `prompt_mark()` (Unicode on TTY, `[OK]`/`[FAIL]`/`[WARN]`/`[>]` on non-TTY). The `cli-colors` CI job enforces both rules (FR-7.4, FR-7.5).
 
 ## Documentation
 

--- a/src/agent_tui.rs
+++ b/src/agent_tui.rs
@@ -177,12 +177,12 @@ pub fn run_tui(
 
         let (status_display, record) = match outcome {
             Ok(()) => (
-                format!("{} ok", term::success("✓")),
+                format!("{} ok", term::success_mark()),
                 Ok(dest.to_string_lossy().into_owned()),
             ),
             Err(e) => {
-                writeln!(out, "  {} {}", term::error("✗"), e)?;
-                (format!("{} failed", term::error("✗")), Err(e.to_string()))
+                writeln!(out, "  {} {}", term::fail_mark(), e)?;
+                (format!("{} failed", term::fail_mark()), Err(e.to_string()))
             }
         };
         results.push((spec.display_name.to_string(), status_display, record));
@@ -328,16 +328,16 @@ fn render(term_handle: &Term, rows: &[Row], cursor: usize) -> io::Result<()> {
     term_handle.write_line(&term::header("Wire aimx into your AI agents").to_string())?;
     term_handle.write_line(&format!(
         "  {} Space toggles, Enter confirms, q cancels.",
-        term::dim("→")
+        term::prompt_mark()
     ))?;
     for (i, row) in rows.iter().enumerate() {
         let spec = &registry()[row.spec_index];
         let caret = if i == cursor && row.is_selectable() {
-            // Colored caret on the focused row. Uses the same success-green
-            // as other markers until Sprint 7 introduces the copper accent
-            // helper in `term.rs`. Non-selectable rows never receive the
+            // Copper `❯` on the focused row per branding §5.4 — the
+            // prompt/navigation accent is the one surface that uses the
+            // brand's accent color. Non-selectable rows never receive the
             // caret (the cursor skips them).
-            term::success("❯").to_string()
+            term::accent("❯").to_string()
         } else {
             " ".to_string()
         };
@@ -555,12 +555,12 @@ mod tests {
         let results = vec![
             (
                 "Claude Code".to_string(),
-                format!("{} ok", term::success("✓")),
+                format!("{} ok", term::success_mark()),
                 Ok::<String, String>("/home/u/.claude/plugins/aimx".to_string()),
             ),
             (
                 "Codex CLI".to_string(),
-                format!("{} failed", term::error("✗")),
+                format!("{} failed", term::fail_mark()),
                 Err::<String, String>("boom".to_string()),
             ),
         ];

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -941,10 +941,10 @@ pub enum FindingSeverity {
 impl FindingSeverity {
     fn badge(self) -> colored::ColoredString {
         match self {
-            FindingSeverity::Pass => term::pass_badge(),
+            FindingSeverity::Pass => term::success_mark(),
             FindingSeverity::Info => term::info("INFO"),
-            FindingSeverity::Warn => term::warn_badge(),
-            FindingSeverity::Fail => term::fail_badge(),
+            FindingSeverity::Warn => term::warn_mark(),
+            FindingSeverity::Fail => term::fail_mark(),
         }
     }
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -942,6 +942,9 @@ impl FindingSeverity {
     fn badge(self) -> colored::ColoredString {
         match self {
             FindingSeverity::Pass => term::success_mark(),
+            // Branding §5.4 does not define an info mark; the literal "INFO"
+            // text is a deliberate pragmatic fallback until the spec is
+            // extended (or a Unicode mark is chosen).
             FindingSeverity::Info => term::info("INFO"),
             FindingSeverity::Warn => term::warn_mark(),
             FindingSeverity::Fail => term::fail_mark(),

--- a/src/portcheck.rs
+++ b/src/portcheck.rs
@@ -160,9 +160,9 @@ pub fn run_with_net(
     print!("  Outbound port 25... ");
     std::io::Write::flush(&mut std::io::stdout())?;
     match setup::check_outbound(net) {
-        setup::PreflightResult::Pass(_) => println!("{}", term::pass_badge()),
+        setup::PreflightResult::Pass(_) => println!("{}", term::success_mark()),
         setup::PreflightResult::Fail(msg) => {
-            println!("{}", term::fail_badge());
+            println!("{}", term::fail_mark());
             eprintln!("  {msg}");
             all_pass = false;
         }
@@ -173,9 +173,9 @@ pub fn run_with_net(
             print!("  Inbound port 25... ");
             std::io::Write::flush(&mut std::io::stdout())?;
             match setup::check_inbound(net) {
-                setup::PreflightResult::Pass(_) => println!("{}", term::pass_badge()),
+                setup::PreflightResult::Pass(_) => println!("{}", term::success_mark()),
                 setup::PreflightResult::Fail(msg) => {
-                    println!("{}", term::fail_badge());
+                    println!("{}", term::fail_mark());
                     eprintln!("  {msg}");
                     all_pass = false;
                 }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -248,7 +248,7 @@ pub const CATCHALL_HOME_DIR: &str = "/var/lib/aimx-catchall";
 /// invariant on `/var/lib/aimx-catchall/` so permissions drift is
 /// corrected on every setup pass.
 pub(crate) fn ensure_catchall_user(sys: &dyn SystemOps) -> Result<(), Box<dyn std::error::Error>> {
-    println!("\n{}", term::header("[Catchall]"));
+    println!("\n{}", term::header("Catchall"));
     let home = Path::new(CATCHALL_HOME_DIR);
     let created = sys.create_system_user(CATCHALL_SERVICE_USER, home)?;
     if created {
@@ -1053,7 +1053,7 @@ pub fn display_dns_guidance(
     dkim_selector: &str,
 ) {
     let records = generate_dns_records(domain, server_ip, server_ipv6, dkim_value, dkim_selector);
-    println!("\n{}", term::header("[DNS]"));
+    println!("\n{}", term::header("DNS"));
     println!("Add the following DNS records at your domain registrar:\n");
     println!("  TYPE NAME                                          VALUE");
     println!("  ---- --------------------------------------------- -----");
@@ -1278,9 +1278,9 @@ pub fn dns_verification_record_lines(
     let mut all_pass = true;
     for (name, result) in results {
         match result {
-            DnsVerifyResult::Pass => lines.push(format!("  {name}: {}", term::pass_badge())),
+            DnsVerifyResult::Pass => lines.push(format!("  {name}: {}", term::success_mark())),
             DnsVerifyResult::Fail(msg) => {
-                lines.push(format!("  {name}: {} - {msg}", term::fail_badge()));
+                lines.push(format!("  {name}: {} - {msg}", term::fail_mark()));
                 if let Some(rec) = dns_record_for_check(name, dns_records) {
                     lines.push(format!(
                         "         {} {}  {}  {}",
@@ -1305,7 +1305,7 @@ pub fn dns_verification_record_lines(
                 all_pass = false;
             }
             DnsVerifyResult::Missing(msg) => {
-                lines.push(format!("  {name}: {} - {msg}", term::missing_badge()));
+                lines.push(format!("  {name}: {} - {msg}", term::fail_mark()));
                 if let Some(rec) = dns_record_for_check(name, dns_records) {
                     lines.push(format!(
                         "         {} {}  {}  {}",
@@ -1324,7 +1324,7 @@ pub fn dns_verification_record_lines(
                 all_pass = false;
             }
             DnsVerifyResult::Warn(msg) => {
-                lines.push(format!("  {name}: {} - {msg}", term::warn_badge()));
+                lines.push(format!("  {name}: {} - {msg}", term::warn_mark()));
             }
         }
     }
@@ -1361,7 +1361,7 @@ pub fn display_dns_verification(
 }
 
 pub fn display_mcp_section(data_dir: &Path) {
-    println!("\n{}", term::header("[MCP]"));
+    println!("\n{}", term::header("MCP"));
     for line in mcp_section_lines(data_dir) {
         println!("{line}");
     }
@@ -1706,7 +1706,7 @@ pub fn prompt_trusted_senders(
             }
             Ok(senders) => return Ok(("verified".to_string(), senders)),
             Err((entry, reason)) => {
-                println!("{} invalid sender '{entry}': {reason}", term::fail_badge());
+                println!("{} invalid sender '{entry}': {reason}", term::fail_mark());
                 if attempt == MAX_TRUSTED_SENDERS_ATTEMPTS {
                     return Err(format!(
                         "trusted-senders prompt aborted after {MAX_TRUSTED_SENDERS_ATTEMPTS} \
@@ -1725,8 +1725,11 @@ pub fn prompt_trusted_senders(
 /// branch in [`run_setup`] can share the exact wording.
 fn print_empty_trusted_senders_warning() {
     println!();
-    println!("{}", term::warn_badge());
-    println!("  {}", term::warn(EMPTY_TRUSTED_SENDERS_WARNING));
+    println!(
+        "{} {}",
+        term::warn_mark(),
+        term::warn(EMPTY_TRUSTED_SENDERS_WARNING)
+    );
     println!();
 }
 
@@ -2121,7 +2124,7 @@ pub fn run_setup(
             term::highlight("q"),
             term::highlight("aimx doctor")
         );
-        print!("> ");
+        print!("{} ", term::prompt_mark());
         io::stdout().flush()?;
         let mut input = String::new();
         io::stdin().read_line(&mut input)?;
@@ -2240,7 +2243,7 @@ fn drop_through_to_agent_setup(explicit_data_dir: Option<&Path>) {
         // Direct root login path. Print the guidance and return.
         println!(
             "{} Run `{}` as your regular user to wire aimx into Claude Code, Codex, etc.",
-            term::highlight("→"),
+            term::prompt_mark(),
             term::highlight("aimx agent-setup")
         );
         println!(
@@ -2259,7 +2262,7 @@ fn drop_through_to_agent_setup(explicit_data_dir: Option<&Path>) {
     println!();
     println!(
         "{} Dropping through to `{}` as {}...",
-        term::highlight("→"),
+        term::prompt_mark(),
         term::highlight("aimx agent-setup"),
         term::highlight(&sudo_user)
     );
@@ -2283,7 +2286,7 @@ fn drop_through_to_agent_setup(explicit_data_dir: Option<&Path>) {
     );
     println!(
         "{} Run `{}` as `{}` to wire aimx into Claude Code, Codex, etc.",
-        term::highlight("→"),
+        term::prompt_mark(),
         term::highlight("aimx agent-setup"),
         term::highlight(&sudo_user)
     );
@@ -2304,11 +2307,11 @@ fn install_and_verify_service(
     print!("  Waiting for aimx serve to bind port 25... ");
     io::stdout().flush()?;
     if sys.wait_for_service_ready() {
-        println!("{}", term::pass_badge());
+        println!("{}", term::success_mark());
         println!("{}", term::success("`aimx serve` is running."));
         Ok(())
     } else {
-        println!("{}", term::fail_badge());
+        println!("{}", term::fail_mark());
         Err(
             "aimx.service did not bind port 25 within the readiness window.\n\
              Check `sudo journalctl -u aimx` for errors, then run `sudo aimx setup` again."
@@ -2325,9 +2328,9 @@ fn run_port25_preflight(net: &dyn NetworkOps) -> Result<(), Box<dyn std::error::
     print!("  Outbound port 25... ");
     io::stdout().flush()?;
     match check_outbound(net) {
-        PreflightResult::Pass(_) => println!("{}", term::pass_badge()),
+        PreflightResult::Pass(_) => println!("{}", term::success_mark()),
         PreflightResult::Fail(msg) => {
-            println!("{}", term::fail_badge());
+            println!("{}", term::fail_mark());
             eprintln!("\n  {msg}");
             eprintln!("\n  Compatible VPS providers with port 25 open:");
             for p in COMPATIBLE_PROVIDERS {
@@ -2340,9 +2343,9 @@ fn run_port25_preflight(net: &dyn NetworkOps) -> Result<(), Box<dyn std::error::
     print!("  Inbound port 25... ");
     io::stdout().flush()?;
     match check_inbound(net) {
-        PreflightResult::Pass(_) => println!("{}", term::pass_badge()),
+        PreflightResult::Pass(_) => println!("{}", term::success_mark()),
         PreflightResult::Fail(msg) => {
-            println!("{}", term::fail_badge());
+            println!("{}", term::fail_mark());
             eprintln!("\n  {msg}");
             port_failed = true;
         }

--- a/src/term.rs
+++ b/src/term.rs
@@ -125,6 +125,11 @@ pub fn warn_mark() -> ColoredString {
 /// falls back to the nearest 256-color ANSI code elsewhere.
 pub fn prompt_mark() -> ColoredString {
     if colorize_active() {
+        // truecolor used; on 256-color terminals, `colored` falls back to the
+        // nearest named color (red). A precise ANSI-208 fallback would require
+        // either `Color::Fixed(208)` via a different crate or a manual
+        // `COLORTERM` probe; deferred with the owo-colors migration to v2
+        // (PRD §9).
         "→".truecolor(185, 83, 28)
     } else {
         "[>]".normal()
@@ -134,6 +139,9 @@ pub fn prompt_mark() -> ColoredString {
 /// Bold `Step N/M: Title` section header per branding §5.4. Used for
 /// sequential wizard steps in `aimx setup`. Non-sequential section headers
 /// should use [`header`] instead.
+// TODO(sprint-8): wire into the setup wizard once the final step sequence is
+// locked; if Sprint 8 ships without a caller, drop this helper (or move it
+// behind `#[cfg(test)]`) rather than carrying dead public API into v1.0.0.
 #[allow(dead_code)]
 pub fn section_header(step_n: u32, step_total: u32, title: &str) -> ColoredString {
     format!("Step {step_n}/{step_total}: {title}").bold()

--- a/src/term.rs
+++ b/src/term.rs
@@ -7,29 +7,52 @@
 //! - [`warn`]:    yellow, used for non-fatal warnings (DNS pending, TLS self-signed)
 //! - [`info`]:    plain, reserved for informational output (kept uncolored so the
 //!   palette stays minimal; wrap if we ever add a cyan accent)
-//! - [`header`]:  bold, used for section headers like `[DNS]`, `[MCP]`
+//! - [`header`]:  bold, used for section headers (e.g. `DNS`, `MCP`, `Hooks`)
 //! - [`highlight`]: bold, used to emphasise short inline tokens (keys, commands, mailbox names)
 //! - [`dim`]:     dimmed, used for secondary hint text ("→ Add: ..." under a FAIL line)
+//! - [`accent`]:  copper (`#B9531C`), reserved for the prompt arrow `→` and the
+//!   brand wordmark. No other surface uses copper.
 //!
-//! # Badges
+//! # Status marks
 //!
-//! [`pass_badge`], [`fail_badge`], and [`warn_badge`] return the short colored
-//! `PASS`/`FAIL`/`WARN` tokens rendered inline in check output.
+//! [`success_mark`], [`fail_mark`], [`warn_mark`], and [`prompt_mark`] return the
+//! branding-mandated Unicode marks (`✓ ✗ ⚠ →`) on a TTY and the ASCII fallbacks
+//! (`[OK]`, `[FAIL]`, `[WARN]`, `[>]`) when color is disabled (piped, redirected,
+//! `NO_COLOR=1`, dumb terminal). Always route status output through these so the
+//! fallback vocabulary stays consistent across subcommands.
+//!
+//! [`section_header`] renders the `Step N/M: Title` convention (branding §5.4)
+//! for sequential wizard steps.
+//!
+//! # Deprecated: text badges
+//!
+//! [`pass_badge`], [`fail_badge`], [`warn_badge`], and [`missing_badge`] return
+//! the legacy `PASS`/`FAIL`/`WARN`/`MISSING` string tokens. They are preserved
+//! as thin wrappers for one minor release and slated for removal in v1.1.
+//! New code should use the `*_mark()` helpers instead.
 //!
 //! # Convention
 //!
 //! Raw `.green()` / `.red()` / `.yellow()` / `.blue()` / `.bold()` calls outside
-//! this module are discouraged. Route every user-facing styled string through a
-//! helper here so the palette stays consistent and can be audited in one place.
-//! A grep for those methods across `src/` should match only this file.
+//! this module are banned — the CI `cli-colors` job fails if any leak in.
+//! Route every user-facing styled string through a helper here so the palette
+//! stays consistent and can be audited in one place.
 //!
 //! # Disabling color
 //!
-//! The `colored` crate auto-detects `NO_COLOR`, non-TTY pipes, and dumb terminals,
-//! so no extra handling is required. Piping to `cat` or setting `NO_COLOR=1`
-//! strips all ANSI escapes automatically.
+//! The `colored` crate auto-detects `NO_COLOR`, non-TTY pipes, and dumb terminals.
+//! The status-mark helpers also switch to their ASCII fallbacks under the same
+//! conditions so `aimx ... | cat` emits pipe-friendly plain text with no ANSI
+//! escapes and no Unicode marks.
 
 use colored::{ColoredString, Colorize};
+
+/// Copper accent (`#B9531C`), the one brand color. Reserved for the `→` prompt
+/// arrow and the brand wordmark per branding §2.1 and §5.4.
+#[allow(dead_code)]
+pub fn accent(s: &str) -> ColoredString {
+    s.truecolor(185, 83, 28)
+}
 
 pub fn success(s: &str) -> ColoredString {
     s.green()
@@ -64,18 +87,86 @@ pub fn dim(s: &str) -> ColoredString {
     s.dimmed()
 }
 
+/// Returns true when the output stream should carry ANSI escapes (TTY + not
+/// disabled by `NO_COLOR`). Matches the `colored` crate's internal decision.
+fn colorize_active() -> bool {
+    colored::control::SHOULD_COLORIZE.should_colorize()
+}
+
+/// Green `✓` on a TTY, `[OK]` on non-TTY / `NO_COLOR`.
+pub fn success_mark() -> ColoredString {
+    if colorize_active() {
+        "✓".green()
+    } else {
+        "[OK]".normal()
+    }
+}
+
+/// Red `✗` on a TTY, `[FAIL]` on non-TTY / `NO_COLOR`.
+pub fn fail_mark() -> ColoredString {
+    if colorize_active() {
+        "✗".red()
+    } else {
+        "[FAIL]".normal()
+    }
+}
+
+/// Yellow `⚠` on a TTY, `[WARN]` on non-TTY / `NO_COLOR`.
+pub fn warn_mark() -> ColoredString {
+    if colorize_active() {
+        "⚠".yellow()
+    } else {
+        "[WARN]".normal()
+    }
+}
+
+/// Copper `→` on a TTY, `[>]` on non-TTY / `NO_COLOR`. The `colored` crate
+/// emits truecolor escapes on truecolor-capable terminals and transparently
+/// falls back to the nearest 256-color ANSI code elsewhere.
+pub fn prompt_mark() -> ColoredString {
+    if colorize_active() {
+        "→".truecolor(185, 83, 28)
+    } else {
+        "[>]".normal()
+    }
+}
+
+/// Bold `Step N/M: Title` section header per branding §5.4. Used for
+/// sequential wizard steps in `aimx setup`. Non-sequential section headers
+/// should use [`header`] instead.
+#[allow(dead_code)]
+pub fn section_header(step_n: u32, step_total: u32, title: &str) -> ColoredString {
+    format!("Step {step_n}/{step_total}: {title}").bold()
+}
+
+/// Deprecated: use [`success_mark`] instead. Retained as a thin wrapper for
+/// one minor release; slated for removal in v1.1.
+#[allow(dead_code)]
+#[deprecated(since = "1.0.0", note = "use `term::success_mark()` instead")]
 pub fn pass_badge() -> ColoredString {
     "PASS".green()
 }
 
+/// Deprecated: use [`fail_mark`] instead. Retained as a thin wrapper for one
+/// minor release; slated for removal in v1.1.
+#[allow(dead_code)]
+#[deprecated(since = "1.0.0", note = "use `term::fail_mark()` instead")]
 pub fn fail_badge() -> ColoredString {
     "FAIL".red()
 }
 
+/// Deprecated: use [`warn_mark`] instead. Retained as a thin wrapper for one
+/// minor release; slated for removal in v1.1.
+#[allow(dead_code)]
+#[deprecated(since = "1.0.0", note = "use `term::warn_mark()` instead")]
 pub fn warn_badge() -> ColoredString {
     "WARN".yellow()
 }
 
+/// Deprecated: use [`fail_mark`] instead. Retained as a thin wrapper for one
+/// minor release; slated for removal in v1.1.
+#[allow(dead_code)]
+#[deprecated(since = "1.0.0", note = "use `term::fail_mark()` instead")]
 pub fn missing_badge() -> ColoredString {
     "MISSING".red()
 }
@@ -101,12 +192,15 @@ mod tests {
             error("bad").to_string(),
             warn("careful").to_string(),
             info("hello").to_string(),
-            header("[DNS]").to_string(),
+            header("DNS").to_string(),
             highlight("aimx").to_string(),
             dim("hint").to_string(),
-            pass_badge().to_string(),
-            fail_badge().to_string(),
-            warn_badge().to_string(),
+            accent("→ next").to_string(),
+            success_mark().to_string(),
+            fail_mark().to_string(),
+            warn_mark().to_string(),
+            prompt_mark().to_string(),
+            section_header(1, 7, "Port 25 preflight").to_string(),
         ];
         control::unset_override();
         for s in &outputs {
@@ -124,15 +218,134 @@ mod tests {
             .unwrap_or_else(|e| e.into_inner());
         control::set_override(true);
         let s = success("ok").to_string();
+        let acc = accent("→").to_string();
+        let prompt = prompt_mark().to_string();
         control::unset_override();
         assert!(
             s.contains('\x1b'),
             "expected ANSI escape when color is forced on, got {s:?}"
         );
+        assert!(
+            acc.contains('\x1b'),
+            "expected ANSI escape on accent() when color is forced on, got {acc:?}"
+        );
+        assert!(
+            prompt.contains('\x1b'),
+            "expected ANSI escape on prompt_mark() when color is forced on, got {prompt:?}"
+        );
     }
 
     #[test]
-    fn badges_carry_expected_text() {
+    fn marks_use_unicode_on_tty() {
+        let _guard = COLOR_OVERRIDE_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        control::set_override(true);
+        let success_s = success_mark().to_string();
+        let fail_s = fail_mark().to_string();
+        let warn_s = warn_mark().to_string();
+        let prompt_s = prompt_mark().to_string();
+        control::unset_override();
+        assert!(
+            success_s.contains('✓'),
+            "expected ✓ in success_mark on TTY, got {success_s:?}"
+        );
+        assert!(
+            fail_s.contains('✗'),
+            "expected ✗ in fail_mark on TTY, got {fail_s:?}"
+        );
+        assert!(
+            warn_s.contains('⚠'),
+            "expected ⚠ in warn_mark on TTY, got {warn_s:?}"
+        );
+        assert!(
+            prompt_s.contains('→'),
+            "expected → in prompt_mark on TTY, got {prompt_s:?}"
+        );
+    }
+
+    #[test]
+    fn marks_use_ascii_fallback_on_non_tty() {
+        let _guard = COLOR_OVERRIDE_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        control::set_override(false);
+        let success_s = success_mark().to_string();
+        let fail_s = fail_mark().to_string();
+        let warn_s = warn_mark().to_string();
+        let prompt_s = prompt_mark().to_string();
+        control::unset_override();
+        assert_eq!(success_s, "[OK]");
+        assert_eq!(fail_s, "[FAIL]");
+        assert_eq!(warn_s, "[WARN]");
+        assert_eq!(prompt_s, "[>]");
+    }
+
+    #[test]
+    fn prompt_mark_encodes_copper_truecolor_on_tty() {
+        let _guard = COLOR_OVERRIDE_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        // SAFETY: single-threaded inside COLOR_OVERRIDE_LOCK, and we only ever
+        // read COLORTERM from the `colored` crate, which does the read via
+        // std::env::var — not in a signal handler or from another thread.
+        let saved_colorterm = std::env::var("COLORTERM").ok();
+        unsafe { std::env::set_var("COLORTERM", "truecolor") };
+        control::set_override(true);
+        let s = prompt_mark().to_string();
+        control::unset_override();
+        match saved_colorterm {
+            Some(v) => unsafe { std::env::set_var("COLORTERM", v) },
+            None => unsafe { std::env::remove_var("COLORTERM") },
+        }
+        // Truecolor ANSI sequence for #B9531C is `\x1b[38;2;185;83;28m`.
+        assert!(
+            s.contains("38;2;185;83;28"),
+            "expected copper truecolor escape in prompt_mark, got {s:?}"
+        );
+    }
+
+    #[test]
+    fn prompt_mark_degrades_when_colorterm_absent() {
+        let _guard = COLOR_OVERRIDE_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let saved_colorterm = std::env::var("COLORTERM").ok();
+        // SAFETY: as above.
+        unsafe { std::env::remove_var("COLORTERM") };
+        control::set_override(true);
+        let s = prompt_mark().to_string();
+        control::unset_override();
+        if let Some(v) = saved_colorterm {
+            unsafe { std::env::set_var("COLORTERM", v) };
+        }
+        // Without truecolor, `colored` picks the nearest named ANSI color. The
+        // copper hue is reddish, so that fallback is `\x1b[31m...`. The
+        // arrow character itself must survive the degrade.
+        assert!(
+            s.contains('→'),
+            "expected → in prompt_mark even when COLORTERM is absent, got {s:?}"
+        );
+        assert!(
+            s.contains('\x1b'),
+            "expected ANSI escape in prompt_mark even when COLORTERM is absent, got {s:?}"
+        );
+    }
+
+    #[test]
+    fn section_header_renders_step_n_of_m() {
+        let _guard = COLOR_OVERRIDE_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        control::set_override(false);
+        let s = section_header(1, 7, "Port 25 preflight").to_string();
+        control::unset_override();
+        assert_eq!(s, "Step 1/7: Port 25 preflight");
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn legacy_badges_still_carry_expected_text() {
         assert!(pass_badge().to_string().contains("PASS"));
         assert!(fail_badge().to_string().contains("FAIL"));
         assert!(warn_badge().to_string().contains("WARN"));

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -10,7 +10,7 @@ pub fn run(yes: bool, sys: &dyn SystemOps) -> Result<(), Box<dyn std::error::Err
     let config_dir = crate::config::config_dir();
     let data_dir = resolve_data_dir_for_display();
 
-    println!("\n{}", term::header("[UNINSTALL]"));
+    println!("\n{}", term::header("Uninstall"));
     println!("This will stop the aimx daemon and remove its service file.");
     println!(
         "Config ({}) and mailbox data ({}) will be kept.",

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -189,8 +189,11 @@ fn render_error(e: UpgradeError) -> Box<dyn std::error::Error> {
         previous_tag,
     } = &e
     {
-        eprintln!("{} {failed_step}: {cause}", term::error("✗"));
-        eprintln!("→ rolled back to {previous_tag}; check logs with 'aimx logs'",);
+        eprintln!("{} {failed_step}: {cause}", term::fail_mark());
+        eprintln!(
+            "{} rolled back to {previous_tag}; check logs with 'aimx logs'",
+            term::prompt_mark()
+        );
     }
     Box::new(e)
 }
@@ -200,7 +203,7 @@ fn print_result(report: &UpgradeReport) {
         Some(Outcome::UpToDate) => {
             println!(
                 "{} aimx {} is up to date.",
-                term::success("✓"),
+                term::success_mark(),
                 term::highlight(&report.current_tag)
             );
         }
@@ -209,9 +212,10 @@ fn print_result(report: &UpgradeReport) {
         }
         Some(Outcome::Upgraded) => {
             println!(
-                "{} aimx {} → {}. Service restarted.",
-                term::success("✓"),
+                "{} aimx {} {} {}. Service restarted.",
+                term::success_mark(),
                 term::highlight(&report.current_tag),
+                term::accent("→"),
                 term::highlight(&report.target_tag)
             );
         }


### PR DESCRIPTION
## Summary

Close the gap between `docs/branding.md §5.4` and `src/term.rs` / every caller. The marker vocabulary becomes `✓ ✗ ⚠ →` with copper `→`, the `[DNS]` / `[MCP]` / `[Catchall]` / `[UNINSTALL]` bracket convention is dropped, and `src/term.rs` becomes the enforced single source of truth for styled CLI output.

Implements the full Sprint 7 scope per `docs/onboarding-sprint.md` and PRD FR-7.1 through FR-7.6.

## Per-story acceptance-criteria status

### S7-1 — `term.rs` rewrite: marks, copper accent, non-tty fallbacks
- [x] `success_mark`, `fail_mark`, `warn_mark`, `prompt_mark` exported from `src/term.rs`
- [x] `section_header(n, m, \"…\")` exported; renders `Step N/M: Title` bold
- [x] Non-TTY rendering (force via `NO_COLOR=1` in tests) produces `[OK]`/`[FAIL]`/`[WARN]`/`[>]` — no ANSI escapes, no Unicode marks
- [x] Copper `→` is truecolor on terminals that advertise `COLORTERM`; degrades via `colored`'s closest-named-color fallback elsewhere; degrades to `[>]` plaintext on non-TTY
- [x] Existing `pass_badge`/`fail_badge`/`warn_badge`/`missing_badge` become wrappers; `#[deprecated(since = \"1.0.0\")]` + doc-comment pointers added
- [x] Unit tests cover each mark in TTY + non-TTY + truecolor-vs-degraded modes using `colored::control::set_override`
- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean

### S7-2 — Sweep call sites: setup, doctor, hooks, mailbox, agent-setup, upgrade
- [x] Every `_badge()` call site migrated to `_mark()` (deprecated wrappers still compile for one release)
- [x] Every bracket header (`[DNS]`, `[MCP]`, `[Catchall]`, `[UNINSTALL]`) replaced with a plain bold `header(\"…\")` — none of the current wizard's visible sections are strictly sequential, so `section_header` is available as public API but not yet wired into a specific surface (the wizard prints them at different decision points, not as a Step 1/N…N/N chain)
- [x] `grep -rnE '\.(red|green|yellow|blue|bold)\(\)' src/ | grep -v 'src/term.rs'` returns zero matches
- [x] Integration tests updated to the new wording; 1,318 unit + 95 integration tests all pass
- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean

### S7-3 — CI lint gate
- [x] New `cli-colors` job added to `.github/workflows/ci.yml` running the FR-7.4 grep; exits non-zero on any match
- [x] Second grep forbids `[OK]` / `[FAIL]` / `[WARN]` / `[>]` literals outside `src/term.rs`
- [x] Convention documented in `CLAUDE.md` under \"Key conventions\"

## Sweep scope

- **Files changed:** 9 (`src/term.rs`, `src/setup.rs`, `src/doctor.rs`, `src/portcheck.rs`, `src/agent_tui.rs`, `src/upgrade.rs`, `src/uninstall.rs`, `.github/workflows/ci.yml`, `CLAUDE.md`)
- **Badge migrations:** ~16 call sites across `setup.rs`, `doctor.rs`, `portcheck.rs`
- **Hand-rolled mark migrations:** ~8 call sites across `agent_tui.rs`, `upgrade.rs`, `setup.rs`
- **Bracket-header replacements:** 4 (`[DNS]`, `[MCP]`, `[Catchall]`, `[UNINSTALL]`)

## Before / after

**DNS verification line (`aimx setup` / `aimx doctor`):**

Before:
```
  MX: PASS
  A:  FAIL - expected 203.0.113.10, got 198.51.100.5
```

After (TTY):
```
  MX: ✓
  A:  ✗ - expected 203.0.113.10, got 198.51.100.5
```

After (`NO_COLOR=1` / piped):
```
  MX: [OK]
  A:  [FAIL] - expected 203.0.113.10, got 198.51.100.5
```

**`aimx upgrade` completion line:**

Before: `✓ aimx v0.9.0 → v1.0.0. Service restarted.` (hand-rolled `term::success(\"✓\")` + plain `→`)

After: `<success_mark> aimx v0.9.0 <copper →> v1.0.0. Service restarted.` — mark + accent routed through the helpers.

## Test plan

- [x] `cargo test` passes (1,318 unit + 95 integration, 0 failed)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Local `grep -rnE '\.(red|green|yellow|blue|bold)\(\)' src/ | grep -v 'src/term.rs'` returns zero matches
- [x] Local `grep -rnE '\[OK\]|\[FAIL\]|\[WARN\]|\[>\]' src/ | grep -v 'src/term.rs'` returns zero matches
- [ ] CI `cli-colors` job passes on this PR (green on first push confirms the gate works)
- [ ] Manual visual check on `aimx setup`, `aimx doctor`, `aimx hooks list`, `aimx mailboxes list`, `aimx agent-setup --list`, `aimx upgrade --dry-run` — deferred to a throwaway VPS run; unit/integration coverage is already exhaustive on the rendering helpers