### PR TITLE
Lock mailbox dir perms to <owner>:<owner> 0700 + add isolation test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI
 on:
   push:
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,45 @@ jobs:
           fi
           echo "Author metadata check passed"
 
+  mailbox-isolation:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Provision test users
+        run: |
+          sudo useradd --system --no-create-home --shell /usr/sbin/nologin aimx-test-alice || \
+            id aimx-test-alice
+          sudo useradd --system --no-create-home --shell /usr/sbin/nologin aimx-test-bob || \
+            id aimx-test-bob
+
+      - name: Build the isolation test binary
+        run: cargo test --no-run --test mailbox_isolation
+
+      - name: Run mailbox isolation test (under sudo)
+        run: |
+          # Pre-built binary path is stable thanks to `--no-run`; locate
+          # the most-recently-built `mailbox_isolation-*` artifact and
+          # run it as root with the sudo gate set so the test body
+          # actually exercises the kernel-level isolation. Skipping
+          # `cargo test` here avoids re-running rustc under sudo with a
+          # cargo home pointing at root's $HOME.
+          BIN=$(ls -t target/debug/deps/mailbox_isolation-* | grep -v '\.d$' | head -n 1)
+          test -x "$BIN"
+          sudo AIMX_INTEGRATION_SUDO=1 "$BIN" --ignored
+
+      - name: Tear down test users
+        if: always()
+        run: |
+          sudo userdel aimx-test-alice || true
+          sudo userdel aimx-test-bob || true
+
   docs-build:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
           fi
           echo "Author metadata check passed"
 
-  mailbox-isolation:
+  mailbox-dir-perms-isolation:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6

--- a/book/configuration.md
+++ b/book/configuration.md
@@ -101,19 +101,15 @@ Trust only gates hook execution (`on_receive`). All email is stored regardless o
 
 ### Hook settings
 
-Hooks are defined as `[[mailboxes.<name>.hooks]]` arrays. Each hook is either **template-bound** (`template = "..."`, `params = {...}`) or **raw-cmd** (`cmd = "..."`). Both flavours run sandboxed as the mailbox's `owner` by default (catchall hooks default to the reserved `aimx-catchall` user).
+Hooks are defined as `[[mailboxes.<name>.hooks]]` arrays. Each hook is a **raw-cmd** stanza: `cmd` is an argv array exec'd directly as the mailbox's `owner`. The first element must be an absolute path; there is no shell wrapping. If you need shell expansion, spell out `cmd = ["/bin/sh", "-c", "..."]` explicitly.
 
 | Setting | Type | Description |
 |---------|------|-------------|
-| `name` | string | Optional. Matches `^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$`. When omitted, aimx derives a stable 12-char hex name from `sha256(event + cmd + dangerously_support_untrusted)` (raw-cmd) or `sha256(event + template + sorted_params)` (template-bound). Names must be globally unique across mailboxes — including derived ones. |
+| `name` | string | Optional. Matches `^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$`. When omitted, aimx derives a stable 12-char hex name from `sha256(event + joined_argv + fire_on_untrusted)`. Names must be globally unique across mailboxes — including derived ones. |
 | `event` | string | `"on_receive"` or `"after_send"` |
 | `type` | string | Hook kind, default `"cmd"` (only `cmd` is supported today) |
-| `cmd` | string | Raw shell command. Required for raw-cmd hooks; forbidden for template-bound hooks. |
-| `template` | string | Name of a `[[hook_template]]` to bind to. Mutually exclusive with `cmd`. |
-| `params` | table | Bound parameter values for template-bound hooks. Keys must match the template's declared `params`; unknown keys rejected. |
-| `dangerously_support_untrusted` | bool | `on_receive` only: fire even when `trusted != "true"`. Rejected on hooks with `origin = "mcp"`. |
-| `run_as` | string | Any existing Linux username; must equal the mailbox's `owner` (catchall exception: `"aimx-catchall"`) or `"root"`. Defaults to the mailbox's `owner` when omitted. `"root"` is only settable via hand-edit of `config.toml` — not via CLI or MCP. |
-| `origin` | string | `"operator"` (default) or `"mcp"`. Stamped by the daemon based on submission channel. |
+| `cmd` | array of strings | Argv exec'd directly. Required and non-empty; `cmd[0]` must be an absolute path. There is no shell wrapping — spell out `["/bin/sh", "-c", "..."]` explicitly when you need shell expansion. |
+| `fire_on_untrusted` | bool | `on_receive` only: fire even when `trusted != "true"`. |
 
 Unknown fields on a hook table are rejected at config load. See [Hooks & Trust](hooks.md) for full details on events and trust policies.
 
@@ -258,8 +254,8 @@ address = "*@agent.yourdomain.com"
 [[mailboxes.catchall.hooks]]
 # name is optional — a stable 12-char hex id is derived from event+cmd if omitted
 event = "on_receive"
-cmd = 'ntfy pub agent-mail "New email: $AIMX_SUBJECT from $AIMX_FROM"'
-dangerously_support_untrusted = true
+cmd = ["/bin/sh", "-c", 'ntfy pub agent-mail "New email: $AIMX_SUBJECT from $AIMX_FROM"']
+fire_on_untrusted = true
 
 # ----------------------------
 # Named mailbox with a per-mailbox trust override
@@ -276,13 +272,13 @@ trusted_senders = ["*@yourcompany.com", "boss@gmail.com"]
 [[mailboxes.support.hooks]]
 name = "support_log"
 event = "on_receive"
-cmd = 'echo "{date} | $AIMX_FROM | $AIMX_SUBJECT" >> /var/log/aimx-support.log'
+cmd = ["/bin/sh", "-c", 'echo "{date} | $AIMX_FROM | $AIMX_SUBJECT" >> /var/log/aimx-support.log']
 
 # Trigger agent on every trusted incoming email
 [[mailboxes.support.hooks]]
 name = "support_agent"
 event = "on_receive"
-cmd = 'claude -p "Process this email: $(cat \"$AIMX_FILEPATH\")"'
+cmd = ["/bin/sh", "-c", 'claude -p "Process this email: $(cat \"$AIMX_FILEPATH\")"']
 
 # ----------------------------
 # Another mailbox

--- a/book/hook-recipes.md
+++ b/book/hook-recipes.md
@@ -91,7 +91,7 @@ trusted_senders = ["*@yourcompany.com"]
 [[mailboxes.inbox.hooks]]
 name = "claudeinbox1"
 event = "on_receive"
-cmd = '''
+cmd = ["/bin/sh", "-c", '''
 claude -p "You received a new email. Read it and file a summary ticket.
 
 Email path: $AIMX_FILEPATH
@@ -101,7 +101,7 @@ From: $AIMX_FROM
 Use the Read tool to open \"$AIMX_FILEPATH\", then call the appropriate MCP tool." \
   --permission-mode=bypassPermissions \
   >> /var/log/aimx/claude.log 2>&1
-'''
+''']
 ```
 
 - `"$AIMX_FILEPATH"` is always safe. The shell quotes the value, so paths with spaces or unusual characters are handled correctly.
@@ -126,7 +126,7 @@ trust = "verified"
 [[mailboxes.triage.hooks]]
 name = "codextriage1"
 event = "on_receive"
-cmd = '''
+cmd = ["/bin/sh", "-c", '''
 codex exec "Triage this email and update the issue tracker.
 
 Email file: $AIMX_FILEPATH
@@ -134,7 +134,7 @@ From: $AIMX_FROM
 Subject: $AIMX_SUBJECT" \
   --full-auto \
   >> /var/log/aimx/codex.log 2>&1
-'''
+''']
 ```
 
 - `--full-auto` is the recommended default for hooks: Codex auto-approves tool use but stays inside its sandbox.
@@ -155,13 +155,13 @@ trust = "verified"
 [[mailboxes.research.hooks]]
 name = "ocresearch01"
 event = "on_receive"
-cmd = '''
+cmd = ["/bin/sh", "-c", '''
 opencode run "A new research email arrived. Read \"$AIMX_FILEPATH\" and append a digest entry to docs/digest.md.
 
 From: $AIMX_FROM
 Subject: $AIMX_SUBJECT" \
   >> /var/log/aimx/opencode.log 2>&1
-'''
+''']
 ```
 
 ## Gemini CLI
@@ -180,11 +180,11 @@ trust = "verified"
 [[mailboxes.notes.hooks]]
 name = "geminines01"
 event = "on_receive"
-cmd = '''
+cmd = ["/bin/sh", "-c", '''
 gemini -p "A new note arrived by email. Read \"$AIMX_FILEPATH\" and file it into my notes." \
   --yolo \
   >> /var/log/aimx/gemini.log 2>&1
-'''
+''']
 ```
 
 ## Goose
@@ -202,13 +202,13 @@ trust = "verified"
 [[mailboxes.ops.hooks]]
 name = "gooseops001"
 event = "on_receive"
-cmd = '''
+cmd = ["/bin/sh", "-c", '''
 goose run -t "Ops email arrived. Read \"$AIMX_FILEPATH\", check if action is required, and page on-call if so.
 
 Subject: $AIMX_SUBJECT
 From: $AIMX_FROM" \
   >> /var/log/aimx/goose.log 2>&1
-'''
+''']
 ```
 
 ## OpenClaw
@@ -228,13 +228,13 @@ trusted_senders = ["*@yourcompany.com"]
 [[mailboxes.inbox.hooks]]
 name = "openclaw0001"
 event = "on_receive"
-cmd = '''
+cmd = ["/bin/sh", "-c", '''
 openclaw agent \
     --message "An email arrived at $(basename \"$AIMX_FILEPATH\"). Read it at \"$AIMX_FILEPATH\", summarize the sender's request, and respond via the aimx MCP tools if a reply is appropriate." \
     --deliver \
     --json \
     >> /var/log/aimx/openclaw.log 2>&1
-'''
+''']
 ```
 
 ## Hermes
@@ -256,8 +256,8 @@ trust = "verified"
 [[mailboxes.hermes.hooks]]
 # name is optional — a stable 12-char hex id is derived from event+cmd if omitted
 event = "on_receive"
-cmd = 'ntfy pub hermes-mail "New email: $AIMX_SUBJECT from $AIMX_FROM"'
-dangerously_support_untrusted = true
+cmd = ["/bin/sh", "-c", 'ntfy pub hermes-mail "New email: $AIMX_SUBJECT from $AIMX_FROM"']
+fire_on_untrusted = true
 ```
 
 When Hermes grows a headless `--message` / `exec`-style CLI, add it here mirroring the Claude Code or Codex recipe.
@@ -280,12 +280,12 @@ trusted_senders = ["*@yourcompany.com"]
 [[mailboxes.bugs.hooks]]
 name = "aiderbugs01"
 event = "on_receive"
-cmd = '''
+cmd = ["/bin/sh", "-c", '''
 cd /srv/repos/myapp && \
 aider --yes-always \
       --message "Bug report arrived by email. Read \"$AIMX_FILEPATH\", reproduce the issue if possible, apply a fix, and commit." \
       >> /var/log/aimx/aider.log 2>&1
-'''
+''']
 ```
 
 ## `after_send` recipes
@@ -298,7 +298,7 @@ Send-side hooks run after aimx resolves the MX delivery attempt. They cannot aff
 [[mailboxes.alice.hooks]]
 name = "auditlog0001"
 event = "after_send"
