### PR TITLE
[Hardening Sprint 1 cleanup] Remove smtp_helo_name knob; HELO is always config.domain

### DIFF
--- a/book/configuration.md
+++ b/book/configuration.md
@@ -55,7 +55,6 @@ Hook commands receive additional `AIMX_*` env vars carrying the triggering email
 | `trusted_senders` | array | `[]` | Default allowlist of glob patterns applied to every mailbox. Per-mailbox `trusted_senders` replaces this list (no merging). |
 | `verify_host` | string | `https://check.aimx.email` | Base URL of the verifier service used by `aimx portcheck` and `aimx setup`. Can be overridden per-invocation with the `--verify-host` flag. |
 | `enable_ipv6` | bool | `false` | Advanced. Opt into IPv6 outbound delivery. See [IPv6 delivery](#ipv6-delivery-advanced). |
-| `smtp_helo_name` | string | *(defaults to `domain`)* | Advanced. EHLO / HELO identity the outbound SMTP transport presents to recipient MXs. Leave unset on a single-host install — the default uses `domain`, which matches your DKIM / SPF / DMARC keys. Set this explicitly only when your sending host's FQDN differs from `domain` (e.g., a dedicated outbound relay named `mail.example.com` delivering mail for `domain = "agent.example.com"`). Must be a valid DNS hostname. |
 
 `aimx setup` asks for a list of trusted sender addresses interactively on
 the first run (comma-separated, accepts plain addresses and globs like

--- a/src/config.rs
+++ b/src/config.rs
@@ -107,14 +107,6 @@ pub struct Config {
     #[serde(default)]
     pub enable_ipv6: bool,
 
-    /// Optional EHLO / HELO identity the outbound SMTP transport
-    /// presents to recipient MXs. Defaults to `config.domain` when
-    /// unset. Operators on multi-tenant VPSes whose sending host has a
-    /// different FQDN from `config.domain` (e.g., a dedicated relay)
-    /// set this explicitly. Hardening PRD §6.2.
-    #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub smtp_helo_name: Option<String>,
-
     /// Optional `[upgrade]` section. Overrides the release-manifest URL used
     /// by `aimx upgrade` (PRD FR-4.6). The `AIMX_RELEASE_MANIFEST_URL` env
     /// var takes precedence over this value when both are set.
@@ -1330,58 +1322,6 @@ fn validate_trust_values(config: &Config) -> Result<(), String> {
     Ok(())
 }
 
-/// Validate an RFC 1123–ish DNS hostname used for EHLO identity.
-///
-/// Rules:
-/// - Non-empty, ≤ 253 bytes total.
-/// - Each dot-separated label is 1–63 bytes, `[A-Za-z0-9-]`, and cannot
-///   start or end with a hyphen.
-/// - At least one label; trailing dot is not allowed (matches what an
-///   SMTP peer will accept as an EHLO parameter).
-///
-/// Used only for `Config.smtp_helo_name` at this point. Keeping it
-/// local to the module (rather than exporting) means the validator
-/// stays private to the load-time path.
-fn validate_helo_name(value: &str) -> Result<(), String> {
-    if value.is_empty() {
-        return Err("smtp_helo_name is empty; set a valid hostname or remove the field".into());
-    }
-    if value.len() > 253 {
-        return Err(format!(
-            "smtp_helo_name '{value}' exceeds 253 bytes (RFC 1035 cap)"
-        ));
-    }
-    if value.ends_with('.') {
-        return Err(format!(
-            "smtp_helo_name '{value}' has a trailing dot; drop it"
-        ));
-    }
-    for label in value.split('.') {
-        if label.is_empty() {
-            return Err(format!(
-                "smtp_helo_name '{value}' has an empty label (double dot or leading dot)"
-            ));
-        }
-        if label.len() > 63 {
-            return Err(format!(
-                "smtp_helo_name '{value}' has a label longer than 63 bytes: '{label}'"
-            ));
-        }
-        if label.starts_with('-') || label.ends_with('-') {
-            return Err(format!(
-                "smtp_helo_name '{value}' has a label starting/ending with '-': '{label}'"
-            ));
-        }
-        if !label.chars().all(|c| c.is_ascii_alphanumeric() || c == '-') {
-            return Err(format!(
-                "smtp_helo_name '{value}' has an invalid label '{label}'; \
-                 labels must match [A-Za-z0-9-]"
-            ));
-        }
-    }
-    Ok(())
-}
-
 impl Config {
     /// Load and validate a `config.toml`. Returns both the parsed
     /// `Config` and a vector of non-fatal warnings (orphan mailbox
@@ -1417,9 +1357,6 @@ impl Config {
             }
         }
         validate_trust_values(&config).map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
-        if let Some(helo) = config.smtp_helo_name.as_deref() {
-            validate_helo_name(helo).map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
-        }
         let mut warnings = validate_hook_templates(&config.hook_templates)
             .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
         let mailbox_warnings = validate_mailbox_owners(&config)
@@ -1442,17 +1379,6 @@ impl Config {
         let content = toml::to_string_pretty(self)?;
         std::fs::write(path, content)?;
         Ok(())
-    }
-
-    /// Effective EHLO / HELO identity for outbound SMTP. Returns the
-    /// operator-supplied `smtp_helo_name` when set, else falls back to
-    /// `config.domain`. The value is validated at load time (see
-    /// [`validate_helo_name`]) so callers may use it verbatim.
-    ///
-    /// Hardening PRD §6.2: outbound mail must introduce itself with
-    /// the sender's own hostname, never the dialed MX.
-    pub fn smtp_helo_name(&self) -> &str {
-        self.smtp_helo_name.as_deref().unwrap_or(&self.domain)
     }
 
     /// Load the config from the canonical path returned by [`config_path`].
@@ -2248,7 +2174,6 @@ dangerously_support_untrusted = true
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         };
 
@@ -2408,7 +2333,6 @@ trusted_senders = []
             mailboxes: HashMap::new(),
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         };
         config.save(&path).unwrap();
@@ -2450,7 +2374,6 @@ trusted_senders = []
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         };
         config.save(&path).unwrap();
