### PR TITLE
[Hardening polish] Backlog: 5 of 6 non-blockers from Sprints 1-3

### DIFF
--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -79,6 +79,15 @@ pub fn ingest_email(
     // production — any operator setting this in `aimx serve` would see
     // every matching inbound message rejected, which is louder than
     // silent.
+    //
+    // WARNING for future test authors: this env var is process-wide.
+    // Any concurrently-running SMTP test that ingests the matching
+    // recipient (e.g., `bob@test.local` — the fixture used in
+    // `src/smtp/tests.rs`) will observe the forced failure and flake.
+    // Gate tests that set this with `#[serial_test::serial]`, and
+    // prefer the `IngestFailForGuard` RAII guard in `src/smtp/tests.rs`
+    // over raw `set_var` / `remove_var` so a panicked assertion can't
+    // leak the var into the next test.
     if let Ok(target) = std::env::var("AIMX_TEST_INGEST_FAIL_FOR")
         && !target.is_empty()
         && target.eq_ignore_ascii_case(rcpt)

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -160,7 +160,7 @@ pub fn delete_mailbox(config: &Config, name: &str) -> Result<(), Box<dyn std::er
 
     let inbox = config.inbox_dir(name);
     let sent = config.sent_dir(name);
-    let mut leftover_error: Option<std::io::Error> = None;
+    let mut leftovers: Vec<String> = Vec::new();
     if inbox.exists()
         && let Err(e) = std::fs::remove_dir_all(&inbox)
     {
@@ -170,7 +170,7 @@ pub fn delete_mailbox(config: &Config, name: &str) -> Result<(), Box<dyn std::er
             "mailbox '{name}' config removed but inbox dir cleanup failed; \
              remove manually to reclaim space",
         );
-        leftover_error = Some(e);
+        leftovers.push(format!("  - {}: {e}", inbox.display()));
     }
     if sent.exists()
         && let Err(e) = std::fs::remove_dir_all(&sent)
@@ -181,15 +181,13 @@ pub fn delete_mailbox(config: &Config, name: &str) -> Result<(), Box<dyn std::er
             "mailbox '{name}' config removed but sent dir cleanup failed; \
              remove manually to reclaim space",
         );
-        // Keep the first error if inbox also failed, otherwise record this one.
-        if leftover_error.is_none() {
-            leftover_error = Some(e);
-        }
+        leftovers.push(format!("  - {}: {e}", sent.display()));
     }
 
