### PR TITLE
[CI cleanup] Drop cli-colors job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -280,39 +280,6 @@ jobs:
             grep -q -- "--force" /tmp/down.log
           '
 
-  # Onboarding Sprint 7 (S7-3 / FR-7.4): enforce that every user-facing styled
-  # string lands via a helper in `src/term.rs`. Raw `.red()/.green()/.yellow()/
-  # .blue()/.bold()` calls outside `term.rs` bypass the palette audit and cause
-  # the CLI vocabulary to drift. The ASCII fallback literals `[OK]/[FAIL]/
-  # [WARN]/[>]` must also only come from `term.rs` so the fallback surface
-  # stays in one place.
-  cli-colors:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Forbid raw color methods outside term.rs
-        run: |
-          set +e
-          matches="$(grep -rnE '\.(red|green|yellow|blue|bold)\(\)' src/ | grep -v 'src/term.rs')"
-          if [ -n "$matches" ]; then
-            echo "ERROR: raw .red()/.green()/.yellow()/.blue()/.bold() calls are not allowed outside src/term.rs."
-            echo "Route styled output through helpers in src/term.rs instead (FR-7.4)."
-            echo "$matches"
-            exit 1
-          fi
-
-      - name: Forbid non-tty fallback literals outside term.rs
-        run: |
-          set +e
-          matches="$(grep -rnE '\[OK\]|\[FAIL\]|\[WARN\]|\[>\]' src/ | grep -v 'src/term.rs')"
-          if [ -n "$matches" ]; then
-            echo "ERROR: the [OK]/[FAIL]/[WARN]/[>] fallback literals must only come from term.rs helpers."
-            echo "Use term::success_mark()/fail_mark()/warn_mark()/prompt_mark() instead (FR-7.5)."
-            echo "$matches"
-            exit 1
-          fi
-
   # Onboarding Sprint 8 (S8 review NB-1): build the mdBook docs so CI
   # catches markdown-syntax drift on every PR. The book sources live
   # under `book/`; `book.toml` sits in `website/` (with `src = "../book"`)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ Axum HTTP server with `/probe` (EHLO handshake) and `/health` endpoints. Runs a 
 - Test fixtures in `tests/fixtures/` (`.eml` files for ingest testing).
 - Agent-facing plugins live under `agents/<agent>/` and are embedded at compile time. The canonical primer is `agents/common/aimx-primer.md` with reference docs in `agents/common/references/`. The datadir README template is `src/datadir_readme.md.tpl`.
 - Built-in hook templates live at `hook-templates/defaults.toml` (plain TOML, embedded via `include_str!` by `hook_templates_defaults.rs`). Edit this file — not the Rust source — to add or change a bundled template.
-- CLI output styling is centralised in `src/term.rs`. Raw `.red()` / `.green()` / `.yellow()` / `.blue()` / `.bold()` calls outside `term.rs` are banned — route through `term::success` / `error` / `warn` / `info` / `header` / `highlight` / `dim` / `accent`. Status marks use `term::success_mark()` / `fail_mark()` / `warn_mark()` / `prompt_mark()` (Unicode on TTY, `[OK]`/`[FAIL]`/`[WARN]`/`[>]` on non-TTY). The `cli-colors` CI job enforces both rules (FR-7.4, FR-7.5).
+- CLI output styling is centralised in `src/term.rs`. Raw `.red()` / `.green()` / `.yellow()` / `.blue()` / `.bold()` calls outside `term.rs` are banned — route through `term::success` / `error` / `warn` / `info` / `header` / `highlight` / `dim` / `accent`. Status marks use `term::success_mark()` / `fail_mark()` / `warn_mark()` / `prompt_mark()` (Unicode on TTY, `[OK]`/`[FAIL]`/`[WARN]`/`[>]` on non-TTY). These are project conventions (FR-7.4, FR-7.5); keep styled output routed through `term.rs`.
 
 ## Documentation
 

--- a/src/term.rs
+++ b/src/term.rs
@@ -31,9 +31,8 @@
 //! # Convention
 //!
 //! Raw `.green()` / `.red()` / `.yellow()` / `.blue()` / `.bold()` calls outside
-//! this module are banned — the CI `cli-colors` job fails if any leak in.
-//! Route every user-facing styled string through a helper here so the palette
-//! stays consistent and can be audited in one place.
+//! this module are banned by project convention (FR-7.4). Keep styled output
+//! routed through a helper here so the palette stays consistent and auditable.
 //!
 //! # Disabling color
 //!


### PR DESCRIPTION
## Summary

- Removes the `cli-colors` CI job from `.github/workflows/ci.yml` — the two grep gates that banned raw `.red()/.green()/.yellow()/.blue()/.bold()` and `[OK]/[FAIL]/[WARN]/[>]` literals outside `src/term.rs`.
- Keeps FR-7.4 / FR-7.5 as project conventions — the rule is real, it's just human-enforced via review now rather than CI.
- Updates `CLAUDE.md` and the `src/term.rs` module docstring so neither still claims a CI job enforces the rule.

After merge, pushes will run 5 CI jobs (`core-tests`, `integration-isolation`, `install-sh`, `docs-build`, `verifier-tests`) instead of 6.

## Test plan

- [ ] CI on this PR shows 5 jobs instead of 6, and all pass
- [ ] `grep -rn "cli-colors" .` from repo root returns nothing
- [ ] `cargo fmt -- --check` and `cargo clippy --all-targets -- -D warnings` pass locally
