### PR TITLE
ci: fetch full history in jobs that read RELEASE_TAG

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history + tags so `build.rs`' `git describe --tags --always
+          # --dirty` can reach the most recent release tag and emit a bare
+          # SemVer `RELEASE_TAG` (e.g. `0.0.0-fixture-N-g<sha>`). With the
+          # default shallow/no-tags checkout, describe falls back to a raw
+          # short hash and `aimx_version_renders_full_metadata` fails when
+          # the hash happens to start with a hex letter (`a`–`f`).
+          fetch-depth: 0
 
       - uses: dtolnay/rust-toolchain@stable
         with:
@@ -51,6 +59,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # See core-tests rationale: `build.rs` needs tag history so
+          # `RELEASE_TAG` is a bare-SemVer describe output instead of a
+          # raw short hash.
+          fetch-depth: 0
 
       - uses: dtolnay/rust-toolchain@stable
 


### PR DESCRIPTION
## Summary

- Add `fetch-depth: 0` to the two CI jobs that compile the binary (`core-tests` and `integration-isolation`) so `build.rs` can resolve the most recent release tag via `git describe --tags --always --dirty`.
- Without this, `actions/checkout@v4` shallow-clones with no tags, describe falls back to a bare short hash, and `aimx_version_renders_full_metadata` fails whenever the commit hash starts with `a`-`f` (as `f6e9bcc` did on the PR #147 merge).
- After this change, describe returns `0.0.0-fixture-N-g<sha>` (post-`strip_legacy_v_prefix`), which passes the bare-SemVer assertion.

## Context

CI run [24894113230](https://github.com/uzyn/aimx/actions/runs/24894113230) on `main` failed with:

```
thread 'aimx_version_renders_full_metadata' panicked at tests/integration.rs:5487:5:
tag token must be bare SemVer or `dev`: "f6e9bcc" in "aimx f6e9bcc (f6e9bcc3) x86_64-unknown-linux-gnu built 2026-04-24"
```

The test (added in Sprint 8.0.1 / 236645c) had only ever passed by luck — previous merge commit hashes happened to start with a digit. This PR removes the flakiness.

## Not included in this PR

CI also has two failures from a separate root cause: the GitHub fixture release is currently tagged `v0.0.0-fixture` on the remote, but the source tree post-Sprint 8.0.1 expects the bare-SemVer tag `0.0.0-fixture`. That causes 404s in:

- `install-sh: Fresh install under alpine:latest` (404 on `/releases/download/0.0.0-fixture/...`)
- `integration-isolation: Run release end-to-end` (404 on `/releases/tags/0.0.0-fixture`)

That fix is an operator action (rename the GitHub tag + release), not a code change. Flagged separately to the maintainer.

## Test plan

- [ ] `core-tests: Run tests` is green on this PR (validates fix A).
- [ ] `integration-isolation: Run release end-to-end` stays red (expected — blocked on the tag rename, not this PR).
- [ ] `install-sh: Fresh install under alpine` stays red (same — blocked on the tag rename).