@@ -2471,160 +2394,6 @@ trusted_senders = []
             !mailbox_section.contains("trusted_senders"),
             "unset mailbox trusted_senders should not serialize: {mailbox_section}"
         );
-    }
-
-    // ----- Sprint 1 S1-3: smtp_helo_name field + validator -----
-
-    #[test]
-    fn smtp_helo_name_helper_defaults_to_domain() {
-        let toml_str = "domain = \"example.com\"\n[mailboxes]\n";
-        let cfg: Config = toml::from_str(toml_str).unwrap();
-        assert_eq!(cfg.smtp_helo_name(), "example.com");
-    }
-
-    #[test]
-    fn smtp_helo_name_helper_returns_override_when_set() {
-        let toml_str =
-            "domain = \"example.com\"\nsmtp_helo_name = \"mail.example.com\"\n[mailboxes]\n";
-        let cfg: Config = toml::from_str(toml_str).unwrap();
-        assert_eq!(cfg.smtp_helo_name(), "mail.example.com");
-    }
-
-    #[test]
-    fn smtp_helo_name_roundtrips_byte_stable_when_set() {
-        let tmp = TempDir::new().unwrap();
-        let path = tmp.path().join("config.toml");
-        let mut mailboxes = HashMap::new();
-        mailboxes.insert(
-            "catchall".to_string(),
-            MailboxConfig {
-                address: "*@test.com".to_string(),
-                owner: "aimx-catchall".to_string(),
-                hooks: vec![],
-                trust: None,
-                trusted_senders: None,
-                allow_root_catchall: false,
-            },
-        );
-        let cfg = Config {
-            domain: "test.com".to_string(),
-            data_dir: tmp.path().to_path_buf(),
-            dkim_selector: "aimx".to_string(),
-            trust: "none".to_string(),
-            trusted_senders: vec![],
-            hook_templates: Vec::new(),
-            mailboxes,
-            verify_host: None,
-            enable_ipv6: false,
-            smtp_helo_name: Some("relay.test.com".to_string()),
-            upgrade: None,
-        };
-        cfg.save(&path).unwrap();
-        let on_disk = std::fs::read_to_string(&path).unwrap();
-        assert!(
-            on_disk.contains("smtp_helo_name = \"relay.test.com\""),
-            "serialized config must contain the helo override: {on_disk}"
-        );
-        let loaded = Config::load_ignore_warnings(&path).unwrap();
-        assert_eq!(loaded.smtp_helo_name.as_deref(), Some("relay.test.com"));
-    }
-
-    #[test]
-    fn smtp_helo_name_omitted_when_unset() {
-        let tmp = TempDir::new().unwrap();
-        let path = tmp.path().join("config.toml");
-        let cfg = Config {
-            domain: "test.com".to_string(),
-            data_dir: tmp.path().to_path_buf(),
-            dkim_selector: "aimx".to_string(),
-            trust: "none".to_string(),
-            trusted_senders: vec![],
-            hook_templates: Vec::new(),
-            mailboxes: HashMap::new(),
-            verify_host: None,
-            enable_ipv6: false,
-            smtp_helo_name: None,
-            upgrade: None,
-        };
-        cfg.save(&path).unwrap();
-        let on_disk = std::fs::read_to_string(&path).unwrap();
-        assert!(
-            !on_disk.contains("smtp_helo_name"),
-            "unset smtp_helo_name must not serialize: {on_disk}"
-        );
-    }
-
-    #[test]
-    fn validate_helo_name_accepts_valid_hostnames() {
-        for good in [
-            "example.com",
-            "mail.example.com",
-            "aimx-relay.internal",
-            "mx1.sub.example.co.uk",
-            "a",
-            "A1.B2.C3",
-        ] {
-            assert!(
-                super::validate_helo_name(good).is_ok(),
-                "expected valid: {good}"
-            );
-        }
-    }
-
-    #[test]
-    fn validate_helo_name_rejects_invalid_hostnames() {
-        let cases = [
-            "",
-            "example..com",
-            ".example.com",
-            "example.com.",
-            "-bad.example.com",
-            "bad-.example.com",
-            "has space.example.com",
-            "has/slash.example.com",
-        ];
-        for bad in cases {
-            assert!(
-                super::validate_helo_name(bad).is_err(),
-                "expected invalid: {bad}"
-            );
-        }
-        // Overlong label (>63 chars).
-        let long_label = "a".repeat(64);
-        assert!(super::validate_helo_name(&long_label).is_err());
-        // Overlong total (>253 chars) — build by joining labels.
-        let long = (0..30).map(|_| "abcdefghij").collect::<Vec<_>>().join(".");
-        assert!(long.len() > 253);
-        assert!(super::validate_helo_name(&long).is_err());
-    }
-
-    #[test]
-    fn load_rejects_invalid_smtp_helo_name() {
-        let tmp = TempDir::new().unwrap();
-        let path = tmp.path().join("config.toml");
-        std::fs::write(
-            &path,
-            "domain = \"test.com\"\nsmtp_helo_name = \"bad helo!\"\n[mailboxes]\n",
-        )
-        .unwrap();
-        let err = Config::load(&path).unwrap_err().to_string();
-        assert!(
-            err.contains("smtp_helo_name"),
-            "expected helo error, got: {err}"
-        );
-    }
-
-    #[test]
-    fn load_accepts_valid_smtp_helo_name() {
-        let tmp = TempDir::new().unwrap();
-        let path = tmp.path().join("config.toml");
-        std::fs::write(
-            &path,
-            "domain = \"test.com\"\nsmtp_helo_name = \"mail.test.com\"\n[mailboxes]\n",
-        )
-        .unwrap();
-        let cfg = Config::load_ignore_warnings(&path).unwrap();
-        assert_eq!(cfg.smtp_helo_name(), "mail.test.com");
     }
 
     #[test]
