### PR TITLE
[Sprint 1] Symlink isolation + outbound EHLO

### DIFF
--- a/book/configuration.md
+++ b/book/configuration.md
@@ -55,6 +55,7 @@ Hook commands receive additional `AIMX_*` env vars carrying the triggering email
 | `trusted_senders` | array | `[]` | Default allowlist of glob patterns applied to every mailbox. Per-mailbox `trusted_senders` replaces this list (no merging). |
 | `verify_host` | string | `https://check.aimx.email` | Base URL of the verifier service used by `aimx portcheck` and `aimx setup`. Can be overridden per-invocation with the `--verify-host` flag. |
 | `enable_ipv6` | bool | `false` | Advanced. Opt into IPv6 outbound delivery. See [IPv6 delivery](#ipv6-delivery-advanced). |
+| `smtp_helo_name` | string | *(defaults to `domain`)* | Advanced. EHLO / HELO identity the outbound SMTP transport presents to recipient MXs. Leave unset on a single-host install — the default uses `domain`, which matches your DKIM / SPF / DMARC keys. Set this explicitly only when your sending host's FQDN differs from `domain` (e.g., a dedicated outbound relay named `mail.example.com` delivering mail for `domain = "agent.example.com"`). Must be a valid DNS hostname. |
 
 `aimx setup` asks for a list of trusted sender addresses interactively on
 the first run (comma-separated, accepts plain addresses and globs like

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,6 +107,14 @@ pub struct Config {
     #[serde(default)]
     pub enable_ipv6: bool,
 
+    /// Optional EHLO / HELO identity the outbound SMTP transport
+    /// presents to recipient MXs. Defaults to `config.domain` when
+    /// unset. Operators on multi-tenant VPSes whose sending host has a
+    /// different FQDN from `config.domain` (e.g., a dedicated relay)
+    /// set this explicitly. Hardening PRD §6.2.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub smtp_helo_name: Option<String>,
+
     /// Optional `[upgrade]` section. Overrides the release-manifest URL used
     /// by `aimx upgrade` (PRD FR-4.6). The `AIMX_RELEASE_MANIFEST_URL` env
     /// var takes precedence over this value when both are set.
@@ -1322,6 +1330,58 @@ fn validate_trust_values(config: &Config) -> Result<(), String> {
     Ok(())
 }
 
+/// Validate an RFC 1123–ish DNS hostname used for EHLO identity.
+///
+/// Rules:
+/// - Non-empty, ≤ 253 bytes total.
+/// - Each dot-separated label is 1–63 bytes, `[A-Za-z0-9-]`, and cannot
+///   start or end with a hyphen.
+/// - At least one label; trailing dot is not allowed (matches what an
+///   SMTP peer will accept as an EHLO parameter).
+///
+/// Used only for `Config.smtp_helo_name` at this point. Keeping it
+/// local to the module (rather than exporting) means the validator
+/// stays private to the load-time path.
+fn validate_helo_name(value: &str) -> Result<(), String> {
+    if value.is_empty() {
+        return Err("smtp_helo_name is empty; set a valid hostname or remove the field".into());
+    }
+    if value.len() > 253 {
+        return Err(format!(
+            "smtp_helo_name '{value}' exceeds 253 bytes (RFC 1035 cap)"
+        ));
+    }
+    if value.ends_with('.') {
+        return Err(format!(
+            "smtp_helo_name '{value}' has a trailing dot; drop it"
+        ));
+    }
+    for label in value.split('.') {
+        if label.is_empty() {
+            return Err(format!(
+                "smtp_helo_name '{value}' has an empty label (double dot or leading dot)"
+            ));
+        }
+        if label.len() > 63 {
+            return Err(format!(
+                "smtp_helo_name '{value}' has a label longer than 63 bytes: '{label}'"
+            ));
+        }
+        if label.starts_with('-') || label.ends_with('-') {
+            return Err(format!(
+                "smtp_helo_name '{value}' has a label starting/ending with '-': '{label}'"
+            ));
+        }
+        if !label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
+            return Err(format!(
+                "smtp_helo_name '{value}' has an invalid label '{label}'; \
+                 labels must match [A-Za-z0-9-]"
+            ));
+        }
+    }
+    Ok(())
+}
+
 impl Config {
     /// Load and validate a `config.toml`. Returns both the parsed
     /// `Config` and a vector of non-fatal warnings (orphan mailbox
@@ -1357,6 +1417,9 @@ impl Config {
             }
         }
         validate_trust_values(&config).map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+        if let Some(helo) = config.smtp_helo_name.as_deref() {
+            validate_helo_name(helo).map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+        }
         let mut warnings = validate_hook_templates(&config.hook_templates)
             .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
         let mailbox_warnings = validate_mailbox_owners(&config)
@@ -1379,6 +1442,17 @@ impl Config {
         let content = toml::to_string_pretty(self)?;
         std::fs::write(path, content)?;
         Ok(())
+    }
+
+    /// Effective EHLO / HELO identity for outbound SMTP. Returns the
+    /// operator-supplied `smtp_helo_name` when set, else falls back to
+    /// `config.domain`. The value is validated at load time (see
+    /// [`validate_helo_name`]) so callers may use it verbatim.
+    ///
+    /// Hardening PRD §6.2: outbound mail must introduce itself with
+    /// the sender's own hostname, never the dialed MX.
+    pub fn smtp_helo_name(&self) -> &str {
+        self.smtp_helo_name.as_deref().unwrap_or(&self.domain)
     }
 
     /// Load the config from the canonical path returned by [`config_path`].
@@ -2174,6 +2248,7 @@ dangerously_support_untrusted = true
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         };
 
@@ -2333,6 +2408,7 @@ trusted_senders = []
             mailboxes: HashMap::new(),
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         };
         config.save(&path).unwrap();
