### PR TITLE
[Sprint 3] Atomic CLI fallbacks + delete ordering

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -62,6 +62,54 @@ pub fn dkim_dir() -> PathBuf {
     config_dir().join("dkim")
 }
 
+/// Atomically replace `path` with the TOML serialization of `config`.
+///
+/// Writes to a sibling `.<filename>.tmp.<pid>` file in the same parent
+/// directory as `path`, fsyncs it, then renames over the target. On
+/// POSIX `rename(2)` is atomic for same-filesystem targets, so readers
+/// see either the old snapshot or the new one; never a truncated file.
+/// On failure the temp file is cleaned up best-effort so subsequent
+/// retries don't trip over stale state.
+///
+/// This is the single source of truth for config-file durability used
+/// by both the daemon (`mailbox_handler::write_config_atomic` delegates
+/// here) and the CLI (`Config::save` delegates here).
+///
+/// **Unknown-key / comment behaviour (v1):** re-serializes `config`
+/// through `toml::to_string_pretty`, so any TOML fields the operator
+/// added that are not modeled in the `Config` struct are dropped on
+/// rewrite, and human-authored comments are erased. v1 assumes
+/// `config.toml` is machine-authored (edits go through `aimx setup` /
+/// `aimx mailboxes create|delete` / `aimx hooks ...`).
+pub fn write_atomic(path: &Path, config: &Config) -> std::io::Result<()> {
+    use std::io::Write;
+
+    let serialized = toml::to_string_pretty(config)
+        .map_err(|e| std::io::Error::other(format!("toml serialize: {e}")))?;
+
+    let parent = path.parent().unwrap_or(Path::new("."));
+    let file_name = path
+        .file_name()
+        .and_then(|s| s.to_str())
+        .unwrap_or("config.toml");
+    let tmp_name = format!(".{file_name}.tmp.{}", std::process::id());
+    let tmp_path = parent.join(tmp_name);
+
+    // Scope the file handle so it closes before rename (paranoia on
+    // platforms where an open handle can block a rename).
+    {
+        let mut f = std::fs::File::create(&tmp_path)?;
+        f.write_all(serialized.as_bytes())?;
+        f.sync_all()?;
+    }
+
+    if let Err(e) = std::fs::rename(&tmp_path, path) {
+        let _ = std::fs::remove_file(&tmp_path);
+        return Err(e);
+    }
+    Ok(())
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 pub struct Config {
     pub domain: String,
@@ -1375,10 +1423,18 @@ impl Config {
         Ok((config, warnings))
     }
 
+    /// Persist the config to `path` atomically via temp-then-rename.
+    ///
+    /// Delegates to [`write_atomic`] so CLI fallback callers (`mailbox
+    /// create/delete`, `hooks create/delete`) get the same crash-safety
+    /// guarantee the daemon already had via
+    /// [`crate::mailbox_handler::write_config_atomic`]. Either the new
+    /// snapshot is fully durable or the existing file is left byte-for-byte
+    /// unchanged; a `config.toml` is never truncated mid-write.
     pub fn save(&self, path: &Path) -> Result<(), Box<dyn std::error::Error>> {
-        let content = toml::to_string_pretty(self)?;
-        std::fs::write(path, content)?;
-        Ok(())
+        write_atomic(path, self).map_err(|e| -> Box<dyn std::error::Error> {
+            format!("failed to write {}: {e}", path.display()).into()
+        })
     }
 
     /// Load the config from the canonical path returned by [`config_path`].
@@ -2172,6 +2228,127 @@ dangerously_support_untrusted = true
         config.save(&path).unwrap();
         let loaded = Config::load_ignore_warnings(&path).unwrap();
         assert_eq!(config, loaded);
+    }
+
+    /// Hardening PRD §6.4 / S3-1: `Config::save` must be crash-safe.
+    /// When the underlying write fails (here: parent dir missing, so
+    /// `File::create` on the temp file returns ENOENT), the on-disk
+    /// target file must remain byte-for-byte unchanged.
+    #[test]
+    fn save_is_atomic_and_preserves_original_on_failure() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+
+        let mut mailboxes = HashMap::new();
+        mailboxes.insert(
+            "catchall".to_string(),
+            MailboxConfig {
+                address: "*@test.com".to_string(),
+                owner: "aimx-catchall".to_string(),
+                hooks: vec![],
+                trust: None,
+                trusted_senders: None,
+                allow_root_catchall: false,
+            },
+        );
+        let original = Config {
+            domain: "test.com".to_string(),
+            data_dir: tmp.path().to_path_buf(),
+            dkim_selector: "aimx".to_string(),
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            hook_templates: Vec::new(),
+            mailboxes,
+            verify_host: None,
+            enable_ipv6: false,
+            upgrade: None,
+        };
+        // Seed the file via the happy path first.
+        original.save(&path).unwrap();
+        let original_bytes = std::fs::read(&path).unwrap();
+
+        // Mutate a copy, then force `save` to fail by pointing at a path
+        // whose parent directory does not exist. `write_atomic` creates
+        // the temp file in that (missing) parent, so `File::create`
+        // returns ENOENT before any rename can run.
+        let mut mutated = original.clone();
+        mutated.domain = "changed.example".to_string();
+        let bad_parent = tmp.path().join("does").join("not").join("exist");
+        let bad_target = bad_parent.join("config.toml");
+        let err = mutated.save(&bad_target).unwrap_err();
+        assert!(
+            err.to_string().contains("config.toml") || err.to_string().contains("No such"),
+            "save error should mention the target or the missing-path cause: {err}"
+        );
+
+        // Original file on disk is untouched.
+        let after = std::fs::read(&path).unwrap();
+        assert_eq!(
+            after, original_bytes,
+            "failed save must not disturb the original config.toml",
+        );
+
+        // No stray temp file in the original parent dir.
+        let leftover: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| {
+                e.file_name()
+                    .to_string_lossy()
+                    .starts_with(".config.toml.tmp.")
+            })
+            .collect();
+        assert!(
+            leftover.is_empty(),
+            "temp file must not leak into the happy-path parent dir",
+        );
+    }
+
+    /// `write_atomic` drops the temp file in the *target's* parent so
+    /// `rename(2)` stays on one filesystem. A successful write over an
+    /// existing target replaces the inode contents; a failed write
+    /// leaves the target bytes alone.
+    #[test]
+    fn write_atomic_uses_target_parent_for_temp_file() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+
+        let mut mailboxes = HashMap::new();
+        mailboxes.insert(
+            "catchall".to_string(),
+            MailboxConfig {
+                address: "*@test.com".to_string(),
+                owner: "aimx-catchall".to_string(),
+                hooks: vec![],
+                trust: None,
+                trusted_senders: None,
+                allow_root_catchall: false,
+            },
+        );
+        let cfg = Config {
+            domain: "test.com".to_string(),
+            data_dir: tmp.path().to_path_buf(),
+            dkim_selector: "aimx".to_string(),
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            hook_templates: Vec::new(),
+            mailboxes,
+            verify_host: None,
+            enable_ipv6: false,
+            upgrade: None,
+        };
+        super::write_atomic(&path, &cfg).unwrap();
+        assert!(path.exists());
+        // On success the temp file is renamed; no `.tmp.` stragglers.
+        let leftover: Vec<_> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .filter(|e| e.file_name().to_string_lossy().contains(".tmp."))
+            .collect();
+        assert!(
+            leftover.is_empty(),
+            "temp file should be renamed, not left behind"
+        );
     }
 
     #[test]

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -754,7 +754,12 @@ fn apply_create_direct(
     // next daemon restart.
     validate_hooks(&new_config, &OrphanSkipContext::strict())
         .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
-    new_config.save(&crate::config::config_path())?;
+    // Use the same temp-then-rename helper the pruner and daemon use so
+    // the CLI fallback path is crash-safe (hardening PRD §6.4 / S3-3).
+    let path = crate::config::config_path();
+    crate::mailbox_handler::write_config_atomic(&path, &new_config).map_err(
+        |e| -> Box<dyn std::error::Error> { format!("failed to rewrite config.toml: {e}").into() },
+    )?;
     Ok(())
 }
 