@@ -3671,7 +3440,6 @@ allow_root_catchall = true
             },
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         };
         let toml_str = toml::to_string_pretty(&cfg).unwrap();
@@ -3795,7 +3563,6 @@ allow_root_catchall = true
             mailboxes: HashMap::new(),
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         }
     }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1937,7 +1937,6 @@ mod tests {
             mailboxes: std::collections::HashMap::new(),
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         }
     }
@@ -2408,7 +2407,6 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         };
 
@@ -2937,7 +2935,6 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         };
 
@@ -3010,7 +3007,6 @@ mod tests {
             mailboxes: std::collections::HashMap::new(),
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         }
     }
@@ -3406,7 +3402,6 @@ template=valid-two exit_code=missing-digits timed_out=false\n\
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         }
     }

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -828,7 +828,6 @@ mod tests {
             mailboxes: HashMap::new(),
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         }
     }

--- a/src/hook_handler.rs
+++ b/src/hook_handler.rs
@@ -805,7 +805,6 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         }
     }

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -896,7 +896,6 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         }
     }
@@ -1421,7 +1420,6 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         }
     }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -946,7 +946,6 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         }
     }
@@ -2473,7 +2472,6 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         };
 

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -637,7 +637,6 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         }
     }
@@ -1175,7 +1174,6 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         }
     }

--- a/src/mailbox_handler.rs
+++ b/src/mailbox_handler.rs
@@ -490,7 +490,6 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         }
     }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1459,7 +1459,6 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         }
     }

--- a/src/send_handler.rs
+++ b/src/send_handler.rs
@@ -757,7 +757,6 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         };
         let config_handle = ConfigHandle::new(config);