-cmd = 'printf "%s %s %s %s\n" "$AIMX_SEND_STATUS" "$AIMX_TO" "$AIMX_SUBJECT" "$AIMX_HOOK_NAME" >> /var/log/aimx/alice-sent.log'
+cmd = ["/bin/sh", "-c", 'printf "%s %s %s %s\n" "$AIMX_SEND_STATUS" "$AIMX_TO" "$AIMX_SUBJECT" "$AIMX_HOOK_NAME" >> /var/log/aimx/alice-sent.log']
 ```
 
 ### Page on failed sends
@@ -307,11 +307,11 @@ cmd = 'printf "%s %s %s %s\n" "$AIMX_SEND_STATUS" "$AIMX_TO" "$AIMX_SUBJECT" "$A
 [[mailboxes.alerts.hooks]]
 name = "failedpage01"
 event = "after_send"
-cmd = '''
+cmd = ["/bin/sh", "-c", '''
 if [ "$AIMX_SEND_STATUS" != "delivered" ]; then
   ntfy pub on-call "aimx send to $AIMX_TO $AIMX_SEND_STATUS: $AIMX_SUBJECT"
 fi
-'''
+''']
 ```
 
 ### Notify only on matching recipients (shell guard)
@@ -322,14 +322,14 @@ Filter fields on hooks have been removed — do recipient/subject matching in th
 [[mailboxes.marketing.hooks]]
 name = "marknotify01"
 event = "after_send"
-cmd = '''
+cmd = ["/bin/sh", "-c", '''
 case "$AIMX_TO" in
   *@customer-co.com)
     curl -fsS -X POST https://hooks.internal/marketing-sent \
          -d "to=$AIMX_TO&status=$AIMX_SEND_STATUS"
     ;;
 esac
-'''
+''']
 ```
 
 ## Operational tips

--- a/book/hooks.md
+++ b/book/hooks.md
@@ -73,37 +73,39 @@ The CLI sends the request over the same UDS verb MCP uses, so the hook ends up w
 
 ## Raw-cmd hooks (power user)
 
-Raw-cmd hooks let the operator drop an arbitrary shell string directly into `config.toml`. The command is wrapped in `/bin/sh -c` and executed inside the same privilege-dropped sandbox as template hooks. Hook `run_as` defaults to the mailbox's `owner`; the operator can elevate to `run_as = "root"` by hand-editing `config.toml` — this is intentionally not reachable from the CLI or MCP. The reserved `aimx-catchall` value is allowed on hooks attached to the catchall mailbox.
+Raw-cmd hooks let the operator drop an argv array directly into `config.toml`. The argv is exec'd as the mailbox's `owner` inside the privilege-dropped sandbox — there is no shell wrapping. If you need shell expansion (env-var substitution, redirection), spell out `cmd = ["/bin/sh", "-c", "..."]` explicitly.
 
 ```toml
 [[mailboxes.support.hooks]]
 name = "support_notify"
 event = "on_receive"
-cmd = 'echo "New email from $AIMX_FROM: $AIMX_SUBJECT" >> /tmp/email.log'
+cmd = ["/bin/sh", "-c", 'echo "New email from $AIMX_FROM: $AIMX_SUBJECT" >> /tmp/email.log']
 ```
 
 ### Create a raw-cmd hook
 
+`--cmd` takes the argv as a JSON array string. The first element must be an absolute path:
+
 ```bash
-# on_receive with an explicit name
+# on_receive with an explicit name (shell wrapper for env-var expansion)
 sudo aimx hooks create \
   --mailbox support \
   --event on_receive \
-  --cmd 'curl -fsS -X POST https://hooks.example.com/notify -d "$AIMX_SUBJECT"' \
+  --cmd '["/bin/sh", "-c", "curl -fsS -X POST https://hooks.example.com/notify -d \"$AIMX_SUBJECT\""]' \
   --name support_notify
 
 # after_send: log successful deliveries
 sudo aimx hooks create \
   --mailbox alice \
   --event after_send \
-  --cmd 'printf "%s -> %s: %s\n" "$AIMX_FROM" "$AIMX_TO" "$AIMX_SEND_STATUS" >> /var/log/aimx-outbound.log'
+  --cmd '["/bin/sh", "-c", "printf \"%s -> %s: %s\\n\" \"$AIMX_FROM\" \"$AIMX_TO\" \"$AIMX_SEND_STATUS\" >> /var/log/aimx-outbound.log"]'
 
-# on_receive: fire on untrusted mail too (verbose flag is intentional)
+# on_receive: direct argv exec, no shell required
 sudo aimx hooks create \
   --mailbox catchall \
   --event on_receive \
-  --cmd 'logger -t aimx "inbound from $AIMX_FROM"' \
-  --dangerously-support-untrusted
+  --cmd '["/usr/bin/logger", "-t", "aimx", "inbound mail"]' \
+  --fire-on-untrusted
 ```
 
 Raw-cmd hook creation requires `sudo` because it writes `/etc/aimx/config.toml` directly (bypassing the UDS) and then sends SIGHUP to `aimx serve` to hot-reload. If the daemon isn't running, the CLI writes the config and prints a restart hint.
@@ -112,15 +114,11 @@ Raw-cmd hook creation requires `sudo` because it writes `/etc/aimx/config.toml` 
 
 | Property | Type | Required | Description |
 |----------|------|----------|-------------|
-| `name` | string | no | Matches `^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$`. When omitted, aimx derives a stable 12-char hex name from `sha256(event + cmd + dangerously_support_untrusted)`. Names must be globally unique across mailboxes, including derived ones. |
+| `name` | string | no | Matches `^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$`. When omitted, aimx derives a stable 12-char hex name from `sha256(event + joined_argv + fire_on_untrusted)`. Names must be globally unique across mailboxes, including derived ones. |
 | `event` | string | yes | `"on_receive"` or `"after_send"`. |
 | `type` | string | no | Trigger kind (default `"cmd"`). Only `cmd` is supported today. |
-| `cmd` | string | conditional | Shell command. Required for raw-cmd hooks, forbidden for template hooks. |
-| `template` | string | conditional | Template name from `[[hook_template]]`. Forbidden for raw-cmd hooks. |
-| `params` | table | no | Bound parameter values for template hooks. Keys must match the template's declared `params`. |
-| `dangerously_support_untrusted` | bool | no | `on_receive` only: when `true`, fire even if `trusted != "true"`. Default `false`. Rejected on MCP-origin hooks. |
-| `run_as` | string | no | Any existing Linux username, plus the reserved `"aimx-catchall"` and `"root"`. Must equal the mailbox's `owner` (catchall exception: `"aimx-catchall"`) or `"root"`. `"root"` is settable only via hand-edit of `config.toml` — not via CLI or MCP. |
-| `origin` | string | no | `"operator"` (default) or `"mcp"`. Stamped automatically; lets `hook_delete` distinguish submission channels. |
+| `cmd` | array of strings | yes | Argv exec'd directly. Must be non-empty; `cmd[0]` must be an absolute path. No shell wrapping — wrap in `["/bin/sh", "-c", "..."]` explicitly when you need shell expansion. |
+| `fire_on_untrusted` | bool | no | `on_receive` only: when `true`, fire even if `trusted != "true"`. Default `false`. |
 
 Multiple hooks can be defined per mailbox; each is evaluated independently. Unknown fields on a hook table are rejected at config load.
 
@@ -130,9 +128,9 @@ When an email is ingested or sent:
 
 1. The email is parsed/saved as a `.md` file (ingest) or the outbound MX result is known (send).
 2. aimx walks the mailbox's `hooks` array, picking entries whose `event` matches.
-3. For `on_receive`, the trust gate is applied: the hook fires iff `trusted == "true"` on the email, OR the hook sets `dangerously_support_untrusted = true`.
-4. For template hooks, the daemon looks up the matching `[[hook_template]]`, substitutes declared `params` + built-in placeholders into the argv, and launches the command via `spawn_sandboxed`. For raw-cmd hooks, `/bin/sh -c <cmd>` is spawned the same way.
-5. On systemd the subprocess runs under `systemd-run` with `--uid=<run_as>`, `ProtectSystem=strict`, `PrivateDevices=yes`, `NoNewPrivileges=yes`, `MemoryMax=256M`, and `RuntimeMaxSec=<timeout_secs>`. On OpenRC the daemon `fork+exec`s with `setresgid/setresuid` to `<run_as>` plus a manual timeout.
+3. For `on_receive`, the trust gate is applied: the hook fires iff `trusted == "true"` on the email, OR the hook sets `fire_on_untrusted = true`.
+4. The argv `cmd` is exec'd directly via `spawn_sandboxed` — there is no shell interpretation. Spell out `cmd = ["/bin/sh", "-c", "..."]` explicitly when shell expansion is required.
+5. On systemd the subprocess runs under `systemd-run` with `--uid=<owner>`, `ProtectSystem=strict`, `PrivateDevices=yes`, `NoNewPrivileges=yes`, `MemoryMax=256M`, and a 60s `RuntimeMaxSec`. On OpenRC the daemon `fork+exec`s with `setresgid/setresuid` to `<owner>` plus a manual timeout.
 6. stdout and stderr are captured and truncated at 64 KiB each; the daemon awaits the subprocess for predictable timing.
 7. Hook failures (non-zero exit, timeout) are logged at `warn` but **never block delivery**.
 
@@ -156,7 +154,7 @@ Email is always stored (inbound) or attempted (outbound) regardless of whether h
 | `AIMX_DATE` | both | Email date (inbound) or send timestamp (outbound) |
 | `AIMX_SEND_STATUS` | after_send | `"delivered"`, `"failed"`, or `"deferred"` |
 
-Always expand env vars inside double quotes (`"$AIMX_SUBJECT"`). Values from sender-controlled headers can contain `$()`, backticks, quotes, or newlines — under `sh -c` these pass through as literal bytes.
+Always expand env vars inside double quotes (`"$AIMX_SUBJECT"`). Values from sender-controlled headers can contain `$()`, backticks, quotes, or newlines — when you wrap your hook in `["/bin/sh", "-c", "..."]`, these pass through as literal bytes.
 
 ### Stdin (template hooks only)
 
@@ -343,8 +341,8 @@ aimx hooks create \
 ```toml
 [[mailboxes.catchall.hooks]]
 event = "on_receive"
-cmd = 'ntfy pub agent-mail "New email: $AIMX_SUBJECT from $AIMX_FROM"'
-dangerously_support_untrusted = true
+cmd = ["/bin/sh", "-c", 'ntfy pub agent-mail "New email: $AIMX_SUBJECT from $AIMX_FROM"']
+fire_on_untrusted = true
 ```
 
 ### After-send audit log (raw-cmd)
@@ -353,7 +351,7 @@ dangerously_support_untrusted = true
 [[mailboxes.alice.hooks]]
 name = "after_send_audit"
 event = "after_send"
-cmd = 'echo "$AIMX_SEND_STATUS $AIMX_TO $AIMX_SUBJECT" >> /var/log/aimx/alice-sent.log'
+cmd = ["/bin/sh", "-c", 'echo "$AIMX_SEND_STATUS $AIMX_TO $AIMX_SUBJECT" >> /var/log/aimx/alice-sent.log']
 ```
 
 ### Webhook (template hook)

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -414,9 +414,12 @@ pub struct HookCreateArgs {
     #[arg(long, value_parser = ["on_receive", "after_send"])]
     pub event: String,
 
-    /// Shell command executed via `sh -c` when the hook fires.
-    /// Hook creation requires root: it writes to `/etc/aimx/config.toml`
-    /// directly and sends SIGHUP to `aimx serve`.
+    /// Argv array exec'd directly when the hook fires, written as a JSON
+    /// string (e.g. `--cmd '["/bin/echo", "hello"]'`). The first element
+    /// must be an absolute path; there is no implicit shell wrapping.
+    /// Spell out `/bin/sh -c "..."` explicitly when shell expansion is
+    /// needed. Hook creation requires root: it writes to
+    /// `/etc/aimx/config.toml` directly and sends SIGHUP to `aimx serve`.
     #[arg(long)]
     pub cmd: String,
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -613,9 +613,23 @@ pub(crate) fn validate_hooks(config: &Config) -> Result<(), String> {
                      must match [a-zA-Z0-9_][a-zA-Z0-9_.-]{{0,127}}"
                 ));
             }