@@ -2374,6 +2450,7 @@ trusted_senders = []
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         };
         config.save(&path).unwrap();
@@ -2394,6 +2471,160 @@ trusted_senders = []
             !mailbox_section.contains("trusted_senders"),
             "unset mailbox trusted_senders should not serialize: {mailbox_section}"
         );
+    }
+
+    // ----- Sprint 1 S1-3: smtp_helo_name field + validator -----
+
+    #[test]
+    fn smtp_helo_name_helper_defaults_to_domain() {
+        let toml_str = "domain = \"example.com\"\n[mailboxes]\n";
+        let cfg: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.smtp_helo_name(), "example.com");
+    }
+
+    #[test]
+    fn smtp_helo_name_helper_returns_override_when_set() {
+        let toml_str =
+            "domain = \"example.com\"\nsmtp_helo_name = \"mail.example.com\"\n[mailboxes]\n";
+        let cfg: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.smtp_helo_name(), "mail.example.com");
+    }
+
+    #[test]
+    fn smtp_helo_name_roundtrips_byte_stable_when_set() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        let mut mailboxes = HashMap::new();
+        mailboxes.insert(
+            "catchall".to_string(),
+            MailboxConfig {
+                address: "*@test.com".to_string(),
+                owner: "aimx-catchall".to_string(),
+                hooks: vec![],
+                trust: None,
+                trusted_senders: None,
+                allow_root_catchall: false,
+            },
+        );
+        let cfg = Config {
+            domain: "test.com".to_string(),
+            data_dir: tmp.path().to_path_buf(),
+            dkim_selector: "aimx".to_string(),
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            hook_templates: Vec::new(),
+            mailboxes,
+            verify_host: None,
+            enable_ipv6: false,
+            smtp_helo_name: Some("relay.test.com".to_string()),
+            upgrade: None,
+        };
+        cfg.save(&path).unwrap();
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            on_disk.contains("smtp_helo_name = \"relay.test.com\""),
+            "serialized config must contain the helo override: {on_disk}"
+        );
+        let loaded = Config::load_ignore_warnings(&path).unwrap();
+        assert_eq!(loaded.smtp_helo_name.as_deref(), Some("relay.test.com"));
+    }
+
+    #[test]
+    fn smtp_helo_name_omitted_when_unset() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        let cfg = Config {
+            domain: "test.com".to_string(),
+            data_dir: tmp.path().to_path_buf(),
+            dkim_selector: "aimx".to_string(),
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            hook_templates: Vec::new(),
+            mailboxes: HashMap::new(),
+            verify_host: None,
+            enable_ipv6: false,
+            smtp_helo_name: None,
+            upgrade: None,
+        };
+        cfg.save(&path).unwrap();
+        let on_disk = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            !on_disk.contains("smtp_helo_name"),
+            "unset smtp_helo_name must not serialize: {on_disk}"
+        );
+    }
+
+    #[test]
+    fn validate_helo_name_accepts_valid_hostnames() {
+        for good in [
+            "example.com",
+            "mail.example.com",
+            "aimx-relay.internal",
+            "mx1.sub.example.co.uk",
+            "a",
+            "A1.B2.C3",
+        ] {
+            assert!(
+                super::validate_helo_name(good).is_ok(),
+                "expected valid: {good}"
+            );
+        }
+    }
+
+    #[test]
+    fn validate_helo_name_rejects_invalid_hostnames() {
+        let cases = [
+            "",
+            "example..com",
+            ".example.com",
+            "example.com.",
+            "-bad.example.com",
+            "bad-.example.com",
+            "has space.example.com",
+            "has/slash.example.com",
+        ];
+        for bad in cases {
+            assert!(
+                super::validate_helo_name(bad).is_err(),
+                "expected invalid: {bad}"
+            );
+        }
+        // Overlong label (>63 chars).
+        let long_label = "a".repeat(64);
+        assert!(super::validate_helo_name(&long_label).is_err());
+        // Overlong total (>253 chars) — build by joining labels.
+        let long = (0..30).map(|_| "abcdefghij").collect::<Vec<_>>().join(".");
+        assert!(long.len() > 253);
+        assert!(super::validate_helo_name(&long).is_err());
+    }
+
+    #[test]
+    fn load_rejects_invalid_smtp_helo_name() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "domain = \"test.com\"\nsmtp_helo_name = \"bad helo!\"\n[mailboxes]\n",
+        )
+        .unwrap();
+        let err = Config::load(&path).unwrap_err().to_string();
+        assert!(
+            err.contains("smtp_helo_name"),
+            "expected helo error, got: {err}"
+        );
+    }
+
+    #[test]
+    fn load_accepts_valid_smtp_helo_name() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        std::fs::write(
+            &path,
+            "domain = \"test.com\"\nsmtp_helo_name = \"mail.test.com\"\n[mailboxes]\n",
+        )
+        .unwrap();
+        let cfg = Config::load_ignore_warnings(&path).unwrap();
+        assert_eq!(cfg.smtp_helo_name(), "mail.test.com");
     }
 
     #[test]
@@ -3440,6 +3671,7 @@ allow_root_catchall = true
             },
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         };
         let toml_str = toml::to_string_pretty(&cfg).unwrap();
@@ -3563,6 +3795,7 @@ allow_root_catchall = true
             mailboxes: HashMap::new(),
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         }
     }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1937,6 +1937,7 @@ mod tests {
             mailboxes: std::collections::HashMap::new(),
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         }
     }
@@ -2407,6 +2408,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         };
 
@@ -2935,6 +2937,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         };
 
@@ -3007,6 +3010,7 @@ mod tests {
             mailboxes: std::collections::HashMap::new(),
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         }
     }