@@ -1355,7 +1354,6 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         };
         let ctx = SendContext {

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -509,7 +509,7 @@ async fn run_serve(
         }
         None => Arc::new(LettreTransport::new(
             config.enable_ipv6,
-            config.smtp_helo_name(),
+            config.domain.clone(),
         )),
     };
 
@@ -1552,7 +1552,6 @@ mod tests {
                 mailboxes,
                 verify_host: None,
                 enable_ipv6: false,
-                smtp_helo_name: None,
                 upgrade: None,
             };
 
@@ -1864,7 +1863,6 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         }
     }
@@ -2026,7 +2024,6 @@ mod tests {
                 mailboxes,
                 verify_host: None,
                 enable_ipv6: false,
-                smtp_helo_name: None,
                 upgrade: None,
             };
             let handle_cfg = ConfigHandle::new(config);

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1471,7 +1471,6 @@ pub fn finalize_setup(
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         };
         install_config_file(&cfg, &config_path)?;

--- a/src/smtp/tests.rs
+++ b/src/smtp/tests.rs
@@ -88,7 +88,6 @@ fn test_config(data_dir: &std::path::Path) -> Config {
         mailboxes,
         verify_host: None,
         enable_ipv6: false,
-        smtp_helo_name: None,
         upgrade: None,
     }
 }
@@ -836,7 +835,6 @@ async fn test_ingest_failure_returns_451() {
         mailboxes: HashMap::new(),
         verify_host: None,
         enable_ipv6: false,
-        smtp_helo_name: None,
         upgrade: None,
     };
     let (port, _shutdown) = start_server(config).await;

--- a/src/state_handler.rs
+++ b/src/state_handler.rs
@@ -373,7 +373,6 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         };
         StateContext::new(data_dir.to_path_buf(), ConfigHandle::new(config))
@@ -763,7 +762,6 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         };
         let sctx = StateContext::new(tmp.path().to_path_buf(), ConfigHandle::new(config));
@@ -858,7 +856,6 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         };
         let sctx = StateContext::new(tmp.path().to_path_buf(), ConfigHandle::new(config));
@@ -956,7 +953,6 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         };
         let sctx = StateContext::new(tmp.path().to_path_buf(), ConfigHandle::new(config));
@@ -1036,7 +1032,6 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         };
         let sctx = StateContext::new(tmp.path().to_path_buf(), ConfigHandle::new(config));