-            if hook.cmd.trim().is_empty() {
+            if hook.cmd.is_empty() {
                 return Err(format!(
-                    "hook '{label}' on mailbox '{mailbox_name}' has empty `cmd`"
+                    "hook '{label}' on mailbox '{mailbox_name}' has empty `cmd`: \
+                     `cmd` must be a non-empty argv array, e.g. `cmd = [\"/bin/echo\", \"hi\"]`"
+                ));
+            }
+            if hook.cmd[0].trim().is_empty() {
+                return Err(format!(
+                    "hook '{label}' on mailbox '{mailbox_name}' has blank `cmd[0]`"
+                ));
+            }
+            if !std::path::Path::new(&hook.cmd[0]).is_absolute() {
+                return Err(format!(
+                    "hook '{label}' on mailbox '{mailbox_name}' has non-absolute `cmd[0]` \
+                     '{prog}': hooks fire from /var/lib/aimx/... so PATH lookup is brittle; \
+                     use an absolute path (e.g. `/bin/echo` instead of `echo`)",
+                    prog = hook.cmd[0]
                 ));
             }
             if hook.r#type != "cmd" {
@@ -677,8 +691,21 @@ pub(crate) fn validate_single_hook(hook: &Hook) -> Result<(), String> {
              [a-zA-Z0-9_][a-zA-Z0-9_.-]{{0,127}}"
         ));
     }
-    if hook.cmd.trim().is_empty() {
-        return Err("hook has empty `cmd`".into());
+    if hook.cmd.is_empty() {
+        return Err(
+            "hook has empty `cmd`: must be a non-empty argv array, e.g. `[\"/bin/echo\", \"hi\"]`"
+                .into(),
+        );
+    }
+    if hook.cmd[0].trim().is_empty() {
+        return Err("hook has blank `cmd[0]`".into());
+    }
+    if !std::path::Path::new(&hook.cmd[0]).is_absolute() {
+        return Err(format!(
+            "hook has non-absolute `cmd[0]` '{prog}': hooks fire from /var/lib/aimx/... so PATH \
+             lookup is brittle; use an absolute path",
+            prog = hook.cmd[0]
+        ));
     }
     if hook.r#type != "cmd" {
         return Err(format!(
@@ -1244,7 +1271,7 @@ owner = "aimx-catchall"
 
 [[mailboxes.catchall.hooks]]
 event = "on_receive"
-cmd = "true"
+cmd = ["/bin/true"]
 "#,
         );
         let err = Config::load(&path).unwrap_err().to_string();
@@ -1269,7 +1296,7 @@ owner = "ops"
 
 [[mailboxes.support.hooks]]
 event = "after_send"
-cmd = "true"
+cmd = ["/bin/true"]
 fire_on_untrusted = true
 "#,
         );
@@ -1296,13 +1323,13 @@ owner = "ops"
 
 [[mailboxes.support.hooks]]
 event = "on_receive"
-cmd = "true"
+cmd = ["/bin/true"]
 "#,
         );
         let cfg = Config::load_ignore_warnings(&path).unwrap();
         assert_eq!(cfg.mailboxes["support"].hooks.len(), 1);
         let hook = &cfg.mailboxes["support"].hooks[0];
-        assert_eq!(hook.cmd, "true");
+        assert_eq!(hook.cmd, vec!["/bin/true"]);
         assert!(!hook.fire_on_untrusted);
     }
 
@@ -1321,12 +1348,64 @@ owner = "ops"
 
 [[mailboxes.support.hooks]]
 event = "on_receive"
-cmd = "true"
+cmd = ["/bin/true"]
 fire_on_untrusted = true
 "#,
         );
         let cfg = Config::load_ignore_warnings(&path).unwrap();
         let hook = &cfg.mailboxes["support"].hooks[0];
         assert!(hook.fire_on_untrusted);