@@ -774,7 +779,12 @@ fn apply_delete_direct(config: &Config, name: &str) -> Result<(), Box<dyn std::e
     if !removed {
         return Err(format!("Hook '{name}' not found").into());
     }
-    new_config.save(&crate::config::config_path())?;
+    // Atomic write-temp-then-rename; symmetric with apply_create_direct
+    // and the pruner at the top of this module (hardening PRD §6.4).
+    let path = crate::config::config_path();
+    crate::mailbox_handler::write_config_atomic(&path, &new_config).map_err(
+        |e| -> Box<dyn std::error::Error> { format!("failed to rewrite config.toml: {e}").into() },
+    )?;
     Ok(())
 }
 
@@ -1505,5 +1515,93 @@ mod tests {
             "expected ORPHAN-TEMPLATE-RUN_AS in findings, got: {findings:?}"
         );
         super::prune_preflight_check(&cfg).expect("orphan-only findings must not block prune");
+    }
+
+    /// Build a minimal raw-cmd `Hook` for the save-failure tests. The
+    /// `run_as: Some("root")` is deliberate so the post-apply invariant
+    /// check (`validate_hooks` with a strict orphan context) always
+    /// resolves — `root` is a reserved run_as name.
+    fn raw_cmd_hook(cmd: &str) -> crate::hook::Hook {
+        crate::hook::Hook {
+            name: None,
+            event: HookEvent::OnReceive,
+            r#type: "cmd".into(),
+            cmd: cmd.into(),
+            dangerously_support_untrusted: false,
+            origin: crate::hook::HookOrigin::Operator,
+            template: None,
+            params: std::collections::BTreeMap::new(),
+            run_as: Some("root".into()),
+        }
+    }
+
+    /// Hardening PRD §6.4 / S3-3: `apply_create_direct` must write
+    /// `config.toml` via temp-then-rename and must NOT truncate or
+    /// otherwise mutate the file when the underlying write fails.
+    #[test]
+    fn apply_create_direct_preserves_config_on_save_failure() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::create_dir_all(tmp.path()).unwrap();
+        let cfg = base_config();
+        {
+            // Seed the file at the real config path.
+            let _guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
+            cfg.save(&crate::config::config_path()).unwrap();
+        }
+        let real_path = tmp.path().join("config.toml");
+        let bytes_before = std::fs::read(&real_path).unwrap();
+
+        // Point config_path() at a nonexistent parent so write_atomic
+        // fails on `File::create` for the temp file.
+        let bad_dir = tmp.path().join("does").join("not").join("exist");
+        let _bad_guard = crate::config::test_env::ConfigDirOverride::set(&bad_dir);
+
+        let err = super::apply_create_direct(&cfg, "alice", raw_cmd_hook("echo hi")).unwrap_err();
+        assert!(
+            !err.to_string().is_empty(),
+            "non-empty error message expected on write failure",
+        );
+
+        drop(_bad_guard);
+        // Original file on disk is byte-for-byte unchanged.
+        let bytes_after = std::fs::read(&real_path).unwrap();
+        assert_eq!(
+            bytes_after, bytes_before,
+            "failed apply_create_direct must not rewrite config.toml",
+        );
+    }
+
+    /// Hardening PRD §6.4 / S3-3: same invariant as above, for the
+    /// delete-hook direct path. Prove the pre-existing hook survives
+    /// untouched on save failure.
+    #[test]
+    fn apply_delete_direct_preserves_config_on_save_failure() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        // Start from a config that already carries a hook so delete has
+        // something to find.
+        let mut cfg = base_config();
+        let hook = raw_cmd_hook("echo hi");
+        let hook_name = effective_hook_name(&hook);
+        cfg.mailboxes.get_mut("alice").unwrap().hooks.push(hook);
+
+        {
+            let _guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
+            cfg.save(&crate::config::config_path()).unwrap();
+        }
+        let real_path = tmp.path().join("config.toml");
+        let bytes_before = std::fs::read(&real_path).unwrap();
+
+        let bad_dir = tmp.path().join("nope").join("nah");
+        let _bad_guard = crate::config::test_env::ConfigDirOverride::set(&bad_dir);
+
+        let err = super::apply_delete_direct(&cfg, &hook_name).unwrap_err();
+        assert!(!err.to_string().is_empty());
+
+        drop(_bad_guard);
+        let bytes_after = std::fs::read(&real_path).unwrap();
+        assert_eq!(
+            bytes_after, bytes_before,
+            "failed apply_delete_direct must not rewrite config.toml",
+        );
     }
 }

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -143,20 +143,56 @@ pub fn delete_mailbox(config: &Config, name: &str) -> Result<(), Box<dyn std::er
         return Err(format!("Mailbox '{name}' does not exist").into());
     }
 