--- a/src/transport.rs
+++ b/src/transport.rs
@@ -44,10 +44,9 @@ pub trait MailTransport {
 ///
 /// `helo_name` is the EHLO / HELO identity the transport presents to
 /// recipient MXs. It is captured at construction time from
-/// [`crate::config::Config::smtp_helo_name`] so a later config reload
-/// that swaps the value does not require re-plumbing the transport.
-/// Hardening PRD §6.2: outbound mail must never introduce itself with
-/// the dialed MX hostname.
+/// `config.domain` — the same value DKIM / SPF / DMARC key on, which is
+/// what recipient MTAs expect to see in the EHLO line. Hardening PRD §6.2:
+/// outbound mail must never introduce itself with the dialed MX hostname.
 pub struct LettreTransport {
     enable_ipv6: bool,
     helo_name: String,
@@ -88,9 +87,8 @@ pub(crate) fn select_connect_target(
 }
 
 impl LettreTransport {
-    /// Construct a transport bound to a specific HELO identity. Call
-    /// sites pass `config.smtp_helo_name().to_string()` (see
-    /// `crate::serve::run_serve`).
+    /// Construct a transport bound to `config.domain` as its HELO identity.
+    /// Call sites pass `config.domain.clone()` (see `crate::serve::run_serve`).
     pub fn new(enable_ipv6: bool, helo_name: impl Into<String>) -> Self {
         Self {
             enable_ipv6,
@@ -265,9 +263,9 @@ impl LettreTransport {
 
         let transport = lettre::SmtpTransport::builder_dangerous(&connect_target)
             .hello_name(lettre::transport::smtp::extension::ClientId::Domain(
-                // Hardening PRD §6.2: EHLO identity is ours, not the
-                // dialed MX. Captured from `Config::smtp_helo_name()`
-                // at construction time.
+                // Hardening PRD §6.2: EHLO identity is our own domain,
+                // never the dialed MX. Always `config.domain` so DKIM /
+                // SPF / DMARC alignment stays consistent.
                 self.helo_name.clone(),
             ))
             .port(25)
@@ -459,55 +457,22 @@ mod tests {
 
     #[test]
     fn lettre_transport_stores_helo_name_from_constructor() {
-        // Sprint 1 S1-4: the EHLO identity must come from config, not
-        // from the dialed MX host. The constructor captures the value
-        // so `try_deliver` can pass it to lettre verbatim.
+        // Hardening PRD §6.2: the EHLO identity must come from config
+        // (specifically `config.domain`), not from the dialed MX host.
+        // The constructor captures the value so `try_deliver` can pass
+        // it to lettre verbatim.
         let t = LettreTransport::new(false, "example.com");
         assert_eq!(t.helo_name(), "example.com");
     }
 
     #[test]
-    fn lettre_transport_helo_name_preserves_override() {
-        // When an operator sets `smtp_helo_name = "mail.example.com"`
-        // the transport surfaces that value, not `config.domain`.
-        let t = LettreTransport::new(true, "mail.example.com");
-        assert_eq!(t.helo_name(), "mail.example.com");
-    }
-
-    #[test]
-    fn config_smtp_helo_name_defaults_to_domain() {
-        // Sprint 1 S1-3: the helper returns `config.domain` when the
-        // optional field is unset.
+    fn lettre_transport_helo_name_tracks_config_domain() {
+        // End-to-end: serve builds the transport from `config.domain`.
+        // The transport surfaces that value as its EHLO identity.
         use crate::config::Config;
-        let toml_str = "domain = \"example.com\"\n[mailboxes]\n";
-        let cfg: Config = toml::from_str(toml_str).unwrap();
-        assert_eq!(cfg.smtp_helo_name(), "example.com");
-    }
-
-    #[test]
-    fn config_smtp_helo_name_returns_override_when_set() {
-        use crate::config::Config;
-        let toml_str =
-            "domain = \"example.com\"\nsmtp_helo_name = \"mail.example.com\"\n[mailboxes]\n";
-        let cfg: Config = toml::from_str(toml_str).unwrap();
-        assert_eq!(cfg.smtp_helo_name(), "mail.example.com");
-    }
-
-    #[test]
-    fn lettre_transport_integrates_with_config_helper() {
-        // End-to-end: the transport fed by `Config::smtp_helo_name()`
-        // carries the effective value, regardless of whether the
-        // operator set the override.
-        use crate::config::Config;
-        let default_cfg: Config = toml::from_str("domain = \"a.example\"\n[mailboxes]\n").unwrap();
-        let override_cfg: Config = toml::from_str(
-            "domain = \"a.example\"\nsmtp_helo_name = \"relay.example\"\n[mailboxes]\n",
-        )
-        .unwrap();
-        let t_default = LettreTransport::new(false, default_cfg.smtp_helo_name());
-        let t_override = LettreTransport::new(false, override_cfg.smtp_helo_name());
-        assert_eq!(t_default.helo_name(), "a.example");
-        assert_eq!(t_override.helo_name(), "relay.example");
+        let cfg: Config = toml::from_str("domain = \"a.example\"\n[mailboxes]\n").unwrap();
+        let t = LettreTransport::new(false, cfg.domain.clone());
+        assert_eq!(t.helo_name(), "a.example");
     }
 
     #[test]

--- a/src/trust.rs
+++ b/src/trust.rs
@@ -175,7 +175,6 @@ mod tests {
             mailboxes: HashMap::new(),
             verify_host: None,
             enable_ipv6: false,
-            smtp_helo_name: None,
             upgrade: None,
         }
     }


### PR DESCRIPTION
## Summary

Follow-up to #142. The optional `smtp_helo_name` config field added for "split-FQDN operators" is dropped. DKIM / SPF / DMARC all key on `config.domain`; a HELO that diverges from those is strictly worse for deliverability, never better. The "dedicated relay with different FQDN" story in the Sprint 1 PRD was hypothetical — no real deployment benefits from introducing outbound mail with a hostname that differs from the signing domain. Simpler to hardcode.

## Changes
- Remove `Config.smtp_helo_name` field and `Config::smtp_helo_name()` helper
- Remove the RFC 1123 validator (`validate_helo_name`) and its `Config::load` hook
- `LettreTransport` still carries `helo_name: String` at construction, but `serve.rs` now passes `config.domain.clone()` directly
- Drop the `smtp_helo_name` row in `book/configuration.md`
- Prune round-trip / validator / accept-reject tests for the removed field

Outbound EHLO is `config.domain` by construction. No operator knob left to misconfigure.

## Test plan
- [x] `cargo build` clean
- [x] `cargo test` — 1426 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [ ] Manual smoke test (capture `Received:` header from a public mailbox showing `config.domain` as EHLO) — deferred to release verification, same as before