### PR TITLE
[Sprint 2] DATA partial-success contract

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1477,14 +1477,6 @@ impl Config {
     pub fn sent_dir(&self, name: &str) -> PathBuf {
         self.data_dir.join("sent").join(name)
     }
-
-    pub fn resolve_mailbox(&self, local_part: &str) -> String {
-        if self.mailboxes.contains_key(local_part) {
-            local_part.to_string()
-        } else {
-            "catchall".to_string()
-        }
-    }
 }
 
 /// Shared, swappable handle to the daemon's in-memory `Config`.
@@ -2180,18 +2172,6 @@ dangerously_support_untrusted = true
         config.save(&path).unwrap();
         let loaded = Config::load_ignore_warnings(&path).unwrap();
         assert_eq!(config, loaded);
-    }
-
-    #[test]
-    fn resolve_mailbox_known() {
-        let config: Config = toml::from_str(sample_toml()).unwrap();
-        assert_eq!(config.resolve_mailbox("support"), "support");
-    }
-
-    #[test]
-    fn resolve_mailbox_unknown_falls_to_catchall() {
-        let config: Config = toml::from_str(sample_toml()).unwrap();
-        assert_eq!(config.resolve_mailbox("unknown"), "catchall");
     }
 
     #[test]

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -13,6 +13,30 @@ use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+/// Decide whether a recipient address routes to a configured mailbox.
+///
+/// Returns `Some(mailbox_name)` when either a concrete mailbox matches
+/// the local part or a catchall (`*@<domain>`) exists; `None` when no
+/// mailbox can accept the recipient. Called from both the SMTP
+/// `handle_rcpt_to` preflight (so unknown recipients are rejected at
+/// RCPT time with `550 5.1.1`) and from `ingest_email` itself (so the
+/// RCPT-time decision and the DATA-time decision never drift).
+///
+/// The caller is responsible for checking that the domain matches
+/// `config.domain`; this helper is agnostic about the recipient's
+/// domain and only looks at the local part against the configured
+/// mailboxes.
+pub fn resolve_recipient_mailbox(config: &Config, rcpt: &str) -> Option<String> {
+    let local_part = extract_local_part(rcpt);
+    if config.mailboxes.contains_key(local_part) {
+        return Some(local_part.to_string());
+    }
+    if config.mailboxes.contains_key("catchall") {
+        return Some("catchall".to_string());
+    }
+    None
+}
+
 pub fn run(rcpt: &str, config: Config) -> Result<(), Box<dyn std::error::Error>> {
     // Install the shared tracing subscriber so the INFO/WARN lines emitted
     // below land on stderr for the manual stdin path. `aimx serve` installs
@@ -48,15 +72,33 @@ pub fn ingest_email(
     received_from_ip: IpAddr,
     envelope_mail_from: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let local_part = extract_local_part(rcpt);
-    let mailbox = config.resolve_mailbox(local_part);
+    // Test-only seam: force a synthetic ingest failure for a specific
+    // recipient so we can drive the DATA partial-success contract
+    // (§6.3) in integration tests. Mirrors the shape of
+    // `AIMX_TEST_MAIL_DROP` in `src/transport.rs`. A no-op in
+    // production — any operator setting this in `aimx serve` would see
+    // every matching inbound message rejected, which is louder than
+    // silent.
+    if let Ok(target) = std::env::var("AIMX_TEST_INGEST_FAIL_FOR")
+        && !target.is_empty()
+        && target.eq_ignore_ascii_case(rcpt)
+    {
+        return Err(format!("AIMX_TEST_INGEST_FAIL_FOR forced failure for rcpt={rcpt}").into());
+    }
+
+    let mailbox = match resolve_recipient_mailbox(config, rcpt) {
+        Some(m) => m,
+        None => {
+            return Err(format!("no mailbox routes recipient {rcpt}").into());
+        }
+    };
     let inbox_dir = config.inbox_dir(&mailbox);
 
     std::fs::create_dir_all(&inbox_dir)?;
     // Chown the mailbox directory to the configured owner (PRD §6.3).
-    // Missing mailbox config (which shouldn't happen since resolve_mailbox
-    // falls back to "catchall", which is always present) would make the
-    // chown a silent no-op; `get` returns None in that case.
+    // `resolve_recipient_mailbox` already guaranteed the mailbox entry
+    // exists, so `get` returns `Some` on the happy path; the `if let`
+    // is a belt-and-braces guard.
     if let Some(mb_cfg) = config.mailboxes.get(&mailbox) {
         // The inbox directory may already exist from a prior delivery.
         // We still re-apply the chown/chmod here to heal any drift —
@@ -1256,6 +1298,64 @@ mod tests {
         assert!(inbox(tmp.path(), "catchall").exists());
         let entries = collect_md_files(&inbox(tmp.path(), "catchall"));
         assert_eq!(entries.len(), 1);
+    }
+
+    fn no_catchall_config(tmp: &Path) -> Config {
+        let mut cfg = test_config(tmp);
+        cfg.mailboxes.remove("catchall");
+        cfg
+    }
+
+    #[test]
+    fn resolve_recipient_mailbox_known_local_part() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        assert_eq!(
+            resolve_recipient_mailbox(&config, "alice@test.com"),
+            Some("alice".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_recipient_mailbox_unknown_uses_catchall_when_present() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        assert_eq!(
+            resolve_recipient_mailbox(&config, "nobody@test.com"),
+            Some("catchall".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_recipient_mailbox_unknown_without_catchall_returns_none() {
+        let tmp = TempDir::new().unwrap();
+        let config = no_catchall_config(tmp.path());
+        assert_eq!(resolve_recipient_mailbox(&config, "nobody@test.com"), None);
+    }
+
+    #[test]
+    fn resolve_recipient_mailbox_known_without_catchall_still_routes() {
+        let tmp = TempDir::new().unwrap();
+        let config = no_catchall_config(tmp.path());
+        assert_eq!(
+            resolve_recipient_mailbox(&config, "alice@test.com"),
+            Some("alice".to_string())
+        );
+    }
+
+    #[test]
+    fn ingest_rejects_unknown_recipient_without_catchall() {
+        let tmp = TempDir::new().unwrap();
+        let config = no_catchall_config(tmp.path());
+        let result = ingest_email(
+            &config,
+            &test_locks(),
+            "nobody@test.com",
+            plain_text_eml(),
+            sentinel_ip(),
+            None,
+        );
+        assert!(result.is_err(), "expected error when no mailbox routes");
     }
 
     #[test]

--- a/src/smtp/session.rs
+++ b/src/smtp/session.rs
@@ -373,13 +373,24 @@ impl SmtpSession {
         if addr.is_empty() {
             return "501 Syntax: RCPT TO:<address>\r\n".to_string();
         }
-        let configured_domain = self.params.config_handle.load().domain.clone();
-        if !recipient_domain_matches(&addr, &configured_domain) {
+        let config = self.params.config_handle.load();
+        if !recipient_domain_matches(&addr, &config.domain) {
             eprintln!(
                 "[{}] RCPT rejected (relay): recipient={} configured_domain={}",
-                self.params.peer_addr, addr, configured_domain
+                self.params.peer_addr, addr, config.domain
             );
             return "550 5.7.1 relay not permitted\r\n".to_string();
+        }
+        // S2-1: mailbox-routing preflight. Reject at RCPT time when no
+        // mailbox (concrete or catchall) can accept the address. Keeps
+        // the RCPT-time and DATA-time decisions in sync via the shared
+        // `resolve_recipient_mailbox` helper.
+        if crate::ingest::resolve_recipient_mailbox(&config, &addr).is_none() {
+            eprintln!(
+                "[{}] RCPT rejected (no mailbox): recipient={}",
+                self.params.peer_addr, addr
+            );
+            return format!("550 5.1.1 <{addr}>: Recipient address rejected: User unknown\r\n");
         }
         session_state.forward_paths.push(addr);
         session_state.state = State::RcptTo;
@@ -551,30 +562,45 @@ impl SmtpSession {
 
         let size = data.len();
         let rcpt_count = session_state.forward_paths.len();
-        if succeeded > 0 {
+        let from = session_state.reverse_path.clone();
+        let peer = self.params.peer_addr;
+
+        // Structured observability signal for every delivery outcome.
+        // Target `aimx::smtp` matches the convention used by the other
+        // daemon subsystems; fields mirror the PRD §7.3 contract so
+        // `aimx logs` can filter on a stable shape.
+        tracing::info!(
+            target: "aimx::smtp",
+            peer = %peer,
+            from = %from,
+            rcpts = rcpt_count,
+            succeeded = succeeded,
+            failed = failed,
+            size = size,
+            "data delivery outcome"
+        );
+
+        if failed == 0 && succeeded > 0 {
             session_state.message_count += 1;
             session_state.total_bytes += size;
-            if failed > 0 {
-                eprintln!(
-                    "[{}] Message partially accepted from={} rcpts={} succeeded={} failed={} size={}",
-                    self.params.peer_addr,
-                    session_state.reverse_path,
-                    rcpt_count,
-                    succeeded,
-                    failed,
-                    size
-                );
-            } else {
-                eprintln!(
-                    "[{}] Message accepted from={} rcpts={} size={}",
-                    self.params.peer_addr, session_state.reverse_path, rcpt_count, size
-                );
-            }
+            eprintln!("[{peer}] Message accepted from={from} rcpts={rcpt_count} size={size}");
             Ok("250 OK message accepted\r\n".to_string())
+        } else if succeeded > 0 {
+            // S2-2 / §6.3: any post-354 failure is surfaced as 451 so
+            // the sending MTA retries the message rather than treating
+            // partial loss as success. Both the per-recipient files
+            // that did land and the session counters are updated — the
+            // retry will re-deliver duplicates but that is the price of
+            // lossless semantics.
+            session_state.message_count += 1;
+            session_state.total_bytes += size;
+            eprintln!(
+                "[{peer}] Message partially accepted from={from} rcpts={rcpt_count} succeeded={succeeded} failed={failed} size={size}"
+            );
+            Ok("451 4.3.0 Temporary failure on partial accept; please retry\r\n".to_string())
         } else {
             eprintln!(
-                "[{}] Message rejected from={} rcpts={} all_failed size={}",
-                self.params.peer_addr, session_state.reverse_path, rcpt_count, size
+                "[{peer}] Message rejected from={from} rcpts={rcpt_count} all_failed size={size}"
             );
             Ok("451 Temporary failure, please retry\r\n".to_string())
         }

--- a/src/smtp/tests.rs
+++ b/src/smtp/tests.rs
@@ -825,6 +825,21 @@ async fn test_ingest_failure_returns_451() {
     std::fs::write(&blocker, "x").unwrap();
     let bad_data_dir = blocker.join("data");
 
+    // A mailbox entry must exist so the RCPT preflight (S2-1) accepts;
+    // the failure is forced later at `create_dir_all` time because the
+    // data_dir parent is a regular file.
+    let mut mailboxes = HashMap::new();
+    mailboxes.insert(
+        "alice".to_string(),
+        MailboxConfig {
+            address: "alice@test.local".to_string(),
+            owner: "root".to_string(),
+            hooks: vec![],
+            trust: None,
+            trusted_senders: None,
+            allow_root_catchall: false,
+        },
+    );
     let config = Config {
         domain: "test.local".to_string(),
         data_dir: bad_data_dir,
@@ -832,7 +847,7 @@ async fn test_ingest_failure_returns_451() {
         trust: "none".to_string(),
         trusted_senders: vec![],
         hook_templates: Vec::new(),
-        mailboxes: HashMap::new(),
+        mailboxes,
         verify_host: None,
         enable_ipv6: false,
         upgrade: None,
@@ -843,7 +858,8 @@ async fn test_ingest_failure_returns_451() {
 
     client.send_and_read("EHLO test.com").await;
     client.send_and_read("MAIL FROM:<sender@test.com>").await;
-    client.send_and_read("RCPT TO:<alice@test.local>").await;
+    let resp = client.send_and_read("RCPT TO:<alice@test.local>").await;
+    assert!(resp.starts_with("250"), "RCPT should accept: {resp}");
     client.send_and_read("DATA").await;
     client.send(test_email()).await;
     let resp = client.send_and_read(".").await;
@@ -1268,4 +1284,209 @@ async fn test_mixed_text_and_binary_attachments_with_body() {
         content.contains("data.bin"),
         "Frontmatter should reference data.bin attachment"
     );
+}
+
+// ---------------------------------------------------------------------------
+// S2-1: RCPT-time mailbox-routing preflight
+// ---------------------------------------------------------------------------
+
+fn test_config_no_catchall(data_dir: &std::path::Path) -> Config {
+    let mut mailboxes = HashMap::new();
+    mailboxes.insert(
+        "alice".to_string(),
+        MailboxConfig {
+            address: "alice@test.local".to_string(),
+            owner: "root".to_string(),
+            hooks: vec![],
+            trust: None,
+            trusted_senders: None,
+            allow_root_catchall: false,
+        },
+    );
+    Config {
+        domain: "test.local".to_string(),
+        data_dir: data_dir.to_path_buf(),
+        dkim_selector: "aimx".to_string(),
+        trust: "none".to_string(),
+        trusted_senders: vec![],
+        hook_templates: Vec::new(),
+        mailboxes,
+        verify_host: None,
+        enable_ipv6: false,
+        upgrade: None,
+    }
+}
+
+#[tokio::test]
+async fn test_rcpt_rejects_unknown_mailbox_no_catchall() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config_no_catchall(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    client.send_and_read("EHLO client.example.com").await;
+    client.send_and_read("MAIL FROM:<sender@example.com>").await;
+
+    let resp = client.send_and_read("RCPT TO:<bob@test.local>").await;
+    assert!(
+        resp.starts_with("550 5.1.1"),
+        "Expected 550 5.1.1 for unknown recipient: {resp}"
+    );
+
+    let resp = client.send_and_read("RCPT TO:<alice@test.local>").await;
+    assert!(
+        resp.starts_with("250"),
+        "Expected 250 for known recipient: {resp}"
+    );
+
+    client.send_and_read("QUIT").await;
+}
+
+#[tokio::test]
+async fn test_rcpt_catchall_accepts_any_local_part() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    client.send_and_read("EHLO client.example.com").await;
+    client.send_and_read("MAIL FROM:<sender@example.com>").await;
+
+    // With a catchall present, an unknown local part still resolves.
+    let resp = client
+        .send_and_read("RCPT TO:<randomuser@test.local>")
+        .await;
+    assert!(
+        resp.starts_with("250"),
+        "Expected 250 with catchall present: {resp}"
+    );
+
+    client.send_and_read("QUIT").await;
+}
+
+// ---------------------------------------------------------------------------
+// S2-2 / S2-3: DATA partial-success contract
+// ---------------------------------------------------------------------------
+
+fn test_config_two_mailboxes(data_dir: &std::path::Path) -> Config {
+    let mut mailboxes = HashMap::new();
+    mailboxes.insert(
+        "alice".to_string(),
+        MailboxConfig {
+            address: "alice@test.local".to_string(),
+            owner: "root".to_string(),
+            hooks: vec![],
+            trust: None,
+            trusted_senders: None,
+            allow_root_catchall: false,
+        },
+    );
+    mailboxes.insert(
+        "bob".to_string(),
+        MailboxConfig {
+            address: "bob@test.local".to_string(),
+            owner: "root".to_string(),
+            hooks: vec![],
+            trust: None,
+            trusted_senders: None,
+            allow_root_catchall: false,
+        },
+    );
+    Config {
+        domain: "test.local".to_string(),
+        data_dir: data_dir.to_path_buf(),
+        dkim_selector: "aimx".to_string(),
+        trust: "none".to_string(),
+        trusted_senders: vec![],
+        hook_templates: Vec::new(),
+        mailboxes,
+        verify_host: None,
+        enable_ipv6: false,
+        upgrade: None,
+    }
+}
+
+fn mixed_test_email() -> &'static str {
+    "From: sender@example.com\r\nTo: alice@test.local, bob@test.local\r\nSubject: Mixed\r\nDate: Mon, 01 Jan 2024 00:00:00 +0000\r\nMessage-ID: <mixed@example.com>\r\n\r\nHello both\r\n"
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_partial_success_returns_451() {
+    // Serialise env var access because `AIMX_TEST_INGEST_FAIL_FOR` is a
+    // process-wide seam. `serial_test::serial` keeps the other
+    // concurrent SMTP tests from observing the forced failure.
+    unsafe {
+        std::env::set_var("AIMX_TEST_INGEST_FAIL_FOR", "bob@test.local");
+    }
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config_two_mailboxes(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    client.send_and_read("EHLO client.example.com").await;
+    client.send_and_read("MAIL FROM:<sender@example.com>").await;
+    let resp = client.send_and_read("RCPT TO:<alice@test.local>").await;
+    assert!(resp.starts_with("250"), "alice RCPT: {resp}");
+    let resp = client.send_and_read("RCPT TO:<bob@test.local>").await;
+    assert!(resp.starts_with("250"), "bob RCPT: {resp}");
+
+    let resp = client.send_and_read("DATA").await;
+    assert!(resp.starts_with("354"), "DATA preamble: {resp}");
+
+    client.send(mixed_test_email()).await;
+    let resp = client.send_and_read(".").await;
+    assert!(
+        resp.starts_with("451 4.3.0"),
+        "Expected 451 4.3.0 on partial-success: {resp}"
+    );
+
+    client.send_and_read("QUIT").await;
+
+    // alice succeeded, bob's ingest was forced to fail.
+    let alice_mds = collect_md_files(&inbox(tmp.path(), "alice"));
+    let bob_mds = collect_md_files(&inbox(tmp.path(), "bob"));
+    assert_eq!(alice_mds.len(), 1, "alice should have one message");
+    assert_eq!(bob_mds.len(), 0, "bob should have no message");
+
+    unsafe {
+        std::env::remove_var("AIMX_TEST_INGEST_FAIL_FOR");
+    }
+}
+
+#[tokio::test]
+#[serial_test::serial]
+async fn test_multi_rcpt_all_success_returns_250() {
+    // Guard against any lingering env var from parallel-scheduled tests.
+    unsafe {
+        std::env::remove_var("AIMX_TEST_INGEST_FAIL_FOR");
+    }
+    let tmp = tempfile::TempDir::new().unwrap();
+    let config = test_config_two_mailboxes(tmp.path());
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    client.send_and_read("EHLO client.example.com").await;
+    client.send_and_read("MAIL FROM:<sender@example.com>").await;
+    client.send_and_read("RCPT TO:<alice@test.local>").await;
+    client.send_and_read("RCPT TO:<bob@test.local>").await;
+    client.send_and_read("DATA").await;
+
+    client.send(mixed_test_email()).await;
+    let resp = client.send_and_read(".").await;
+    assert!(
+        resp.starts_with("250"),
+        "Expected 250 on all-success: {resp}"
+    );
+
+    client.send_and_read("QUIT").await;
+
+    let alice_mds = collect_md_files(&inbox(tmp.path(), "alice"));
+    let bob_mds = collect_md_files(&inbox(tmp.path(), "bob"));
+    assert_eq!(alice_mds.len(), 1);
+    assert_eq!(bob_mds.len(), 1);
 }


### PR DESCRIPTION
## Summary

Closes Sprint 2 of the `hardening` track (PRD §6.3, milestone M3). Multi-recipient outbound mail can no longer return `250 OK` while silently dropping some recipients.

- **S2-1 — RCPT-time mailbox-routing preflight.** New `resolve_recipient_mailbox(&Config, &str) -> Option<String>` helper in `src/ingest.rs`, shared by `handle_rcpt_to` and `ingest_email` so RCPT-time and DATA-time decisions never drift. Unknown recipients are now rejected at RCPT time with `550 5.1.1 <addr>: Recipient address rejected: User unknown`. Catchall (`*@<domain>`) behaviour is preserved. The stale `Config::resolve_mailbox` (which returned `"catchall"` even when no catchall was configured) is removed.
- **S2-2 — `451 4.3.0` on any post-354 failure.** `deliver_message` returns `451 4.3.0 Temporary failure on partial accept; please retry` whenever `failed > 0`, regardless of `succeeded` count. The all-fail path keeps its existing `451 Temporary failure, please retry`. All-success remains `250 OK`. A structured `tracing::info!` line on the `aimx::smtp` target carries `peer`, `from`, `rcpts`, `succeeded`, `failed`, `size` for every delivery outcome (§7.3).
- **S2-3 — Mixed-success test + ingest test seam.** `AIMX_TEST_INGEST_FAIL_FOR=<rcpt>` env var in `ingest_email` forces a synthetic per-recipient failure. Mirrors `AIMX_TEST_MAIL_DROP` in `src/transport.rs`.

## Test plan

- [x] `cargo test` (1433 tests, 0 failures, pre-existing `ignored` tests remain ignored)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Unit tests for `resolve_recipient_mailbox` (known local part, catchall fallback, no-catchall reject, known-without-catchall)
- [x] `ingest_email` rejects an unknown recipient when no catchall is configured
- [x] New SMTP integration tests:
  - `test_rcpt_rejects_unknown_mailbox_no_catchall` — RCPT is rejected with `550 5.1.1`
  - `test_rcpt_catchall_accepts_any_local_part` — any local part accepted when catchall is present
  - `test_partial_success_returns_451` — alice succeeds, bob is force-failed, response is `451 4.3.0`, alice's `.md` landed, bob's did not
  - `test_multi_rcpt_all_success_returns_250` — both mailboxes land a file, response is `250`
- [x] Existing `test_ingest_failure_returns_451` still passes (updated to seed `alice` so the S2-1 preflight accepts the RCPT and the all-fail path is exercised end-to-end)
- [x] Env-var-bearing tests are `#[serial_test::serial]` so the seam doesn't leak across parallel SMTP tests