-    // Remove both inbox and sent directories.
+    // Hardening PRD §6.4 / S3-2: save-then-delete ordering.
+    //
+    // 1. Clone the config and drop the mailbox entry in memory.
+    // 2. Persist the new config atomically (temp-then-rename). If this
+    //    fails, the data dirs on disk are untouched, so the operator can
+    //    retry without first resurrecting the mailbox files.
+    // 3. Only after the save succeeds do we `remove_dir_all` the inbox
+    //    and sent dirs. If step 3 fails the config is already authoritative;
+    //    warn the operator by name+error so they can clean up the
+    //    leftover directories, and propagate the error so the CLI exits
+    //    non-zero.
+    let mut new_config = config.clone();
+    new_config.mailboxes.remove(name);
+    new_config.save(&crate::config::config_path())?;
+
     let inbox = config.inbox_dir(name);
-    if inbox.exists() {
-        std::fs::remove_dir_all(&inbox)?;
-    }
     let sent = config.sent_dir(name);
-    if sent.exists() {
-        std::fs::remove_dir_all(&sent)?;
+    let mut leftover_error: Option<std::io::Error> = None;
+    if inbox.exists()
+        && let Err(e) = std::fs::remove_dir_all(&inbox)
+    {
+        tracing::warn!(
+            path = %inbox.display(),
+            error = %e,
+            "mailbox '{name}' config removed but inbox dir cleanup failed; \
+             remove manually to reclaim space",
+        );
+        leftover_error = Some(e);
+    }
+    if sent.exists()
+        && let Err(e) = std::fs::remove_dir_all(&sent)
+    {
+        tracing::warn!(
+            path = %sent.display(),
+            error = %e,
+            "mailbox '{name}' config removed but sent dir cleanup failed; \
+             remove manually to reclaim space",
+        );
+        // Keep the first error if inbox also failed, otherwise record this one.
+        if leftover_error.is_none() {
+            leftover_error = Some(e);
+        }
     }
 
-    let mut config = config.clone();
-    config.mailboxes.remove(name);
-
-    config.save(&crate::config::config_path())?;
+    if let Some(e) = leftover_error {
+        return Err(format!(
+            "mailbox '{name}' removed from config.toml but filesystem cleanup failed: {e}",
+        )
+        .into());
+    }
 
     Ok(())
 }
