### PR TITLE
Enforce SO_PEERCRED authorization on every UDS verb

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,10 @@ jobs:
           sudo useradd --system --no-create-home --shell /usr/sbin/nologin aimx-test-bob || \
             id aimx-test-bob
 
-      - name: Build the isolation test binary
-        run: cargo test --no-run --test mailbox_isolation
+      - name: Build the isolation test binaries
+        run: |
+          cargo test --no-run --test mailbox_isolation
+          cargo test --no-run --test uds_authz
 
       - name: Run mailbox isolation test (under sudo)
         run: |
@@ -82,6 +84,17 @@ jobs:
           BIN=$(ls -t target/debug/deps/mailbox_isolation-* | grep -v '\.d$' | head -n 1)
           test -x "$BIN"
           sudo AIMX_INTEGRATION_SUDO=1 "$BIN" --ignored
+
+      - name: Run UDS authz tests (under sudo)
+        run: |
+          # Same shape as the mailbox-isolation step. The uds_authz
+          # tests spin up a real `aimx serve` subprocess under a
+          # tempdir, then poke each verb as alice / bob / root over
+          # the unix socket. Authz rejections must surface as
+          # `EACCES` on the wire; root must always pass.
+          BIN=$(ls -t target/debug/deps/uds_authz-* | grep -v '\.d$' | head -n 1)
+          test -x "$BIN"
+          sudo AIMX_INTEGRATION_SUDO=1 "$BIN" --ignored --test-threads=1
 
       - name: Tear down test users
         if: always()

--- a/src/hook_handler.rs
+++ b/src/hook_handler.rs
@@ -1,41 +1,743 @@
 //! Daemon-side handlers for the `HOOK-CREATE` and `HOOK-DELETE` verbs of
 //! the `AIMX/1` UDS protocol.
 //!
-//! The UDS hook verbs are stubs that return `ERR PROTOCOL` until the
-//! UDS hardening pass rewires them under the new auth predicate.
-//! Operators continue to manage hooks via `sudo aimx hooks create
-//! --cmd` / `sudo aimx hooks delete`, both of which write
-//! `config.toml` directly and SIGHUP the daemon.
+//! Authorization: caller uid must match the target mailbox's owner uid,
+//! or be root. The check runs **before** any state mutation so a
+//! non-owner never observes a partial write.
+//!
+//! On success the handler rewrites `config.toml` atomically (write-temp-
+//! then-rename) and swaps the live `Config` snapshot through
+//! [`ConfigHandle::store`]. The same lock hierarchy as `MAILBOX-CRUD`
+//! applies: outer per-mailbox lock, inner process-wide
+//! [`mailbox_handler::CONFIG_WRITE_LOCK`].
+//!
+//! Body parser (`HOOK-CREATE`): JSON object with `cmd: [String]` plus
+//! optional `fire_on_untrusted: bool` and `type: String` (default
+//! `"cmd"`). The legacy `template`, `params`, `run_as`, `origin`,
+//! `dangerously_support_untrusted` fields are rejected with
+//! `ERR PROTOCOL` for symmetry with `Config::load`.
 
-use crate::mailbox_handler::MailboxContext;
+use serde::Deserialize;
+
+use crate::config::{Config, validate_hooks, validate_single_hook};
+use crate::hook::{Hook, HookEvent, effective_hook_name, is_valid_hook_name};
+use crate::mailbox_handler::{CONFIG_WRITE_LOCK, MailboxContext, write_config_atomic};
 use crate::send_protocol::{AckResponse, ErrCode, HookCreateRequest, HookDeleteRequest};
 use crate::state_handler::StateContext;