@@ -3402,6 +3406,7 @@ template=valid-two exit_code=missing-digits timed_out=false\n\
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         }
     }

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -828,6 +828,7 @@ mod tests {
             mailboxes: HashMap::new(),
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         }
     }

--- a/src/hook_handler.rs
+++ b/src/hook_handler.rs
@@ -805,6 +805,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         }
     }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -896,6 +896,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         }
     }
@@ -1420,6 +1421,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         }
     }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -946,6 +946,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         }
     }
@@ -2472,6 +2473,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         };
 

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -637,6 +637,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         }
     }
@@ -1174,6 +1175,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         }
     }

--- a/src/mailbox_handler.rs
+++ b/src/mailbox_handler.rs
@@ -490,6 +490,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         }
     }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -319,7 +319,11 @@ impl AimxMcpServer {
 
         let folder = resolve_folder(params.folder.as_deref())?;
         let mailbox_dir = folder_dir(&config, &params.mailbox, folder);
-        let filepath = resolve_email_path(&mailbox_dir, &params.id).ok_or_else(|| {
+        // Sprint 1 S1-2: read paths audit — `email_read` goes through
+        // the strict resolver so a planted symlink or escape path
+        // cannot exfiltrate another mailbox's mail via `email_read`,
+        // not just via the MARK verbs.
+        let filepath = resolve_email_path_strict(&mailbox_dir, &params.id).ok_or_else(|| {
             format!(
                 "Email '{}' not found in mailbox '{}'.",
                 params.id, params.mailbox
@@ -396,7 +400,11 @@ impl AimxMcpServer {
         }
 
         let mailbox_dir = config.inbox_dir(&params.mailbox);
-        let filepath = resolve_email_path(&mailbox_dir, &params.id).ok_or_else(|| {
+        // Sprint 1 S1-2: `email_reply` reads the parent message to
+        // inherit threading headers; route through the strict resolver
+        // so a symlink cannot leak another mailbox's message into a
+        // reply composition.
+        let filepath = resolve_email_path_strict(&mailbox_dir, &params.id).ok_or_else(|| {
             format!(
                 "Email '{}' not found in mailbox '{}'.",
                 params.id, params.mailbox
@@ -1126,16 +1134,90 @@ pub fn list_emails(
 /// Resolve the on-disk path for an email by ID. Returns `Some(path)` when
 /// the email exists either as a flat `<id>.md` or as a bundle
 /// `<id>/<id>.md` inside `mailbox_dir`.
+///
+/// Thin wrapper over [`resolve_email_path_strict`]; see that function
+/// for the symlink + canonical-containment rejection rules. Kept as a
+/// named entry point so call sites read as "resolve an email path"
+/// without exposing the strictness mechanic in the caller.
+///
+/// Currently only used by the test-only `set_read_status` helper in
+/// this module and by the delegation unit test. Production call sites
+/// invoke [`resolve_email_path_strict`] directly to make the strict
+/// contract explicit at each use point (Sprint 1 S1-2 audit).
+#[allow(dead_code)]
 pub fn resolve_email_path(mailbox_dir: &std::path::Path, id: &str) -> Option<PathBuf> {
+    resolve_email_path_strict(mailbox_dir, id)
+}
+
+/// Strict email-path resolver used by every read/rewrite verb in the
+/// daemon. Returns `Some(path)` only when every condition holds:
+///
+/// - The candidate exists as a regular file (flat `<id>.md` or bundle
+///   inner `<id>/<id>.md`).
+/// - Neither the candidate nor (for the bundle case) the bundle
+///   directory is a symlink. `symlink_metadata` is used so symlinks are
+///   never followed during the check.
+/// - The canonicalized candidate path is a descendant of the
+///   canonicalized `mailbox_dir`. This defends against `..`-style
+///   escapes even if upstream validation is bypassed.
+///
+/// Rejections return `None` (not an error) so upstream handlers keep
+/// emitting the existing `NotFound` shape — a differentiated error
+/// would leak whether the target exists in a sibling mailbox
+/// (PRD §6.1).
+///
+/// Duplicate layouts (a flat `<id>.md` symlink AND a sibling bundle
+/// `<id>/<id>.md`) are a tampering signal and also reject: the strict
+/// resolver never silently falls back from a rejected flat candidate
+/// to the bundle form.
+pub fn resolve_email_path_strict(mailbox_dir: &std::path::Path, id: &str) -> Option<PathBuf> {
+    let mailbox_canon = std::fs::canonicalize(mailbox_dir).ok()?;
+
     let flat = mailbox_dir.join(format!("{id}.md"));
-    if flat.exists() {
-        return Some(flat);
+    match std::fs::symlink_metadata(&flat) {
+        Ok(md) => {
+            // Flat candidate exists on disk. Reject any non-regular
+            // entry (symlink, dir, device, fifo). If the flat candidate
+            // is tampered with, we do NOT fall back to the bundle form
+            // — the duplicate itself is suspicious.
+            if !md.file_type().is_file() {
+                return None;
+            }
+            let candidate = std::fs::canonicalize(&flat).ok()?;
+            if !candidate.starts_with(&mailbox_canon) {
+                return None;
+            }
+            return Some(flat);
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Fall through to bundle lookup.
+        }
+        Err(_) => return None,
     }
-    let bundle_md = mailbox_dir.join(id).join(format!("{id}.md"));
-    if bundle_md.exists() {
-        return Some(bundle_md);
+
+    let bundle_dir = mailbox_dir.join(id);
+    match std::fs::symlink_metadata(&bundle_dir) {
+        Ok(md) => {
+            if !md.file_type().is_dir() {
+                return None;
+            }
+        }
+        Err(_) => return None,
     }
-    None
+    let bundle_md = bundle_dir.join(format!("{id}.md"));
+    match std::fs::symlink_metadata(&bundle_md) {
+        Ok(md) => {
+            if !md.file_type().is_file() {
+                return None;
+            }
+        }
+        Err(_) => return None,
+    }
+    let candidate = std::fs::canonicalize(&bundle_md).ok()?;
+    if !candidate.starts_with(&mailbox_canon) {
+        return None;
+    }
+    Some(bundle_md)
 }
 
 /// Inbound/outbound folder selector for MCP tools.
@@ -1377,6 +1459,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         }
     }
@@ -2315,5 +2398,179 @@ mod tests {
         assert_eq!(json["effective_name"], "abc123");
         assert_eq!(json["substituted_argv"][0], "/bin/echo");
         assert_eq!(json["substituted_argv"][1], "hi");
+    }
+
+    // ----- Sprint 1 S1-1: resolve_email_path_strict -----
+
+    fn write_flat_email(dir: &std::path::Path, id: &str) {
+        std::fs::create_dir_all(dir).unwrap();
+        std::fs::write(dir.join(format!("{id}.md")), "+++\n+++\nbody\n").unwrap();
+    }
+
+    fn write_bundle_email(dir: &std::path::Path, id: &str) {
+        let bundle = dir.join(id);
+        std::fs::create_dir_all(&bundle).unwrap();
+        std::fs::write(bundle.join(format!("{id}.md")), "+++\n+++\nbody\n").unwrap();
+    }
+
+    #[test]
+    fn strict_resolver_accepts_flat_regular_file() {
+        let tmp = TempDir::new().unwrap();
+        let mailbox = tmp.path().join("inbox").join("alice");
+        write_flat_email(&mailbox, "2025-06-01-001");
+        let out = resolve_email_path_strict(&mailbox, "2025-06-01-001");
+        assert_eq!(out, Some(mailbox.join("2025-06-01-001.md")));
+    }
+
+    #[test]
+    fn strict_resolver_accepts_bundle_inner_regular_file() {
+        let tmp = TempDir::new().unwrap();
+        let mailbox = tmp.path().join("inbox").join("alice");
+        write_bundle_email(&mailbox, "2025-06-01-002");
+        let out = resolve_email_path_strict(&mailbox, "2025-06-01-002");
+        assert_eq!(
+            out,
+            Some(mailbox.join("2025-06-01-002").join("2025-06-01-002.md"))
+        );
+    }
+
+    #[test]
+    fn strict_resolver_rejects_flat_symlink_even_when_target_valid() {
+        let tmp = TempDir::new().unwrap();
+        let alice = tmp.path().join("inbox").join("alice");
+        let bob = tmp.path().join("inbox").join("bob");
+        std::fs::create_dir_all(&alice).unwrap();
+        write_flat_email(&bob, "2025-06-01-003");
+
+        let target = bob.join("2025-06-01-003.md");
+        let link = alice.join("2025-06-01-003.md");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        // Symlink target is a real regular file — strict resolver must
+        // still reject the symlink on the candidate side.
+        assert_eq!(resolve_email_path_strict(&alice, "2025-06-01-003"), None);
+        // Bob's copy still resolves for Bob.
+        assert_eq!(
+            resolve_email_path_strict(&bob, "2025-06-01-003"),
+            Some(target)
+        );
+    }
+
+    #[test]
+    fn strict_resolver_rejects_bundle_inner_symlink() {
+        let tmp = TempDir::new().unwrap();
+        let alice = tmp.path().join("inbox").join("alice");
+        let bob = tmp.path().join("inbox").join("bob");
+        write_bundle_email(&bob, "2025-06-01-004");
+        let alice_bundle = alice.join("2025-06-01-004");
+        std::fs::create_dir_all(&alice_bundle).unwrap();
+
+        let target = bob.join("2025-06-01-004").join("2025-06-01-004.md");
+        let link = alice_bundle.join("2025-06-01-004.md");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        assert_eq!(resolve_email_path_strict(&alice, "2025-06-01-004"), None);
+    }
+
+    #[test]
+    fn strict_resolver_rejects_bundle_dir_symlink() {
+        // The bundle DIRECTORY itself is a symlink pointing at another
+        // mailbox's bundle.
+        let tmp = TempDir::new().unwrap();
+        let alice = tmp.path().join("inbox").join("alice");
+        let bob = tmp.path().join("inbox").join("bob");
+        std::fs::create_dir_all(&alice).unwrap();
+        write_bundle_email(&bob, "2025-06-01-005");
+
+        let target = bob.join("2025-06-01-005");
+        let link = alice.join("2025-06-01-005");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        assert_eq!(resolve_email_path_strict(&alice, "2025-06-01-005"), None);
+    }
+
+    #[test]
+    fn strict_resolver_rejects_flat_symlink_with_sibling_bundle() {
+        // Duplicate layout (flat symlink + real bundle) is a tampering
+        // signal — the resolver must NOT silently fall back to the
+        // bundle form.
+        let tmp = TempDir::new().unwrap();
+        let alice = tmp.path().join("inbox").join("alice");
+        let bob = tmp.path().join("inbox").join("bob");
+        std::fs::create_dir_all(&alice).unwrap();
+        write_flat_email(&bob, "2025-06-01-006");
+        // Plant flat symlink in alice pointing to bob's flat file.
+        let target = bob.join("2025-06-01-006.md");
+        let link = alice.join("2025-06-01-006.md");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+        // And a sibling real bundle in alice with the same id.
+        write_bundle_email(&alice, "2025-06-01-006");
+
+        assert_eq!(resolve_email_path_strict(&alice, "2025-06-01-006"), None);
+    }
+
+    #[test]
+    fn strict_resolver_rejects_missing_id() {
+        let tmp = TempDir::new().unwrap();
+        let alice = tmp.path().join("inbox").join("alice");
+        std::fs::create_dir_all(&alice).unwrap();
+        assert_eq!(
+            resolve_email_path_strict(&alice, "2099-01-01-missing"),
+            None
+        );
+    }
+
+    #[test]
+    fn strict_resolver_rejects_escape_via_canonicalization() {
+        // `..`-escape defense: a path whose canonical form lands
+        // outside the mailbox dir must be rejected. We engineer this
+        // by making the whole mailbox dir itself a symlink pointing
+        // elsewhere, so the inner file's canonical path is outside
+        // what the caller treats as the mailbox tree.
+        let tmp = TempDir::new().unwrap();
+        let real_storage = tmp.path().join("storage").join("alice-real");
+        write_flat_email(&real_storage, "2025-06-01-007");
+
+        let visible_root = tmp.path().join("inbox");
+        std::fs::create_dir_all(&visible_root).unwrap();
+        let visible_alice = visible_root.join("alice");
+        std::os::unix::fs::symlink(&real_storage, &visible_alice).unwrap();
+
+        // Pretend the caller treats the symlinked path as the mailbox
+        // dir. Canonicalize(candidate) = real_storage/... which still
+        // starts_with canonicalize(visible_alice) = real_storage — so
+        // this is actually accepted (the dir-level symlink is resolved
+        // on BOTH sides). The escape check catches the case where
+        // candidate canonicalizes OUTSIDE the mailbox canonical root,
+        // which we exercise with the bundle-dir-symlink test above.
+        // Here we assert the resolver does NOT accidentally allow the
+        // flat candidate to leak through when id contains `..`-like
+        // structure. The id validation happens at the caller; we just
+        // prove canonical-containment works for the normal path.
+        assert!(
+            resolve_email_path_strict(&visible_alice, "2025-06-01-007").is_some(),
+            "legitimate dir-level symlink to a regular file should still resolve"
+        );
+    }
+
+    #[test]
+    fn resolve_email_path_wrapper_delegates_to_strict() {
+        // The thin wrapper must behave identically to the strict
+        // resolver — no divergent logic between the two.
+        let tmp = TempDir::new().unwrap();
+        let alice = tmp.path().join("inbox").join("alice");
+        let bob = tmp.path().join("inbox").join("bob");
+        std::fs::create_dir_all(&alice).unwrap();
+        write_flat_email(&bob, "2025-06-01-008");
+
+        let target = bob.join("2025-06-01-008.md");
+        let link = alice.join("2025-06-01-008.md");
+        std::os::unix::fs::symlink(&target, &link).unwrap();
+
+        assert_eq!(
+            resolve_email_path(&alice, "2025-06-01-008"),
+            resolve_email_path_strict(&alice, "2025-06-01-008")
+        );
+        assert_eq!(resolve_email_path(&alice, "2025-06-01-008"), None);
     }
 }

--- a/src/send_handler.rs
+++ b/src/send_handler.rs
@@ -757,6 +757,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         };
         let config_handle = ConfigHandle::new(config);
@@ -1354,6 +1355,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         };
         let ctx = SendContext {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -507,7 +507,10 @@ async fn run_serve(
             );
             Arc::new(FileDropTransport::new(drop_path))
         }
-        None => Arc::new(LettreTransport::new(config.enable_ipv6)),
+        None => Arc::new(LettreTransport::new(
+            config.enable_ipv6,
+            config.smtp_helo_name(),
+        )),
     };
 
     // Wrap the starting Config in a live, swappable handle. Every
@@ -1549,6 +1552,7 @@ mod tests {
                 mailboxes,
                 verify_host: None,
                 enable_ipv6: false,
+                smtp_helo_name: None,
                 upgrade: None,
             };
 
@@ -1860,6 +1864,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         }
     }
@@ -2021,6 +2026,7 @@ mod tests {
                 mailboxes,
                 verify_host: None,
                 enable_ipv6: false,
+                smtp_helo_name: None,
                 upgrade: None,
             };
             let handle_cfg = ConfigHandle::new(config);

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1471,6 +1471,7 @@ pub fn finalize_setup(
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         };
         install_config_file(&cfg, &config_path)?;

--- a/src/smtp/tests.rs
+++ b/src/smtp/tests.rs
@@ -88,6 +88,7 @@ fn test_config(data_dir: &std::path::Path) -> Config {
         mailboxes,
         verify_host: None,
         enable_ipv6: false,
+        smtp_helo_name: None,
         upgrade: None,
     }
 }
@@ -835,6 +836,7 @@ async fn test_ingest_failure_returns_451() {
         mailboxes: HashMap::new(),
         verify_host: None,
         enable_ipv6: false,
+        smtp_helo_name: None,
         upgrade: None,
     };
     let (port, _shutdown) = start_server(config).await;

--- a/src/state_handler.rs
+++ b/src/state_handler.rs
@@ -30,7 +30,7 @@ use tokio::sync::Mutex as AsyncMutex;
 use crate::config::ConfigHandle;
 use crate::frontmatter::InboundFrontmatter;
 use crate::mailbox_locks::MailboxLocks;
-use crate::mcp::resolve_email_path;
+use crate::mcp::resolve_email_path_strict;
 use crate::ownership::chown_as_owner;
 use crate::send_protocol::{AckResponse, ErrCode, MarkFolder, MarkRequest};
 use crate::uds_authz::{Caller, enforce_mailbox_owner_or_root};
@@ -160,9 +160,25 @@ pub async fn handle_mark(ctx: &StateContext, req: &MarkRequest, caller: &Caller)
     let _guard = lock.lock().await;
 
     let mailbox_dir = folder_dir(&ctx.data_dir, &req.mailbox, req.folder);
-    let filepath = match resolve_email_path(&mailbox_dir, &req.id) {
+    let filepath = match resolve_email_path_strict(&mailbox_dir, &req.id) {
         Some(p) => p,
         None => {
+            // A strict-resolver rejection can mean either "no such file"
+            // or "symlink / canonical-containment violation". Both map
+            // to `NotFound` on the wire (no existence leak per PRD
+            // §6.1), but we log at `info` on `aimx::state` so operators
+            // can spot probe attempts (PRD §7.3). The log payload is
+            // intentionally coarse — we don't disambiguate symlink vs.
+            // absent-file at the handler level to avoid leaking that
+            // fact into anything that tails the log stream downstream.
+            tracing::info!(
+                target: "aimx::state",
+                reason = "symlink_or_escape",
+                mailbox = %req.mailbox,
+                id = %req.id,
+                folder = req.folder.as_str(),
+                "MARK rejected: email not resolvable under mailbox dir"
+            );
             return AckResponse::Err {
                 code: ErrCode::NotFound,
                 reason: format!(
@@ -357,6 +373,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         };
         StateContext::new(data_dir.to_path_buf(), ConfigHandle::new(config))
@@ -746,6 +763,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         };
         let sctx = StateContext::new(tmp.path().to_path_buf(), ConfigHandle::new(config));
@@ -840,6 +858,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         };
         let sctx = StateContext::new(tmp.path().to_path_buf(), ConfigHandle::new(config));
@@ -890,6 +909,171 @@ mod tests {
             unsafe { libc::geteuid() },
             "file ownership must be unchanged after chown failure"
         );
+    }
+
+    /// Sprint 1 S1-2: cross-mailbox symlink attack. Alice plants a
+    /// symlink in her own mailbox pointing at bob's real email. The
+    /// MARK handler must reject (`NotFound`) and leave bob's file
+    /// byte-for-byte unchanged; alice's symlink is also unchanged (no
+    /// replacement-write lands on it).
+    #[tokio::test]
+    async fn mark_rejects_cross_mailbox_symlink_attack() {
+        let tmp = TempDir::new().unwrap();
+
+        // Configure two mailboxes owned by `root` so the authz check
+        // short-circuits to the "internal root" bypass and we can
+        // focus the assertion on the symlink rejection itself.
+        let mut mailboxes = std::collections::HashMap::new();
+        mailboxes.insert(
+            "alice".to_string(),
+            crate::config::MailboxConfig {
+                address: "alice@example.com".into(),
+                owner: "root".into(),
+                hooks: vec![],
+                trust: None,
+                trusted_senders: None,
+                allow_root_catchall: false,
+            },
+        );
+        mailboxes.insert(
+            "bob".to_string(),
+            crate::config::MailboxConfig {
+                address: "bob@example.com".into(),
+                owner: "root".into(),
+                hooks: vec![],
+                trust: None,
+                trusted_senders: None,
+                allow_root_catchall: false,
+            },
+        );
+        let config = crate::config::Config {
+            domain: "example.com".into(),
+            data_dir: tmp.path().to_path_buf(),
+            dkim_selector: "aimx".into(),
+            trust: "none".into(),
+            trusted_senders: vec![],
+            hook_templates: Vec::new(),
+            mailboxes,
+            verify_host: None,
+            enable_ipv6: false,
+            smtp_helo_name: None,
+            upgrade: None,
+        };
+        let sctx = StateContext::new(tmp.path().to_path_buf(), ConfigHandle::new(config));
+
+        // Plant bob's real email.
+        let bob_meta = sample_meta("2025-06-01-777", false);
+        let bob_inbox = tmp.path().join("inbox").join("bob");
+        write_email(&bob_inbox, "2025-06-01-777", &bob_meta);
+        let bob_file = bob_inbox.join("2025-06-01-777.md");
+        let bob_bytes_before = std::fs::read(&bob_file).unwrap();
+
+        // Plant alice's symlink pointing at bob's real file.
+        let alice_inbox = tmp.path().join("inbox").join("alice");
+        std::fs::create_dir_all(&alice_inbox).unwrap();
+        let alice_link = alice_inbox.join("2025-06-01-777.md");
+        std::os::unix::fs::symlink(&bob_file, &alice_link).unwrap();
+
+        // Sanity: alice's entry is a symlink on disk before the MARK.
+        let pre = std::fs::symlink_metadata(&alice_link).unwrap();
+        assert!(pre.file_type().is_symlink());
+
+        let req = MarkRequest {
+            mailbox: "alice".to_string(),
+            id: "2025-06-01-777".to_string(),
+            folder: MarkFolder::Inbox,
+            read: true,
+        };
+        match handle_mark(&sctx, &req, &Caller::internal_root()).await {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::NotFound),
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+
+        // Bob's real file is unchanged byte-for-byte.
+        let bob_bytes_after = std::fs::read(&bob_file).unwrap();
+        assert_eq!(
+            bob_bytes_before, bob_bytes_after,
+            "bob's file must be byte-for-byte unchanged after alice's probe"
+        );
+
+        // Alice's entry is still a symlink — no replacement-write
+        // landed on it.
+        let post = std::fs::symlink_metadata(&alice_link).unwrap();
+        assert!(
+            post.file_type().is_symlink(),
+            "alice's planted symlink must not have been replaced by a regular file"
+        );
+    }
+
+    /// Sprint 1 S1-2: bundle-layout variant of the cross-mailbox
+    /// symlink attack. Alice plants `alice/<id>/<id>.md` as a symlink
+    /// to `bob/<id>/<id>.md`. Same expected outcome.
+    #[tokio::test]
+    async fn mark_rejects_cross_mailbox_bundle_symlink_attack() {
+        let tmp = TempDir::new().unwrap();
+
+        let mut mailboxes = std::collections::HashMap::new();
+        for name in ["alice", "bob"] {
+            mailboxes.insert(
+                name.to_string(),
+                crate::config::MailboxConfig {
+                    address: format!("{name}@example.com"),
+                    owner: "root".into(),
+                    hooks: vec![],
+                    trust: None,
+                    trusted_senders: None,
+                    allow_root_catchall: false,
+                },
+            );
+        }
+        let config = crate::config::Config {
+            domain: "example.com".into(),
+            data_dir: tmp.path().to_path_buf(),
+            dkim_selector: "aimx".into(),
+            trust: "none".into(),
+            trusted_senders: vec![],
+            hook_templates: Vec::new(),
+            mailboxes,
+            verify_host: None,
+            enable_ipv6: false,
+            smtp_helo_name: None,
+            upgrade: None,
+        };
+        let sctx = StateContext::new(tmp.path().to_path_buf(), ConfigHandle::new(config));
+
+        // Bob has a real bundle.
+        let id = "2025-06-01-888";
+        let bob_bundle = tmp.path().join("inbox").join("bob").join(id);
+        std::fs::create_dir_all(&bob_bundle).unwrap();
+        let bob_meta = sample_meta(id, false);
+        let toml_str = toml::to_string(&bob_meta).unwrap();
+        let content = format!("+++\n{toml_str}+++\n\nbob body\n");
+        let bob_inner = bob_bundle.join(format!("{id}.md"));
+        std::fs::write(&bob_inner, content).unwrap();
+        let bob_bytes_before = std::fs::read(&bob_inner).unwrap();
+
+        // Alice has her own bundle directory but the inner `.md` is a
+        // symlink to bob's file.
+        let alice_bundle = tmp.path().join("inbox").join("alice").join(id);
+        std::fs::create_dir_all(&alice_bundle).unwrap();
+        let alice_inner = alice_bundle.join(format!("{id}.md"));
+        std::os::unix::fs::symlink(&bob_inner, &alice_inner).unwrap();
+
+        let req = MarkRequest {
+            mailbox: "alice".to_string(),
+            id: id.to_string(),
+            folder: MarkFolder::Inbox,
+            read: true,
+        };
+        match handle_mark(&sctx, &req, &Caller::internal_root()).await {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::NotFound),
+            other => panic!("expected NotFound, got {other:?}"),
+        }
+
+        let bob_bytes_after = std::fs::read(&bob_inner).unwrap();
+        assert_eq!(bob_bytes_before, bob_bytes_after);
+        let post = std::fs::symlink_metadata(&alice_inner).unwrap();
+        assert!(post.file_type().is_symlink());
     }
 
     #[tokio::test]

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -41,8 +41,16 @@ pub trait MailTransport {
 /// (see `enable_ipv6`): SOHO / home IPv6 ranges are routinely blocked by
 /// large MX providers, so the daemon pins the outbound connection to A
 /// records unless the operator opts in via `config.toml`.
+///
+/// `helo_name` is the EHLO / HELO identity the transport presents to
+/// recipient MXs. It is captured at construction time from
+/// [`crate::config::Config::smtp_helo_name`] so a later config reload
+/// that swaps the value does not require re-plumbing the transport.
+/// Hardening PRD §6.2: outbound mail must never introduce itself with
+/// the dialed MX hostname.
 pub struct LettreTransport {
     enable_ipv6: bool,
+    helo_name: String,
 }
 
 /// Outcome of picking a connect target for outbound SMTP.
@@ -80,8 +88,21 @@ pub(crate) fn select_connect_target(
 }
 
 impl LettreTransport {
-    pub fn new(enable_ipv6: bool) -> Self {
-        Self { enable_ipv6 }
+    /// Construct a transport bound to a specific HELO identity. Call
+    /// sites pass `config.smtp_helo_name().to_string()` (see
+    /// `crate::serve::run_serve`).
+    pub fn new(enable_ipv6: bool, helo_name: impl Into<String>) -> Self {
+        Self {
+            enable_ipv6,
+            helo_name: helo_name.into(),
+        }
+    }
+
+    /// Read the HELO identity this transport presents. Exposed for
+    /// tests (and for code that wants to log the value).
+    #[allow(dead_code)]
+    pub fn helo_name(&self) -> &str {
+        &self.helo_name
     }
 
     /// Resolves an MX hostname's A records only (no AAAA).
@@ -244,7 +265,10 @@ impl LettreTransport {
 
         let transport = lettre::SmtpTransport::builder_dangerous(&connect_target)
             .hello_name(lettre::transport::smtp::extension::ClientId::Domain(
-                host.to_string(),
+                // Hardening PRD §6.2: EHLO identity is ours, not the
+                // dialed MX. Captured from `Config::smtp_helo_name()`
+                // at construction time.
+                self.helo_name.clone(),
             ))
             .port(25)
             .tls(lettre::transport::smtp::client::Tls::Opportunistic(
@@ -431,6 +455,59 @@ mod tests {
             Err(TransportError::Temp("timeout".into()))
         });
         assert!(matches!(result, Err(TransportError::Temp(_))));
+    }
+
+    #[test]
+    fn lettre_transport_stores_helo_name_from_constructor() {
+        // Sprint 1 S1-4: the EHLO identity must come from config, not
+        // from the dialed MX host. The constructor captures the value
+        // so `try_deliver` can pass it to lettre verbatim.
+        let t = LettreTransport::new(false, "example.com");
+        assert_eq!(t.helo_name(), "example.com");
+    }
+
+    #[test]
+    fn lettre_transport_helo_name_preserves_override() {
+        // When an operator sets `smtp_helo_name = "mail.example.com"`
+        // the transport surfaces that value, not `config.domain`.
+        let t = LettreTransport::new(true, "mail.example.com");
+        assert_eq!(t.helo_name(), "mail.example.com");
+    }
+
+    #[test]
+    fn config_smtp_helo_name_defaults_to_domain() {
+        // Sprint 1 S1-3: the helper returns `config.domain` when the
+        // optional field is unset.
+        use crate::config::Config;
+        let toml_str = "domain = \"example.com\"\n[mailboxes]\n";
+        let cfg: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.smtp_helo_name(), "example.com");
+    }
+
+    #[test]
+    fn config_smtp_helo_name_returns_override_when_set() {
+        use crate::config::Config;
+        let toml_str =
+            "domain = \"example.com\"\nsmtp_helo_name = \"mail.example.com\"\n[mailboxes]\n";
+        let cfg: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(cfg.smtp_helo_name(), "mail.example.com");
+    }
+
+    #[test]
+    fn lettre_transport_integrates_with_config_helper() {
+        // End-to-end: the transport fed by `Config::smtp_helo_name()`
+        // carries the effective value, regardless of whether the
+        // operator set the override.
+        use crate::config::Config;
+        let default_cfg: Config = toml::from_str("domain = \"a.example\"\n[mailboxes]\n").unwrap();
+        let override_cfg: Config = toml::from_str(
+            "domain = \"a.example\"\nsmtp_helo_name = \"relay.example\"\n[mailboxes]\n",
+        )
+        .unwrap();
+        let t_default = LettreTransport::new(false, default_cfg.smtp_helo_name());
+        let t_override = LettreTransport::new(false, override_cfg.smtp_helo_name());
+        assert_eq!(t_default.helo_name(), "a.example");
+        assert_eq!(t_override.helo_name(), "relay.example");
     }
 
     #[test]

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -175,6 +175,7 @@ mod tests {
             mailboxes: HashMap::new(),
             verify_host: None,
             enable_ipv6: false,
+            smtp_helo_name: None,
             upgrade: None,
         }
     }


### PR DESCRIPTION
## Summary

Closes **M1 (security P0)** and **M2 (deliverability P0)** of the `hardening` track — Sprint 1 (`docs/hardening-sprint.md` stories S1-1…S1-4, backed by `docs/hardening-prd.md` §6.1 and §6.2).

- **S1-1 — Strict email-path resolver.** `resolve_email_path_strict` in `src/mcp.rs` rejects symlinks via `symlink_metadata` (flat `<id>.md`, bundle dir, and bundle inner `<id>/<id>.md`) and enforces `canonicalize(candidate).starts_with(canonicalize(mailbox_dir))`. Duplicate layouts (flat symlink + sibling real bundle) also reject, per PRD §8.3. The legacy `resolve_email_path` is retained as a thin wrapper so both paths share the same strict behavior.
- **S1-2 — Cross-mailbox symlink fix + log.** `handle_mark` (state_handler) and every other current resolver caller (`email_read`, `email_reply` in mcp.rs) switch to the strict variant. Rejections emit a structured `tracing::info!` on `aimx::state` with `reason = "symlink_or_escape"`, `mailbox`, `id`, `folder` (PRD §7.3). Integration tests prove alice's probe against bob's mail (flat + bundle layouts) returns `NotFound`, leaves bob's bytes unchanged, and never replaces alice's symlink with a regular file.
- **S1-3 — `smtp_helo_name` config field.** New optional `smtp_helo_name: Option<String>` on `Config` with `#[serde(default, skip_serializing_if = "Option::is_none")]`. `Config::smtp_helo_name()` helper falls back to `config.domain`. RFC 1123-ish hostname validation runs at `Config::load` (rejects empty, spaces, slashes, overlong labels/total, leading/trailing dots, `-`-bracketed labels).
- **S1-4 — Correct EHLO identity.** `LettreTransport` now carries a `helo_name: String` field populated from `Config::smtp_helo_name()` at construction time; `try_deliver` passes `ClientId::Domain(self.helo_name.clone())` to lettre instead of the dialed MX hostname. `book/configuration.md` documents the new knob — single-host installs need nothing, split-FQDN hosts set it explicitly.

## Test plan

- [x] `cargo test` — 1437 passed, 0 failed (1341 lib + 95 integration + 1 base64 roundtrip; 5 ignored require root/sudo)
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] New unit tests in `src/mcp.rs` cover flat-symlink rejection, bundle-inner-symlink rejection, bundle-dir-symlink rejection, flat-symlink + sibling-bundle rejection, wrapper/strict parity
- [x] New integration tests in `src/state_handler.rs` cover cross-mailbox symlink attack (flat + bundle variants) — `NotFound` response, bob's file byte-for-byte unchanged, alice's symlink unchanged
- [x] New unit tests in `src/transport.rs` cover `helo_name` construction + integration with `Config::smtp_helo_name()`
- [x] New unit tests in `src/config.rs` cover field roundtrip (serializes when set, omits when unset), helper default/override, validator accept/reject, load-time rejection for invalid hostnames
- [ ] Manual deliverability smoke test (capture `Received:` header from Gmail / personal IMAP after a real outbound send) — requires a live DNS-configured host; not run in this PR but documented in the S1-4 acceptance criteria for the next release verification

## Notes for reviewers

- No wire-format changes to `AIMX/1`; storage layout and CLI surface unchanged.
- The legacy `resolve_email_path` is kept (as a strict-delegating wrapper) to limit the blast radius of this PR — a follow-up can prune it if the audit is exhaustive.
- `dangerous_accept_invalid_certs(true)` on outbound TLS is deliberately retained per PRD §10.1.1 (matches Postfix/Exim/Sendmail defaults; strict mode is MTA-STS / DANE work deferred to a future track).