@@ -893,6 +929,66 @@ mod tests {
         assert!(!tmp.path().join("sent").join("alice").exists());
         let reloaded = Config::load_resolved_ignore_warnings().unwrap();
         assert!(!reloaded.mailboxes.contains_key("alice"));
+    }
+
+    /// Hardening PRD §6.4 / S3-2: when the atomic config save fails,
+    /// `delete_mailbox` must leave both `inbox/<name>/` and `sent/<name>/`
+    /// byte-for-byte untouched so the operator can retry. We induce a
+    /// save failure by pointing `AIMX_CONFIG_DIR` at a nonexistent
+    /// directory — `write_atomic` then hits ENOENT on `File::create`
+    /// for the temp file before any rename runs.
+    #[test]
+    fn delete_mailbox_preserves_data_dirs_on_save_failure() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let guard = setup_config_file(tmp.path(), &config);
+
+        create_mailbox(&config, "alice", "ops").unwrap();
+        let config = Config::load_resolved_ignore_warnings().unwrap();
+        assert!(config.mailboxes.contains_key("alice"));
+
+        // Seed some data in both inbox and sent so the save-first ordering
+        // is observable.
+        let inbox = tmp.path().join("inbox").join("alice");
+        let sent = tmp.path().join("sent").join("alice");
+        std::fs::create_dir_all(&inbox).unwrap();
+        std::fs::create_dir_all(&sent).unwrap();
+        let inbox_file = inbox.join("2025-01-01-120000-hello.md");
+        let sent_file = sent.join("2025-01-01-120001-reply.md");
+        std::fs::write(&inbox_file, b"inbox body").unwrap();
+        std::fs::write(&sent_file, b"sent body").unwrap();
+
+        let config_path = crate::config::config_path();
+        let config_bytes_before = std::fs::read(&config_path).unwrap();
+
+        // Swap the config-dir override to a nonexistent path so the
+        // next `config_path()` resolves into a missing parent dir.
+        drop(guard);
+        let bad_dir = tmp.path().join("does").join("not").join("exist");
+        let _bad_guard = ConfigDirOverride::set(&bad_dir);
+
+        let err = delete_mailbox(&config, "alice")
+            .expect_err("delete_mailbox must fail when config save fails");
+        drop(_bad_guard);
+        // The original error message surface is implementation-defined;
+        // just require non-empty so operators see something.
+        assert!(!err.to_string().is_empty());
+
+        // Reinstate the real config path so we can re-read it.
+        let _guard = ConfigDirOverride::set(tmp.path());
+
+        // Data dirs are byte-for-byte unchanged.
+        assert!(inbox.exists(), "inbox dir must survive save failure");
+        assert!(sent.exists(), "sent dir must survive save failure");
+        assert_eq!(std::fs::read(&inbox_file).unwrap(), b"inbox body");
+        assert_eq!(std::fs::read(&sent_file).unwrap(), b"sent body");
+
+        // config.toml is byte-for-byte unchanged.
+        let config_bytes_after = std::fs::read(&config_path).unwrap();
+        assert_eq!(
+            config_bytes_after, config_bytes_before,
+            "config.toml must not be truncated or rewritten on save failure",
+        );
     }
 
     #[test]