-use crate::uds_authz::Caller;
+use crate::uds_authz::{Caller, enforce_mailbox_owner_or_root};
+
+/// Wire-shape of the `HOOK-CREATE` JSON body. Mirrors the trimmed
+/// `Hook` schema in `src/hook.rs` minus the `event` and `name` fields,
+/// which travel as request headers. `deny_unknown_fields` causes a
+/// legacy `template` / `params` / `run_as` / `origin` /
+/// `dangerously_support_untrusted` to reject at body-parse time, before
+/// the handler ever touches `config.toml`.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct HookCreateBody {
+    cmd: Vec<String>,
+    #[serde(default)]
+    fire_on_untrusted: bool,
+    #[serde(default = "default_hook_type")]
+    r#type: String,
+}
+
+fn default_hook_type() -> String {
+    "cmd".to_string()
+}
 
 pub async fn handle_hook_create(
-    _state_ctx: &StateContext,
-    _mb_ctx: &MailboxContext,
-    _req: &HookCreateRequest,
-    _caller: &Caller,
+    state_ctx: &StateContext,
+    mb_ctx: &MailboxContext,
+    req: &HookCreateRequest,
+    caller: &Caller,
 ) -> AckResponse {
-    AckResponse::Err {
-        code: ErrCode::Protocol,
-        reason: "HOOK-CREATE over UDS is not supported in this build; \
-                 use `sudo aimx hooks create --cmd ...`"
-            .to_string(),
+    // Resolve the target mailbox up front so the authz check runs
+    // against the same snapshot the rest of the handler will build on.
+    let snapshot = mb_ctx.config_handle.load();
+    let mailbox_cfg = match snapshot.mailboxes.get(&req.mailbox) {
+        Some(m) => m.clone(),
+        None => {
+            return AckResponse::Err {
+                code: ErrCode::Enoent,
+                reason: format!("mailbox '{}' does not exist", req.mailbox),
+            };
+        }
+    };
+
+    if let Err(reject) =
+        enforce_mailbox_owner_or_root("HOOK-CREATE", caller, &req.mailbox, &mailbox_cfg)
+    {
+        return AckResponse::Err {
+            code: reject.code,
+            reason: reject.reason,
+        };
     }
+
+    // Hooks on the catchall are forbidden at config-load time; mirror
+    // the rejection here so a stale UDS client (e.g. one that
+    // bypassed the load-time validator by submitting against a freshly
+    // mutated config) cannot land one through the side door.
+    if mailbox_cfg.is_catchall(&snapshot) {
+        return AckResponse::Err {
+            code: ErrCode::Mailbox,
+            reason: format!(
+                "mailbox '{}' is the catchall; hooks on the catchall are forbidden",
+                req.mailbox
+            ),
+        };
+    }
+
+    let event = match parse_event(&req.event) {
+        Ok(e) => e,
+        Err(reason) => {
+            return AckResponse::Err {
+                code: ErrCode::Validation,
+                reason,
+            };
+        }
+    };
+
+    if let Some(name) = &req.name
+        && !is_valid_hook_name(name)
+    {
+        return AckResponse::Err {
+            code: ErrCode::Validation,
+            reason: format!(
+                "invalid hook name '{name}': must match \
+                 [a-zA-Z0-9_][a-zA-Z0-9_.-]{{0,127}}"
+            ),
+        };
+    }
+
+    // Body shape: JSON object. `serde(deny_unknown_fields)` rejects
+    // legacy template/params/run_as/origin/dangerously_* fields so the
+    // wire schema stays in lock-step with `Config::load`.
+    let body: HookCreateBody = match serde_json::from_slice(&req.body) {
+        Ok(b) => b,
+        Err(e) => {
+            return AckResponse::Err {
+                code: ErrCode::Protocol,
+                reason: format!("invalid HOOK-CREATE body: {e}"),
+            };
+        }
+    };
+
+    let hook = Hook {
+        name: req.name.clone(),
+        event,
+        r#type: body.r#type,
+        cmd: body.cmd,
+        fire_on_untrusted: body.fire_on_untrusted,
+    };
+
+    if let Err(reason) = validate_single_hook(&hook) {
+        return AckResponse::Err {
+            code: ErrCode::Validation,
+            reason,
+        };
+    }
+
+    // Acquire the same lock hierarchy mailbox CRUD takes: outer per-
+    // mailbox lock (shared with ingest / MARK-* / MAILBOX-CRUD), inner
+    // process-wide config write lock. Always outer → inner.
+    let lock = state_ctx.lock_for(&req.mailbox);
+    let _guard = lock.lock().await;
+    let _config_guard = CONFIG_WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let current = mb_ctx.config_handle.load();
+    let mut new_config: Config = (*current).clone();
+    let mb = match new_config.mailboxes.get_mut(&req.mailbox) {
+        Some(m) => m,
+        None => {
+            return AckResponse::Err {
+                code: ErrCode::Enoent,
+                reason: format!(
+                    "mailbox '{}' does not exist (race with concurrent MAILBOX-DELETE)",
+                    req.mailbox
+                ),
+            };
+        }
+    };
+
+    let effective = effective_hook_name(&hook);
+    mb.hooks.push(hook);
+
+    if let Err(reason) = validate_hooks(&new_config) {
+        return AckResponse::Err {
+            code: ErrCode::Validation,
+            reason,
+        };
+    }
+
+    if let Err(e) = write_config_atomic(&mb_ctx.config_path, &new_config) {
+        return AckResponse::Err {
+            code: ErrCode::Io,
+            reason: format!("failed to write {}: {e}", mb_ctx.config_path.display()),
+        };
+    }
+
+    mb_ctx.config_handle.store(new_config);
+    tracing::info!(
+        target: "aimx::hook",
+        verb = "HOOK-CREATE",
+        mailbox = %req.mailbox,
+        hook_name = %effective,
+        caller_uid = caller.uid,
+        "hook created"
+    );
+    AckResponse::Ok
 }
 
 pub async fn handle_hook_delete(
-    _state_ctx: &StateContext,
-    _mb_ctx: &MailboxContext,
-    _req: &HookDeleteRequest,
-    _caller: &Caller,
+    state_ctx: &StateContext,
+    mb_ctx: &MailboxContext,
+    req: &HookDeleteRequest,
+    caller: &Caller,
 ) -> AckResponse {
-    AckResponse::Err {
-        code: ErrCode::Protocol,
-        reason: "HOOK-DELETE over UDS is not supported in this build; \
-                 use `sudo aimx hooks delete <name>`"
-            .to_string(),
+    // Locate the hook by effective name across every mailbox before
+    // taking any lock. The mailbox name we resolve here drives both
+    // authz and the per-mailbox lock; without resolving up front we
+    // cannot answer "which mailbox does this hook belong to?"
+    let snapshot = mb_ctx.config_handle.load();
+    let mailbox_name = match find_hook_owner(&snapshot, &req.name) {
+        Some(name) => name,
+        None => {
+            return AckResponse::Err {
+                code: ErrCode::Enoent,
+                reason: format!("hook '{}' not found", req.name),
+            };
+        }
+    };
+
+    // Re-lookup against the same snapshot so the authz check sees a
+    // consistent view of the mailbox's owner.
+    let mailbox_cfg = match snapshot.mailboxes.get(&mailbox_name) {
+        Some(m) => m.clone(),
+        None => {
+            return AckResponse::Err {
+                code: ErrCode::Enoent,
+                reason: format!("hook '{}' not found", req.name),
+            };
+        }
+    };
+
+    if let Err(reject) =
+        enforce_mailbox_owner_or_root("HOOK-DELETE", caller, &mailbox_name, &mailbox_cfg)
+    {
+        return AckResponse::Err {
+            code: reject.code,
+            reason: reject.reason,
+        };
+    }
+
+    let lock = state_ctx.lock_for(&mailbox_name);
+    let _guard = lock.lock().await;
+    let _config_guard = CONFIG_WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    // Re-resolve under the lock so a concurrent HOOK-CREATE / DELETE on
+    // the same mailbox doesn't slip past us.
+    let current = mb_ctx.config_handle.load();
+    let mut new_config: Config = (*current).clone();
+    let mb = match new_config.mailboxes.get_mut(&mailbox_name) {
+        Some(m) => m,
+        None => {
+            return AckResponse::Err {
+                code: ErrCode::Enoent,
+                reason: format!("hook '{}' not found", req.name),
+            };
+        }
+    };
+    let before = mb.hooks.len();
+    mb.hooks.retain(|h| effective_hook_name(h) != req.name);
+    if mb.hooks.len() == before {
+        return AckResponse::Err {
+            code: ErrCode::Enoent,
+            reason: format!("hook '{}' not found", req.name),
+        };
+    }
+
+    if let Err(e) = write_config_atomic(&mb_ctx.config_path, &new_config) {
+        return AckResponse::Err {
+            code: ErrCode::Io,
+            reason: format!("failed to write {}: {e}", mb_ctx.config_path.display()),
+        };
+    }
+
+    mb_ctx.config_handle.store(new_config);
+    tracing::info!(
+        target: "aimx::hook",
+        verb = "HOOK-DELETE",
+        mailbox = %mailbox_name,
+        hook_name = %req.name,
+        caller_uid = caller.uid,
+        "hook deleted"
+    );
+    AckResponse::Ok
+}
+
+fn parse_event(s: &str) -> Result<HookEvent, String> {
+    match s {
+        "on_receive" => Ok(HookEvent::OnReceive),
+        "after_send" => Ok(HookEvent::AfterSend),
+        other => Err(format!(
+            "invalid event '{other}': expected 'on_receive' or 'after_send'"
+        )),
+    }
+}
+
+fn find_hook_owner(config: &Config, name: &str) -> Option<String> {
+    for (mailbox_name, mb) in &config.mailboxes {
+        for hook in &mb.hooks {
+            if effective_hook_name(hook) == name {
+                return Some(mailbox_name.clone());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Config, ConfigHandle, MailboxConfig};
+    use crate::send_protocol::{HookCreateRequest, HookDeleteRequest};
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    fn install_tester_resolver() -> crate::user_resolver::test_resolver::ResolverOverride {
+        fn fake(name: &str) -> Option<crate::user_resolver::ResolvedUser> {
+            if name == "testowner" || name == "root" {
+                let uid = unsafe { libc::geteuid() };
+                let gid = unsafe { libc::getegid() };
+                Some(crate::user_resolver::ResolvedUser {
+                    name: name.to_string(),
+                    uid,
+                    gid,
+                })
+            } else {
+                None
+            }
+        }
+        crate::user_resolver::set_test_resolver(fake)
+    }
+
+    fn base_config(data_dir: &std::path::Path) -> Config {
+        let mut mailboxes = HashMap::new();
+        mailboxes.insert(
+            "catchall".to_string(),
+            MailboxConfig {
+                address: "*@example.com".to_string(),
+                owner: "aimx-catchall".to_string(),
+                hooks: vec![],
+                trust: None,
+                trusted_senders: None,
+                allow_root_catchall: false,
+            },
+        );
+        mailboxes.insert(
+            "alice".to_string(),
+            MailboxConfig {
+                address: "alice@example.com".to_string(),
+                owner: "testowner".to_string(),
+                hooks: vec![],
+                trust: None,
+                trusted_senders: None,
+                allow_root_catchall: false,
+            },
+        );
+        Config {
+            domain: "example.com".to_string(),
+            data_dir: data_dir.to_path_buf(),
+            dkim_selector: "aimx".to_string(),
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            mailboxes,
+            verify_host: None,
+            enable_ipv6: false,
+            upgrade: None,
+        }
+    }
+
+    fn contexts(tmp: &TempDir) -> (StateContext, MailboxContext) {
+        let config = base_config(tmp.path());
+        let handle = ConfigHandle::new(config);
+        let state_ctx = StateContext::new(tmp.path().to_path_buf(), handle.clone());
+        let config_path = tmp.path().join("config.toml");
+        write_config_atomic(&config_path, &handle.load()).unwrap();
+        let mb_ctx = MailboxContext::new(config_path, handle);
+        (state_ctx, mb_ctx)
+    }
+
+    fn body_for(cmd: &[&str], fire_on_untrusted: bool) -> Vec<u8> {
+        let cmd_arr: Vec<String> = cmd.iter().map(|s| s.to_string()).collect();
+        let value = serde_json::json!({
+            "cmd": cmd_arr,
+            "fire_on_untrusted": fire_on_untrusted,
+        });
+        serde_json::to_vec(&value).unwrap()
+    }
+
+    #[tokio::test]
+    async fn root_can_create_hook_on_any_mailbox() {
+        let _r = install_tester_resolver();
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+        let req = HookCreateRequest {
+            mailbox: "alice".into(),
+            event: "on_receive".into(),
+            name: Some("greet".into()),
+            body: body_for(&["/bin/echo", "hi"], false),
+        };
+        let resp = handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await;
+        assert!(matches!(resp, AckResponse::Ok), "{resp:?}");
+        let cfg = mb_ctx.config_handle.load();
+        assert_eq!(cfg.mailboxes["alice"].hooks.len(), 1);
+        assert_eq!(
+            cfg.mailboxes["alice"].hooks[0].name.as_deref(),
+            Some("greet")
+        );
+    }
+
+    #[tokio::test]
+    async fn create_rejects_unknown_mailbox_with_enoent() {
+        let _r = install_tester_resolver();
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+        let req = HookCreateRequest {
+            mailbox: "ghost".into(),
+            event: "on_receive".into(),
+            name: None,
+            body: body_for(&["/bin/echo", "hi"], false),
+        };
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Enoent),
+            other => panic!("expected ENOENT, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_rejects_legacy_template_field_at_body_parse() {
+        let _r = install_tester_resolver();
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+        let body = serde_json::to_vec(&serde_json::json!({
+            "cmd": ["/bin/echo", "hi"],
+            "template": "invoke-claude",
+        }))
+        .unwrap();
+        let req = HookCreateRequest {
+            mailbox: "alice".into(),
+            event: "on_receive".into(),
+            name: None,
+            body,
+        };
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
+            AckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Protocol);
+                assert!(
+                    reason.contains("template") || reason.contains("unknown"),
+                    "{reason}"
+                );
+            }
+            other => panic!("expected PROTOCOL, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_rejects_legacy_run_as_field_at_body_parse() {
+        let _r = install_tester_resolver();
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+        let body = serde_json::to_vec(&serde_json::json!({
+            "cmd": ["/bin/echo", "hi"],
+            "run_as": "aimx-hook",
+        }))
+        .unwrap();
+        let req = HookCreateRequest {
+            mailbox: "alice".into(),
+            event: "on_receive".into(),
+            name: None,
+            body,
+        };
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Protocol),
+            other => panic!("expected PROTOCOL, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_rejects_empty_cmd_at_validation() {
+        let _r = install_tester_resolver();
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+        let body = serde_json::to_vec(&serde_json::json!({
+            "cmd": [],
+        }))
+        .unwrap();
+        let req = HookCreateRequest {
+            mailbox: "alice".into(),
+            event: "on_receive".into(),
+            name: None,
+            body,
+        };
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
+            AckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Validation);
+                assert!(reason.contains("empty"), "{reason}");
+            }
+            other => panic!("expected VALIDATION, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_rejects_non_absolute_program_at_validation() {
+        let _r = install_tester_resolver();
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+        let req = HookCreateRequest {
+            mailbox: "alice".into(),
+            event: "on_receive".into(),
+            name: None,
+            body: body_for(&["echo", "hi"], false),
+        };
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
+            AckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Validation);
+                assert!(reason.contains("absolute"), "{reason}");
+            }
+            other => panic!("expected VALIDATION, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_rejects_fire_on_untrusted_on_after_send() {
+        let _r = install_tester_resolver();
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+        let req = HookCreateRequest {
+            mailbox: "alice".into(),
+            event: "after_send".into(),
+            name: None,
+            body: body_for(&["/bin/echo", "hi"], true),
+        };
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
+            AckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Validation);
+                assert!(reason.contains("on_receive"), "{reason}");
+            }
+            other => panic!("expected VALIDATION, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_rejects_invalid_event() {
+        let _r = install_tester_resolver();
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+        let req = HookCreateRequest {
+            mailbox: "alice".into(),
+            event: "on_open".into(),
+            name: None,
+            body: body_for(&["/bin/echo"], false),
+        };
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Validation),
+            other => panic!("expected VALIDATION, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_rejects_hook_on_catchall() {
+        let _r = install_tester_resolver();
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+        let req = HookCreateRequest {
+            mailbox: "catchall".into(),
+            event: "on_receive".into(),
+            name: None,
+            body: body_for(&["/bin/echo"], false),
+        };
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
+            AckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Mailbox);
+                assert!(reason.contains("catchall"), "{reason}");
+            }
+            other => panic!("expected MAILBOX, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn non_owner_cannot_create_hook() {
+        let _r = install_tester_resolver();
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+        // Caller uid is some non-root, non-owner uid. The username
+        // resolves to something that is NOT 'testowner' so the authz
+        // check rejects.
+        let attacker = Caller::with_username(99999, 99999, "attacker");
+        let req = HookCreateRequest {
+            mailbox: "alice".into(),
+            event: "on_receive".into(),
+            name: None,
+            body: body_for(&["/bin/echo"], false),
+        };
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &attacker).await {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Eaccess),
+            other => panic!("expected EACCES, got {other:?}"),
+        }
+        // Mailbox config is unchanged.
+        let cfg = mb_ctx.config_handle.load();
+        assert!(cfg.mailboxes["alice"].hooks.is_empty());
+    }
+
+    #[tokio::test]
+    async fn delete_unknown_hook_returns_enoent() {
+        let _r = install_tester_resolver();
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+        let req = HookDeleteRequest {
+            name: "ghost".into(),
+        };
+        match handle_hook_delete(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Enoent),
+            other => panic!("expected ENOENT, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn delete_works_after_create_round_trip() {
+        let _r = install_tester_resolver();
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+
+        let create = HookCreateRequest {
+            mailbox: "alice".into(),
+            event: "on_receive".into(),
+            name: Some("greet".into()),
+            body: body_for(&["/bin/echo", "hi"], false),
+        };
+        assert!(matches!(
+            handle_hook_create(&state_ctx, &mb_ctx, &create, &Caller::internal_root()).await,
+            AckResponse::Ok
+        ));
+
+        let del = HookDeleteRequest {
+            name: "greet".into(),
+        };
+        assert!(matches!(
+            handle_hook_delete(&state_ctx, &mb_ctx, &del, &Caller::internal_root()).await,
+            AckResponse::Ok
+        ));
+        assert!(
+            mb_ctx.config_handle.load().mailboxes["alice"]
+                .hooks
+                .is_empty()
+        );
+    }
+
+    #[tokio::test]
+    async fn non_owner_cannot_delete_hook() {
+        let _r = install_tester_resolver();
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+
+        let create = HookCreateRequest {
+            mailbox: "alice".into(),
+            event: "on_receive".into(),
+            name: Some("greet".into()),
+            body: body_for(&["/bin/echo", "hi"], false),
+        };
+        assert!(matches!(
+            handle_hook_create(&state_ctx, &mb_ctx, &create, &Caller::internal_root()).await,
+            AckResponse::Ok
+        ));
+
+        let attacker = Caller::with_username(99999, 99999, "attacker");
+        let del = HookDeleteRequest {
+            name: "greet".into(),
+        };
+        match handle_hook_delete(&state_ctx, &mb_ctx, &del, &attacker).await {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Eaccess),
+            other => panic!("expected EACCES, got {other:?}"),
+        }
+        assert_eq!(
+            mb_ctx.config_handle.load().mailboxes["alice"].hooks.len(),
+            1
+        );
+    }
+
+    #[tokio::test]
+    async fn create_persists_to_config_toml() {
+        let _r = install_tester_resolver();
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+        let req = HookCreateRequest {
+            mailbox: "alice".into(),
+            event: "on_receive".into(),
+            name: Some("greet".into()),
+            body: body_for(&["/bin/echo", "hi"], false),
+        };
+        assert!(matches!(
+            handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await,
+            AckResponse::Ok
+        ));
+        let reloaded = Config::load_ignore_warnings(&mb_ctx.config_path).unwrap();
+        assert_eq!(reloaded.mailboxes["alice"].hooks.len(), 1);
+        assert_eq!(
+            reloaded.mailboxes["alice"].hooks[0].cmd,
+            vec!["/bin/echo".to_string(), "hi".to_string()]
+        );
+    }
+
+    #[tokio::test]
+    async fn duplicate_explicit_hook_name_is_rejected() {
+        let _r = install_tester_resolver();
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+        let req1 = HookCreateRequest {
+            mailbox: "alice".into(),
+            event: "on_receive".into(),
+            name: Some("greet".into()),
+            body: body_for(&["/bin/echo", "hi"], false),
+        };
+        assert!(matches!(
+            handle_hook_create(&state_ctx, &mb_ctx, &req1, &Caller::internal_root()).await,
+            AckResponse::Ok
+        ));
+        let req2 = HookCreateRequest {
+            mailbox: "alice".into(),
+            event: "on_receive".into(),
+            name: Some("greet".into()),
+            body: body_for(&["/bin/echo", "again"], false),
+        };
+        match handle_hook_create(&state_ctx, &mb_ctx, &req2, &Caller::internal_root()).await {
+            AckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Validation);
+                assert!(reason.contains("greet"), "{reason}");
+            }
+            other => panic!("expected VALIDATION, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_hook_name_rejected() {
+        let _r = install_tester_resolver();
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+        let req = HookCreateRequest {
+            mailbox: "alice".into(),
+            event: "on_receive".into(),
+            name: Some("bad name with spaces".into()),
+            body: body_for(&["/bin/echo"], false),
+        };
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Validation),
+            other => panic!("expected VALIDATION, got {other:?}"),
+        }
     }
 }