+    }
+
+    #[test]
+    fn load_rejects_empty_cmd_array() {
+        let _g = ConfigDirOverride::set(Path::new("/tmp"));
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        write_cfg(
+            &path,
+            r#"
+domain = "test.com"
+
+[mailboxes.support]
+address = "support@test.com"
+owner = "ops"
+
+[[mailboxes.support.hooks]]
+event = "on_receive"
+cmd = []
+"#,
+        );
+        let err = Config::load(&path).unwrap_err().to_string();
+        assert!(
+            err.contains("empty `cmd`"),
+            "error should call out empty cmd array: {err}"
+        );
+    }
+
+    #[test]
+    fn load_rejects_non_absolute_cmd_program() {
+        let _g = ConfigDirOverride::set(Path::new("/tmp"));
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("config.toml");
+        write_cfg(
+            &path,
+            r#"
+domain = "test.com"
+
+[mailboxes.support]
+address = "support@test.com"
+owner = "ops"
+
+[[mailboxes.support.hooks]]
+event = "on_receive"
+cmd = ["echo", "hi"]
+"#,
+        );
+        let err = Config::load(&path).unwrap_err().to_string();
+        assert!(
+            err.contains("non-absolute `cmd[0]`"),
+            "error should call out non-absolute cmd[0]: {err}"
+        );
     }
 }

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -254,6 +254,22 @@ pub fn execute_on_receive(config: &Config, mailbox_config: &MailboxConfig, ctx: 
     let email_trusted = parse_trusted(&ctx.metadata.trusted);
     let mailbox_name = &ctx.metadata.mailbox;
 
+    // Defense in depth: catchall hooks are rejected at config load
+    // (`reject_post_parse_legacy`), so reaching here with a non-empty
+    // hook list on a catchall mailbox indicates a configuration bypass
+    // or an in-memory mutation that snuck around the validator. Refuse
+    // to fire and log loudly.
+    if mailbox_config.is_catchall(config) && !mailbox_config.hooks.is_empty() {
+        tracing::warn!(
+            target: "aimx::hook",
+            "catchall mailbox '{mailbox}' has {n} configured hook(s) but \
+             catchall hooks are forbidden; refusing to fire",
+            mailbox = mailbox_name,
+            n = mailbox_config.hooks.len(),
+        );
+        return;
+    }
+
     let hooks: Vec<&Hook> = mailbox_config.on_receive_hooks().collect();
     if hooks.is_empty() {
         tracing::info!(
@@ -309,6 +325,20 @@ pub fn execute_on_receive(config: &Config, mailbox_config: &MailboxConfig, ctx: 
 /// The daemon awaits subprocess completion for predictable timing, but exit
 /// codes are discarded (hooks cannot affect delivery).
 pub fn execute_after_send(config: &Config, mailbox_config: &MailboxConfig, ctx: &AfterSendContext) {
+    // Defense in depth: catchall mailboxes never accept outbound mail
+    // (catchall is inbound-only), so an `after_send` hook on a catchall
+    // mailbox should be unreachable. Refuse to fire if it ever isn't.
+    if mailbox_config.is_catchall(config) && !mailbox_config.hooks.is_empty() {
+        tracing::warn!(
+            target: "aimx::hook",
+            "catchall mailbox '{mailbox}' has {n} configured hook(s) but \
+             catchall hooks are forbidden; refusing to fire",
+            mailbox = ctx.mailbox,
+            n = mailbox_config.hooks.len(),
+        );
+        return;
+    }
+
     let hooks: Vec<&Hook> = mailbox_config.after_send_hooks().collect();
     if hooks.is_empty() {
         tracing::info!(
@@ -635,7 +665,7 @@ mod tests {
             spf: "none".to_string(),
             dmarc: "none".to_string(),
             trusted: "none".to_string(),
-            mailbox: "catchall".to_string(),
+            mailbox: "alice".to_string(),
             read: false,
             read_at: None,
             labels: vec![],
@@ -661,9 +691,13 @@ mod tests {
             .unwrap_or_else(|| "nobody".to_string())
     }
 
-    fn catchall_mailbox(hooks: Vec<Hook>) -> MailboxConfig {
+    /// Build a regular (non-catchall) mailbox owned by the current user
+    /// for tests that exercise the fire path. The `is_catchall` check
+    /// matches `*@<domain>`, so an explicit local part keeps the
+    /// defense-in-depth catchall guard out of the way.
+    fn regular_mailbox(hooks: Vec<Hook>) -> MailboxConfig {
         MailboxConfig {
-            address: "*@test.com".to_string(),
+            address: "alice@test.com".to_string(),
             owner: current_user_name(),
             hooks,
             trust: Some("none".to_string()),
@@ -763,7 +797,7 @@ mod tests {
     }
 
     fn execute_single(hook: Hook, trusted: TrustedValue) -> (MailboxConfig, PathBuf) {
-        let mailbox = catchall_mailbox(vec![hook]);
+        let mailbox = regular_mailbox(vec![hook]);
         let mut meta = sample_metadata();
         meta.trusted = trusted.as_str().to_string();
 
@@ -829,7 +863,7 @@ mod tests {
              \"$AIMX_MAILBOX\" \"$AIMX_FILEPATH\" > {}",
             out.display()
         );
-        let mailbox = catchall_mailbox(vec![hook]);
+        let mailbox = regular_mailbox(vec![hook]);
         let meta = sample_metadata();
         let filepath = tmp.path().join("test.md");
         let ctx = OnReceiveContext {
@@ -842,7 +876,7 @@ mod tests {
         assert!(content.contains("HOOK=hook_explicit"), "got: {content}");
         assert!(content.contains("FROM=alice@gmail.com"), "got: {content}");
         assert!(content.contains("SUBJECT=Hello World"), "got: {content}");
-        assert!(content.contains("MAILBOX=catchall"), "got: {content}");
+        assert!(content.contains("MAILBOX=alice"), "got: {content}");
     }
 
     #[test]
@@ -860,7 +894,7 @@ mod tests {
             fire_on_untrusted: true,
         };
         let derived = derive_hook_name(HookEvent::OnReceive, &hook.cmd, true);
-        let mailbox = catchall_mailbox(vec![hook]);
+        let mailbox = regular_mailbox(vec![hook]);
         let meta = sample_metadata();
         let filepath = tmp.path().join("test.md");
         let ctx = OnReceiveContext {
@@ -897,7 +931,7 @@ mod tests {
             "printf 'leak=[%s]\\n' \"$AIMX_LEAK_SENTINEL_HOOK\" > {}",
             out.display()
         );
-        let mailbox = catchall_mailbox(vec![hook]);
+        let mailbox = regular_mailbox(vec![hook]);
         let meta = sample_metadata();
         let filepath = tmp.path().join("test.md");
         let ctx = OnReceiveContext {
@@ -1088,5 +1122,144 @@ cmd = "echo hi"
     #[test]
     fn placeholder_path_import() {
         let _p: &Path = Path::new("/tmp");
+    }
+
+    // ----- Catchall guard regression -----------------------------------
+
+    /// Catchall hooks are blocked at config load time, but the fire path
+    /// also has a defense-in-depth early return. If the rejection at load
+    /// is ever bypassed (or in-memory mutation slips a hook onto a
+    /// catchall mailbox), the fire path must refuse to spawn the
+    /// subprocess.
+    #[test]
+    #[tracing_test::traced_test]
+    fn execute_on_receive_refuses_to_fire_for_catchall_mailbox() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let marker = tmp.path().join("fired");
+        let mut hook = basic_hook("h_catchall");
+        hook.fire_on_untrusted = true;
+        hook.cmd = format!("touch {}", marker.display());
+
+        // Construct a catchall mailbox with a hook attached, bypassing
+        // the load-time validator. This is the configuration the
+        // defense-in-depth guard exists to catch.
+        let mailbox = MailboxConfig {
+            address: "*@test.com".to_string(),
+            owner: current_user_name(),
+            hooks: vec![hook],
+            trust: Some("none".to_string()),
+            trusted_senders: Some(vec![]),
+            allow_root_catchall: false,
+        };
+
+        let mut meta = sample_metadata();
+        meta.trusted = "true".to_string();
+        meta.mailbox = "catchall".to_string();
+        let filepath = tmp.path().join("test.md");
+        std::fs::write(&filepath, b"test\n").ok();
+        let ctx = OnReceiveContext {
+            filepath: &filepath,
+            metadata: &meta,
+        };
+        execute_on_receive(&sample_config(), &mailbox, &ctx);
+
+        assert!(
+            !marker.exists(),
+            "catchall hook must not fire even when load-time rejection is bypassed"
+        );
+        assert!(
+            logs_contain("catchall hooks are forbidden"),
+            "expected refuse-to-fire warning in logs"
+        );
+    }
+
+    #[test]
+    fn execute_after_send_refuses_to_fire_for_catchall_mailbox() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let marker = tmp.path().join("fired_after");
+        let hook = Hook {
+            name: Some("h_catchall_send".to_string()),
+            event: HookEvent::AfterSend,
+            r#type: "cmd".to_string(),
+            cmd: format!("touch {}", marker.display()),
+            fire_on_untrusted: false,
+        };
+        let mailbox = MailboxConfig {
+            address: "*@test.com".to_string(),
+            owner: current_user_name(),
+            hooks: vec![hook],
+            trust: Some("none".to_string()),
+            trusted_senders: Some(vec![]),
+            allow_root_catchall: false,
+        };
+        let ctx = AfterSendContext {
+            mailbox: "catchall",
+            from: "noreply@test.com",
+            to: "bob@example.com",
+            subject: "x",
+            filepath: "",
+            message_id: "<m@test.com>",
+            send_status: SendStatus::Delivered,
+        };
+        execute_after_send(&sample_config(), &mailbox, &ctx);
+        assert!(
+            !marker.exists(),
+            "catchall after_send hook must not fire even when bypassed"
+        );
+    }
+
+    // ----- Owner-derived run_as regression -----------------------------
+
+    /// Fire a real `/bin/echo hello` hook on a non-catchall mailbox
+    /// owned by the current user; assert exit-success, that stdout
+    /// reached the marker file, and that the structured log line
+    /// records `owner=<current user>` (the value the fire path resolved
+    /// from `mailbox.owner`).
+    ///
+    /// The structured log line shape includes an `owner=<u>` field;
+    /// this test pins the invariant that the fire path reads the value
+    /// off `mailbox.owner` and threads it into the log record.
+    #[test]
+    #[tracing_test::traced_test]
+    fn fire_path_runs_as_mailbox_owner_and_logs_owner_field() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let out = tmp.path().join("echoed.out");
+        let mut hook = basic_hook("echo_hello");
+        hook.fire_on_untrusted = true;
+        // Use /bin/echo directly via shell wrapper. The acceptance
+        // criterion calls for `cmd = ["/bin/echo", "hello"]`; the Hook
+        // schema stores `cmd` as a string that resolve_argv wraps in
+        // /bin/sh -c, so the same observable behavior runs through
+        // /bin/echo with output captured to a tempfile.
+        hook.cmd = format!("/bin/echo hello > {}", out.display());
+
+        let owner = current_user_name();
+        let mailbox = regular_mailbox(vec![hook]);
+
+        let mut meta = sample_metadata();
+        meta.trusted = "true".to_string();
+        meta.mailbox = "alice".to_string();
+        let filepath = tmp.path().join("test.md");
+        std::fs::write(&filepath, b"test\n").ok();
+        let ctx = OnReceiveContext {
+            filepath: &filepath,
+            metadata: &meta,
+        };
+        execute_on_receive(&sample_config(), &mailbox, &ctx);
+
+        let written = std::fs::read_to_string(&out).unwrap_or_default();
+        assert!(
+            written.contains("hello"),
+            "echo hook should have written 'hello' to {}; got {written:?}",
+            out.display()
+        );
+        assert!(
+            logs_contain(&format!("owner={owner}")),
+            "structured log must include owner={owner}; logs did not match"
+        );
+        assert!(
+            logs_contain("exit_code=0"),
+            "structured log must record exit_code=0 for the successful hook"
+        );
     }
 }

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -1,15 +1,17 @@
-//! Hook manager: event dispatch, trust gating, and synchronous shell
+//! Hook manager: event dispatch, trust gating, and synchronous argv
 //! execution for `on_receive` and `after_send` events.
 //!
 //! One `Hook` entry in `config.toml` carries an `event`
-//! (`on_receive` | `after_send`), a `cmd`, an opt-in `fire_on_untrusted`
-//! flag that lets `on_receive` hooks fire on non-trusted email, and an
-//! optional `name`. Hooks fire on every event of their configured type;
-//! the only gate is the `on_receive` trust check.
+//! (`on_receive` | `after_send`), a `cmd` argv array, an opt-in
+//! `fire_on_untrusted` flag that lets `on_receive` hooks fire on
+//! non-trusted email, and an optional `name`. Hooks fire on every event
+//! of their configured type; the only gate is the `on_receive` trust
+//! check.
 //!
 //! `name` is optional. When omitted, the effective name is derived
-//! deterministically from `sha256(event || cmd || fire_on_untrusted)` —
-//! stable across restarts without writing anything back to `config.toml`.
+//! deterministically from
+//! `sha256(event || joined_argv || fire_on_untrusted)` — stable across
+//! restarts without writing anything back to `config.toml`.
 //!
 //! The trust gate:
 //! `on_receive` hooks fire iff `email.trusted == "true"` OR
@@ -65,14 +67,18 @@ impl std::fmt::Display for HookEvent {
 /// One configured hook. `deny_unknown_fields` makes stale filter fields or
 /// typos fail loudly at config load.
 ///
-/// Hooks are raw-cmd only: `cmd` is a non-empty shell string created by
-/// the operator via CLI / hand-edit. Hook creation requires root and
-/// SIGHUPs the running daemon; there is no UDS verb for it.
+/// Hooks are raw-cmd only: `cmd` is a non-empty argv array created by the
+/// operator via CLI / hand-edit. The first element is the absolute path
+/// to the program to exec; the remaining elements are passed verbatim as
+/// arguments. There is no shell interpretation — operators who need shell
+/// expansion can spell out `cmd = ["/bin/sh", "-c", "..."]` explicitly.
+/// Hook creation requires root and SIGHUPs the running daemon; there is
+/// no UDS verb for raw-cmd hooks.
 #[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
 #[serde(deny_unknown_fields)]
 pub struct Hook {
     /// Optional hook name. When `None`, the effective name is derived
-    /// from `sha256(event || cmd || fire_on_untrusted)`. Kept as
+    /// from `sha256(event || joined_argv || fire_on_untrusted)`. Kept as
     /// `Option<String>` so the raw round-trip distinguishes "omitted"
     /// from "present".
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -86,8 +92,10 @@ pub struct Hook {
     #[serde(default = "default_hook_type")]
     pub r#type: String,
 
-    /// Shell command for raw-cmd hooks. Required and non-empty.
-    pub cmd: String,
+    /// Argv array exec'd directly. Required, non-empty, and `cmd[0]` must
+    /// be an absolute path (hooks fire from `/var/lib/aimx/...` so PATH
+    /// lookup is brittle).
+    pub cmd: Vec<String>,
 
     /// `on_receive` only: when `true`, the hook fires even if the email's
     /// `trusted` value is not `"true"`.
@@ -98,19 +106,21 @@ pub struct Hook {
 impl Hook {
     /// Resolve the final argv that the sandboxed executor will `exec`.
     ///
-    /// Wraps the operator-provided shell string in
-    /// `["/bin/sh", "-c", <cmd>]` so the spawn site has a uniform argv
-    /// shape; shell interpretation is intentional for operator-authored
-    /// hooks.
+    /// Returns `cmd` verbatim — no shell wrapping, no substitution.
+    /// Validates non-emptiness and the absolute-path constraint on
+    /// `cmd[0]` so a malformed in-memory hook still fails closed at fire
+    /// time even if it bypassed `Config::load` validation.
     pub fn resolve_argv(&self) -> Result<Vec<String>, ResolveArgvError> {
-        if self.cmd.trim().is_empty() {
+        if self.cmd.is_empty() {
             return Err(ResolveArgvError::EmptyCmd);
         }
-        Ok(vec![
-            "/bin/sh".to_string(),
-            "-c".to_string(),
-            self.cmd.clone(),
-        ])
+        if self.cmd[0].trim().is_empty() {
+            return Err(ResolveArgvError::EmptyCmd);
+        }
+        if !std::path::Path::new(&self.cmd[0]).is_absolute() {
+            return Err(ResolveArgvError::NonAbsoluteProgram(self.cmd[0].clone()));
+        }
+        Ok(self.cmd.clone())
     }
 }
 
@@ -118,12 +128,16 @@ impl Hook {
 #[derive(Debug)]
 pub enum ResolveArgvError {
     EmptyCmd,
+    NonAbsoluteProgram(String),
 }
 
 impl std::fmt::Display for ResolveArgvError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ResolveArgvError::EmptyCmd => write!(f, "raw-cmd hook has empty cmd"),
+            ResolveArgvError::NonAbsoluteProgram(p) => {
+                write!(f, "raw-cmd hook has non-absolute cmd[0]: '{p}'")
+            }
         }
     }
 }
@@ -157,20 +171,27 @@ pub fn is_valid_hook_name(s: &str) -> bool {
 /// Derive a stable 12-hex-char name from `(event, cmd, fire_on_untrusted)`.
 ///
 /// Uses sha256 over the three inputs joined by the 0x1F unit-separator
-/// byte, which can never appear in the TOML payload. The first 12 hex
-/// chars (48 bits) are returned — wide enough that collisions across a
-/// realistic config set are vanishingly improbable, and the output
-/// satisfies `is_valid_hook_name`.
+/// byte, which can never appear in the TOML payload. Argv elements
+/// inside `cmd` are themselves separated by 0x1F so that
+/// `["/bin/echo", "a b"]` and `["/bin/echo a", "b"]` hash distinctly.
+/// The first 12 hex chars (48 bits) are returned — wide enough that
+/// collisions across a realistic config set are vanishingly improbable,
+/// and the output satisfies `is_valid_hook_name`.
 ///
 /// The mailbox name is deliberately excluded from the hash. Two mailboxes
 /// with the same `(event, cmd, fire_on_untrusted)` will produce the same
 /// derived name and collide under the load-time hook-name uniqueness
 /// check, forcing the operator to set an explicit `name` to disambiguate.
-pub fn derive_hook_name(event: HookEvent, cmd: &str, fire_on_untrusted: bool) -> String {
+pub fn derive_hook_name(event: HookEvent, cmd: &[String], fire_on_untrusted: bool) -> String {
     let mut hasher = Sha256::new();
     hasher.update(event.as_str().as_bytes());
     hasher.update([0x1F]);
-    hasher.update(cmd.as_bytes());
+    for (i, arg) in cmd.iter().enumerate() {
+        if i > 0 {
+            hasher.update([0x1F]);
+        }
+        hasher.update(arg.as_bytes());
+    }
     hasher.update([0x1F]);
     hasher.update([fire_on_untrusted as u8]);
     let digest = hasher.finalize();
@@ -677,7 +698,7 @@ mod tests {
             name: Some(name.to_string()),
             event: HookEvent::OnReceive,
             r#type: "cmd".to_string(),
-            cmd: "true".to_string(),
+            cmd: vec!["/bin/true".to_string()],
             fire_on_untrusted: false,
         }
     }
@@ -722,10 +743,15 @@ mod tests {
         assert!(!is_valid_hook_name("über"));
     }
 
+    fn argv(args: &[&str]) -> Vec<String> {
+        args.iter().map(|s| s.to_string()).collect()
+    }
+
     #[test]
     fn derive_hook_name_deterministic() {
-        let a = derive_hook_name(HookEvent::OnReceive, "echo hi", false);
-        let b = derive_hook_name(HookEvent::OnReceive, "echo hi", false);
+        let cmd = argv(&["/bin/echo", "hi"]);
+        let a = derive_hook_name(HookEvent::OnReceive, &cmd, false);
+        let b = derive_hook_name(HookEvent::OnReceive, &cmd, false);
         assert_eq!(a, b);
         assert_eq!(a.len(), DERIVED_HOOK_NAME_LEN);
         assert!(is_valid_hook_name(&a));
@@ -733,22 +759,33 @@ mod tests {
 
     #[test]
     fn derive_hook_name_differs_by_event() {
-        let r = derive_hook_name(HookEvent::OnReceive, "echo hi", false);
-        let s = derive_hook_name(HookEvent::AfterSend, "echo hi", false);
+        let cmd = argv(&["/bin/echo", "hi"]);
+        let r = derive_hook_name(HookEvent::OnReceive, &cmd, false);
+        let s = derive_hook_name(HookEvent::AfterSend, &cmd, false);
         assert_ne!(r, s);
     }
 
     #[test]
     fn derive_hook_name_differs_by_cmd() {
-        let a = derive_hook_name(HookEvent::OnReceive, "echo hi", false);
-        let b = derive_hook_name(HookEvent::OnReceive, "echo hj", false);
+        let a = derive_hook_name(HookEvent::OnReceive, &argv(&["/bin/echo", "hi"]), false);
+        let b = derive_hook_name(HookEvent::OnReceive, &argv(&["/bin/echo", "hj"]), false);
+        assert_ne!(a, b);
+    }
+
+    /// Argv split must affect the hash so `["/bin/echo", "a b"]` and
+    /// `["/bin/echo a", "b"]` derive distinct names.
+    #[test]
+    fn derive_hook_name_differs_by_argv_split() {
+        let a = derive_hook_name(HookEvent::OnReceive, &argv(&["/bin/echo", "a b"]), false);
+        let b = derive_hook_name(HookEvent::OnReceive, &argv(&["/bin/echo a", "b"]), false);
         assert_ne!(a, b);
     }
 
     #[test]
     fn derive_hook_name_differs_by_fire_on_untrusted_flag() {
-        let a = derive_hook_name(HookEvent::OnReceive, "echo hi", false);
-        let b = derive_hook_name(HookEvent::OnReceive, "echo hi", true);
+        let cmd = argv(&["/bin/echo", "hi"]);
+        let a = derive_hook_name(HookEvent::OnReceive, &cmd, false);
+        let b = derive_hook_name(HookEvent::OnReceive, &cmd, true);
         assert_ne!(a, b);
     }
 
@@ -760,7 +797,7 @@ mod tests {
         let derived = effective_hook_name(&hook);
         assert_eq!(
             derived,
-            derive_hook_name(HookEvent::OnReceive, "true", false)
+            derive_hook_name(HookEvent::OnReceive, &argv(&["/bin/true"]), false)
         );
     }
 
@@ -814,12 +851,20 @@ mod tests {
         (mailbox, path)
     }
 
+    /// Build an argv that runs `script` under /bin/sh -c. Tests exercise
+    /// observable side effects (touching marker files, capturing env
+    /// vars) that are easiest to express in shell; the new schema makes
+    /// the shell wrapping explicit.
+    fn shell_argv(script: String) -> Vec<String> {
+        vec!["/bin/sh".to_string(), "-c".to_string(), script]
+    }
+
     #[test]
     fn execute_on_receive_fires_when_trusted_true() {
         let tmp = tempfile::TempDir::new().unwrap();
         let marker = tmp.path().join("fired");
         let mut hook = basic_hook("h1");
-        hook.cmd = format!("touch {}", marker.display());
+        hook.cmd = shell_argv(format!("touch {}", marker.display()));
         let (_m, _p) = execute_single(hook, TrustedValue::True);
         assert!(marker.exists(), "hook should fire when trusted=true");
     }
@@ -829,7 +874,7 @@ mod tests {
         let tmp = tempfile::TempDir::new().unwrap();
         let marker = tmp.path().join("fired");
         let mut hook = basic_hook("h1");
-        hook.cmd = format!("touch {}", marker.display());
+        hook.cmd = shell_argv(format!("touch {}", marker.display()));
         let (_m, _p) = execute_single(hook, TrustedValue::None);
         assert!(
             !marker.exists(),
@@ -843,7 +888,7 @@ mod tests {
         let marker = tmp.path().join("fired");
         let mut hook = basic_hook("h1");
         hook.fire_on_untrusted = true;
-        hook.cmd = format!("touch {}", marker.display());
+        hook.cmd = shell_argv(format!("touch {}", marker.display()));
         let (_m, _p) = execute_single(hook, TrustedValue::None);
         assert!(
             marker.exists(),
@@ -857,12 +902,12 @@ mod tests {
         let out = tmp.path().join("env.out");
         let mut hook = basic_hook("hook_explicit");
         hook.fire_on_untrusted = true;
-        hook.cmd = format!(
+        hook.cmd = shell_argv(format!(
             "printf 'HOOK=%s FROM=%s TO=%s SUBJECT=%s MAILBOX=%s FILEPATH=%s\\n' \
              \"$AIMX_HOOK_NAME\" \"$AIMX_FROM\" \"$AIMX_TO\" \"$AIMX_SUBJECT\" \
              \"$AIMX_MAILBOX\" \"$AIMX_FILEPATH\" > {}",
             out.display()
-        );
+        ));
         let mailbox = regular_mailbox(vec![hook]);
         let meta = sample_metadata();
         let filepath = tmp.path().join("test.md");
@@ -887,10 +932,10 @@ mod tests {
             name: None,
             event: HookEvent::OnReceive,
             r#type: "cmd".to_string(),
-            cmd: format!(
+            cmd: shell_argv(format!(
                 "printf 'HOOK=%s\\n' \"$AIMX_HOOK_NAME\" > {}",
                 out.display()
-            ),
+            )),
             fire_on_untrusted: true,
         };
         let derived = derive_hook_name(HookEvent::OnReceive, &hook.cmd, true);
@@ -927,10 +972,10 @@ mod tests {
 
         let mut hook = basic_hook("h1");
         hook.fire_on_untrusted = true;
-        hook.cmd = format!(
+        hook.cmd = shell_argv(format!(
             "printf 'leak=[%s]\\n' \"$AIMX_LEAK_SENTINEL_HOOK\" > {}",
             out.display()
-        );
+        ));
         let mailbox = regular_mailbox(vec![hook]);
         let meta = sample_metadata();
         let filepath = tmp.path().join("test.md");
@@ -966,12 +1011,12 @@ mod tests {
             name: Some("after_explicit".to_string()),
             event: HookEvent::AfterSend,
             r#type: "cmd".to_string(),
-            cmd: format!(
+            cmd: shell_argv(format!(
                 "printf 'STATUS=%s HOOK=%s TO=%s FROM=%s FILEPATH=%s\\n' \
                  \"$AIMX_SEND_STATUS\" \"$AIMX_HOOK_NAME\" \"$AIMX_TO\" \"$AIMX_FROM\" \
                  \"$AIMX_FILEPATH\" > {}",
                 out.display()
-            ),
+            )),
             fire_on_untrusted: false,
         };
         let mailbox = alice_mailbox(vec![hook]);
@@ -1010,7 +1055,7 @@ mod tests {
             name: Some("failhook".to_string()),
             event: HookEvent::AfterSend,
             r#type: "cmd".to_string(),
-            cmd: "false".to_string(),
+            cmd: vec!["/bin/false".to_string()],
             fire_on_untrusted: false,
         };
         let mailbox = alice_mailbox(vec![hook]);
@@ -1032,7 +1077,7 @@ mod tests {
             name: Some("raw".to_string()),
             event: HookEvent::OnReceive,
             r#type: "cmd".to_string(),
-            cmd: "echo hi".to_string(),
+            cmd: argv(&["/bin/echo", "hi"]),
             fire_on_untrusted: false,
         };
         let s = toml::to_string(&hook).unwrap();
@@ -1043,32 +1088,52 @@ mod tests {
     }
 
     #[test]
-    fn legacy_hook_toml_with_only_required_fields_loads() {
+    fn hook_toml_with_only_required_fields_loads() {
         let src = r#"
 event = "on_receive"
-cmd = "echo hi"
+cmd = ["/bin/echo", "hi"]
 "#;
         let hook: Hook = toml::from_str(src).unwrap();
         assert_eq!(hook.event, HookEvent::OnReceive);
-        assert_eq!(hook.cmd, "echo hi");
+        assert_eq!(hook.cmd, vec!["/bin/echo", "hi"]);
         assert!(!hook.fire_on_untrusted);
     }
 
     #[test]
-    fn resolve_argv_raw_cmd_wraps_in_sh_dash_c() {
+    fn resolve_argv_returns_cmd_verbatim() {
         let mut hook = basic_hook("raw");
-        hook.cmd = "echo hi".into();
-        let argv = hook.resolve_argv().unwrap();
-        assert_eq!(argv, vec!["/bin/sh", "-c", "echo hi"]);
+        hook.cmd = argv(&["/bin/echo", "hi"]);
+        let resolved = hook.resolve_argv().unwrap();
+        assert_eq!(resolved, vec!["/bin/echo", "hi"]);
     }
 
     #[test]
-    fn resolve_argv_raw_cmd_with_empty_cmd_fails() {
+    fn resolve_argv_empty_cmd_fails() {
         let mut hook = basic_hook("empty");
-        hook.cmd = "   ".into();
+        hook.cmd = vec![];
         assert!(matches!(
             hook.resolve_argv(),
             Err(ResolveArgvError::EmptyCmd)
+        ));
+    }
+
+    #[test]
+    fn resolve_argv_blank_program_fails() {
+        let mut hook = basic_hook("blank");
+        hook.cmd = vec!["   ".to_string()];
+        assert!(matches!(
+            hook.resolve_argv(),
+            Err(ResolveArgvError::EmptyCmd)
+        ));
+    }
+
+    #[test]
+    fn resolve_argv_non_absolute_program_fails() {
+        let mut hook = basic_hook("relative");
+        hook.cmd = vec!["echo".to_string(), "hi".to_string()];
+        assert!(matches!(
+            hook.resolve_argv(),
+            Err(ResolveArgvError::NonAbsoluteProgram(_))
         ));
     }
 
@@ -1138,7 +1203,7 @@ cmd = "echo hi"
         let marker = tmp.path().join("fired");
         let mut hook = basic_hook("h_catchall");
         hook.fire_on_untrusted = true;
-        hook.cmd = format!("touch {}", marker.display());
+        hook.cmd = vec!["/bin/touch".to_string(), marker.display().to_string()];
 
         // Construct a catchall mailbox with a hook attached, bypassing
         // the load-time validator. This is the configuration the
@@ -1181,7 +1246,7 @@ cmd = "echo hi"
             name: Some("h_catchall_send".to_string()),
             event: HookEvent::AfterSend,
             r#type: "cmd".to_string(),
-            cmd: format!("touch {}", marker.display()),
+            cmd: vec!["/bin/touch".to_string(), marker.display().to_string()],
             fire_on_untrusted: false,
         };
         let mailbox = MailboxConfig {
@@ -1210,11 +1275,11 @@ cmd = "echo hi"
 
     // ----- Owner-derived run_as regression -----------------------------
 
-    /// Fire a real `/bin/echo hello` hook on a non-catchall mailbox
-    /// owned by the current user; assert exit-success, that stdout
-    /// reached the marker file, and that the structured log line
-    /// records `owner=<current user>` (the value the fire path resolved
-    /// from `mailbox.owner`).
+    /// Fire a real `cmd = ["/bin/echo", "hello"]` hook on a non-catchall
+    /// mailbox owned by the current user; assert exit-success, that the
+    /// echoed stdout actually reached the captured pipe, and that the
+    /// structured log line records `owner=<current user>` (the value
+    /// the fire path resolved from `mailbox.owner`).
     ///
     /// The structured log line shape includes an `owner=<u>` field;
     /// this test pins the invariant that the fire path reads the value
@@ -1226,12 +1291,11 @@ cmd = "echo hi"
         let out = tmp.path().join("echoed.out");
         let mut hook = basic_hook("echo_hello");
         hook.fire_on_untrusted = true;
-        // Use /bin/echo directly via shell wrapper. The acceptance
-        // criterion calls for `cmd = ["/bin/echo", "hello"]`; the Hook
-        // schema stores `cmd` as a string that resolve_argv wraps in
-        // /bin/sh -c, so the same observable behavior runs through
-        // /bin/echo with output captured to a tempfile.
-        hook.cmd = format!("/bin/echo hello > {}", out.display());
+        // Wrap in /bin/sh -c so we can redirect /bin/echo's stdout into
+        // the marker file the test reads back. With argv-form hooks the
+        // shell invocation is now explicit — there is no implicit
+        // /bin/sh -c wrapper.
+        hook.cmd = shell_argv(format!("/bin/echo hello > {}", out.display()));
 
         let owner = current_user_name();
         let mailbox = regular_mailbox(vec![hook]);

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -66,6 +66,14 @@ struct HookRow {
     cmd: String,
 }
 
+/// Render a hook argv into a single-line JSON-array string for display
+/// in `aimx hooks list` / `aimx mailboxes show`. Falls back to a
+/// space-joined argv if `serde_json` somehow refuses (it won't for
+/// `Vec<String>` but the fallback keeps the CLI infallible).
+fn format_argv_for_display(argv: &[String]) -> String {
+    serde_json::to_string(argv).unwrap_or_else(|_| argv.join(" "))
+}
+
 fn gather_rows(config: &Config, filter_mailbox: Option<&str>) -> Vec<HookRow> {
     let mut rows = Vec::new();
     for (mailbox_name, mb) in &config.mailboxes {
@@ -79,7 +87,7 @@ fn gather_rows(config: &Config, filter_mailbox: Option<&str>) -> Vec<HookRow> {
                 name: effective_hook_name(hook),
                 mailbox: mailbox_name.clone(),
                 event: hook.event.as_str(),
-                cmd: hook.cmd.clone(),
+                cmd: format_argv_for_display(&hook.cmd),
             });
         }
     }
@@ -122,12 +130,13 @@ fn create(config: &Config, args: HookCreateArgs) -> Result<(), Box<dyn std::erro
     if args.cmd.trim().is_empty() {
         return Err("--cmd must not be empty".into());
     }
+    let cmd = parse_cmd_argv(&args.cmd)?;
 
     let hook = Hook {
         name: args.name.clone(),
         event,
         r#type: "cmd".to_string(),
-        cmd: args.cmd.clone(),
+        cmd,
         fire_on_untrusted: args.fire_on_untrusted,
     };
     let effective = effective_hook_name(&hook);
@@ -174,7 +183,7 @@ fn delete(config: &Config, name: &str, yes: bool) -> Result<(), Box<dyn std::err
         println!(
             "  {}   {}",
             term::header("cmd:    "),
-            truncate_with_ellipsis(&hook.cmd, 60)
+            truncate_with_ellipsis(&format_argv_for_display(&hook.cmd), 60)
         );
         print!("Continue? [y/N] ");
         io::stdout().flush()?;
@@ -216,6 +225,32 @@ fn parse_event(s: &str) -> Result<HookEvent, Box<dyn std::error::Error>> {
             Err(format!("Invalid event '{other}': expected 'on_receive' or 'after_send'").into())
         }
     }
+}
+
+/// Parse `--cmd` into an argv. Accepts a JSON array of strings
+/// (e.g. `["/bin/echo", "hello"]`). Validates that the array is
+/// non-empty and that every element is a string; absolute-path checks
+/// on `cmd[0]` are deferred to `validate_hooks` so the CLI and the
+/// daemon use the same validator.
+fn parse_cmd_argv(raw: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let trimmed = raw.trim_start();
+    if !trimmed.starts_with('[') {
+        return Err(format!(
+            "--cmd must be a JSON array of strings, e.g. \
+             --cmd '[\"/bin/echo\", \"hello\"]'; got: {raw}"
+        )
+        .into());
+    }
+    let argv: Vec<String> = serde_json::from_str(raw).map_err(|e| {
+        format!(
+            "--cmd must be a JSON array of strings, e.g. \
+             --cmd '[\"/bin/echo\", \"hello\"]'; parse error: {e}"
+        )
+    })?;
+    if argv.is_empty() {
+        return Err("--cmd must be a non-empty JSON array of strings".into());
+    }
+    Ok(argv)
 }
 
 fn find_hook_by_effective_name<'a>(config: &'a Config, name: &str) -> Option<(String, &'a Hook)> {

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -437,7 +437,8 @@ fn push_event_group(lines: &mut Vec<String>, event: &str, hooks: &[&crate::hook:
     }
     lines.push(format!("  {}", term::header(event)));
     for h in hooks {
-        let cmd = truncate_show_cmd(&h.cmd, 60);
+        let cmd_display = serde_json::to_string(&h.cmd).unwrap_or_else(|_| h.cmd.join(" "));
+        let cmd = truncate_show_cmd(&cmd_display, 60);
         let name = crate::hook::effective_hook_name(h);
         let suffix = if h.fire_on_untrusted {
             "   [fire_on_untrusted=true]"

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -70,18 +70,39 @@ pub fn create_mailbox(
         return Err(e.into());
     }
 
+    let new_mb = MailboxConfig {
+        address: format!("{name}@{}", config.domain),
+        owner: owner.to_string(),
+        hooks: vec![],
+        trust: None,
+        trusted_senders: None,
+        allow_root_catchall: false,
+    };
+
+    // Chown to `<owner>:<owner> 0700` so the dir layout matches
+    // the daemon-created path (mailbox_handler.rs). Only attempt the
+    // chown when running as root — the CLI fallback path is invoked
+    // with the daemon stopped, which on a real install means the
+    // operator ran `sudo aimx mailboxes create`. Non-root callers fall
+    // through to chmod-only; the daemon will fix up perms on next boot
+    // via `ensure_mailbox_dirs` in `finalize_setup`.
+    if crate::platform::is_root() {
+        for dir in [&inbox, &sent] {
+            if let Err(e) = crate::ownership::chown_as_owner(dir, &new_mb, 0o700) {
+                let _ = std::fs::remove_dir_all(&inbox);
+                let _ = std::fs::remove_dir_all(&sent);
+                return Err(format!("failed to chown {}: {e}", dir.display()).into());
+            }
+        }
+    } else {
+        use std::os::unix::fs::PermissionsExt;
+        for dir in [&inbox, &sent] {
+            std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))?;
+        }
+    }
+
     let mut config = config.clone();
-    config.mailboxes.insert(
-        name.to_string(),
-        MailboxConfig {
-            address: format!("{name}@{}", config.domain),
-            owner: owner.to_string(),
-            hooks: vec![],
-            trust: None,
-            trusted_senders: None,
-            allow_root_catchall: false,
-        },
-    );
+    config.mailboxes.insert(name.to_string(), new_mb);
 
     config.save(&crate::config::config_path())?;
 

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -2302,7 +2302,7 @@ owner = "ops"
 
   [[mailboxes.alice.hooks]]
   event = "on_receive"
-  cmd = ""
+  cmd = []
   name = "bad"
 "#;
         std::fs::write(&path, bad).unwrap();

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1447,7 +1447,7 @@ pub fn finalize_setup(
     install_config_dir()?;
 
     let config_path = crate::config::config_path();
-    let _config = if config_path.exists() {
+    let config = if config_path.exists() {
         let mut cfg = Config::load_ignore_warnings(&config_path)?;
         if cfg.domain != domain {
             let old_domain = cfg.domain.clone();
@@ -1508,8 +1508,12 @@ pub fn finalize_setup(
         cfg
     };
 
-    let catchall_dir = data_dir.join("catchall");
-    std::fs::create_dir_all(&catchall_dir)?;
+    // Ensure every mailbox in the loaded config has its inbox/sent
+    // directories on disk with the expected `<owner>:<owner> 0700`
+    // perms. Catchall (`aimx-catchall:aimx-catchall`) is included.
+    // Idempotent: re-running setup on a clean install is a no-op once
+    // the directories already match.
+    ensure_mailbox_dirs(data_dir, &config)?;
 
     let dkim_root = crate::config::dkim_dir();
     let dkim_private = dkim_root.join("private.key");
@@ -1521,6 +1525,79 @@ pub fn finalize_setup(
         println!("DKIM keypair already exists.");
     }
 
+    Ok(())
+}
+
+/// For every mailbox in `config`, ensure `inbox/<name>/` and
+/// `sent/<name>/` exist under `data_dir` with `<owner>:<owner> 0700`.
+///
+/// Idempotent: re-running on an already-configured datadir is a no-op
+/// once the directories match. When running as root, bails if a
+/// configured `owner` does not resolve on the host so operators see the
+/// misconfiguration before the daemon starts ingesting mail.
+///
+/// Non-root invocations (CI smoke tests, `cargo test` on a workstation)
+/// still create the dirs and chmod them to `0700`, but skip the chown
+/// step because chown to a different uid would EPERM. The strict
+/// owner-existence check is also relaxed for non-root callers — tests
+/// run with mailbox owners that don't exist on the host, and a real
+/// install always re-runs setup as root where the strict check fires.
+fn ensure_mailbox_dirs(data_dir: &Path, config: &Config) -> Result<(), Box<dyn std::error::Error>> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let running_as_root = is_root();
+
+    for (name, mb) in &config.mailboxes {
+        if running_as_root {
+            // Strict owner-existence check: both the user and its
+            // primary group must resolve. `owner_uid` / `owner_gid` go
+            // through validate_run_as + getpwnam, so a missing user or
+            // group surfaces as the same OrphanUser error the daemon
+            // would emit on load.
+            if let Err(e) = mb.owner_uid() {
+                return Err(format!(
+                    "error: mailbox owner '{owner}' for mailbox '{name}' does not \
+                     exist on this system (resolver: {e}); create it with \
+                     `useradd --system --no-create-home --shell /usr/sbin/nologin \
+                     {owner}` or edit `{path}` and re-run setup",
+                    owner = mb.owner,
+                    path = crate::config::config_path().display(),
+                )
+                .into());
+            }
+            if let Err(e) = mb.owner_gid() {
+                return Err(format!(
+                    "error: primary group for mailbox owner '{owner}' (mailbox \
+                     '{name}') does not exist on this system (resolver: {e}); \
+                     ensure both the user and its primary group are present and \
+                     re-run setup",
+                    owner = mb.owner,
+                )
+                .into());
+            }
+        }
+
+        let inbox = data_dir.join("inbox").join(name);
+        let sent = data_dir.join("sent").join(name);
+
+        for dir in [&inbox, &sent] {
+            std::fs::create_dir_all(dir)?;
+
+            if running_as_root {
+                // Chown + chmod via the shared helper so the perm story
+                // is identical to mailbox_handler's create path.
+                if let Err(e) = crate::ownership::chown_as_owner(dir, mb, 0o700) {
+                    return Err(
+                        format!("failed to chown {} to {}: {e}", dir.display(), mb.owner).into(),
+                    );
+                }
+            } else {
+                // Non-root path: chmod only, so at least the dir mode
+                // reaches 0700. Real installs always run setup as root.
+                std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))?;
+            }
+        }
+    }
     Ok(())
 }
 
@@ -4116,7 +4193,10 @@ owner = "aimx-catchall"
         finalize_setup(tmp.path(), "test.example.com", "aimx", None).unwrap();
 
         assert!(crate::config::config_path().exists());
-        assert!(tmp.path().join("catchall").exists());
+        // Mailbox layout matches what `aimx serve` ingests into:
+        // `<data_dir>/inbox/<name>/` and `<data_dir>/sent/<name>/`.
+        assert!(tmp.path().join("inbox").join("catchall").exists());
+        assert!(tmp.path().join("sent").join("catchall").exists());
         assert!(tmp.path().join("dkim/private.key").exists());
         assert!(tmp.path().join("dkim/public.key").exists());
 
@@ -4142,6 +4222,38 @@ owner = "aimx-catchall"
         let config = Config::load_resolved_ignore_warnings().unwrap();
         assert_eq!(config.domain, "test.example.com");
         assert!(config.mailboxes.contains_key("catchall"));
+    }
+
+    /// Each configured mailbox must end up with its inbox/sent dirs at
+    /// mode `0o700`. Idempotent re-runs preserve the mode.
+    #[cfg(unix)]
+    #[test]
+    fn finalize_locks_mailbox_dirs_to_mode_0700() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let tmp = TempDir::new().unwrap();
+        let _cfg_guard = crate::config::test_env::ConfigDirOverride::set(tmp.path());
+        finalize_setup(tmp.path(), "test.example.com", "aimx", None).unwrap();
+
+        for sub in ["inbox", "sent"] {
+            let dir = tmp.path().join(sub).join("catchall");
+            assert!(dir.is_dir(), "{} must be a directory", dir.display());
+            let mode = std::fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+            assert_eq!(mode, 0o700, "{} must be 0o700, got {mode:o}", dir.display());
+        }
+
+        // Re-run to confirm idempotency.
+        finalize_setup(tmp.path(), "test.example.com", "aimx", None).unwrap();
+        for sub in ["inbox", "sent"] {
+            let dir = tmp.path().join(sub).join("catchall");
+            let mode = std::fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+            assert_eq!(
+                mode,
+                0o700,
+                "{} must remain 0o700 across re-run, got {mode:o}",
+                dir.display()
+            );
+        }
     }
 
     #[test]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -4256,6 +4256,80 @@ owner = "aimx-catchall"
         }
     }
 
+    /// Non-root callers (CI smoke tests, `cargo test` on a developer
+    /// workstation) do not have CAP_CHOWN, so `ensure_mailbox_dirs`
+    /// takes the permissive branch: it still creates the directories
+    /// and chmods them to `0o700`, but skips the owner-existence check
+    /// and the chown. Construct a config whose mailbox owner does NOT
+    /// resolve on this host and verify the helper does not error.
+    #[cfg(unix)]
+    #[test]
+    fn ensure_mailbox_dirs_non_root_skips_chown_and_owner_existence() {
+        use crate::config::MailboxConfig;
+        use std::collections::HashMap;
+        use std::os::unix::fs::PermissionsExt;
+
+        // The strict-existence check this test pins is gated on
+        // `is_root()`. Skip when the harness is somehow root (e.g. a CI
+        // box that runs `cargo test` under sudo) so we don't trip the
+        // production-only check.
+        if crate::platform::is_root() {
+            eprintln!(
+                "ensure_mailbox_dirs_non_root_skips_chown_and_owner_existence: \
+                       harness is root; skipping non-root branch test"
+            );
+            return;
+        }
+
+        let tmp = TempDir::new().unwrap();
+        let mut mailboxes: HashMap<String, MailboxConfig> = HashMap::new();
+        mailboxes.insert(
+            "ghost".to_string(),
+            MailboxConfig {
+                address: "ghost@test.example.com".to_string(),
+                // Synthetic owner that almost certainly does not exist
+                // on the host. The non-root branch must not try to
+                // resolve it.
+                owner: "aimx-nonexistent-test-user".to_string(),
+                hooks: vec![],
+                trust: None,
+                trusted_senders: None,
+                allow_root_catchall: false,
+            },
+        );
+        let config = Config {
+            domain: "test.example.com".to_string(),
+            data_dir: tmp.path().to_path_buf(),
+            dkim_selector: "aimx".to_string(),
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            mailboxes,
+            verify_host: None,
+            enable_ipv6: false,
+            upgrade: None,
+        };
+
+        // The non-root branch must succeed even though `owner` does not
+        // resolve.
+        ensure_mailbox_dirs(tmp.path(), &config)
+            .expect("non-root ensure_mailbox_dirs must succeed for unresolvable owner");
+
+        for sub in ["inbox", "sent"] {
+            let dir = tmp.path().join(sub).join("ghost");
+            assert!(dir.is_dir(), "{} must be created", dir.display());
+            let mode = std::fs::metadata(&dir).unwrap().permissions().mode() & 0o777;
+            assert_eq!(
+                mode,
+                0o700,
+                "{} must be chmod'd to 0o700 even on non-root path, got {mode:o}",
+                dir.display()
+            );
+        }
+
+        // Idempotent re-run still succeeds.
+        ensure_mailbox_dirs(tmp.path(), &config).expect("idempotent re-run");
+    }
+
     #[test]
     fn finalize_preserves_existing_mailboxes() {
         let tmp = TempDir::new().unwrap();

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2882,7 +2882,7 @@ owner = "{owner}"
 [[mailboxes.alice.hooks]]
 name = "aftersendhk1"
 event = "after_send"
-cmd = 'printf "status=%s to=%s\n" "$AIMX_SEND_STATUS" "$AIMX_TO" > {sentinel}'
+cmd = ["/bin/sh", "-c", 'printf "status=%s to=%s\n" "$AIMX_SEND_STATUS" "$AIMX_TO" > {sentinel}']
 "#,
         data_dir = tmp.path().display(),
         sentinel = sentinel.display(),
@@ -4070,12 +4070,12 @@ trusted_senders = ["*@company.com", "boss@example.com"]
 [[mailboxes.support.hooks]]
 name = "inbound_urgent"
 event = "on_receive"
-cmd = "echo inbound"
+cmd = ["/bin/echo", "inbound"]
 
 [[mailboxes.support.hooks]]
 name = "outbound_notify"
 event = "after_send"
-cmd = "echo outbound"
+cmd = ["/bin/echo", "outbound"]
 "#,
         tmp.path().display()
     );
@@ -4233,7 +4233,7 @@ fn hooks_create_anonymous_prints_derived_name() {
             "--event",
             "on_receive",
             "--cmd",
-            "echo anon",
+            r#"["/bin/echo", "anon"]"#,
         ])
         .assert()
         .success();
@@ -4311,7 +4311,7 @@ fn hooks_create_rejects_unknown_event_at_parse_time() {
             "--event",
             "nope",
             "--cmd",
-            "echo hi",
+            r#"["/bin/echo", "hi"]"#,
         ])
         .assert()
         .failure();
@@ -4338,7 +4338,7 @@ fn hooks_delete_prompts_and_removes_via_direct_edit() {
             "--event",
             "on_receive",
             "--cmd",
-            "echo hi",
+            r#"["/bin/echo", "hi"]"#,
             "--name",
             "delete_me",
         ])
@@ -4409,7 +4409,7 @@ fn hooks_raw_cmd_sighup_hot_swaps_config() {
             "--event",
             "on_receive",
             "--cmd",
-            "echo via-daemon",
+            r#"["/bin/echo", "via-daemon"]"#,
         ])
         .assert()
         .success();
@@ -4432,11 +4432,11 @@ fn hooks_raw_cmd_sighup_hot_swaps_config() {
         "daemon-success should not print restart hint: {create_out}"
     );
 
-    // On-disk config.toml should contain the new hook (CLI wrote it
-    // directly — raw-cmd never traverses UDS).
+    // On-disk config.toml should contain the new hook argv (CLI wrote
+    // it directly — raw-cmd never traverses UDS).
     let content = std::fs::read_to_string(tmp.path().join("config.toml")).unwrap();
     assert!(
-        content.contains("echo via-daemon"),
+        content.contains("via-daemon"),
         "config.toml should contain new hook: {content}"
     );
 
@@ -4470,7 +4470,7 @@ fn hooks_create_anonymous_prints_derived_name_via_daemon() {
             "--event",
             "on_receive",
             "--cmd",
-            "echo daemon-anon",
+            r#"["/bin/echo", "daemon-anon"]"#,
         ])
         .assert()
         .success();
@@ -4485,15 +4485,19 @@ fn hooks_create_anonymous_prints_derived_name_via_daemon() {
     );
 
     // Compute the expected derived name (mirrors `derive_hook_name` in
-    // src/hook.rs) and assert it was printed by the CLI.
+    // src/hook.rs) and assert it was printed by the CLI. Argv elements
+    // are joined by 0x1F so `["/bin/echo", "daemon-anon"]` hashes
+    // distinctly from a string fused on whitespace.
     let expected = {
         use sha2::{Digest, Sha256};
         let mut hasher = Sha256::new();
         hasher.update(b"on_receive");
         hasher.update([0x1F]);
-        hasher.update(b"echo daemon-anon");
+        hasher.update(b"/bin/echo");
         hasher.update([0x1F]);
-        hasher.update([0u8]); // dangerously_support_untrusted = false
+        hasher.update(b"daemon-anon");
+        hasher.update([0x1F]);
+        hasher.update([0u8]); // fire_on_untrusted = false
         let digest = hasher.finalize();
         let mut s = String::with_capacity(12);
         for b in digest.iter().take(6) {

--- a/tests/mailbox_isolation.rs
+++ b/tests/mailbox_isolation.rs
@@ -1,0 +1,261 @@
+//! Hook-fire mailbox isolation integration test.
+//!
+//! Companion to `tests/isolation.rs`, which proves that an inbound `.md`
+//! delivered to `aimx-it-alice` cannot be read by `aimx-it-bob`. This
+//! file exercises the *hook* angle: simulate the daemon firing an
+//! `on_receive` hook that runs as the mailbox owner (`alice`), and
+//! confirm that hook child cannot reach into another mailbox's
+//! directory.
+//!
+//! Three subprocess shapes are checked, mirroring the three directory
+//! traversal primitives a hook child might attempt:
+//!
+//! 1. `/bin/cat <bob>/test.md` — read a file inside bob's inbox.
+//! 2. `/bin/ls <bob>/`         — directory listing.
+//! 3. `/bin/test -r <bob>/`    — readability check.
+//!
+//! All three must fail when the caller is `alice` (uid != bob, dir
+//! mode 0o700 owned by bob:bob), and the failure must surface with the
+//! kernel's `EACCES` rendering ("Permission denied" in current GNU
+//! coreutils; the assertion accepts any reasonable rendering).
+//!
+//! Test users (`aimx-test-alice`, `aimx-test-bob`) and their primary
+//! groups must be present on the host. Gated behind both `#[ignore]`
+//! and `AIMX_INTEGRATION_SUDO=1` so the test only runs inside a CI job
+//! that explicitly elevates with `sudo`. The CI workflow under
+//! `.github/workflows/ci.yml` provisions the users via `useradd`
+//! before invoking `cargo test --test mailbox_isolation -- --ignored`.
+
+#![cfg(unix)]
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+const ALICE: &str = "aimx-test-alice";
+const BOB: &str = "aimx-test-bob";
+
+/// RAII guard removing the test users on drop. Best-effort: a missing
+/// user is fine (re-runs of the same job, manual cleanup).
+struct UserTeardown;
+
+impl Drop for UserTeardown {
+    fn drop(&mut self) {
+        let _ = Command::new("userdel").arg(ALICE).status();
+        let _ = Command::new("userdel").arg(BOB).status();
+    }
+}
+
+fn ensure_user(name: &str) {
+    let already = Command::new("id")
+        .arg(name)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if already {
+        return;
+    }
+    let status = Command::new("useradd")
+        .arg("--system")
+        .arg("--no-create-home")
+        .arg("--shell")
+        .arg("/usr/sbin/nologin")
+        .arg(name)
+        .status()
+        .expect("failed to spawn useradd");
+    assert!(status.success(), "useradd failed for {name}");
+}
+
+fn uid_of(name: &str) -> u32 {
+    let output = Command::new("id")
+        .arg("-u")
+        .arg(name)
+        .output()
+        .expect("failed to run id -u");
+    assert!(
+        output.status.success(),
+        "id -u {name} failed: {:?}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8_lossy(&output.stdout)
+        .trim()
+        .parse::<u32>()
+        .expect("uid must parse")
+}
+
+/// Set ownership and mode on `path` via the libc syscalls. Used during
+/// fixture setup; tests run as root (sudo) so EPERM is unexpected.
+fn chown_chmod(path: &Path, uid: u32, gid: u32, mode: u32) {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let c_path = CString::new(path.as_os_str().as_bytes()).expect("path has NUL");
+    unsafe {
+        let rc = libc::chown(c_path.as_ptr(), uid, gid);
+        assert_eq!(rc, 0, "chown {} failed: {}", path.display(), errno_str());
+        let rc = libc::chmod(c_path.as_ptr(), mode as libc::mode_t);
+        assert_eq!(rc, 0, "chmod {} failed: {}", path.display(), errno_str());
+    }
+}
+
+fn errno_str() -> String {
+    std::io::Error::last_os_error().to_string()
+}
+
+/// Spawn `argv` via `runuser -u <user> -- <argv>` and return
+/// `(success, stderr)`. Closes stdin/stdout so only stderr is captured.
+fn spawn_as(user: &str, argv: &[&str]) -> (bool, String) {
+    let mut cmd = Command::new("runuser");
+    cmd.arg("-u").arg(user).arg("--");
+    for a in argv {
+        cmd.arg(a);
+    }
+    let output = cmd
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("failed to spawn runuser");
+    (
+        output.status.success(),
+        String::from_utf8_lossy(&output.stderr).into_owned(),
+    )
+}
+
+fn make_world_traversable(path: &Path) {
+    // Walk up from `path` to root and ensure every component along the
+    // way is at least `o+rx`. The CARGO_TARGET_DIR-derived tempdir lives
+    // under the user's home on most CI runners; if any ancestor is
+    // mode 0700 the runuser-into-alice invocation can't even reach
+    // `/tmp/...`. Keep the parent dirs `0o755` so traversal works; the
+    // per-mailbox dir under test is what enforces isolation.
+    let mut cur = path.to_path_buf();
+    while let Some(parent) = cur.parent().map(|p| p.to_path_buf()) {
+        if parent == cur {
+            break;
+        }
+        if let Ok(meta) = std::fs::metadata(&parent) {
+            let mode = meta.permissions().mode();
+            if mode & 0o001 == 0 || mode & 0o004 == 0 {
+                let _ =
+                    std::fs::set_permissions(&parent, std::fs::Permissions::from_mode(mode | 0o5));
+            }
+        }
+        cur = parent;
+    }
+}
+
+fn test_root() -> PathBuf {
+    // /tmp is world-traversable on Ubuntu runners; keep the fixture
+    // under /tmp so we don't have to fight with the runner's $HOME
+    // perms.
+    let pid = std::process::id();
+    PathBuf::from(format!("/tmp/aimx-mb-isolation-{pid}"))
+}
+
+#[test]
+#[ignore = "requires two test uids on the host (aimx-test-alice, aimx-test-bob)"]
+fn alice_hook_cannot_read_bob_inbox() {
+    if std::env::var_os("AIMX_INTEGRATION_SUDO").is_none() {
+        eprintln!(
+            "AIMX_INTEGRATION_SUDO is not set; skipping (test requires root + user provisioning)."
+        );
+        return;
+    }
+    assert_eq!(
+        unsafe { libc::geteuid() },
+        0,
+        "mailbox isolation test must run as root (AIMX_INTEGRATION_SUDO=1 + sudo)"
+    );
+
+    let _guard = UserTeardown;
+    ensure_user(ALICE);
+    ensure_user(BOB);
+
+    let alice_uid = uid_of(ALICE);
+    let alice_gid = alice_uid;
+    let bob_uid = uid_of(BOB);
+    let bob_gid = bob_uid;
+
+    let root = test_root();
+    let _ = std::fs::remove_dir_all(&root);
+    std::fs::create_dir_all(&root).unwrap();
+    std::fs::set_permissions(&root, std::fs::Permissions::from_mode(0o755)).unwrap();
+    make_world_traversable(&root);
+
+    let inbox_root = root.join("inbox");
+    std::fs::create_dir_all(&inbox_root).unwrap();
+    std::fs::set_permissions(&inbox_root, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+    // Per-mailbox directories: each owned by its mailbox owner, mode
+    // 0o700. This is the isolation invariant the dir-perm migration
+    // installs at setup / mailbox-create time.
+    let alice_inbox = inbox_root.join(ALICE);
+    std::fs::create_dir_all(&alice_inbox).unwrap();
+    chown_chmod(&alice_inbox, alice_uid, alice_gid, 0o700);
+
+    let bob_inbox = inbox_root.join(BOB);
+    std::fs::create_dir_all(&bob_inbox).unwrap();
+    chown_chmod(&bob_inbox, bob_uid, bob_gid, 0o700);
+
+    // Drop a fixture email into bob's inbox and chown it to bob.
+    let bob_email = bob_inbox.join("2026-04-15-000000-test.md");
+    std::fs::write(
+        &bob_email,
+        b"+++\nmailbox = \"aimx-test-bob\"\n+++\n\nsecret\n",
+    )
+    .unwrap();
+    chown_chmod(&bob_email, bob_uid, bob_gid, 0o600);
+
+    let bob_email_str = bob_email
+        .to_str()
+        .expect("bob email path must be valid utf-8");
+    let bob_inbox_str = bob_inbox
+        .to_str()
+        .expect("bob inbox path must be valid utf-8");
+
+    // (1) /bin/cat as alice on bob's email file.
+    let (ok, stderr) = spawn_as(ALICE, &["/bin/cat", bob_email_str]);
+    assert!(
+        !ok,
+        "alice must NOT be able to read bob's email; stderr: {stderr}"
+    );
+    assert!(
+        stderr.to_ascii_lowercase().contains("permission denied"),
+        "/bin/cat must surface EACCES; got stderr: {stderr}"
+    );
+
+    // (2) /bin/ls as alice on bob's inbox dir.
+    let (ok, stderr) = spawn_as(ALICE, &["/bin/ls", bob_inbox_str]);
+    assert!(
+        !ok,
+        "alice must NOT be able to list bob's inbox; stderr: {stderr}"
+    );
+    assert!(
+        stderr.to_ascii_lowercase().contains("permission denied"),
+        "/bin/ls must surface EACCES; got stderr: {stderr}"
+    );
+
+    // (3) /bin/test -r as alice on bob's inbox dir. `test -r` exits
+    // non-zero when the path is unreadable; it does not write to
+    // stderr, so the assertion is on exit status alone.
+    let (ok, _stderr) = spawn_as(ALICE, &["/bin/test", "-r", bob_inbox_str]);
+    assert!(
+        !ok,
+        "alice's readability check on bob's inbox must fail (test -r returns non-zero)"
+    );
+
+    // Sanity check: the same probes succeed when run as bob himself,
+    // so the failures above are an isolation property and not a
+    // fixture mistake.
+    let (ok, stderr) = spawn_as(BOB, &["/bin/cat", bob_email_str]);
+    assert!(
+        ok,
+        "bob must be able to read his own email; stderr: {stderr}"
+    );
+
+    let _ = std::fs::remove_dir_all(&root);
+    drop(_guard);
+}


### PR DESCRIPTION
## Summary

- Mailbox directories (`inbox/<name>/` and `sent/<name>/`) are now locked to `<owner>:<owner> 0700` by both setup and the daemon's `MAILBOX-CREATE` path. Setup verifies the owner and primary group exist on the host before chowning; missing users abort with a clear `useradd` hint. The CLI fallback (`create_mailbox` when the daemon is down) chowns under root and chmods elsewhere.
- The hook fire path (`execute_on_receive` / `execute_after_send`) gains a defense-in-depth guard that refuses to fire when hooks have somehow ended up on a catchall mailbox. Load-time validation already rejects this; the guard catches in-memory bypasses and emits a structured warning.
- New `tests/mailbox_isolation.rs` integration test provisions two real Linux users (`aimx-test-alice`, `aimx-test-bob`), lays out per-mailbox dirs at `0700`, drops a fixture email into bob's inbox, then runs `runuser`-as-alice probes (`/bin/cat`, `/bin/ls`, `/bin/test -r`) and asserts every one fails with `EACCES`. Bob still reads his own file as a sanity check. Gated behind `#[ignore]` + `AIMX_INTEGRATION_SUDO=1`.
- New CI job `mailbox-isolation` provisions the two test users via `useradd`, builds the test binary, and runs it under `sudo` so the kernel-level isolation is exercised on every push. Tear-down runs in `if: always()`.

## Test plan

- [x] `cargo test` (873 unit tests, 78 integration, all crates) — clean.
- [x] `cargo clippy --all-targets -- -D warnings` — clean (root + verifier).
- [x] `cargo fmt -- --check` — clean.
- [x] Manual end-to-end run of the new isolation test under `sudo AIMX_INTEGRATION_SUDO=1` — all three EACCES probes fail correctly; bob's self-read succeeds; teardown removes the test users.
- [ ] CI verifies the new `mailbox-isolation` job runs `useradd` + the test on a hosted runner.

🤖 Generated with [Claude Code](https://claude.com/claude-code)