### PR TITLE
fix: friendly aimx uninstall when no service is installed

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -502,37 +502,60 @@ impl SystemOps for RealSystemOps {
 
     fn uninstall_service_file(&self) -> Result<(), Box<dyn std::error::Error>> {
         use crate::serve::service::{InitSystem, detect_init_system};
+        use std::process::Stdio;
 
         match detect_init_system() {
             InitSystem::Systemd => {
+                let unit_path = Path::new("/etc/systemd/system/aimx.service");
+                if !unit_path.exists() {
+                    println!(
+                        "{}",
+                        term::dim("aimx.service is not installed; skipping service teardown.")
+                    );
+                    return Ok(());
+                }
                 let _ = std::process::Command::new("systemctl")
                     .args(["stop", "aimx"])
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
                     .status();
                 let _ = std::process::Command::new("systemctl")
                     .args(["disable", "aimx"])
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
                     .status();
-                let unit_path = Path::new("/etc/systemd/system/aimx.service");
-                if unit_path.exists() {
-                    std::fs::remove_file(unit_path)?;
-                }
+                std::fs::remove_file(unit_path)?;
                 let _ = std::process::Command::new("systemctl")
                     .args(["daemon-reload"])
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
                     .status();
                 let _ = std::process::Command::new("systemctl")
                     .args(["reset-failed", "aimx"])
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
                     .status();
             }
             InitSystem::OpenRC => {
+                let script_path = Path::new("/etc/init.d/aimx");
+                if !script_path.exists() {
+                    println!(
+                        "{}",
+                        term::dim("aimx.service is not installed; skipping service teardown.")
+                    );
+                    return Ok(());
+                }
                 let _ = std::process::Command::new("rc-service")
                     .args(["aimx", "stop"])
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
                     .status();
                 let _ = std::process::Command::new("rc-update")
                     .args(["del", "aimx", "default"])
+                    .stdout(Stdio::null())
+                    .stderr(Stdio::null())
                     .status();
-                let script_path = Path::new("/etc/init.d/aimx");
-                if script_path.exists() {
-                    std::fs::remove_file(script_path)?;
-                }
+                std::fs::remove_file(script_path)?;
             }
             InitSystem::Unknown => {
                 return Err("Could not detect init system (systemd or OpenRC). \


### PR DESCRIPTION
## Summary

`aimx uninstall` currently calls `systemctl stop aimx`, `systemctl disable aimx`, and `systemctl reset-failed aimx` unconditionally. When the unit was never installed (operator built from source, or a previous uninstall already ran), each of those three commands writes a red error to the user's terminal:

```
Failed to stop aimx.service: Unit aimx.service not loaded.
Failed to disable unit: Unit file aimx.service does not exist.
Failed to reset failed state of unit aimx.service: Unit aimx.service not loaded.
```

Nothing is wrong — there's just nothing to undo. But the output reads like a botched uninstall.

This change makes `aimx uninstall` pre-check whether the unit file exists before issuing service-management commands, and silences the still-issued commands' stdout/stderr in the "unit IS installed" branch so benign chatter from `systemctl` doesn't reach the terminal. Net result: a single dim "aimx.service is not installed; skipping service teardown." line in the not-installed case, and silent service teardown in the installed case.

## Requirements

- [x] In `RealSystemOps::uninstall_service_file` (`src/setup.rs`), when `detect_init_system()` returns `Systemd`, check whether `/etc/systemd/system/aimx.service` exists before running any `systemctl` command. If absent, print one line via `term::dim` and return `Ok(())`.
- [x] Same shape for the OpenRC branch: probe `/etc/init.d/aimx` first; on miss, print the same friendly line and return.
- [x] When the unit IS installed, keep the existing command sequence but redirect each `Command`'s stdout AND stderr to `Stdio::null()`. Errors are still swallowed via `let _ = ...`; the top-level `Uninstall complete.` banner remains the success signal.
- [x] Leave the `Unknown` init-system branch behavior untouched.
- [x] Route the new "not installed" message through `src/term.rs` helpers (`term::dim`) — never raw `.red()` / `.green()` etc.
- [x] `cargo fmt`, `cargo clippy --all-targets -- -D warnings`, and `cargo test` all clean.
- [x] Existing `uninstall::tests::*` continue to pass unchanged — they exercise `MockSys`, which is unaffected.

## Out of scope

- Pre-check via `systemctl is-active` / `is-enabled` — single file probe is canonical (the install side writes exactly that path) and simpler.
- Refactoring `uninstall_service_file` into a per-init-system trait or extracting a shared probe helper — single call site, would be over-engineering.
- Changing `install_service_file`, `aimx setup`, the binary-removal flow, or the confirmation prompt in `uninstall.rs`.
- Re-coloring or rewriting `systemctl`'s stderr — suppressing it is enough.
- Unit-testing `RealSystemOps::uninstall_service_file` itself; it shells out and is not unit-testable. Coverage stays at the `MockSys` level.

## Technical approach

Files modified: `src/setup.rs` — `RealSystemOps::uninstall_service_file`.

- Each branch (`Systemd`, `OpenRC`) now probes the canonical install path first (`/etc/systemd/system/aimx.service` / `/etc/init.d/aimx`). On miss, emit a single `term::dim` line with consistent wording and return `Ok(())`.
- When the file is present, the existing `Command` invocations gain `.stdout(Stdio::null())` and `.stderr(Stdio::null())`; the `let _ = ... .status()` pattern is preserved so non-zero exit codes stay non-fatal.
- `Unknown` branch is unchanged.

Reused helpers (no new code, no new deps):
- `crate::serve::service::detect_init_system()`
- `term::dim` from `src/term.rs`
- `std::process::Stdio::null()`

The same wording is used for both systemd and OpenRC "not installed" messages — the user-facing concept is identical and consistency keeps the message memorable.

## Test plan

Automated:

- `cargo fmt -- --check` — clean.
- `cargo clippy --all-targets -- -D warnings` — clean.
- `cargo test` — all 1345 lib tests + 95 integration tests pass; `uninstall::tests::*` (8 tests) all green.
- `cli-colors` constraint: `grep -rn -E "\.(red|green|yellow|blue|bold)\(\)" src/ | grep -v "src/term.rs"` returns no matches.

Manual smoke (cannot be automated; not run in this environment — flagging here per plan):

- On a host with no `/etc/systemd/system/aimx.service`, run `sudo target/release/aimx uninstall -y`. Expected: one dim "aimx.service is not installed; skipping service teardown." line, no red `systemctl` errors, final banner still `Uninstall complete.`
- On a host where `aimx setup` has been run, run `sudo aimx uninstall -y`. Expected: silent service teardown (no `systemctl` chatter), `Uninstall complete.` banner, `/etc/systemd/system/aimx.service` gone afterwards.

## Notes

- Verified automatically only; manual smoke on real systemd/OpenRC hosts not run from this worktree.
- The verifier crate (`services/verifier/`) is untouched per scope.