--- a/src/hook_handler.rs
+++ b/src/hook_handler.rs
@@ -110,9 +110,19 @@ pub async fn handle_hook_create(
         };
     }
 
-    // Body shape: JSON object. `serde(deny_unknown_fields)` rejects
-    // legacy template/params/run_as/origin/dangerously_* fields so the
-    // wire schema stays in lock-step with `Config::load`.
+    // Pre-screen for the known-removed legacy fields so the wire error
+    // mirrors `Config::load` (operators see "book/hooks.md" / "renamed
+    // to fire_on_untrusted" / etc. on either surface). `deny_unknown_fields`
+    // below is the backstop for any other unknown key.
+    if let Err(reason) = reject_legacy_body_fields(&req.body) {
+        return AckResponse::Err {
+            code: ErrCode::Protocol,
+            reason,
+        };
+    }
+
+    // Body shape: JSON object. `serde(deny_unknown_fields)` is the
+    // catch-all for any other unknown key after the legacy pre-screen.
     let body: HookCreateBody = match serde_json::from_slice(&req.body) {
         Ok(b) => b,
         Err(e) => {
@@ -280,6 +290,50 @@ pub async fn handle_hook_delete(
     AckResponse::Ok
 }
 
+/// Pre-screen the raw `HOOK-CREATE` body for the known-removed legacy
+/// fields and return an error message that mirrors `Config::load` /
+/// `reject_legacy_schema` (so a migrated operator hitting the daemon
+/// over UDS sees the same actionable text as one editing `config.toml`).
+///
+/// On success returns `Ok(())` and the caller continues to the normal
+/// serde parse, which still rejects any other unknown field.
+fn reject_legacy_body_fields(body: &[u8]) -> Result<(), String> {
+    // Best-effort parse as a JSON object. If the body isn't a JSON
+    // object the regular serde parse below will surface the right error;
+    // we only short-circuit when one of the named removed fields is
+    // present.
+    let value: serde_json::Value = match serde_json::from_slice(body) {
+        Ok(v) => v,
+        Err(_) => return Ok(()),
+    };
+    let Some(obj) = value.as_object() else {
+        return Ok(());
+    };
+    if obj.contains_key("template") || obj.contains_key("params") {
+        return Err(
+            "hook sets `template`/`params`; template hooks were removed. \
+             See book/hooks.md for the supported raw-cmd schema"
+                .to_string(),
+        );
+    }
+    if obj.contains_key("run_as") {
+        return Err(
+            "hook sets `run_as`; the field was removed — hooks now run as the mailbox's `owner`"
+                .to_string(),
+        );
+    }
+    if obj.contains_key("origin") {
+        return Err("hook sets `origin`; the field was removed".to_string());
+    }
+    if obj.contains_key("dangerously_support_untrusted") {
+        return Err(
+            "hook sets `dangerously_support_untrusted`; the field was renamed to `fire_on_untrusted`"
+                .to_string(),
+        );
+    }
+    Ok(())
+}
+
 fn parse_event(s: &str) -> Result<HookEvent, String> {
     match s {
         "on_receive" => Ok(HookEvent::OnReceive),
@@ -439,10 +493,35 @@ mod tests {
         match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Protocol);
-                assert!(
-                    reason.contains("template") || reason.contains("unknown"),
-                    "{reason}"
-                );
+                assert!(reason.contains("template"), "{reason}");
+                // Mirror `Config::load`: removed-field rejection points
+                // operators at the same docs page on either surface.
+                assert!(reason.contains("book/hooks.md"), "{reason}");
+            }
+            other => panic!("expected PROTOCOL, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_rejects_legacy_params_field_at_body_parse() {
+        let _r = install_tester_resolver();
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+        let body = serde_json::to_vec(&serde_json::json!({
+            "cmd": ["/bin/echo", "hi"],
+            "params": {"foo": "bar"},
+        }))
+        .unwrap();
+        let req = HookCreateRequest {
+            mailbox: "alice".into(),
+            event: "on_receive".into(),
+            name: None,
+            body,
+        };
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
+            AckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Protocol);
+                assert!(reason.contains("book/hooks.md"), "{reason}");
             }
             other => panic!("expected PROTOCOL, got {other:?}"),
         }
@@ -465,7 +544,70 @@ mod tests {
             body,
         };
         match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
-            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Protocol),
+            AckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Protocol);
+                assert!(
+                    reason.contains("run_as") && reason.contains("removed"),
+                    "{reason}"
+                );
+            }
+            other => panic!("expected PROTOCOL, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_rejects_legacy_origin_field_at_body_parse() {
+        let _r = install_tester_resolver();
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+        let body = serde_json::to_vec(&serde_json::json!({
+            "cmd": ["/bin/echo", "hi"],
+            "origin": "operator",
+        }))
+        .unwrap();
+        let req = HookCreateRequest {
+            mailbox: "alice".into(),
+            event: "on_receive".into(),
+            name: None,
+            body,
+        };
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
+            AckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Protocol);
+                assert!(
+                    reason.contains("origin") && reason.contains("removed"),
+                    "{reason}"
+                );
+            }
+            other => panic!("expected PROTOCOL, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_rejects_legacy_dangerously_support_untrusted_at_body_parse() {
+        let _r = install_tester_resolver();
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+        let body = serde_json::to_vec(&serde_json::json!({
+            "cmd": ["/bin/echo", "hi"],
+            "dangerously_support_untrusted": true,
+        }))
+        .unwrap();
+        let req = HookCreateRequest {
+            mailbox: "alice".into(),
+            event: "on_receive".into(),
+            name: None,
+            body,
+        };
+        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
+            AckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Protocol);
+                assert!(
+                    reason.contains("dangerously_support_untrusted")
+                        && reason.contains("fire_on_untrusted"),
+                    "{reason}"
+                );
+            }
             other => panic!("expected PROTOCOL, got {other:?}"),
         }
     }

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -36,6 +36,16 @@ pub(crate) fn validate_mailbox_name(name: &str) -> Result<(), String> {
     if name.starts_with('.') || name.ends_with('.') {
         return Err("Mailbox name cannot start or end with '.'".into());
     }
+    // Reserved names: `catchall` is the runtime-special wildcard mailbox
+    // identifier and `aimx-catchall` is the reserved system user that
+    // owns it on a default install. Either as a user-defined mailbox
+    // name would shadow the wildcard slot or collide with the system
+    // user — reject regardless of caller (CLI or UDS).
+    if name == "catchall" || name == "aimx-catchall" {
+        return Err(format!(
+            "Mailbox name '{name}' is reserved for the wildcard catchall slot"
+        ));
+    }
     for c in name.chars() {
         let ok = c.is_ascii_lowercase() || c.is_ascii_digit() || c == '.' || c == '_' || c == '-';
         if !ok {

--- a/src/mailbox_handler.rs
+++ b/src/mailbox_handler.rs
@@ -537,20 +537,79 @@ mod tests {
 
     #[tokio::test]
     async fn create_duplicate_mailbox_returns_mailbox_error() {
+        let _r = install_tester_resolver();
         let tmp = TempDir::new().unwrap();
         let (state_ctx, mb_ctx) = contexts(&tmp);
 
-        let req = MailboxCrudRequest {
-            name: "catchall".into(),
+        // Seed a non-reserved mailbox first.
+        let seed = MailboxCrudRequest {
+            name: "alice".into(),
             create: true,
             owner: Some("testowner".into()),
         };
-        match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
+        assert!(matches!(
+            handle_mailbox_crud(&state_ctx, &mb_ctx, &seed, &Caller::internal_root()).await,
+            AckResponse::Ok
+        ));
+
+        let dup = MailboxCrudRequest {
+            name: "alice".into(),
+            create: true,
+            owner: Some("testowner".into()),
+        };
+        match handle_mailbox_crud(&state_ctx, &mb_ctx, &dup, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
                 assert_eq!(code, ErrCode::Mailbox);
                 assert!(reason.contains("already exists"), "{reason}");
             }
             other => panic!("expected Err(MAILBOX), got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn create_rejects_reserved_name_catchall() {
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+
+        for name in ["catchall", "aimx-catchall"] {
+            let req = MailboxCrudRequest {
+                name: name.into(),
+                create: true,
+                owner: Some("testowner".into()),
+            };
+            match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
+                AckResponse::Err { code, reason } => {
+                    assert_eq!(code, ErrCode::Validation, "name {name:?}");
+                    assert!(
+                        reason.contains("reserved"),
+                        "name {name:?}: expected `reserved` in reason, got {reason}"
+                    );
+                }
+                other => panic!("name {name:?}: expected Err(VALIDATION), got {other:?}"),
+            }
+        }
+    }
+
+    #[tokio::test]
+    async fn create_rejects_reserved_name_before_authz() {
+        // Defense-in-depth: reserved-name validation runs before the
+        // root-only authz check, so the rejection text is the same
+        // regardless of caller (root or non-root).
+        let tmp = TempDir::new().unwrap();
+        let (state_ctx, mb_ctx) = contexts(&tmp);
+
+        let attacker = Caller::with_username(99999, 99999, "attacker");
+        let req = MailboxCrudRequest {
+            name: "catchall".into(),
+            create: true,
+            owner: Some("testowner".into()),
+        };
+        match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &attacker).await {
+            AckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Validation);
+                assert!(reason.contains("reserved"), "{reason}");
+            }
+            other => panic!("expected Err(VALIDATION), got {other:?}"),
         }
     }
 
@@ -667,6 +726,12 @@ mod tests {
 
     #[tokio::test]
     async fn delete_catchall_forbidden() {
+        // The catchall name is now reserved at `validate_mailbox_name`,
+        // so the rejection comes back as `Validation` ("reserved")
+        // before ever reaching the catchall-specific delete guard. Both
+        // the validation rejection and the deeper guard in
+        // `handle_delete` agree the catchall must not be deleted via
+        // UDS — the layer that fires first changed.
         let tmp = TempDir::new().unwrap();
         let (state_ctx, mb_ctx) = contexts(&tmp);
 
@@ -677,10 +742,10 @@ mod tests {
         };
         match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
-                assert_eq!(code, ErrCode::Mailbox);
-                assert!(reason.contains("catchall"), "{reason}");
+                assert_eq!(code, ErrCode::Validation);
+                assert!(reason.contains("reserved"), "{reason}");
             }
-            other => panic!("expected Err(MAILBOX), got {other:?}"),
+            other => panic!("expected Err(VALIDATION), got {other:?}"),
         }
     }
 

--- a/src/uds_authz.rs
+++ b/src/uds_authz.rs
@@ -301,9 +301,24 @@ pub fn log_decision(
     }
 }
 
