### PR TITLE
aimx uninstall: delete the binary too

### DIFF
--- a/book/cli.md
+++ b/book/cli.md
@@ -39,7 +39,7 @@ See [Setup](setup.md) for the full walkthrough.
 
 ### `aimx uninstall`
 
-Stop the daemon and remove the installed init-system service file. Non-destructive. Leaves `/etc/aimx/` and `/var/lib/aimx/` intact.
+Stop the daemon, remove the init-system service file, and delete the installed `aimx` binary itself so a subsequent `install.sh` run starts from a clean slate. Leaves `/etc/aimx/` and `/var/lib/aimx/` intact — wipe them manually with `sudo rm -rf /etc/aimx /var/lib/aimx` if you want a full purge.
 
 | Flag | Description |
 |------|-------------|

--- a/book/setup.md
+++ b/book/setup.md
@@ -131,13 +131,13 @@ At the DNS verification step:
 
 ### Uninstalling
 
-To reverse `aimx setup`, stop the daemon and remove its init-system service file:
+To reverse `aimx setup`, stop the daemon, remove its init-system service file, and delete the installed `aimx` binary:
 
 ```bash
 sudo aimx uninstall
 ```
 
-Pass `--yes` to skip the confirmation prompt. Uninstall is intentionally non-destructive: it leaves your config (`/etc/aimx/`) and mailbox data (`/var/lib/aimx/`) in place so a subsequent `aimx setup` reuses them. If you also want to wipe those, remove them manually with `rm -rf`.
+Pass `--yes` to skip the confirmation prompt. Uninstall is intentionally scoped: it removes the service and the binary so a subsequent `install.sh` run starts fresh, but leaves your config (`/etc/aimx/`) and mailbox data (`/var/lib/aimx/`) in place so a subsequent `aimx setup` reuses them. If you also want to wipe those, remove them manually with `rm -rf`.
 
 ## DNS configuration
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1901,6 +1901,9 @@ mod tests {
         fn uninstall_service_file(&self) -> Result<(), Box<dyn std::error::Error>> {
             unreachable!("gather_status must not touch uninstall_service_file")
         }
+        fn remove_file(&self, _path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+            unreachable!("gather_status must not touch remove_file")
+        }
         fn wait_for_service_ready(&self) -> bool {
             unreachable!("gather_status must not touch wait_for_service_ready")
         }

--- a/src/logs.rs
+++ b/src/logs.rs
@@ -143,6 +143,9 @@ mod tests {
         fn uninstall_service_file(&self) -> Result<(), Box<dyn std::error::Error>> {
             unreachable!("logs::run must not touch uninstall_service_file")
         }
+        fn remove_file(&self, _path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+            unreachable!("logs::run must not touch remove_file")
+        }
         fn wait_for_service_ready(&self) -> bool {
             unreachable!("logs::run must not touch wait_for_service_ready")
         }

--- a/src/portcheck.rs
+++ b/src/portcheck.rs
@@ -308,6 +308,9 @@ mod tests {
         fn uninstall_service_file(&self) -> Result<(), Box<dyn std::error::Error>> {
             Ok(())
         }
+        fn remove_file(&self, _path: &std::path::Path) -> Result<(), Box<dyn std::error::Error>> {
+            unreachable!("portcheck::run must not touch remove_file")
+        }
         fn wait_for_service_ready(&self) -> bool {
             true
         }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -50,6 +50,12 @@ pub trait SystemOps {
     /// stopped); file removal is the authoritative step. Returns an error when
     /// the init system is unsupported.
     fn uninstall_service_file(&self) -> Result<(), Box<dyn std::error::Error>>;
+    /// Remove a file on disk. Thin seam over `std::fs::remove_file` so
+    /// tests can observe deletion without touching the real filesystem.
+    /// Used by `aimx uninstall` to delete the installed binary after the
+    /// service unit is gone, so a subsequent `install.sh` run sees a
+    /// clean slate rather than tripping the monotonic-upgrade check.
+    fn remove_file(&self, path: &Path) -> Result<(), Box<dyn std::error::Error>>;
     /// Poll `127.0.0.1:25` until a TCP connection succeeds or the timeout
     /// elapses. Returns `true` if the port became reachable, `false` on timeout.
     fn wait_for_service_ready(&self) -> bool;
@@ -534,6 +540,11 @@ impl SystemOps for RealSystemOps {
                     .into());
             }
         }
+        Ok(())
+    }
+
+    fn remove_file(&self, path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+        std::fs::remove_file(path)?;
         Ok(())
     }
 
@@ -2473,6 +2484,9 @@ pub(crate) mod tests {
         /// `start_service` call succeeds, and the service is left
         /// running on the previous binary.
         pub(crate) start_service_failures_remaining: std::cell::Cell<u32>,
+        /// Ordered list of paths passed to `remove_file`. Used by the
+        /// uninstall tests to assert the installed binary is deleted.
+        pub(crate) removed_files: RefCell<Vec<PathBuf>>,
     }
 
     impl Default for MockSystemOps {
@@ -2496,6 +2510,7 @@ pub(crate) mod tests {
                 stop_service_fails: false,
                 start_service_fails: false,
                 start_service_failures_remaining: std::cell::Cell::new(0),
+                removed_files: RefCell::new(vec![]),
             }
         }
     }