-    if let Some(e) = leftover_error {
+    if !leftovers.is_empty() {
         return Err(format!(
-            "mailbox '{name}' removed from config.toml but filesystem cleanup failed: {e}",
+            "mailbox '{name}' removed from config.toml but filesystem cleanup failed:\n{}",
+            leftovers.join("\n"),
         )
         .into());
     }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1131,24 +1131,6 @@ pub fn list_emails(
     Ok(emails)
 }
 
-/// Resolve the on-disk path for an email by ID. Returns `Some(path)` when
-/// the email exists either as a flat `<id>.md` or as a bundle
-/// `<id>/<id>.md` inside `mailbox_dir`.
-///
-/// Thin wrapper over [`resolve_email_path_strict`]; see that function
-/// for the symlink + canonical-containment rejection rules. Kept as a
-/// named entry point so call sites read as "resolve an email path"
-/// without exposing the strictness mechanic in the caller.
-///
-/// Currently only used by the test-only `set_read_status` helper in
-/// this module and by the delegation unit test. Production call sites
-/// invoke [`resolve_email_path_strict`] directly to make the strict
-/// contract explicit at each use point (Sprint 1 S1-2 audit).
-#[allow(dead_code)]
-pub fn resolve_email_path(mailbox_dir: &std::path::Path, id: &str) -> Option<PathBuf> {
-    resolve_email_path_strict(mailbox_dir, id)
-}
-
 /// Strict email-path resolver used by every read/rewrite verb in the
 /// daemon. Returns `Some(path)` only when every condition holds:
 ///
@@ -1327,7 +1309,7 @@ fn set_read_status(
     }
 
     let mailbox_dir = folder_dir(config, mailbox, folder);
-    let filepath = resolve_email_path(&mailbox_dir, id)
+    let filepath = resolve_email_path_strict(&mailbox_dir, id)
         .ok_or_else(|| format!("Email '{id}' not found in mailbox '{mailbox}'."))?;
 
     let content =
@@ -2520,12 +2502,19 @@ mod tests {
     }
 
     #[test]
-    fn strict_resolver_rejects_escape_via_canonicalization() {
-        // `..`-escape defense: a path whose canonical form lands
-        // outside the mailbox dir must be rejected. We engineer this
-        // by making the whole mailbox dir itself a symlink pointing
-        // elsewhere, so the inner file's canonical path is outside
-        // what the caller treats as the mailbox tree.
+    fn strict_resolver_accepts_dir_level_symlink_to_legitimate_mailbox() {
+        // When the caller treats a symlinked directory as the mailbox
+        // root, canonicalize() resolves the symlink on BOTH sides
+        // (candidate AND mailbox_dir), so `starts_with` still holds
+        // and the flat candidate resolves. This is the expected
+        // positive case — a relocated mailbox dir (e.g., moved to a
+        // different disk and symlinked back) should still work.
+        //
+        // The actual escape-via-canonicalization defense is exercised
+        // by the bundle-dir-symlink test above (where the bundle dir
+        // is a symlink pointing outside the mailbox root). `..`-style
+        // escapes in the id itself are caught upstream by
+        // validate_email_id.
         let tmp = TempDir::new().unwrap();
         let real_storage = tmp.path().join("storage").join("alice-real");
         write_flat_email(&real_storage, "2025-06-01-007");
@@ -2535,41 +2524,9 @@ mod tests {
         let visible_alice = visible_root.join("alice");
         std::os::unix::fs::symlink(&real_storage, &visible_alice).unwrap();
 
-        // Pretend the caller treats the symlinked path as the mailbox
-        // dir. Canonicalize(candidate) = real_storage/... which still
-        // starts_with canonicalize(visible_alice) = real_storage — so
-        // this is actually accepted (the dir-level symlink is resolved
-        // on BOTH sides). The escape check catches the case where
-        // candidate canonicalizes OUTSIDE the mailbox canonical root,
-        // which we exercise with the bundle-dir-symlink test above.
-        // Here we assert the resolver does NOT accidentally allow the
-        // flat candidate to leak through when id contains `..`-like
-        // structure. The id validation happens at the caller; we just
-        // prove canonical-containment works for the normal path.
         assert!(
             resolve_email_path_strict(&visible_alice, "2025-06-01-007").is_some(),
             "legitimate dir-level symlink to a regular file should still resolve"
         );
-    }
-
-    #[test]
-    fn resolve_email_path_wrapper_delegates_to_strict() {
-        // The thin wrapper must behave identically to the strict
-        // resolver — no divergent logic between the two.
-        let tmp = TempDir::new().unwrap();
-        let alice = tmp.path().join("inbox").join("alice");
-        let bob = tmp.path().join("inbox").join("bob");
-        std::fs::create_dir_all(&alice).unwrap();
-        write_flat_email(&bob, "2025-06-01-008");
-
-        let target = bob.join("2025-06-01-008.md");
-        let link = alice.join("2025-06-01-008.md");
-        std::os::unix::fs::symlink(&target, &link).unwrap();
-
-        assert_eq!(
-            resolve_email_path(&alice, "2025-06-01-008"),
-            resolve_email_path_strict(&alice, "2025-06-01-008")
-        );
-        assert_eq!(resolve_email_path(&alice, "2025-06-01-008"), None);
     }
 }

--- a/src/smtp/tests.rs
+++ b/src/smtp/tests.rs
@@ -1412,15 +1412,42 @@ fn mixed_test_email() -> &'static str {
     "From: sender@example.com\r\nTo: alice@test.local, bob@test.local\r\nSubject: Mixed\r\nDate: Mon, 01 Jan 2024 00:00:00 +0000\r\nMessage-ID: <mixed@example.com>\r\n\r\nHello both\r\n"
 }
 
+/// RAII guard for the `AIMX_TEST_INGEST_FAIL_FOR` process-wide env
+/// seam. Sets the var on construction and clears it on drop — even if
+/// an assertion panics mid-test — so the var can never leak into a
+/// subsequent serial test and force spurious failures. Pair with
+/// `#[serial_test::serial]` on the test function.
+struct IngestFailForGuard;
+
+impl IngestFailForGuard {
+    fn new(rcpt: &str) -> Self {
+        // SAFETY: env mutation is process-wide; callers gate their
+        // tests with `#[serial_test::serial]` so no other thread is
+        // concurrently reading the var.
+        unsafe {
+            std::env::set_var("AIMX_TEST_INGEST_FAIL_FOR", rcpt);
+        }
+        Self
+    }
+}
+
+impl Drop for IngestFailForGuard {
+    fn drop(&mut self) {
+        // SAFETY: same as above. Runs on normal exit AND on panic
+        // unwind, which is the whole point of the guard.
+        unsafe {
+            std::env::remove_var("AIMX_TEST_INGEST_FAIL_FOR");
+        }
+    }
+}
+
 #[tokio::test]
 #[serial_test::serial]
 async fn test_partial_success_returns_451() {
-    // Serialise env var access because `AIMX_TEST_INGEST_FAIL_FOR` is a
-    // process-wide seam. `serial_test::serial` keeps the other
-    // concurrent SMTP tests from observing the forced failure.
-    unsafe {
-        std::env::set_var("AIMX_TEST_INGEST_FAIL_FOR", "bob@test.local");
-    }
+    // `AIMX_TEST_INGEST_FAIL_FOR` is a process-wide seam. The RAII
+    // guard clears it on drop even if an assertion panics mid-test,
+    // so the var can never leak into the next serial test.
+    let _fail_guard = IngestFailForGuard::new("bob@test.local");
     let tmp = tempfile::TempDir::new().unwrap();
     let config = test_config_two_mailboxes(tmp.path());
     let (port, _shutdown) = start_server(config).await;
@@ -1451,16 +1478,13 @@ async fn test_partial_success_returns_451() {
     let bob_mds = collect_md_files(&inbox(tmp.path(), "bob"));
     assert_eq!(alice_mds.len(), 1, "alice should have one message");
     assert_eq!(bob_mds.len(), 0, "bob should have no message");
-
-    unsafe {
-        std::env::remove_var("AIMX_TEST_INGEST_FAIL_FOR");
-    }
 }
 
 #[tokio::test]
 #[serial_test::serial]
 async fn test_multi_rcpt_all_success_returns_250() {
-    // Guard against any lingering env var from parallel-scheduled tests.
+    // Defensive: if an earlier test somehow bypassed `IngestFailForGuard`
+    // and left the seam set, clear it before we start.
     unsafe {
         std::env::remove_var("AIMX_TEST_INGEST_FAIL_FOR");
     }


### PR DESCRIPTION
## Summary

Clears 5 of 6 accumulated non-blocking review notes from the `hardening` track's three sprints (see `docs/hardening-sprint.md` → Non-blocking Review Backlog). Low-risk polish, no behavior change to shipped features.

## Changes

### Sprint 1 backlog
- **`src/mcp.rs`** — Rename `strict_resolver_rejects_escape_via_canonicalization` → `strict_resolver_accepts_dir_level_symlink_to_legitimate_mailbox`. The test asserts the positive case (a dir-level symlink onto a legitimate sibling still resolves); its inline comment already admits this. The new name matches the actual behavior. The real canonical-escape defense is already exercised by the bundle-dir-symlink test next to it.
- **`src/mcp.rs`** — Delete the legacy `resolve_email_path` wrapper (and its `resolve_email_path_wrapper_delegates_to_strict` unit test). After Sprint 1's audit every production caller invoked `resolve_email_path_strict` directly; the test-only `set_read_status` helper now does the same.

### Sprint 2 backlog
- **`src/smtp/tests.rs`** — New `IngestFailForGuard` RAII struct for the `AIMX_TEST_INGEST_FAIL_FOR` process-wide seam. `Drop` clears the env var on both normal exit and panic unwind, so a failed assertion in `test_partial_success_returns_451` can no longer leak the var into the next serial test.
- **`src/ingest.rs`** — Add a WARNING block comment at the seam explaining its process-wide scope, naming the `bob@test.local` fixture that can accidentally trip it, and pointing future test authors at `IngestFailForGuard`.

### Sprint 3 backlog
- **`src/mailbox.rs`** — `delete_mailbox` now surfaces **both** leftover paths on post-save cleanup failure via a newline-joined composite error, instead of only the first `io::Error` (the second previously lived only in `tracing::warn!` output). Operators now see both stragglers on CLI stderr at once.

## Deferred

One backlog item remains:
- **(Sprint 2)** tracing-subscriber test for the §7.3 structured log fields (`peer`, `from`, `rcpts`, `succeeded`, `failed`, `size`). Needs a new capture harness not present in the tree today (`tracing_test` or a hand-rolled `Layer`), plus `#[serial]` gating. Judgment call — skipped here because the log contract is stable and the plumbing cost is disproportionate. Left in the backlog for future work.

## Test plan
- [x] `cargo build` clean
- [x] `cargo test` — 1437 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `cargo test --bin aimx delete_mailbox` — 3/3 pass (positive path + save-failure preservation + handler test)