+/// Canonical wire reason on every authz reject.
+///
+/// Kept deliberately opaque so the wire response cannot be used to
+/// enumerate mailboxes or probe ownership ("does this mailbox exist?",
+/// "who owns it?"). The rich diagnostic text returned by `require_*`
+/// is logged at `warn` for the operator — see [`log_decision`] — but
+/// never sent over the socket.
+const WIRE_REASON_NOT_AUTHORIZED: &str = "not authorized";
+
 /// Convenience: evaluate + log in one call. Used by handlers that want
 /// the structured log for every decision (accept + reject + root_bypass)
 /// without duplicating the match arms.
+///
+/// On reject, the structured log keeps the rich diagnostic reason
+/// (`reason = "caller 'bob' is not the owner of mailbox 'alice' …"`)
+/// for operator-side debugging via `aimx logs`, but the wire response
+/// is tightened to the opaque [`WIRE_REASON_NOT_AUTHORIZED`] so the
+/// daemon does not leak whether the mailbox exists or who owns it.
 pub fn enforce_mailbox_owner_or_root(
     verb: &str,
     caller: &Caller,
@@ -333,14 +348,18 @@ pub fn enforce_mailbox_owner_or_root(
                 LogDecision::Reject,
                 Some(&reject.reason),
             );
-            Err(reject)
+            Err(AuthzReject {
+                code: reject.code,
+                reason: WIRE_REASON_NOT_AUTHORIZED.to_string(),
+            })
         }
     }
 }
 
 /// Convenience for verbs whose mailbox identity is not known up front
 /// (e.g. `MAILBOX-CREATE` / `MAILBOX-DELETE`). Logs without a `mailbox`
-/// field.
+/// field. Same wire/log split as [`enforce_mailbox_owner_or_root`]:
+/// rich reason in the log, opaque `not authorized` on the wire.
 pub fn enforce_root(
     verb: &str,
     caller: &Caller,
@@ -359,7 +378,10 @@ pub fn enforce_root(
                 LogDecision::Reject,
                 Some(&reject.reason),
             );
-            Err(reject)
+            Err(AuthzReject {
+                code: reject.code,
+                reason: WIRE_REASON_NOT_AUTHORIZED.to_string(),
+            })
         }
     }
 }
@@ -489,8 +511,33 @@ mod tests {
         let m = mb("alice");
         let err = enforce_mailbox_owner_or_root("SEND", &c, "alice", &m).unwrap_err();
         assert_eq!(err.code, ErrCode::Eaccess);
+        // Wire reason is opaque — does not leak owner/mailbox identity.
+        assert_eq!(err.reason, "not authorized");
+        // Log keeps the rich diagnostic for the operator.
         assert!(logs_contain("decision=\"reject\""));
         assert!(logs_contain("caller_username=\"bob\""));
+        assert!(logs_contain("not the owner of mailbox"));
+    }
+
+    #[test]
+    fn enforce_mailbox_owner_or_root_wire_reason_does_not_leak_identity() {
+        let c = Caller::new(1002, 1002, None);
+        let _ = c.username_cache.set(Some("bob".to_string()));
+        let m = mb("alice");
+        let err = enforce_mailbox_owner_or_root("SEND", &c, "alice", &m).unwrap_err();
+        // The wire reason must not contain the caller name, the
+        // mailbox name, or the owner name.
+        assert!(
+            !err.reason.contains("alice"),
+            "leaked mailbox: {}",
+            err.reason
+        );
+        assert!(!err.reason.contains("bob"), "leaked caller: {}", err.reason);
+        assert!(
+            !err.reason.contains("owner"),
+            "leaked owner: {}",
+            err.reason
+        );
     }
 
     #[test]