--- a/src/mailbox_handler.rs
+++ b/src/mailbox_handler.rs
@@ -35,7 +35,6 @@
 //! interleave their loads + writes, clobbering one stanza on disk and in
 //! memory. Always outer → inner.
 
-use std::io::Write;
 use std::os::unix::fs::MetadataExt;
 use std::path::{Path, PathBuf};
 use std::sync::Mutex;
@@ -434,30 +433,11 @@ fn count_files_if_exists(dir: &Path) -> usize {
 /// tracked for v2; see the test `unknown_stanza_is_dropped_on_rewrite`
 /// below for the contract check.
 pub(crate) fn write_config_atomic(path: &Path, config: &Config) -> std::io::Result<()> {
-    let serialized = toml::to_string_pretty(config)
-        .map_err(|e| std::io::Error::other(format!("toml serialize: {e}")))?;
-
-    let parent = path.parent().unwrap_or(Path::new("."));
-    let file_name = path
-        .file_name()
-        .and_then(|s| s.to_str())
-        .unwrap_or("config.toml");
-    let tmp_name = format!(".{file_name}.tmp.{}", std::process::id());
-    let tmp_path = parent.join(tmp_name);
-
-    // Scope the file handle so it closes before rename (paranoia on
-    // platforms where an open handle can block a rename).
-    {
-        let mut f = std::fs::File::create(&tmp_path)?;
-        f.write_all(serialized.as_bytes())?;
-        f.sync_all()?;
-    }
-
-    if let Err(e) = std::fs::rename(&tmp_path, path) {
-        let _ = std::fs::remove_file(&tmp_path);
-        return Err(e);
-    }
-    Ok(())
+    // Shared implementation lives in `config::write_atomic` so the
+    // daemon path (this function) and the CLI fallback path
+    // (`Config::save` — used by `mailbox create/delete` and
+    // `hooks create/delete`) share one durability contract.
+    crate::config::write_atomic(path, config)
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

Closes M4 of the hardening track. Every `config.toml` write — daemon or CLI — now goes through a single temp-then-rename helper, and `delete_mailbox` no longer strands data when the config save fails.

- **S3-1** — Factored the shared temp-then-rename core into `config::write_atomic`. Both `Config::save` (CLI paths) and `mailbox_handler::write_config_atomic` (daemon paths) delegate to it, so the invariant "no in-place truncation of `config.toml` from any code path" holds everywhere.
- **S3-2** — `delete_mailbox` now saves the new config atomically *before* running `remove_dir_all` on `inbox/<name>/` and `sent/<name>/`. On save failure the data dirs are untouched; on post-save cleanup failure we emit a `tracing::warn!` naming the leftover path and return `Err` so the CLI exits non-zero.
- **S3-3** — `apply_create_direct` and `apply_delete_direct` call `mailbox_handler::write_config_atomic` directly (parallel to the pruner at `src/hooks.rs:491`). Durability is now guaranteed both transitively via `Config::save` and explicitly at the call site.

## Test plan

- [x] Unit: `config::tests::save_is_atomic_and_preserves_original_on_failure` — forced save failure leaves the original `config.toml` byte-for-byte intact; no `.tmp.*` leftovers in the parent dir.
- [x] Unit: `config::tests::write_atomic_uses_target_parent_for_temp_file` — successful write leaves no `.tmp.` files behind; temp file lives in the target's parent so `rename(2)` stays on one filesystem.
- [x] Unit: `mailbox::tests::delete_mailbox_preserves_data_dirs_on_save_failure` — save failure preserves `inbox/<name>/`, `sent/<name>/`, and `config.toml` byte-for-byte; command returns `Err`.
- [x] Unit: `hooks::tests::apply_create_direct_preserves_config_on_save_failure` — save failure leaves `config.toml` byte-for-byte unchanged.
- [x] Unit: `hooks::tests::apply_delete_direct_preserves_config_on_save_failure` — same invariant for delete.
- [x] Existing `delete_mailbox_works`, `save_and_load_roundtrip`, and hook CLI tests all still pass.
- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` all clean.

Each failure-injection test swaps `AIMX_CONFIG_DIR` to a nonexistent directory so `File::create` on the temp file hits `ENOENT` before any rename can execute — a clean in-process failure seam that doesn't need root or permission flips.