@@ -2567,6 +2582,10 @@ pub(crate) mod tests {
         }
         fn uninstall_service_file(&self) -> Result<(), Box<dyn std::error::Error>> {
             *self.service_file_installed.borrow_mut() = false;
+            Ok(())
+        }
+        fn remove_file(&self, path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+            self.removed_files.borrow_mut().push(path.to_path_buf());
             Ok(())
         }
         fn wait_for_service_ready(&self) -> bool {

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -26,7 +26,37 @@ pub fn run(yes: bool, sys: &dyn SystemOps) -> Result<(), Box<dyn std::error::Err
 
     sys.uninstall_service_file()?;
 
+    // Remove the installed binary too. Without this, a subsequent
+    // `install.sh` run sees the leftover executable, reads its version,
+    // and refuses to "downgrade" to the newly-fetched tag. Linux permits
+    // unlinking a running executable — the kernel keeps the inode mapped
+    // until this process exits — so the self-delete here is safe.
+    let binary_removed = match sys.get_aimx_binary_path() {
+        Ok(path) => match sys.remove_file(&path) {
+            Ok(()) => Some(path),
+            Err(e) => {
+                println!(
+                    "{} could not remove binary at {}: {e}",
+                    term::warn_mark(),
+                    path.display()
+                );
+                println!("Remove it manually with: sudo rm {}", path.display());
+                None
+            }
+        },
+        Err(e) => {
+            println!(
+                "{} could not resolve the aimx binary path: {e}",
+                term::warn_mark()
+            );
+            None
+        }
+    };
+
     println!("\n{}\n", term::success_banner("Uninstall complete."));
+    if let Some(path) = &binary_removed {
+        println!("Removed binary: {}", path.display());
+    }
     println!(
         "To wipe config and data manually: sudo rm -rf {} {}",
         config_dir.display(),
@@ -62,6 +92,10 @@ mod tests {
     struct MockSys {
         is_root: bool,
         uninstall_calls: RefCell<u32>,
+        removed_files: RefCell<Vec<PathBuf>>,
+        binary_path: PathBuf,
+        remove_file_fails: bool,
+        binary_path_fails: bool,
     }
 
     impl MockSys {
@@ -69,6 +103,10 @@ mod tests {
             Self {
                 is_root,
                 uninstall_calls: RefCell::new(0),
+                removed_files: RefCell::new(vec![]),
+                binary_path: PathBuf::from("/usr/local/bin/aimx"),
+                remove_file_fails: false,
+                binary_path_fails: false,
             }
         }
     }
@@ -100,7 +138,10 @@ mod tests {
             Ok(())
         }
         fn get_aimx_binary_path(&self) -> Result<PathBuf, Box<dyn std::error::Error>> {
-            Ok(PathBuf::from("/usr/local/bin/aimx"))
+            if self.binary_path_fails {
+                return Err("mock binary-path failure".into());
+            }
+            Ok(self.binary_path.clone())
         }
         fn check_root(&self) -> bool {
             self.is_root
@@ -113,6 +154,13 @@ mod tests {
         }
         fn uninstall_service_file(&self) -> Result<(), Box<dyn std::error::Error>> {
             *self.uninstall_calls.borrow_mut() += 1;
+            Ok(())
+        }
+        fn remove_file(&self, path: &Path) -> Result<(), Box<dyn std::error::Error>> {
+            if self.remove_file_fails {
+                return Err("mock remove_file failure".into());
+            }
+            self.removed_files.borrow_mut().push(path.to_path_buf());
             Ok(())
         }
         fn wait_for_service_ready(&self) -> bool {
@@ -133,6 +181,33 @@ mod tests {
         let sys = MockSys::new(true);
         run(true, &sys).expect("uninstall should succeed");
         assert_eq!(*sys.uninstall_calls.borrow(), 1);
+        let removed = sys.removed_files.borrow();
+        assert_eq!(
+            removed.as_slice(),
+            &[PathBuf::from("/usr/local/bin/aimx")],
+            "uninstall must delete the installed binary so install.sh sees a clean slate"
+        );
+    }
+
+    #[test]
+    fn remove_file_failure_is_non_fatal() {
+        let mut sys = MockSys::new(true);
+        sys.remove_file_fails = true;
+        run(true, &sys).expect("uninstall should succeed even if binary removal fails");
+        assert_eq!(*sys.uninstall_calls.borrow(), 1);
+        assert!(
+            sys.removed_files.borrow().is_empty(),
+            "failing remove_file must not record a successful deletion"
+        );
+    }
+
+    #[test]
+    fn binary_path_failure_is_non_fatal() {
+        let mut sys = MockSys::new(true);
+        sys.binary_path_fails = true;
+        run(true, &sys).expect("uninstall should succeed even if binary path resolution fails");
+        assert_eq!(*sys.uninstall_calls.borrow(), 1);
+        assert!(sys.removed_files.borrow().is_empty());
     }
 
     #[test]

--- a/src/uninstall.rs
+++ b/src/uninstall.rs
@@ -10,8 +10,20 @@ pub fn run(yes: bool, sys: &dyn SystemOps) -> Result<(), Box<dyn std::error::Err
     let config_dir = crate::config::config_dir();
     let data_dir = resolve_data_dir_for_display();
 
+    // Resolve the binary path up front so the confirmation prompt can name
+    // the exact path we are about to delete. The removal itself happens
+    // after `uninstall_service_file` below; reusing this same value keeps
+    // the prompt and the action in sync.
+    let binary_path = sys.get_aimx_binary_path().ok();
+    let binary_path_hint = binary_path
+        .as_ref()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "the installed aimx binary".to_string());
+
     println!("\n{}", term::header("Uninstall"));
-    println!("This will stop the aimx daemon and remove its service file.");
+    println!(
+        "This will stop the aimx daemon, remove its service file, and delete {binary_path_hint}."
+    );
     println!(
         "Config ({}) and mailbox data ({}) will be kept.",
         config_dir.display(),
@@ -31,8 +43,15 @@ pub fn run(yes: bool, sys: &dyn SystemOps) -> Result<(), Box<dyn std::error::Err
     // and refuses to "downgrade" to the newly-fetched tag. Linux permits
     // unlinking a running executable — the kernel keeps the inode mapped
     // until this process exits — so the self-delete here is safe.
-    let binary_removed = match sys.get_aimx_binary_path() {
-        Ok(path) => match sys.remove_file(&path) {
+    //
+    // Note: `get_aimx_binary_path` canonicalises via `current_exe`, so if
+    // the operator installed via an intervening symlink (e.g. a distro
+    // package at `/usr/bin/aimx -> /opt/aimx/bin/aimx`), the real target is
+    // removed but the symlink is left dangling. `install.sh`'s `[ -x … ]`
+    // check evaluates false on a dangling symlink so reinstall still
+    // proceeds; the operator may want to `rm` the stale symlink manually.
+    let binary_removed = match binary_path {
+        Some(path) => match sys.remove_file(&path) {
             Ok(()) => Some(path),
             Err(e) => {
                 println!(
@@ -44,9 +63,9 @@ pub fn run(yes: bool, sys: &dyn SystemOps) -> Result<(), Box<dyn std::error::Err
                 None
             }
         },
-        Err(e) => {
+        None => {
             println!(
-                "{} could not resolve the aimx binary path: {e}",
+                "{} could not resolve the aimx binary path; remove it manually if needed.",
                 term::warn_mark()
             );
             None


### PR DESCRIPTION
## Summary

- `sudo aimx uninstall` now removes the installed `aimx` binary after it removes the init-system service file. This fixes the dead-end where `curl https://aimx.email/install.sh | sh` refuses to run after an uninstall because the leftover binary still reports a version that trips `install.sh`'s monotonic-upgrade check.
- Binary removal is best-effort: a failure logs a warning and a manual-rm hint rather than rolling back. Service-unit removal is still the authoritative step.
- Config (`/etc/aimx/`) and data (`/var/lib/aimx/`) are still explicitly preserved.

## Repro (before this PR)

```
$ sudo aimx uninstall
… Uninstall complete.
$ curl -fsSL https://aimx.email/install.sh | sh
install: error: installed 0.1.0 is newer than target 0.0.1; run 'aimx upgrade --version 0.0.1 --force' to downgrade explicitly
```

Root cause: `src/uninstall.rs` only called `uninstall_service_file`, leaving `/usr/local/bin/aimx` in place. `install.sh:463-477` then saw the orphan and refused.

## Change surface

- `SystemOps::remove_file` trait seam added in `src/setup.rs` (real impl: `std::fs::remove_file`). Every other `SystemOps` mock (`doctor.rs`, `logs.rs`, `portcheck.rs`, inline test mock in `setup.rs`, inline test mock in `uninstall.rs`) gets an impl — `unreachable!()` in modules that never touch file removal, recording in the ones that do.
- `uninstall::run` resolves the running binary via `get_aimx_binary_path()` (already canonicalises via `current_exe`) and removes it. Self-delete is safe on Linux — the kernel keeps the inode mapped for the running process.
- Three new/updated tests in `src/uninstall.rs`: happy path asserts the binary path was recorded; two failure-path tests assert uninstall still returns `Ok` when either `get_aimx_binary_path` or `remove_file` errors.
- `book/cli.md` and `book/setup.md` updated to reflect the new behavior.

## Test plan

- [x] `cargo fmt -- --check`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo test` — 1343 + 95 + 1 pass, 0 fail
- [ ] Manual smoke on a VM: `sudo aimx uninstall` → `which aimx` returns empty → `curl … | sh` installs cleanly without `--force`