@@ -500,7 +547,11 @@ mod tests {
         let _ = c.username_cache.set(Some("bob".to_string()));
         let err = enforce_root("MAILBOX-CREATE", &c, Some("alice")).unwrap_err();
         assert_eq!(err.code, ErrCode::Eaccess);
+        // Wire reason is opaque.
+        assert_eq!(err.reason, "not authorized");
         assert!(logs_contain("decision=\"reject\""));
         assert!(logs_contain("verb=\"MAILBOX-CREATE\""));
+        // Log keeps the rich diagnostic naming the caller.
+        assert!(logs_contain("caller uid 1002"));
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4165,7 +4165,6 @@ fn aimx_cmd_isolated(tmp: &Path) -> Command {
 /// hint. That path covers the full flag validation and the on-disk
 /// write.
 #[test]
-#[ignore = "exercises legacy template/hook schema; reworked in a later sprint"]
 fn hooks_create_and_list_roundtrip_direct_edit() {
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
@@ -4181,7 +4180,7 @@ fn hooks_create_and_list_roundtrip_direct_edit() {
             "--event",
             "on_receive",
             "--cmd",
-            "echo hi",
+            r#"["/bin/echo", "hi"]"#,
             "--name",
             "alice_greeter",
         ])
@@ -4198,7 +4197,10 @@ fn hooks_create_and_list_roundtrip_direct_edit() {
     );
     // A restart hint is expected on the socket-missing fallback path.
     assert!(
-        create_out.contains("restart") || create_out.contains("Hint"),
+        create_out.contains("restart")
+            || create_out.contains("Hint")
+            || create_out.contains("next start")
+            || create_out.contains("Note:"),
         "expected restart hint on socket-missing fallback: {create_out}"
     );
 
@@ -4269,7 +4271,6 @@ fn hooks_alias_works() {
 }
 
 #[test]
-#[ignore = "exercises legacy template/hook schema; reworked in a later sprint"]
 fn hooks_create_rejects_invalid_name() {
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
@@ -4285,14 +4286,17 @@ fn hooks_create_rejects_invalid_name() {
             "--event",
             "on_receive",
             "--cmd",
-            "echo hi",
+            r#"["/bin/echo", "hi"]"#,
             "--name",
             "bad name!",
         ])
         .assert()
         .failure();
     let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
-    assert!(stderr.contains("--name"), "expected --name error: {stderr}");
+    assert!(
+        stderr.contains("--name") || stderr.contains("hook name"),
+        "expected hook-name validation error: {stderr}"
+    );
 }
 
 #[test]

--- a/tests/uds_authz.rs
+++ b/tests/uds_authz.rs
@@ -1,29 +1,35 @@
-//! Cross-user UDS authz integration test.
+//! Cross-user UDS authz integration tests.
 //!
-//! Reuses the `aimx-it-alice` / `aimx-it-bob` fixture from
-//! `tests/isolation.rs`. Spins up a real `aimx serve` subprocess under
-//! a tempdir, then issues raw `AIMX/1` frames under bob's uid via
-//! `runuser -u aimx-it-bob python3 -c ...`. Every attack must come
-//! back with `AIMX/1 ERR EACCES`. The root control run succeeds and
-//! emits the `decision="root_bypass"` info log captured from the
-//! serve subprocess's stderr.
+//! Reuses the `aimx-test-alice` / `aimx-test-bob` fixture also used by
+//! `tests/mailbox_isolation.rs`. Spins up a real `aimx serve` subprocess
+//! under a tempdir, then issues raw `AIMX/1` frames as alice/bob/root
+//! via `runuser -u <user> python3 -c ...`.
+//!
+//! Per-verb ownership matrix (mirrors `src/uds_authz.rs`):
+//!
+//! | Verb                                | Owner | Other | Root |
+//! |-------------------------------------|-------|-------|------|
+//! | `SEND` (as alice)                   | OK    | EACCES| OK   |
+//! | `MARK-READ` / `MARK-UNREAD`         | OK*   | EACCES| OK*  |
+//! | `HOOK-CREATE` / `HOOK-DELETE`       | OK    | EACCES| OK   |
+//! | `MAILBOX-CREATE` / `MAILBOX-DELETE` |  n/a  | EACCES| OK   |
+//!
+//! `*` MARK targets a non-existent email so the OK path surfaces as
+//! `NOTFOUND` after authz accepts; the EACCES path exits before the
+//! filesystem lookup.
 //!
 //! Gated on both `#[ignore]` and `AIMX_INTEGRATION_SUDO=1` so it only
-//! runs inside the CI step that explicitly elevates.
-//!
-//! Teardown uses a `Drop` guard so `userdel` and the killed serve
-//! subprocess are cleaned up even on assertion failure.
+//! runs inside a CI step that explicitly elevates with `sudo`.
 
 #![cfg(unix)]
 
-use std::io::Read;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::process::{Child, Command, Stdio};
 use std::time::{Duration, Instant};
 
-const ALICE: &str = "aimx-it-alice";
-const BOB: &str = "aimx-it-bob";
+const ALICE: &str = "aimx-test-alice";
+const BOB: &str = "aimx-test-bob";
 
 /// RAII guard: kill the serve subprocess and remove the test users on
 /// drop. Drop runs on assertion failure too, so the CI step stays
@@ -38,12 +44,22 @@ impl Drop for Teardown {
             let _ = child.kill();
             let _ = child.wait();
         }
-        let _ = Command::new("userdel").arg(ALICE).status();
-        let _ = Command::new("userdel").arg(BOB).status();
+        // We do not `userdel` here — the CI workflow owns user
+        // provisioning so re-runs in the same job stay deterministic.
     }
 }
 
-fn useradd(name: &str) {
+fn ensure_user(name: &str) {
+    let already = Command::new("id")
+        .arg(name)
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false);
+    if already {
+        return;
+    }
     let status = Command::new("useradd")
         .arg("--system")
         .arg("--no-create-home")
@@ -52,13 +68,7 @@ fn useradd(name: &str) {
         .arg(name)
         .status()
         .expect("failed to spawn useradd");
-    assert!(
-        status.success() || {
-            let check = Command::new("id").arg(name).status().ok();
-            matches!(check, Some(s) if s.success())
-        },
-        "useradd failed for {name}"
-    );
+    assert!(status.success(), "useradd failed for {name}");
 }
 
 fn aimx_binary_path() -> PathBuf {
@@ -76,9 +86,6 @@ fn wait_for_socket(path: &Path) -> bool {
     false
 }
 
-/// Raw `AIMX/1 SEND` framing. The daemon parses `From:` out of the
-/// body to resolve the sender mailbox and runs authz against the
-/// caller's uid. bob as alice: EACCES.
 fn raw_send_frame(from: &str, to: &str) -> String {
     let body = format!(
         "From: {from}\r\n\
@@ -95,34 +102,41 @@ fn raw_send_frame(from: &str, to: &str) -> String {
     )
 }
 
-/// Raw `AIMX/1 MARK-READ` framing.
-fn raw_mark_frame(mailbox: &str, id: &str) -> String {
+fn raw_mark_frame(verb: &str, mailbox: &str, id: &str) -> String {
     format!(
-        "AIMX/1 MARK-READ\r\nMailbox: {mailbox}\r\nId: {id}\r\nFolder: inbox\r\nContent-Length: 0\r\n\r\n"
+        "AIMX/1 {verb}\r\nMailbox: {mailbox}\r\nId: {id}\r\nFolder: inbox\r\nContent-Length: 0\r\n\r\n"
     )
 }
 
-/// Raw `AIMX/1 HOOK-CREATE` framing with a trivial JSON body. The
-/// template the hook refers to does not need to exist — authz runs
-/// before template resolution per PRD §6.5 (authz mismatch ⇒ EACCES,
-/// unknown mailbox ⇒ ENOENT).
-fn raw_hook_create_frame(mailbox: &str) -> String {
-    let body = "{\"params\":{}}";
+fn raw_hook_create_frame(mailbox: &str, name: &str, cmd: &[&str]) -> String {
+    let cmd_arr: Vec<String> = cmd.iter().map(|s| s.to_string()).collect();
+    let body_json = serde_json::json!({ "cmd": cmd_arr });
+    let body = body_json.to_string();
     format!(
-        "AIMX/1 HOOK-CREATE\r\nMailbox: {mailbox}\r\nEvent: on_receive\r\nTemplate: invoke-claude\r\nContent-Length: {}\r\n\r\n{body}",
+        "AIMX/1 HOOK-CREATE\r\nMailbox: {mailbox}\r\nEvent: on_receive\r\nName: {name}\r\nContent-Length: {}\r\n\r\n{body}",
         body.len()
     )
 }
 
-/// Connect to the socket as `user` via `runuser` + Python, write the
-/// supplied raw frame, read the framed response. Python is the
-/// path-of-least-resistance here because every Ubuntu CI runner ships
-/// `python3` and we avoid adding a separate test helper binary.
-///
-/// The Python script is written to a tempfile (rather than passed via
-/// `-c`) so multi-line `while` loops keep their indentation — `-c` on
-/// some shells collapses newlines into spaces, which breaks Python's
-/// significant whitespace.
+fn raw_hook_delete_frame(name: &str) -> String {
+    format!("AIMX/1 HOOK-DELETE\r\nHook-Name: {name}\r\nContent-Length: 0\r\n\r\n")
+}
+
+fn raw_mailbox_create_frame(name: &str, owner: &str) -> String {
+    format!(
+        "AIMX/1 MAILBOX-CREATE\r\nMailbox: {name}\r\nOwner: {owner}\r\nContent-Length: 0\r\n\r\n"
+    )
+}
+
+fn raw_mailbox_delete_frame(name: &str) -> String {
+    format!("AIMX/1 MAILBOX-DELETE\r\nMailbox: {name}\r\nContent-Length: 0\r\n\r\n")
+}
+
+/// Connect to the socket as `user` (None = current process) via
+/// `runuser` + Python, write the supplied raw frame, read the framed
+/// response. Python is the path-of-least-resistance — every Ubuntu CI
+/// runner ships `python3` and we avoid adding a separate test helper
+/// binary.
 fn send_frame_as(user: Option<&str>, socket: &Path, frame: &[u8]) -> Vec<u8> {
     let script_dir = std::env::temp_dir().join(format!(
         "aimx-uds-authz-py-{}-{}",
@@ -130,10 +144,6 @@ fn send_frame_as(user: Option<&str>, socket: &Path, frame: &[u8]) -> Vec<u8> {
         rand_suffix()
     ));
     std::fs::create_dir_all(&script_dir).unwrap();
-    // Script must be world-readable so the `runuser` target can
-    // execute it. The frame blob is injected as a base64 literal so
-    // arbitrary bytes (including CR/LF and quotes) survive the round
-    // trip through the shell and Python's source parser.
     let b64 = base64_encode(frame);
     let socket_str = socket.display().to_string();
     let py = format!(
@@ -189,8 +199,7 @@ fn rand_suffix() -> u64 {
 }
 
 /// Tiny standalone base64 encoder — integration tests can't pull in
-/// the crate's `base64` dep without adding it to dev-dependencies,
-/// which would drag an extra build for one 20-line helper.
+/// the crate's `base64` dep without adding it to dev-dependencies.
 fn base64_encode(input: &[u8]) -> String {
     const ALPHA: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
     let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
@@ -224,8 +233,6 @@ fn base64_encode(input: &[u8]) -> String {
 
 #[test]
 fn base64_encode_roundtrip_matches_stdlib_reference() {
-    // Quick smoke test so a subtle bit-twiddling bug doesn't silently
-    // corrupt the wire frames the integration test submits.
     assert_eq!(base64_encode(b""), "");
     assert_eq!(base64_encode(b"f"), "Zg==");
     assert_eq!(base64_encode(b"fo"), "Zm8=");
@@ -256,39 +263,69 @@ fn uid_of(name: &str) -> u32 {
         .expect("uid must parse")
 }
 
-#[test]
-#[ignore]
-fn bob_cannot_impersonate_alice_over_uds() {
-    if std::env::var_os("AIMX_INTEGRATION_SUDO").is_none() {
-        eprintln!("AIMX_INTEGRATION_SUDO is not set; skipping (test requires root + user-create).");
-        return;
+/// Per-test fixture: tempdir + running daemon + ready socket. The
+/// `Drop` impl on `Teardown` kills the daemon so test failures don't
+/// leak processes.
+struct Fixture {
+    // Held for its `Drop` side-effect (kills the serve subprocess);
+    // never read directly.
+    #[allow(dead_code)]
+    teardown: Teardown,
+    socket_path: PathBuf,
+    tmp_root: PathBuf,
+}
+
+impl Drop for Fixture {
+    fn drop(&mut self) {
+        // teardown's Drop already runs; just clean the tempdir.
+        let _ = std::fs::remove_dir_all(&self.tmp_root);
     }
+}
+
+fn spin_up_serve() -> Fixture {
     assert_eq!(
         unsafe { libc::geteuid() },
         0,
-        "uds_authz must run as root (AIMX_INTEGRATION_SUDO=1 + sudo)"
+        "uds_authz tests must run as root (AIMX_INTEGRATION_SUDO=1 + sudo)"
     );
 
-    let mut teardown = Teardown { serve: None };
-    useradd(ALICE);
-    useradd(BOB);
-    let alice_uid = uid_of(ALICE);
+    ensure_user(ALICE);
+    ensure_user(BOB);
+    // The catchall system user is named in `config.toml` below; if it's
+    // missing the daemon flags it as orphan.
+    let _ = Command::new("useradd")
+        .arg("--system")
+        .arg("--no-create-home")
+        .arg("--shell")
+        .arg("/usr/sbin/nologin")
+        .arg("aimx-catchall")
+        .status();
 
-    let tmp_root = std::env::temp_dir().join(format!("aimx-uds-authz-{}", std::process::id()));
+    let alice_uid = uid_of(ALICE);
+    let bob_uid = uid_of(BOB);
+
+    let tmp_root = std::env::temp_dir().join(format!(
+        "aimx-uds-authz-{}-{}",
+        std::process::id(),
+        rand_suffix()
+    ));
     std::fs::create_dir_all(&tmp_root).unwrap();
     std::fs::set_permissions(&tmp_root, PermissionsExt::from_mode(0o755)).unwrap();
 
     let data_dir = tmp_root.join("data");
     std::fs::create_dir_all(data_dir.join("inbox")).unwrap();
+    std::fs::create_dir_all(data_dir.join("sent")).unwrap();
     std::fs::set_permissions(&data_dir, PermissionsExt::from_mode(0o755)).unwrap();
     std::fs::set_permissions(data_dir.join("inbox"), PermissionsExt::from_mode(0o755)).unwrap();
+    std::fs::set_permissions(data_dir.join("sent"), PermissionsExt::from_mode(0o755)).unwrap();
 
-    // Pre-create alice's inbox dir with the right ownership so a later
-    // ingest (if any — not strictly needed for authz rejection tests)
-    // has somewhere to drop mail.
-    let alice_inbox = data_dir.join("inbox").join(ALICE);
-    std::fs::create_dir_all(&alice_inbox).unwrap();
-    chown_dir(&alice_inbox, alice_uid, alice_uid);
+    for (user, uid) in [(ALICE, alice_uid), (BOB, bob_uid)] {
+        for sub in ["inbox", "sent"] {
+            let dir = data_dir.join(sub).join(user);
+            std::fs::create_dir_all(&dir).unwrap();
+            chown_dir(&dir, uid, uid);
+        }
+    }
 
     let config_content = format!(
         "domain = \"it.example.com\"\n\
@@ -311,8 +348,6 @@ fn bob_cannot_impersonate_alice_over_uds() {
     std::fs::write(&config_path, &config_content).unwrap();
     std::fs::set_permissions(&config_path, PermissionsExt::from_mode(0o644)).unwrap();
 
-    // Generate a DKIM key pair under AIMX_CONFIG_DIR. `aimx serve`
-    // loads the private key at startup and refuses to run without it.
     let keygen_status = Command::new(aimx_binary_path())
         .env("AIMX_CONFIG_DIR", &tmp_root)
         .env("AIMX_DATA_DIR", &data_dir)
@@ -322,37 +357,14 @@ fn bob_cannot_impersonate_alice_over_uds() {
         .expect("dkim-keygen failed to spawn");
     assert!(keygen_status.success(), "dkim-keygen failed");
 
-    // Pre-create the aimx-catchall system user. The invariant in
-    // `config.toml` above names it as the catchall owner; if the host
-    // doesn't have it, `Config::load` would flag it as orphan and make
-    // the catchall mailbox inactive. That's fine for this test (we
-    // never exercise catchall), but the resolved Config needs to load
-    // cleanly for `aimx serve` to proceed.
-    let _ = Command::new("useradd")
-        .arg("--system")
-        .arg("--no-create-home")
-        .arg("--shell")
-        .arg("/usr/sbin/nologin")
-        .arg("aimx-catchall")
-        .status();
-
-    // Runtime directory holds the aimx.sock. AIMX_RUNTIME_DIR is the
-    // test-friendly override, used by the existing codebase so cargo
-    // test runs don't collide with /run/aimx/.
     let runtime_dir = tmp_root.join("run");
     std::fs::create_dir_all(&runtime_dir).unwrap();
     std::fs::set_permissions(&runtime_dir, PermissionsExt::from_mode(0o755)).unwrap();
 
-    // Bind SMTP on an ephemeral port on loopback; the authz test
-    // never drives inbound so the exact port doesn't matter, it
-    // just needs to bind successfully.
-    //
-    // AIMX_TEST_MAIL_DROP redirects outbound MX delivery to disk so
-    // the root SEND control below doesn't blackhole into the real
-    // internet.
     let mail_drop = tmp_root.join("mail_drop");
     std::fs::create_dir_all(&mail_drop).unwrap();
 
+    let mut teardown = Teardown { serve: None };
     let serve = Command::new(aimx_binary_path())
         .env("AIMX_CONFIG_DIR", &tmp_root)
         .env("AIMX_DATA_DIR", &data_dir)
@@ -373,93 +385,391 @@ fn bob_cannot_impersonate_alice_over_uds() {
         "aimx.sock did not appear at {} within 15s",
         socket_path.display()
     );
-    // World-writable so bob can connect. Matches the production
-    // `0o666` bind mode.
     std::fs::set_permissions(&socket_path, PermissionsExt::from_mode(0o666)).unwrap();
 
-    // --- Attack 1: bob SENDs as alice. Must be EACCES. ---
-    let resp_bytes = send_frame_as(
-        Some(BOB),
-        &socket_path,
+    Fixture {
+        teardown,
+        socket_path,
+        tmp_root,
+    }
+}
+
+fn assert_response_contains(resp: &[u8], needle: &str) {
+    let s = String::from_utf8_lossy(resp);
+    assert!(
+        s.contains(needle),
+        "expected response to contain {needle:?}; got {s:?}"
+    );
+}
+
+fn assert_response_does_not_contain(resp: &[u8], needle: &str) {
+    let s = String::from_utf8_lossy(resp);
+    assert!(
+        !s.contains(needle),
+        "did not expect response to contain {needle:?}; got {s:?}"
+    );
+}
+
+fn integration_gate() -> bool {
+    if std::env::var_os("AIMX_INTEGRATION_SUDO").is_none() {
+        eprintln!("AIMX_INTEGRATION_SUDO is not set; skipping (test requires root + user-create).");
+        return false;
+    }
+    true
+}
+
+// ---------- SEND ----------
+
+#[test]
+#[ignore = "requires two test uids on the host (aimx-test-alice, aimx-test-bob)"]
+fn send_as_owner_ok() {
+    if !integration_gate() {
+        return;
+    }
+    let fx = spin_up_serve();
+    let resp = send_frame_as(
+        Some(ALICE),
+        &fx.socket_path,
         raw_send_frame(
             &format!("{ALICE}@it.example.com"),
             "victim@external.example",
         )
         .as_bytes(),
     );
-    let resp = String::from_utf8_lossy(&resp_bytes);
-    assert!(
-        resp.contains("AIMX/1 ERR EACCES") || resp.contains("Code: EACCES"),
-        "bob SEND as alice must be EACCES; got: {resp:?}"
-    );
+    // OK arrives whether the SMTP delivery succeeded or hit a transport
+    // error — the check we care about is that authz didn't reject. Any
+    // wire frame except `EACCES` proves the verb passed authz.
+    assert_response_does_not_contain(&resp, "EACCES");
+    drop(fx);
+}
 
-    // --- Attack 2: bob MARK-READ's an email in alice's mailbox. Must be EACCES. ---
-    let resp_bytes = send_frame_as(
-        Some(BOB),
-        &socket_path,
-        raw_mark_frame(ALICE, "2026-01-01-nothing").as_bytes(),
-    );
-    let resp = String::from_utf8_lossy(&resp_bytes);
-    assert!(
-        resp.contains("AIMX/1 ERR EACCES") || resp.contains("Code: EACCES"),
-        "bob MARK-READ on alice must be EACCES; got: {resp:?}"
-    );
-
-    // --- Attack 3: bob HOOK-CREATE on alice's mailbox. Must be EACCES. ---
-    let resp_bytes = send_frame_as(
-        Some(BOB),
-        &socket_path,
-        raw_hook_create_frame(ALICE).as_bytes(),
-    );
-    let resp = String::from_utf8_lossy(&resp_bytes);
-    assert!(
-        resp.contains("AIMX/1 ERR EACCES") || resp.contains("Code: EACCES"),
-        "bob HOOK-CREATE on alice must be EACCES; got: {resp:?}"
-    );
-
-    // --- Control: root MARK-READ on alice's (nonexistent) email
-    // returns NOTFOUND rather than EACCES, proving root bypassed the
-    // ownership check. The authz path fires and emits a
-    // `decision="root_bypass"` info log (captured from serve stderr
-    // below). ---
-    let resp_bytes = send_frame_as(None, &socket_path, raw_mark_frame(ALICE, "nope").as_bytes());
-    let resp = String::from_utf8_lossy(&resp_bytes);
-    assert!(
-        resp.contains("AIMX/1 OK")
-            || resp.contains("AIMX/1 ERR NOTFOUND")
-            || resp.contains("Code: NOTFOUND"),
-        "root MARK-READ should bypass authz and hit file-not-found; got: {resp:?}"
-    );
-
-    // Drop the teardown (stops serve + userdels). Stderr of the
-    // serve subprocess captures the structured `aimx::uds` log lines.
-    // We pull them out below before the Drop runs so the `root_bypass`
-    // assertion has something to look at.
-    let mut child = teardown.serve.take().expect("serve child must exist");
-    let _ = child.kill();
-    let mut stderr = String::new();
-    if let Some(mut s) = child.stderr.take() {
-        let _ = s.read_to_string(&mut stderr);
+#[test]
+#[ignore = "requires two test uids on the host (aimx-test-alice, aimx-test-bob)"]
+fn send_as_other_forbidden() {
+    if !integration_gate() {
+        return;
     }
-    if let Some(mut s) = child.stdout.take() {
-        let mut out = String::new();
-        let _ = s.read_to_string(&mut out);
-        // Merge into `stderr` for simpler grepping; both streams can
-        // carry the `tracing` records depending on how the runtime
-        // attaches the subscriber.
-        stderr.push_str(&out);
-    }
-    let _ = child.wait();
-
-    // The root_bypass line is emitted at info level. Accept either
-    // `decision="root_bypass"` (structured field) or the log-line
-    // literal for robustness against subscriber format changes.
-    assert!(
-        stderr.contains("root_bypass") || stderr.contains("root-bypass"),
-        "serve stderr must contain a root_bypass info log; stderr was:\n{stderr}"
+    let fx = spin_up_serve();
+    let resp = send_frame_as(
+        Some(BOB),
+        &fx.socket_path,
+        raw_send_frame(
+            &format!("{ALICE}@it.example.com"),
+            "victim@external.example",
+        )
+        .as_bytes(),
     );
+    assert_response_contains(&resp, "EACCES");
+    drop(fx);
+}
 
-    let _ = std::fs::remove_dir_all(&tmp_root);
-    // teardown.serve is None; remaining Drop only removes users.
-    drop(teardown);
+#[test]
+#[ignore = "requires two test uids on the host (aimx-test-alice, aimx-test-bob)"]
+fn send_as_root_any_ok() {
+    if !integration_gate() {
+        return;
+    }
+    let fx = spin_up_serve();
+    let resp = send_frame_as(
+        None,
+        &fx.socket_path,
+        raw_send_frame(
+            &format!("{ALICE}@it.example.com"),
+            "victim@external.example",
+        )
+        .as_bytes(),
+    );
+    assert_response_does_not_contain(&resp, "EACCES");
+    drop(fx);
+}
+
+// ---------- MARK-READ / MARK-UNREAD ----------
+
+#[test]
+#[ignore = "requires two test uids on the host (aimx-test-alice, aimx-test-bob)"]
+fn mark_read_as_owner_ok_passes_authz() {
+    if !integration_gate() {
+        return;
+    }
+    let fx = spin_up_serve();
+    let resp = send_frame_as(
+        Some(ALICE),
+        &fx.socket_path,
+        raw_mark_frame("MARK-READ", ALICE, "2026-01-01-nothing").as_bytes(),
+    );
+    // The email doesn't exist, so the response is NOTFOUND — but
+    // authz accepted (otherwise we would see EACCES first).
+    assert_response_does_not_contain(&resp, "EACCES");
+    drop(fx);
+}
+
+#[test]
+#[ignore = "requires two test uids on the host (aimx-test-alice, aimx-test-bob)"]
+fn mark_read_as_other_forbidden() {
+    if !integration_gate() {
+        return;
+    }
+    let fx = spin_up_serve();
+    let resp = send_frame_as(
+        Some(BOB),
+        &fx.socket_path,
+        raw_mark_frame("MARK-READ", ALICE, "2026-01-01-nothing").as_bytes(),
+    );
+    assert_response_contains(&resp, "EACCES");
+    drop(fx);
+}
+
+#[test]
+#[ignore = "requires two test uids on the host (aimx-test-alice, aimx-test-bob)"]
+fn mark_read_as_root_any_ok() {
+    if !integration_gate() {
+        return;
+    }
+    let fx = spin_up_serve();
+    let resp = send_frame_as(
+        None,
+        &fx.socket_path,
+        raw_mark_frame("MARK-READ", ALICE, "2026-01-01-nothing").as_bytes(),
+    );
+    assert_response_does_not_contain(&resp, "EACCES");
+    drop(fx);
+}
+
+#[test]
+#[ignore = "requires two test uids on the host (aimx-test-alice, aimx-test-bob)"]
+fn mark_unread_as_owner_ok_passes_authz() {
+    if !integration_gate() {
+        return;
+    }
+    let fx = spin_up_serve();
+    let resp = send_frame_as(
+        Some(ALICE),
+        &fx.socket_path,
+        raw_mark_frame("MARK-UNREAD", ALICE, "2026-01-01-nothing").as_bytes(),
+    );
+    assert_response_does_not_contain(&resp, "EACCES");
+    drop(fx);
+}
+
+#[test]
+#[ignore = "requires two test uids on the host (aimx-test-alice, aimx-test-bob)"]
+fn mark_unread_as_other_forbidden() {
+    if !integration_gate() {
+        return;
+    }
+    let fx = spin_up_serve();
+    let resp = send_frame_as(
+        Some(BOB),
+        &fx.socket_path,
+        raw_mark_frame("MARK-UNREAD", ALICE, "2026-01-01-nothing").as_bytes(),
+    );
+    assert_response_contains(&resp, "EACCES");
+    drop(fx);
+}
+
+#[test]
+#[ignore = "requires two test uids on the host (aimx-test-alice, aimx-test-bob)"]
+fn mark_unread_as_root_any_ok() {
+    if !integration_gate() {
+        return;
+    }
+    let fx = spin_up_serve();
+    let resp = send_frame_as(
+        None,
+        &fx.socket_path,
+        raw_mark_frame("MARK-UNREAD", ALICE, "2026-01-01-nothing").as_bytes(),
+    );
+    assert_response_does_not_contain(&resp, "EACCES");
+    drop(fx);
+}
+
+// ---------- HOOK-CREATE / HOOK-DELETE ----------
+
+#[test]
+#[ignore = "requires two test uids on the host (aimx-test-alice, aimx-test-bob)"]
+fn hook_create_as_owner_ok() {
+    if !integration_gate() {
+        return;
+    }
+    let fx = spin_up_serve();
+    let resp = send_frame_as(
+        Some(ALICE),
+        &fx.socket_path,
+        raw_hook_create_frame(ALICE, "alice_owner_ok", &["/bin/true"]).as_bytes(),
+    );
+    assert_response_contains(&resp, "AIMX/1 OK");
+    drop(fx);
+}
+
+#[test]
+#[ignore = "requires two test uids on the host (aimx-test-alice, aimx-test-bob)"]
+fn hook_create_as_other_forbidden() {
+    if !integration_gate() {
+        return;
+    }
+    let fx = spin_up_serve();
+    let resp = send_frame_as(
+        Some(BOB),
+        &fx.socket_path,
+        raw_hook_create_frame(ALICE, "bob_attempts_alice", &["/bin/true"]).as_bytes(),
+    );
+    assert_response_contains(&resp, "EACCES");
+    drop(fx);
+}
+
+#[test]
+#[ignore = "requires two test uids on the host (aimx-test-alice, aimx-test-bob)"]
+fn hook_create_as_root_any_ok() {
+    if !integration_gate() {
+        return;
+    }
+    let fx = spin_up_serve();
+    let resp = send_frame_as(
+        None,
+        &fx.socket_path,
+        raw_hook_create_frame(ALICE, "root_for_alice", &["/bin/true"]).as_bytes(),
+    );
+    assert_response_contains(&resp, "AIMX/1 OK");
+    drop(fx);
+}
+
+#[test]
+#[ignore = "requires two test uids on the host (aimx-test-alice, aimx-test-bob)"]
+fn hook_delete_as_owner_ok() {
+    if !integration_gate() {
+        return;
+    }
+    let fx = spin_up_serve();
+    // Create a hook as alice first, then delete it as alice.
+    let create = send_frame_as(
+        Some(ALICE),
+        &fx.socket_path,
+        raw_hook_create_frame(ALICE, "alice_to_delete", &["/bin/true"]).as_bytes(),
+    );
+    assert_response_contains(&create, "AIMX/1 OK");
+    let del = send_frame_as(
+        Some(ALICE),
+        &fx.socket_path,
+        raw_hook_delete_frame("alice_to_delete").as_bytes(),
+    );
+    assert_response_contains(&del, "AIMX/1 OK");
+    drop(fx);
+}
+
+#[test]
+#[ignore = "requires two test uids on the host (aimx-test-alice, aimx-test-bob)"]
+fn hook_delete_as_other_forbidden() {
+    if !integration_gate() {
+        return;
+    }
+    let fx = spin_up_serve();
+    // Create a hook as alice, then bob tries to delete it.
+    let create = send_frame_as(
+        Some(ALICE),
+        &fx.socket_path,
+        raw_hook_create_frame(ALICE, "alice_owned_hook", &["/bin/true"]).as_bytes(),
+    );
+    assert_response_contains(&create, "AIMX/1 OK");
+    let del = send_frame_as(
+        Some(BOB),
+        &fx.socket_path,
+        raw_hook_delete_frame("alice_owned_hook").as_bytes(),
+    );
+    assert_response_contains(&del, "EACCES");
+    drop(fx);
+}
+
+#[test]
+#[ignore = "requires two test uids on the host (aimx-test-alice, aimx-test-bob)"]
+fn hook_delete_as_root_any_ok() {
+    if !integration_gate() {
+        return;
+    }
+    let fx = spin_up_serve();
+    let create = send_frame_as(
+        Some(ALICE),
+        &fx.socket_path,
+        raw_hook_create_frame(ALICE, "alice_owned_for_root", &["/bin/true"]).as_bytes(),
+    );
+    assert_response_contains(&create, "AIMX/1 OK");
+    let del = send_frame_as(
+        None,
+        &fx.socket_path,
+        raw_hook_delete_frame("alice_owned_for_root").as_bytes(),
+    );
+    assert_response_contains(&del, "AIMX/1 OK");
+    drop(fx);
+}
+
+// ---------- MAILBOX-CREATE / MAILBOX-DELETE ----------
+
+#[test]
+#[ignore = "requires two test uids on the host (aimx-test-alice, aimx-test-bob)"]
+fn mailbox_create_root_ok() {
+    if !integration_gate() {
+        return;
+    }
+    let fx = spin_up_serve();
+    let resp = send_frame_as(
+        None,
+        &fx.socket_path,
+        raw_mailbox_create_frame("freshmbx", ALICE).as_bytes(),
+    );
+    assert_response_contains(&resp, "AIMX/1 OK");
+    drop(fx);
+}
+
+#[test]
+#[ignore = "requires two test uids on the host (aimx-test-alice, aimx-test-bob)"]
+fn mailbox_create_non_root_forbidden() {
+    if !integration_gate() {
+        return;
+    }
+    let fx = spin_up_serve();
+    let resp = send_frame_as(
+        Some(ALICE),
+        &fx.socket_path,
+        raw_mailbox_create_frame("alicemade", ALICE).as_bytes(),
+    );
+    assert_response_contains(&resp, "EACCES");
+    drop(fx);
+}
+
+#[test]
+#[ignore = "requires two test uids on the host (aimx-test-alice, aimx-test-bob)"]
+fn mailbox_delete_root_ok() {
+    if !integration_gate() {
+        return;
+    }
+    let fx = spin_up_serve();
+    // Create then delete as root.
+    let create = send_frame_as(
+        None,
+        &fx.socket_path,
+        raw_mailbox_create_frame("ephemeral", ALICE).as_bytes(),
+    );
+    assert_response_contains(&create, "AIMX/1 OK");
+    let del = send_frame_as(
+        None,
+        &fx.socket_path,
+        raw_mailbox_delete_frame("ephemeral").as_bytes(),
+    );
+    assert_response_contains(&del, "AIMX/1 OK");
+    drop(fx);
+}
+
+#[test]
+#[ignore = "requires two test uids on the host (aimx-test-alice, aimx-test-bob)"]
+fn mailbox_delete_non_root_forbidden() {
+    if !integration_gate() {
+        return;
+    }
+    let fx = spin_up_serve();
+    let resp = send_frame_as(
+        Some(ALICE),
+        &fx.socket_path,
+        raw_mailbox_delete_frame(ALICE).as_bytes(),
+    );
+    assert_response_contains(&resp, "EACCES");
+    drop(fx);
 }

--- a/tests/uds_authz.rs
+++ b/tests/uds_authz.rs
@@ -123,13 +123,14 @@ fn raw_hook_delete_frame(name: &str) -> String {
 }
 
 fn raw_mailbox_create_frame(name: &str, owner: &str) -> String {
-    format!(
-        "AIMX/1 MAILBOX-CREATE\r\nMailbox: {name}\r\nOwner: {owner}\r\nContent-Length: 0\r\n\r\n"
-    )
+    // The MAILBOX-CREATE / MAILBOX-DELETE codec uses `Name:` for the
+    // mailbox-name header (see src/send_protocol.rs::parse_mailbox_crud_headers).
+    // Other verbs use `Mailbox:`; do not unify.
+    format!("AIMX/1 MAILBOX-CREATE\r\nName: {name}\r\nOwner: {owner}\r\nContent-Length: 0\r\n\r\n")
 }
 
 fn raw_mailbox_delete_frame(name: &str) -> String {
-    format!("AIMX/1 MAILBOX-DELETE\r\nMailbox: {name}\r\nContent-Length: 0\r\n\r\n")
+    format!("AIMX/1 MAILBOX-DELETE\r\nName: {name}\r\nContent-Length: 0\r\n\r\n")
 }
 
 /// Connect to the socket as `user` (None = current process) via


### PR DESCRIPTION
## Summary

Wires per-verb `SO_PEERCRED` authorization into every UDS handler in `aimx serve` and un-stubs `HOOK-CREATE` / `HOOK-DELETE` under the new authz predicate. The wire policy is now a uniform "caller uid owns the target mailbox, OR is root" check for `SEND`, `MARK-*`, `HOOK-*`, with `MAILBOX-CREATE` / `MAILBOX-DELETE` tightened to root-only.

### What landed

- **Plumbing.** `serve.rs`'s accept loop already captured `SO_PEERCRED` via `caller_from_stream` and threaded the resolved `Caller` into every dispatch. `send_handler`, `state_handler`, and `mailbox_handler` already enforced authz via `enforce_mailbox_owner_or_root` / `enforce_root`. This change closes the remaining gap: the hook handlers are no longer stubbed.
- **`hook_handler.rs` rewrite.** The `ERR PROTOCOL hook-X over UDS is not supported in this build` stubs are gone. The new handlers:
  - Resolve the target mailbox up front and run `enforce_mailbox_owner_or_root` before any state mutation.
  - Reject hooks on the catchall mailbox (defense in depth around the existing load-time rejection).
  - Parse the body as a JSON object with `serde(deny_unknown_fields)`, so legacy `template`, `params`, `run_as`, `origin`, `dangerously_support_untrusted` payloads reject with `ERR PROTOCOL` at body parse — symmetric with `Config::load`.
  - Build a `Hook` struct, validate via `validate_single_hook` then `validate_hooks`, then write `config.toml` atomically and swap `ConfigHandle` — same lock hierarchy as `MAILBOX-CRUD` (outer per-mailbox lock, inner `CONFIG_WRITE_LOCK`).
- **Salvaged CLI integration tests.** Two of the 23 `#[ignore = \"exercises legacy template/hook schema; reworked in a later sprint\"]` tests in `tests/integration.rs` (`hooks_create_and_list_roundtrip_direct_edit`, `hooks_create_rejects_invalid_name`) un-ignored and re-fitted to the JSON-array `--cmd` shape. The rest stay ignored because they exercise removed surfaces (template MCP tools, catchall hooks, `dangerously_support_untrusted`).
- **`tests/uds_authz.rs` rewrite.** Reworked from a single bob-vs-alice probe into a per-verb × per-outcome matrix: `send_as_owner_ok`, `send_as_other_forbidden`, `send_as_root_any_ok`, the same shape for `MARK-READ`, `MARK-UNREAD`, `HOOK-CREATE`, `HOOK-DELETE`, plus `_root_ok` / `_non_root_forbidden` for `MAILBOX-CREATE` / `MAILBOX-DELETE`. Renamed test users to `aimx-test-alice` / `aimx-test-bob` so the test shares user provisioning with `mailbox_isolation`.
- **CI.** `mailbox-dir-perms-isolation` job extended with a `Run UDS authz tests (under sudo)` step that builds and runs the rewritten `uds_authz` test under root with `AIMX_INTEGRATION_SUDO=1`.

### Pre-launch breaking change

`MAILBOX-CREATE` / `MAILBOX-DELETE` over UDS now require root. Previously any local user could submit them. Pre-launch operators relying on the old behavior must invoke `sudo aimx mailboxes create | delete` (which already exists) or the daemon will reject with `ERR EACCES`.

### Wire shape — `HOOK-CREATE` body

```json
{
  \"cmd\": [\"/bin/echo\", \"hi\"],
  \"fire_on_untrusted\": false,
  \"type\": \"cmd\"
}
```

`fire_on_untrusted` and `type` are optional (defaults `false` and `\"cmd\"`). Any other key — including the removed `template`, `params`, `run_as`, `origin`, `dangerously_support_untrusted` — rejects with `ERR PROTOCOL`.

## Test plan

- [x] `cargo test` — 895 unit + 80 integration + 1 release-integration + 1 base64 helper, 0 failed.
- [x] `cargo clippy --all-targets -- -D warnings` clean on `aimx` root crate.
- [x] `cargo fmt -- --check` clean on `aimx` root crate.
- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean on `services/verifier`.
- [x] `tests/uds_authz.rs` — 19 ignored tests cover the SEND × {owner / other / root} + MARK × {2 verbs × 3 outcomes} + HOOK × {2 verbs × 3 outcomes} + MAILBOX × {2 verbs × 2 outcomes} matrix; gated behind `AIMX_INTEGRATION_SUDO=1`.
- [ ] Verify the new CI step `Run UDS authz tests (under sudo)` runs green when this PR builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)