### PR TITLE
Rewrite book chapters for owner-first model; run end-to-end smoke

### DIFF
--- a/book/agent-integration.md
+++ b/book/agent-integration.md
@@ -1,6 +1,6 @@
 # Agent Integration
 
-`aimx agents setup <agent>` is the one command that wires an AI agent into aimx. It installs the agent's plugin/skill package under the caller's `$HOME`, probes `$PATH` for the agent binary, and registers a matching hook template (`invoke-<agent>-<username>`) over the daemon's UDS socket so the agent can immediately create `on_receive` / `after_send` hooks via MCP. No sudo, no manual config edit, no second `aimx setup` run. When you are done, `aimx agents remove <agent>` removes what was installed.
+`aimx agents setup <agent>` is the one command that wires an AI agent into aimx. It installs the agent's plugin/skill package under the caller's `$HOME` so the agent can call aimx's MCP tools and (when the operator asks it to) create `on_receive` / `after_send` hooks via MCP. No sudo, no manual config edit, no second `aimx setup` run. When you are done, `aimx agents remove <agent>` removes what was installed.
 
 > **Names.** `aimx agents` (plural noun, with `setup` / `remove` / `list` verbs) matches the rest of the CLI's CRUD shape (`aimx mailboxes`, `aimx hooks`).
 
@@ -16,20 +16,16 @@ What this does, in order:
 
 1. **Refuse root.** `sudo aimx agents setup ...` is rejected. Run it as the user whose agent you are configuring.
 2. **Install plugin files.** The plugin tree embedded in the `aimx` binary is written under the agent's per-user destination (e.g. `~/.claude/plugins/aimx/`). File mode `0o644`, directory mode `0o755`.
-3. **Probe `$PATH`.** aimx walks `$PATH` in order looking for the agent's canonical binary name (for example `claude` for `claude-code`). First match wins.
-4. **Register the template.** aimx connects to `/run/aimx/aimx.sock` and submits a `TEMPLATE-CREATE` verb. The template is named `invoke-<agent>-<username>` (e.g. `invoke-claude-alice`), carries `cmd = [<found_path>, ...<spec args>]`, and sets `run_as` to the caller's username. The daemon hot-swaps its in-memory config so the template is live immediately — no SIGHUP, no restart.
-5. **Print confirmation.** The installer prints a single line confirming the template registration (plus any activation hint the agent requires, such as a `claude mcp add` command).
+3. **Print activation hint.** The installer prints any external command the agent still needs (such as a `claude mcp add` command) so MCP discovery picks up the new server.
 
 Example output for alice running `aimx agents setup claude-code`:
 
 ```text
 Installed plugin files to /home/alice/.claude/plugins/aimx/
-Template invoke-claude-alice registered
-  cmd:     /home/alice/.local/bin/claude -p {prompt}
-  run_as:  alice
+Next: run `claude mcp add --scope user aimx /usr/local/bin/aimx mcp` and restart Claude Code.
 ```
 
-After this, alice can create hooks via MCP by referencing `invoke-claude-alice` — no operator intervention required.
+After this, alice's agent can call aimx's MCP tools (including `hook_create` / `hook_list` / `hook_delete`) for any mailbox alice owns. The bundled plugin includes a "Wiring yourself up as a mailbox hook" section with the verified `cmd` argv to use with `hook_create` — the agent reads its own skill at session start and writes its own `cmd` recipe at hook-creation time, no operator intervention required.
 
 ## Discovering supported agents
 
@@ -72,9 +68,9 @@ Under `AIMX_NONINTERACTIVE=1`, the drop-through is skipped (no TTY is assumed).
 - **Runs as the current user.** `aimx agents setup` refuses to run as root by default.
 - **`--dangerously-allow-root` escape hatch.** For single-user root-login VPS setups that have no separate operator account, pass `--dangerously-allow-root` to wire aimx into `/root`'s home. The flag applies uniformly to the TUI, per-agent runs, and `--no-interactive`. It is **never** passed implicitly by the `aimx setup` drop-through — you must opt in by hand. On any machine with a regular user, prefer `sudo -u <user> aimx agents setup` instead.
 - **Writes only to `$HOME`.** Nothing under `/etc` or `/var` is touched by the plugin-install step.
-- **Template registration uses UDS `SO_PEERCRED`.** The daemon reads the caller's uid directly from the socket; the `run_as` of the registered template must equal the caller's username. This is how isolation between users is enforced — alice cannot register a template that runs as bob.
+- **Hook authorization is by mailbox ownership.** When the agent later calls `hook_create`, the daemon reads the caller's uid via `SO_PEERCRED` and accepts the request only if the caller owns the target mailbox (or is root). Hooks always exec as the mailbox's owner uid — there is no per-hook `run_as` override.
 - **Offline.** The plugin tree is embedded at compile time. No network access is required.
-- **Idempotent re-runs.** Re-running `aimx agents setup <agent>` with `--force` overwrites existing plugin files. Use `--redetect` to re-probe `$PATH` and refresh `cmd[0]` if your agent binary moved. Use `--no-template` to skip the template-registration step entirely (plugin-install only).
+- **Idempotent re-runs.** Re-running `aimx agents setup <agent>` with `--force` overwrites existing plugin files.
 
 ## Flags
 
@@ -84,20 +80,16 @@ Under `AIMX_NONINTERACTIVE=1`, the drop-through is skipped (no TTY is assumed).
 | `--no-interactive` | Skip the checkbox TUI when no agent is named; print the same plain registry dump as `--list`. Intended for scripting. |
 | `--dangerously-allow-root` | Footgun. Bypass the root-refusal check and wire aimx into `/root`'s home. Applies uniformly across the TUI, per-agent runs, and `--no-interactive`. See Key properties above. |
 | `--force` | Overwrite existing destination files without prompting. |
-| `--print` | Print plugin contents to stdout instead of writing to disk. Useful for CI and dry runs. Also prints the template that would be registered. |
-| `--no-template` | Skip the `$PATH` probe and `TEMPLATE-CREATE` step. Plugin-install only. |
-| `--redetect` | Re-probe `$PATH` and refresh an existing `invoke-<agent>-<username>` template's `cmd[0]` if the binary moved. |
+| `--print` | Print plugin contents to stdout instead of writing to disk. Useful for CI and dry runs. |
 | `--data-dir <path>` | Global flag. If aimx was set up with a non-default data directory, pass this so the plugin's MCP command is rewritten to include `--data-dir`. |
 
 ## Removing an agent: `aimx agents remove`
 
-`aimx agents remove <agent>` is the inverse of `aimx agents setup`. It runs per-user and refuses root. The command always removes both the plugin files under `$HOME` and the matching `invoke-<agent>-<caller_username>` template over UDS, then prints an agent-specific cleanup hint pointing at any external command you still need to run (for example `claude mcp remove aimx`).
+`aimx agents remove <agent>` is the inverse of `aimx agents setup`. It runs per-user and refuses root. The command removes the plugin files under `$HOME` and prints an agent-specific cleanup hint pointing at any external command you still need to run (for example `claude mcp remove aimx`).
 
 ```bash
 aimx agents remove claude-code
 ```
-
-If the daemon is down (`/run/aimx/aimx.sock` is missing), the plugin files are still removed and the command prints: "daemon unreachable; run `sudo aimx hooks prune --orphans` after restarting to clean up templates." The command exits `2` so scripts can detect the partial cleanup.
 
 ## Supported agents
 
@@ -113,23 +105,13 @@ If the daemon is down (`/run/aimx/aimx.sock` is missing), the plugin files are s
 
 > **Progressive disclosure.** Every agent receives the same canonical aimx primer (`agents/common/aimx-primer.md`). Agents with multi-file skill directories (Claude Code, Codex CLI, OpenClaw, Hermes) also receive `agents/common/references/` as siblings so detailed material loads on demand without bloating the initial context. Single-file agents (OpenCode, Gemini CLI, Goose) receive the primer inline. The `references/` content remains available in the aimx source tree and at `/var/lib/aimx/README.md`.
 
-### Template naming and mapping
+### Per-agent hook recipes
 
-Every template registered by `aimx agents setup` follows the pattern `invoke-<agent>-<username>`. Mapping of agent → template prefix:
+The plugin bundle for each agent ships a "Wiring yourself up as a mailbox hook" section with a copy-paste `cmd` argv. The agent reads its own skill and writes the recipe at hook-creation time — see [Hook Recipes](hook-recipes.md) for the verified invocations.
 
-| Agent | Template name |
-|-------|---------------|
-| `claude-code` | `invoke-claude-<username>` |
-| `codex` | `invoke-codex-<username>` |
-| `opencode` | `invoke-opencode-<username>` |
-| `gemini` | `invoke-gemini-<username>` |
-| `goose` | `invoke-goose-<username>` |
-| `openclaw` | `invoke-openclaw-<username>` |
-| `hermes` | `invoke-hermes-<username>` |
+On a multi-user host, alice and bob each install their own per-`$HOME` copy of the plugin, and each can call `hook_create` only on the mailboxes they own — the daemon enforces ownership via `SO_PEERCRED` on every UDS request.
 
-On a host where alice and bob each run `aimx agents setup claude-code`, the daemon carries both `invoke-claude-alice` and `invoke-claude-bob`. `hook_list_templates` returns only the templates whose `run_as` equals the caller's username, so alice's MCP sees `invoke-claude-alice` and bob's sees `invoke-claude-bob` — never each other's.
-
-See [MCP Server § Hook template tools](mcp.md#hook-template-tools) for the full tool reference.
+See [MCP Server § Hook tools](mcp.md#hook-tools) for the full tool reference.
 
 ### Claude Code
 
@@ -440,21 +422,9 @@ tools.
 
 ## Troubleshooting
 
-### `Could not find <binary> in $PATH`
+### Agent binary not found at runtime
 
-The `$PATH` probe did not find the agent's canonical binary. Install the agent CLI first (for example `npm install -g @anthropic-ai/claude-code` for Claude Code), confirm it lands in a directory on your `$PATH`, then re-run `aimx agents setup <agent>`. If the binary is installed but the probe still misses it (shell alias, non-`$PATH` location), open a fresh shell so the login `$PATH` is in effect, or temporarily `export PATH="$HOME/.local/bin:$PATH"` before re-running.
-
-### `aimx serve is not running; start it and re-run aimx agents setup <agent>`
-
-The UDS socket at `/run/aimx/aimx.sock` is missing. Start the daemon with `sudo systemctl start aimx` (or `sudo rc-service aimx start` on Alpine) and re-run `aimx agents setup <agent>`. The template-registration step is all-or-nothing for v1: if the daemon is down, the plugin files are still written but no template is registered.
-
-### `template-already-exists: invoke-<agent>-<username>`
-
-You already ran `aimx agents setup <agent>` on this host. There are three paths forward:
-
-- **Change nothing.** The existing template is still registered and working; nothing to do.
-- **Refresh `cmd[0]`** (your agent binary moved): run `aimx agents setup <agent> --redetect`. This re-probes `$PATH` and updates the existing template's `cmd[0]` to the current path.
-- **Replace entirely.** Run `aimx agents remove <agent>` first to drop the existing template, then `aimx agents setup <agent>` again to register a fresh one.
+When the agent later fires as a hook, the daemon `exec`s the absolute path you wrote into the hook's `cmd[0]`. If that path doesn't exist, the hook log shows `exit_code = -1` with `spawn-failed`. Run `which <agent>` on the host as the mailbox owner to confirm the binary's path, then re-create the hook with the corrected `cmd[0]` (`aimx hooks delete <name>` followed by `aimx hooks create --cmd ...`).
 
 ### The agent does not see aimx after `agents setup` runs
 

--- a/book/cli.md
+++ b/book/cli.md
@@ -59,7 +59,7 @@ See [Setup: End-to-end verification](setup.md#end-to-end-verification).
 
 ### `aimx doctor`
 
-Print server health: configuration path, mailbox counts and unread counts, a per-mailbox table (Mailbox, Address, Total, Unread, Trust, Senders, Hooks), DKIM key presence, SMTP service state, DNS record verification, and a pointer to `aimx logs` for recent service logs.
+Print server health: configuration path, mailbox counts and unread counts, a per-mailbox table (Mailbox, Address, Total, Unread, Trust, Senders, Hooks), an Ownership section listing each mailbox's `owner` and whether the owner uid resolves on the host, DKIM key presence, SMTP service state, DNS record verification, and a pointer to `aimx logs` for recent service logs. Exits non-zero when any mailbox has an unresolvable owner so monitoring can detect orphans.
 
 No flags.
 
@@ -78,11 +78,13 @@ Tail or follow the `aimx serve` service log. Wraps `journalctl -u aimx` on syste
 
 ### `aimx send`
 
-Compose an RFC 5322 message and submit it to `aimx serve` via `/run/aimx/aimx.sock`. Does not require root. The daemon handles DKIM signing and MX delivery.
+Compose an RFC 5322 message and submit it to `aimx serve` via `/run/aimx/aimx.sock`. Refuses root. The daemon handles DKIM signing and MX delivery.
+
+The caller's euid must own the mailbox resolved from the `From:` local part. The daemon parses `From:` from the submitted body itself (no client-supplied `From-Mailbox:` header) and rejects sends whose mailbox owner does not match the caller with `not authorized: <local_part>@<domain>` (exit code 1). The catchall (`*@domain`) is inbound-only and is never accepted as an outbound sender.
 
 | Flag | Description |
 |------|-------------|
-| `--from <addr>` | Sender address. Must resolve to an explicitly configured (non-wildcard) mailbox. |
+| `--from <addr>` | Sender address. Must resolve to an explicitly configured (non-wildcard) mailbox owned by the caller. |
 | `--to <addr>` | Recipient address. |
 | `--subject <text>` | Subject line. |
 | `--body <text>` | Plain-text body. |
@@ -106,23 +108,27 @@ Alias: `aimx mailbox` works identically to `aimx mailboxes`.
 
 ### `aimx mailboxes create <name>`
 
-Create a mailbox registering `<name>@<domain>` and directories under `inbox/<name>/` and `sent/<name>/`. Hot-reloaded by the daemon; no restart needed.
+Create a mailbox registering `<name>@<domain>` and directories under `inbox/<name>/` and `sent/<name>/` chowned `<owner>:<owner> 0700`. **Requires root** — non-root callers are rejected with exit code 2. The daemon hot-reloads the new mailbox; no restart needed. The `MAILBOX-CREATE` UDS verb is also root-only (per-verb `SO_PEERCRED` check). The reserved literals `catchall` and `aimx-catchall` are rejected with `Validation: reserved`.
 
 | Flag | Description |
 |------|-------------|
-| `--owner <user>` | Linux user that owns the mailbox's storage. When omitted, the CLI prompts (defaulting to `<name>` if a user with that name already exists). Under `AIMX_NONINTERACTIVE=1` the default is accepted when available, otherwise the command errors hard so scripted installs fail fast. |
+| `--owner <user>` | Linux user that owns the mailbox's storage and runs hooks. Required (the CLI prompts when omitted, defaulting to `<name>` if a user with that name already exists). Under `AIMX_NONINTERACTIVE=1` the default is accepted when available, otherwise the command errors hard so scripted installs fail fast. The user must resolve via `getpwnam(3)` on this host. |
 
 ### `aimx mailboxes list`
 
-List all mailboxes with addresses, total count, and unread count.
+List mailboxes you own. Prints addresses, total count, and unread count. Non-root callers see only mailboxes whose owner uid matches their euid; the catchall is filtered out unless the caller is root or `aimx-catchall`.
+
+| Flag | Description |
+|------|-------------|
+| `--all` | Root only. List every mailbox regardless of owner. Non-root callers passing `--all` get `--all requires root`. |
 
 ### `aimx mailboxes show <name>`
 
-Print a mailbox's address, effective trust policy, `trusted_senders`, configured hooks grouped by event, and inbox / sent / unread counts.
+Print a mailbox's address, owner, effective trust policy, `trusted_senders`, configured hooks grouped by event, and inbox / sent / unread counts. Non-root callers may only inspect mailboxes they own.
 
 ### `aimx mailboxes delete <name>`
 
-Delete a mailbox. Refuses non-empty mailboxes with `ERR NONEMPTY` unless `--force` is passed. `catchall` cannot be deleted.
+Delete a mailbox. **Requires root** (matching `MAILBOX-DELETE` UDS authorization). Refuses non-empty mailboxes with `ERR NONEMPTY` unless `--force` is passed. `catchall` cannot be deleted.
 
 | Flag | Description |
 |------|-------------|
@@ -135,58 +141,47 @@ See [Mailboxes: Managing mailboxes](mailboxes.md#managing-mailboxes).
 
 Alias: `aimx hook` works identically to `aimx hooks`.
 
+Authorization: caller must own the target mailbox, or be root. Non-root callers operating on mailboxes they own use the daemon's UDS socket so changes hot-swap into the running config; the daemon verifies ownership via `SO_PEERCRED` and rejects with `EACCES not authorized` otherwise. Root with the daemon stopped falls back to a direct `config.toml` edit + restart hint; non-root with the daemon stopped hard-errors (cannot write the root-owned config).
+
 ### `aimx hooks list`
 
-List hooks. Prints a table of `NAME`, `MAILBOX`, `EVENT`, `ORIGIN`, `CMD`. Anonymous hooks (those without an explicit `name =`) appear under their derived 12-char hex name. Template-bound hooks show a blank `CMD` column; see `aimx hooks templates` for their argv shape.
+List hooks. Non-root callers see only hooks on mailboxes they own. Prints a table of `NAME`, `MAILBOX`, `EVENT`, `CMD`. Anonymous hooks (those without an explicit `name =`) appear under their derived 12-char hex name.
 
 | Flag | Description |
 |------|-------------|
-| `--mailbox <name>` | Filter to one mailbox. |
-
-### `aimx hooks templates`
-
-List hook templates enabled on this install. Prints a table of `NAME`, `DESCRIPTION`, `PARAMS`, `EVENTS`. Alias: `aimx hooks template-list`.
-
-Empty output means no templates are enabled — run `sudo aimx setup` and tick the templates you want.
+| `--mailbox <name>` | Filter to one mailbox you own. |
+| `--all` | Root only. List hooks on every mailbox. |
 
 ### `aimx hooks create`
 
-Create a hook. Exactly one of `--template` or `--cmd` must be supplied.
-
-**Template path (preferred).** `--template` + `--param` submit the request over the daemon's UDS socket. The daemon validates the template exists, all params are declared, the event is allowed, and stamps `origin = "mcp"` on the resulting hook. No root required when the daemon is running.
-
-**Raw-cmd path (power user).** `--cmd` writes `/etc/aimx/config.toml` directly and SIGHUPs the daemon to hot-reload. Requires `sudo`. Stamps `origin = "operator"`.
+Create a hook. `--cmd` takes the argv as a JSON array string; `cmd[0]` must be an absolute path.
 
 | Flag | Description |
 |------|-------------|
-| `--mailbox <name>` | Owning mailbox. Must already exist. |
+| `--mailbox <name>` | Owning mailbox. Must already exist and be owned by the caller (or caller is root). |
 | `--event <event>` | `on_receive` or `after_send`. |
-| `--template <name>` | Bind to a `[[hook_template]]`. Mutually exclusive with `--cmd`. |
-| `--param KEY=VAL` | Declared parameter value for the template. Repeatable. |
-| `--cmd <command>` | Raw shell command executed via `sh -c` when the hook fires. Requires `sudo`. Mutually exclusive with `--template`. |
+| `--cmd <json-array>` | Argv exec'd directly when the hook fires. Required. JSON array string with `cmd[0]` as an absolute path. No shell wrapping — wrap in `["/bin/sh", "-c", "..."]` explicitly when you need shell expansion. |
+| `--stdin <mode>` | `email` (default) pipes the raw `.md` to the hook's stdin; `none` closes stdin immediately. |
+| `--timeout-secs <N>` | Hard subprocess timeout. Default `60`, range `[1, 600]`. SIGTERM at the limit, SIGKILL 5s later. |
+| `--fire-on-untrusted` | Fire even when `trusted != "true"`. Only valid on `--event on_receive`. Rejected on `--event after_send`. |
 | `--name <name>` | Optional. Matches `^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$`. Must be globally unique across all mailboxes. When omitted, a derived 12-char hex name is used. |
-| `--dangerously-support-untrusted` | Fire even when `trusted != "true"`. Only valid on `--event on_receive` + `--cmd`. Rejected with `--template` because MCP-origin hooks cannot opt into untrusted mail. |
 
-Examples:
+Example (as the mailbox owner — no sudo needed when the daemon is running):
 
 ```bash
-# Template hook (agent-origin, safe over UDS)
 aimx hooks create \
   --mailbox accounts \
   --event on_receive \
-  --template invoke-claude \
-  --param prompt="File this and draft a reply."
-
-# Raw-cmd hook (operator-origin, needs sudo)
-sudo aimx hooks create \
-  --mailbox support \
-  --event on_receive \
-  --cmd 'curl -fsS https://hooks.example.com/notify -d "$AIMX_SUBJECT"'
+  --cmd '["/usr/local/bin/claude", "-p", "Read the piped email and act on it.", "--dangerously-skip-permissions"]' \
+  --stdin email \
+  --name accounts_claude
 ```
+
+See [Hook Recipes](hook-recipes.md) for verified per-agent invocations.
 
 ### `aimx hooks delete <name>`
 
-Delete a hook by name. Works for both explicit and derived names (as shown in `aimx hooks list`). Operator-origin hooks require `sudo`; MCP-origin hooks go through the UDS socket.
+Delete a hook by name. Works for both explicit and derived names (as shown in `aimx hooks list`). Authorization is the same as `create`: caller must own the hook's mailbox, or be root.
 
 | Flag | Description |
 |------|-------------|
@@ -204,7 +199,9 @@ No flags. See [MCP Server](mcp.md).
 
 ### `aimx agents setup [agent]`
 
-Install the aimx plugin / skill for a supported agent into the current user's config directory, probe `$PATH` for the agent binary, and register an `invoke-<agent>-<username>` hook template over the daemon's UDS. Refuses to run as root. Run with no arguments to launch the interactive checkbox TUI; pass `--list` (or call `aimx agents list`) to print the supported-agent registry and exit without installing.
+Install the aimx plugin / skill for a supported agent into the current user's config directory. Refuses to run as root. Run with no arguments to launch the interactive checkbox TUI; pass `--list` (or call `aimx agents list`) to print the supported-agent registry and exit without installing.
+
+The plugin bundle teaches the agent how to call aimx's MCP tools and includes a "Wiring yourself up as a mailbox hook" section with the verified `cmd` argv to use with [`aimx hooks create`](#aimx-hooks-create).
 
 | Flag | Description |
 |------|-------------|
@@ -213,9 +210,7 @@ Install the aimx plugin / skill for a supported agent into the current user's co
 | `--no-interactive` | Skip the TUI when no agent is named; print the same plain registry dump. Intended for scripting. |
 | `--dangerously-allow-root` | Footgun. Bypass the root-refusal check and wire aimx into `/root`'s home. Prefer `sudo -u <user> aimx agents setup` on any machine with a regular user. |
 | `--force` | Overwrite existing destination files without prompting. |
-| `--print` | Print the plugin contents and the template that would be registered to stdout instead of writing to disk. |
-| `--no-template` | Install plugin files only; skip the `$PATH` probe and `TEMPLATE-CREATE` over UDS. |
-| `--redetect` | Re-probe `$PATH` and update the existing `invoke-<agent>-<username>` template's `cmd[0]` (for when the agent binary moved). |
+| `--print` | Print the plugin contents to stdout instead of writing to disk. |
 
 See [Agent Integration](agent-integration.md) for per-agent activation steps.
 
@@ -225,7 +220,7 @@ Print the supported-agent registry as a plain table (agent name, destination pat
 
 ### `aimx agents remove <agent>`
 
-Inverse of `aimx agents setup`. Removes the plugin files under `$HOME` and submits `TEMPLATE-DELETE` for `invoke-<agent>-<caller_username>` to the daemon. Refuses to run as root. When the daemon is unreachable, plugin files are still removed and the command exits `2` with a pointer to `sudo aimx hooks prune --orphans`.
+Inverse of `aimx agents setup`. Removes the plugin files under `$HOME`. Refuses to run as root.
 
 | Flag | Description |
 |------|-------------|

--- a/book/configuration.md
+++ b/book/configuration.md
@@ -40,7 +40,7 @@ This changes where `config.toml` and the DKIM keypair (`dkim/private.key`, `dkim
 | `AIMX_TEST_MAIL_DROP` | *(unset)* | When set to a directory path, `aimx serve` writes every outbound submission to that directory instead of delivering via SMTP. The daemon logs a startup warning so it cannot be left on in production by accident. |
 | `NO_COLOR` | *(unset)* | Standard convention. When set to any value, aimx CLI output disables ANSI color. |
 
-Hook commands receive additional `AIMX_*` env vars carrying the triggering email's header fields. See [Hooks & Trust: Hook context](hooks.md#hook-context-env-vars-and-placeholders).
+Hook commands receive additional `AIMX_*` env vars carrying the triggering email's header fields. See [Hooks & Trust: Hook context](hooks.md#hook-context-env-vars-and-stdin).
 
 ## Settings reference
 
@@ -71,9 +71,12 @@ Mailboxes are defined under `[mailboxes.<name>]`:
 | Setting | Type | Default | Description |
 |---------|------|---------|-------------|
 | `address` | string | *(required)* | Email address pattern (e.g. `support@domain.com` or `*@domain.com` for catchall) |
+| `owner` | string | *(required)* | Linux username that owns the mailbox storage and runs hooks. Must resolve via `getpwnam(3)` at config load. The reserved username `aimx-catchall` is used for catchall mailboxes (created on demand by `aimx setup`); the reserved value `root` is allowed but only settable by hand-editing `config.toml`. |
 | `trust` | string | *(inherited)* | Override the global default. Allowed values: `none` or `verified`. Omit to inherit. |
 | `trusted_senders` | array | *(inherited)* | Override the global allowlist. Setting this **replaces** the global list (no merging). Omit to inherit. |
-| `hooks` | array | `[]` | Hooks fired on `on_receive` (inbound) and `after_send` (outbound) events |
+| `hooks` | array | `[]` | Hooks fired on `on_receive` (inbound) and `after_send` (outbound) events. Forbidden on catchall mailboxes (config-load error). |
+
+**Reserved mailbox names.** `catchall` and `aimx-catchall` are reserved literals; `aimx mailboxes create` rejects them, and `MAILBOX-CREATE` over the daemon's UDS rejects them with `Validation: reserved`. The catchall is provisioned by `aimx setup` (when configured) under the wildcard address `*@<domain>` and uses owner `aimx-catchall`.
 
 See [Mailboxes](mailboxes.md) for mailbox management and [Hooks & Trust](hooks.md) for hook configuration.
 
@@ -101,7 +104,7 @@ Trust only gates hook execution (`on_receive`). All email is stored regardless o
 
 ### Hook settings
 
-Hooks are defined as `[[mailboxes.<name>.hooks]]` arrays. Each hook is a **raw-cmd** stanza: `cmd` is an argv array exec'd directly as the mailbox's `owner`. The first element must be an absolute path; there is no shell wrapping. If you need shell expansion, spell out `cmd = ["/bin/sh", "-c", "..."]` explicitly.
+Hooks are defined as `[[mailboxes.<name>.hooks]]` arrays. `cmd` is an argv array exec'd directly as the mailbox's `owner` — the daemon `setuid`s to `mailbox.owner_uid()` before `exec`. The first element must be an absolute path; there is no shell wrapping. If you need shell expansion, spell out `cmd = ["/bin/sh", "-c", "..."]` explicitly.
 
 | Setting | Type | Description |
 |---------|------|-------------|
@@ -111,45 +114,9 @@ Hooks are defined as `[[mailboxes.<name>.hooks]]` arrays. Each hook is a **raw-c
 | `cmd` | array of strings | Argv exec'd directly. Required and non-empty; `cmd[0]` must be an absolute path. There is no shell wrapping — spell out `["/bin/sh", "-c", "..."]` explicitly when you need shell expansion. |
 | `stdin` | string | `"email"` (default) pipes the raw `.md` (frontmatter + body) to the hook's stdin; `"none"` closes stdin immediately so the hook only sees env vars. |
 | `timeout_secs` | int | Hard subprocess timeout in seconds. Default `60`, range `[1, 600]`. SIGTERM at the limit, SIGKILL 5s later. |
-| `fire_on_untrusted` | bool | `on_receive` only: fire even when `trusted != "true"`. |
+| `fire_on_untrusted` | bool | `on_receive` only: fire even when `trusted != "true"`. Rejected on `after_send` hooks at config load with `ERR fire_on_untrusted is on_receive only`. |
 
-Unknown fields on a hook table are rejected at config load. See [Hooks & Trust](hooks.md) for full details on events and trust policies.
-
-### Hook templates
-
-`[[hook_template]]` blocks declare pre-vetted command shapes that agents can bind to via MCP `hook_create`. Each template's `cmd` is an argv array — no shell is ever invoked, and `{placeholder}` slots can only appear inside string argv entries (never as `cmd[0]` or as new argv entries).
-
-| Setting | Type | Default | Description |
-|---------|------|---------|-------------|
-| `name` | string | *(required)* | Unique across all templates. Pattern `[a-z0-9-]+`. |
-| `description` | string | *(required)* | One-liner for the `aimx setup` checkbox UI and the `hook_list_templates` MCP response. |
-| `cmd` | array of strings | *(required)* | Argv for the child process. `cmd[0]` is the binary path; subsequent entries may embed `{name}` placeholders in string values. |
-| `params` | array of strings | `[]` | Declared placeholder names the operator/agent fills at hook-create time. Must be a 1:1 set with the placeholders in `cmd` (minus built-ins). |
-| `stdin` | string | `"email"` | `"email"` (pipe the raw `.md`), `"email_json"` (`{"raw": ...}`), or `"none"`. |
-| `run_as` | string | *(required)* | Linux username the child process runs as. Any user resolvable via `getpwnam(3)` is accepted, plus the reserved `"aimx-catchall"` (for catchall-bound templates) and `"root"` (only settable via root-executed `config.toml` edit; the UDS verb rejects these two values). Templates registered via `aimx agents setup` default to the registering user's username. |
-| `timeout_secs` | int | `60` | Hard subprocess timeout. Range `[1, 600]`. SIGTERM at the limit, SIGKILL 5s later. |
-| `allowed_events` | array of strings | `["on_receive", "after_send"]` | Events the template may be wired to. MCP `hook_create` with a disallowed event is rejected. |
-
-**Built-in placeholders** available in every template's `cmd` (no need to declare them in `params`): `{event}`, `{mailbox}`, `{message_id}`, `{from}`, `{subject}`. Populated at fire time; missing values become empty strings.
-
-Validation at config load rejects: duplicate template `name`, unknown placeholder references, declared-but-unused `params`, placeholder in `cmd[0]`, empty `cmd` array, `timeout_secs` out of range, unsupported `run_as`. A malformed template fails daemon startup rather than the first hook fire.
-
-#### Default hook templates
-
-The aimx binary embeds eight default templates you can enable via `aimx setup` or by pasting them into `config.toml`:
-
-| Template | `cmd[0]` | `params` | `stdin` |
-|----------|----------|----------|---------|
-| `invoke-claude` | `/usr/local/bin/claude` | `prompt` | `email` |
-| `invoke-codex` | `/usr/local/bin/codex` | `prompt` | `email` |
-| `invoke-opencode` | `/usr/local/bin/opencode` | `prompt` | `email` |
-| `invoke-gemini` | `/usr/local/bin/gemini` | `prompt` | `email` |
-| `invoke-goose` | `/usr/local/bin/goose` | `recipe` | `email` |
-| `invoke-openclaw` | `/usr/local/bin/openclaw` | `prompt` | `email` |
-| `invoke-hermes` | `/usr/local/bin/hermes` | `prompt` | `email` |
-| `webhook` | `/usr/bin/curl` | `url` | `email_json` |
-
-Override a template's `cmd[0]` in your `config.toml` if your agent binary lives elsewhere. `aimx doctor` flags any enabled template whose `cmd[0]` is not executable on this box.
+Unknown fields on a hook table are rejected at config load. The legacy fields `template`, `params`, `run_as`, `origin`, and `dangerously_support_untrusted` are also rejected with a pointer to `book/hooks.md` — the template-hook surface and `aimx-hook` shared-uid sandbox have been retired in favor of the per-mailbox owner model. See [Hooks & Trust](hooks.md) for full details on events and trust policies.
 
 ## Storage layout
 
@@ -164,19 +131,21 @@ Override a template's `cmd[0]` in your `config.toml` if your agent binary lives 
 └── aimx.sock                # World-writable UDS for aimx send / hook / mailbox verbs
 
 /var/lib/aimx/               # Mailbox storage
-├── inbox/
-│   ├── catchall/            # Default mailbox
+├── inbox/                   # Each mailbox dir is `<owner>:<owner> 0700`
+│   ├── catchall/            # Default mailbox (owner: aimx-catchall)
 │   │   ├── 2025-04-15-143022-hello.md
 │   │   └── 2025-04-15-153300-invoice-march/   # Attachment bundle
 │   │       ├── 2025-04-15-153300-invoice-march.md
 │   │       ├── invoice.pdf
 │   │       └── receipt.png
-│   └── support/             # Named mailbox
+│   └── support/             # Named mailbox (owner: support-bot)
 │       └── ...
 └── sent/
     └── support/             # Outbound sent copies
         └── ...
 ```
+
+Each mailbox directory is chowned to `<owner>:<owner>` mode `0700` at create time and stays that way through every subsequent write (ingest, send, mark-read). Files inside are written by the daemon as `root:root 0644` — root bypasses dir perms regardless, while the mailbox owner reads via uid match. Other users cannot traverse the directory.
 
 ## IPv6 delivery (advanced)
 
@@ -248,22 +217,19 @@ dkim_selector = "aimx"
 # Mailboxes
 # ----------------------------
 
-# Catchall mailbox: receives all unmatched addresses
+# Catchall mailbox: receives all unmatched addresses.
+# Owned by the reserved `aimx-catchall` system user; hooks on the catchall
+# are forbidden at config load.
 [mailboxes.catchall]
 address = "*@agent.yourdomain.com"
-
-# Notify on any incoming email (opts in to fire on untrusted mail)
-[[mailboxes.catchall.hooks]]
-# name is optional — a stable 12-char hex id is derived from event+cmd if omitted
-event = "on_receive"
-cmd = ["/bin/sh", "-c", 'ntfy pub agent-mail "New email: $AIMX_SUBJECT from $AIMX_FROM"']
-fire_on_untrusted = true
+owner = "aimx-catchall"
 
 # ----------------------------
 # Named mailbox with a per-mailbox trust override
 # ----------------------------
 [mailboxes.support]
 address = "support@agent.yourdomain.com"
+owner = "support-bot"  # Linux user 'support-bot' must exist on the host
 
 # Per-mailbox overrides (both optional. Omit to inherit the top-level defaults).
 # Setting `trusted_senders` here fully replaces the global list (no merging).
@@ -274,19 +240,21 @@ trusted_senders = ["*@yourcompany.com", "boss@gmail.com"]
 [[mailboxes.support.hooks]]
 name = "support_log"
 event = "on_receive"
-cmd = ["/bin/sh", "-c", 'echo "{date} | $AIMX_FROM | $AIMX_SUBJECT" >> /var/log/aimx-support.log']
+cmd = ["/bin/sh", "-c", 'echo "$AIMX_DATE | $AIMX_FROM | $AIMX_SUBJECT" >> /var/log/aimx-support.log']
 
-# Trigger agent on every trusted incoming email
+# Trigger Claude Code on every trusted incoming email; runs as `support-bot`.
 [[mailboxes.support.hooks]]
 name = "support_agent"
 event = "on_receive"
-cmd = ["/bin/sh", "-c", 'claude -p "Process this email: $(cat \"$AIMX_FILEPATH\")"']
+cmd = ["/usr/local/bin/claude", "-p", "Read the piped email and act on it via the aimx MCP server.", "--dangerously-skip-permissions"]
+stdin = "email"
 
 # ----------------------------
 # Another mailbox
 # ----------------------------
 [mailboxes.notifications]
 address = "notifications@agent.yourdomain.com"
+owner = "ubuntu"
 ```
 
 ---

--- a/book/faq.md
+++ b/book/faq.md
@@ -74,40 +74,30 @@ Yes for reads. `rsync -a` or a filesystem snapshot of `/var/lib/aimx/` will prod
 Check in this order:
 
 1. `journalctl -u aimx | grep hook_name=<name>`. Every fire emits one structured line. No line means the hook was gated.
-2. The target email's frontmatter: `trusted = "false"` plus `dangerously_support_untrusted` unset is the most common cause. See the [trust gate](hooks.md#trust-gate-on_receive-only).
-3. If the line is there with a non-zero `exit_code`, it's your shell command. Test the `cmd` string against the saved `.md` manually.
+2. The target email's frontmatter: `trusted = "false"` plus `fire_on_untrusted` unset is the most common cause. See the [trust gate](hooks.md#trust-gate-on_receive-only).
+3. If the line is there with a non-zero `exit_code`, it's your `cmd` argv. Test the argv manually: `sudo -u <owner> /path/to/cmd[0] cmd[1] ...` against the saved `.md`.
 
-### Why can my agent create hooks but not run arbitrary shell commands?
+### What does mailbox ownership mean for security?
 
-This is the core of the hook-templates safety model. A naive design would expose a `hook_create` MCP tool that takes a `cmd` string and writes it to `config.toml`. That's a local RCE waiting to happen: any process that speaks MCP (and the `aimx.sock` UDS is world-writable so hooks can be created without root) could talk the daemon into running arbitrary shell every time mail arrives.
+Every mailbox declares a single Linux `owner` (a user on the host). Ownership is the authorization predicate for everything that touches the mailbox, and it directly constrains what hooks can do:
 
-Hook templates split the problem. The **operator** installs a small set of pre-vetted command *shapes* once, during `aimx setup`:
+- **Storage.** `/var/lib/aimx/inbox/<mailbox>/` and `/var/lib/aimx/sent/<mailbox>/` are `<owner>:<owner> 0700`. Only the owner — and root — can read or list the contents. Other Linux users cannot even traverse the directory.
+- **Hook execution.** The daemon `setuid`s to `mailbox.owner_uid()` before `exec`'ing the hook's `cmd` argv. There is no per-hook `run_as` override.
+- **CRUD authorization.** Creating, listing, and deleting hooks (and reading mail, sending mail) requires the caller to either be root or own the target mailbox. The CLI checks euid; the UDS checks `SO_PEERCRED` — the same predicate.
+
+The "no escalation" property: a hook can do anything the mailbox owner could already do (cron, `~/.bashrc`, systemd `--user`, etc.). It cannot escalate privilege, and it cannot read `bob`'s mail when `alice` owns the mailbox the hook is wired to. A prompt-injected agent running under `alice`'s uid stays scoped to `alice`'s data and `alice`'s file permissions — adding hooks does not widen that scope, because hooks always exec as `alice`.
+
+The previous template-sandbox design was scaffolding around a different question ("how do we let an agent create hooks without giving it shell?"). With mailbox-ownership-as-authorization, the answer is simpler: the agent already has shell as `alice` (it's running under `alice`'s uid); hooks are just one more thing `alice` can do, and the daemon enforces that the hook runs as `alice` regardless of what the agent asked for. To run a hook as root, an operator must hand-edit `/etc/aimx/config.toml` to set `mailbox.owner = "root"` — a path that requires root in the first place.
+
+### Env var expansion: how does it work?
+
+Hook `cmd` is exec'd directly — there is no shell. argv elements pass through verbatim. To get shell expansion of `$AIMX_*` env vars, wrap your `cmd` in `["/bin/sh", "-c", "..."]` explicitly:
 
 ```toml
-[[hook_template]]
-name = "invoke-claude"
-cmd = ["/usr/local/bin/claude", "-p", "{prompt}"]
-params = ["prompt"]
+cmd = ["/bin/sh", "-c", 'echo "$AIMX_SUBJECT" >> /tmp/log']
 ```
 
-The **agent** can then only bind to those shapes, filling declared `{placeholder}` slots with string values:
-
-```json
-{"template": "invoke-claude", "params": {"prompt": "File this email"}}
-```
-
-Two properties make this safe:
-
-1. **No shell invocation.** The daemon builds the argv vector directly from `cmd` + `params` and calls `execvp`. `/bin/sh -c` is never used for template hooks, so there is no string-to-argv parsing step for an attacker to subvert.
-2. **Values can't escape their slot.** Substitution happens after the argv is already split. A parameter value like `"; rm -rf /"` lands as one complete argv entry passed verbatim to the target binary; it cannot introduce new argv entries, redirections, pipes, or quote escapes. NUL, `\r`, and other control bytes are rejected outright.
-
-Raw `cmd` submission is physically impossible over the UDS: the `HOOK-CREATE` verb rejects any request body containing a `cmd`, `run_as`, `dangerously_support_untrusted`, `timeout_secs`, or `stdin` field. Those are template properties — not hook properties — so they can't leak through.
-
-The operator keeps the full-power escape hatch: `sudo aimx hooks create --cmd "..."` writes `config.toml` directly. That requires root, bypasses the UDS, and is intentionally not reachable from MCP.
-
-### Env var vs. `{id}`/`{date}` placeholder: when do I use which?
-
-Env vars (`$AIMX_FROM`, `$AIMX_SUBJECT`, …) carry sender-controlled header content. Always expand them inside double quotes. Never splice them into the `cmd` string. Placeholders (`{id}`, `{date}`) are AIMX-generated (slug and ISO-8601 date) and are substituted into `cmd` directly. Use them when you need the value in a filename or path literal, where a shell variable would not expand.
+Always expand env vars inside double quotes. Sender-controlled header values can contain `$()`, backticks, quotes, or newlines; the double-quoted form passes them through as literal bytes. The literal token `$AIMX_FILEPATH` (no shell wrapping) reaches argv unchanged — useful when the agent itself reads env vars (OpenCode, Hermes do this in inline-prompt mode).
 
 ### Can an `after_send` hook distinguish a deferral from a permanent failure?
 
@@ -123,9 +113,9 @@ Two conditions: the sender address matches a glob in the effective `trusted_send
 
 It replaces. Setting `trusted_senders` under a mailbox fully overrides the top-level list for that mailbox. There is no merge, and an empty per-mailbox list means "nobody" for that mailbox.
 
-### When is `dangerously_support_untrusted` actually appropriate?
+### When is `fire_on_untrusted` actually appropriate?
 
-When the hook's side effect is safe regardless of sender. A logger, a metric counter, a push notification with no email content in the payload. Never use it on a hook that hands the email body to an agent or to any shell command that quotes the body.
+When the hook's side effect is safe regardless of sender. A logger, a metric counter, a push notification with no email content in the payload. Never use it on a hook that hands the email body to an agent or to any shell command that quotes the body. Mailbox isolation (uid-scoped exec + uid-scoped storage) makes the flag a per-owner choice with bounded blast radius — even an adversarial fire on untrusted mail can do no more than what the mailbox owner could already do — but the trust gate is still the primary defense for irreversible side effects. The flag is illegal on `after_send` hooks and rejected at config load.
 
 ## Security model
 
@@ -133,15 +123,15 @@ When the hook's side effect is safe regardless of sender. A logger, a metric cou
 
 ### Can I use AIMX in place of Postfix or Stalwart?
 
-No, and that is intentional. AIMX is a single-operator mail server designed for AI agents on a domain you own, not a general-purpose MTA for human users. It has no IMAP/POP3, no webmail, no per-user authentication, no LMTP, no virtual alias tables, and no submission port on 587. Mailboxes are world-readable by design and every hook and MCP tool addresses the whole mailbox tree.
+No, and that is intentional. AIMX is a single-domain mail server designed for AI agents on a domain you own, not a general-purpose MTA for human users. It has no IMAP/POP3, no webmail, no per-user authentication on the SMTP submission path, no LMTP, no virtual alias tables, and no submission port on 587. Each mailbox is owned by exactly one Linux user, and hooks always run as that user — the boundary is per-mailbox, not per-server.
 
 ### `aimx.sock` is mode `0666`, why is that fine?
 
-Any local user can submit an outbound message, but the DKIM private key (`/etc/aimx/dkim/private.key`, mode `0600`, root-only) stays inside `aimx serve`. The UDS is a signing oracle for the configured mailboxes and that is the intended authorisation boundary. If local users on this host cannot be trusted to send mail under your domain at all, run AIMX on a dedicated host.
+Any local user can connect to the socket, but the daemon enforces per-verb authorization via `SO_PEERCRED` (kernel-supplied peer uid). `SEND` requires the caller to own the From mailbox; `MARK-*` and `HOOK-*` require ownership of the target mailbox; `MAILBOX-CREATE` / `MAILBOX-DELETE` are root-only. The DKIM private key (`/etc/aimx/dkim/private.key`, mode `0600`, root-only) stays inside `aimx serve`, so the socket is a signing oracle scoped to the caller's owned mailboxes — never a free pass to forge mail for someone else's mailbox.
 
-### The mailbox tree is world-readable, why is that fine?
+### The mailbox tree is per-owner, what does that buy me?
 
-AIMX assumes a single-operator server where every local user and agent is inside the trust boundary. If you need per-user mailbox isolation, AIMX is the wrong tool. Run a general-purpose MTA like Postfix or Stalwart instead (see [Can I use AIMX in place of Postfix or Stalwart?](#can-i-use-aimx-in-place-of-postfix-or-stalwart) above). The trade-off is documented in [Security model](getting-started.md#security-model).
+Each `/var/lib/aimx/inbox/<mailbox>/` and `/var/lib/aimx/sent/<mailbox>/` is `<owner>:<owner> 0700`. On a multi-user host, alice cannot read bob's mail — she cannot even traverse the directory to stat its contents. Hooks on alice's mailbox run as alice, so a prompt-injected agent stays scoped to alice's filesystem perms. The trade-off vs. a single shared mailbox tree is that mailbox provisioning requires picking the right owner; `aimx mailboxes create` defaults the owner to a Linux user named after the mailbox if one exists.
 
 ### Who can read the DKIM private key, and what happens if it leaks?
 
@@ -155,7 +145,7 @@ No. `aimx mcp` uses stdio transport. Each MCP client spawns and owns its own pro
 
 ### How do I scope an agent to a single mailbox?
 
-AIMX does not implement MCP-level access control today. Every MCP tool call sees every mailbox. If you need isolation, run a second AIMX instance on a different host (or different IP + config dir) and give each agent its own.
+Every MCP tool call is scoped to mailboxes the calling uid owns: `mailbox_list` filters; `email_*` and `hook_*` reject with `EACCES not authorized` for foreign mailboxes. To pin a single agent to a single mailbox, run that agent under a Linux user that owns only the one mailbox you want (`sudo aimx mailboxes create <name> --owner <user>`). The agent's MCP server inherits the caller's uid via stdio transport, so authorization derives entirely from "which Linux user is running `aimx mcp`."
 
 ### How do I update the installed agent plugin after upgrading AIMX?
 

--- a/book/hook-recipes.md
+++ b/book/hook-recipes.md
@@ -2,291 +2,188 @@
 
 > **Note on log paths.** The `/var/log/aimx/<agent>.log` paths in the recipes below are user-chosen destinations for hook script output. They are NOT aimx's own logs. aimx itself logs to journald (systemd) or the system logger (OpenRC). See [Troubleshooting: Where are the logs?](troubleshooting.md#where-are-the-logs) for details.
 
-This chapter is the canonical cookbook for wiring aimx hooks to every supported AI agent. Each section shows a copy-paste `config.toml` snippet, the agent-specific CLI flags that matter for non-interactive invocation, and notes on exit codes, logs, and gotchas.
+This chapter is the canonical cookbook for wiring aimx hooks to every supported AI agent. Each section shows a copy-paste `aimx hooks create` invocation with the verified `cmd` argv for that agent.
 
-For the underlying mechanics (names, env vars, trust policies, structured logs), see [Hooks & Trust](hooks.md). For installing the aimx plugin/skill into an agent so its MCP tools are discoverable, see [Agent Integration](agent-integration.md).
-
-## Template-first: the easy path
-
-For every agent with a bundled template (`invoke-claude`, `invoke-codex`, `invoke-opencode`, `invoke-gemini`, `invoke-goose`, `invoke-openclaw`, `invoke-hermes`, `webhook`), the recipe reduces to two steps:
-
-1. Operator ticks the template in `aimx setup`. Once per box.
-2. Agent or operator calls `hook_create` (MCP) or `aimx hooks create --template <name> --param <k=v>` (CLI). Per mailbox, per prompt.
-
-Example — wire Claude Code to the `schedule` mailbox:
-
-```bash
-# One-time: enable the template
-sudo aimx setup          # tick invoke-claude in the checkbox UI
-
-# Per mailbox: bind the template
-sudo aimx hooks create \
-  --mailbox schedule \
-  --event on_receive \
-  --template invoke-claude \
-  --param prompt="Handle this scheduling request."
-```
-
-The agent equivalent over MCP looks like:
-
-```json
-{"name": "hook_create", "arguments": {
-  "mailbox": "schedule",
-  "event": "on_receive",
-  "template": "invoke-claude",
-  "params": {"prompt": "Handle this scheduling request."}
-}}
-```
-
-Template hooks run sandboxed under the template's `run_as` user (the registering mailbox owner, never root) and can't be abused by prompt injection — see [Hooks & Trust § Template hooks](hooks.md#template-hooks-recommended).
-
-The raw-cmd recipes below are the **power-user path**: use them when you need a shell pipeline, an exit-code check, multiple output sinks, or a flag the template doesn't expose.
+For the underlying mechanics (ownership, env vars, trust policies, structured logs), see [Hooks & Trust](hooks.md). For installing the aimx plugin/skill into an agent so its MCP tools are discoverable, see [Agent Integration](agent-integration.md).
 
 ## What counts as a hook recipe?
 
-A hook recipe is a `[[mailboxes.<name>.hooks]]` block whose `cmd` invokes an AI agent non-interactively against an incoming email. The recipe pattern is always:
+A hook recipe is a `[[mailboxes.<name>.hooks]]` block (or the equivalent `aimx hooks create` invocation) whose `cmd` invokes an AI agent or HTTP endpoint non-interactively against an incoming email. The recipe pattern is always:
 
 1. Email lands in the mailbox, aimx writes the `.md` file to disk.
-2. aimx evaluates the trust gate. A hook fires iff `trusted == "true"` on the email OR the hook sets `dangerously_support_untrusted = true`.
-3. aimx fires the shell `cmd`. User-controlled header values are delivered as env vars (`AIMX_HOOK_NAME`, `AIMX_FROM`, `AIMX_SUBJECT`, `AIMX_TO`, `AIMX_MAILBOX`, `AIMX_FILEPATH`). The two aimx-controlled placeholders `{id}` and `{date}` are substituted into the command string.
-4. The agent reads the email body (typically by `cat`-ing `"$AIMX_FILEPATH"`) and takes action: replying, filing a ticket, updating a calendar, whatever.
+2. aimx evaluates the trust gate. A hook fires iff `trusted == "true"` on the email OR the hook sets `fire_on_untrusted = true`.
+3. aimx exec's the argv directly as the mailbox's owner. There is no `/bin/sh` between aimx and the agent. The piped email body (`stdin = "email"`) or the `$AIMX_FILEPATH` env var (`stdin = "none"`) hands the agent the email content.
+4. The agent reads the email and takes action: replying, filing a ticket, updating a calendar, whatever.
 5. Exit code is logged (one structured line per fire) but does not block delivery.
 
-> **Why env vars, not `{from}`/`{subject}` substitution?** User-controlled fields like `From:` and `Subject:` can contain arbitrary bytes, including shell metacharacters (`$()`, backticks, `;`, quotes). Splicing them into the command string, even with shell-escape quoting, is fragile. Delivering them as env vars and expanding with `"$AIMX_FROM"` inside double quotes is safe no matter what the sender puts in the header.
+> **Why argv and not shell?** User-controlled fields like `From:` and `Subject:` can contain arbitrary bytes, including shell metacharacters (`$()`, backticks, `;`, quotes). Splicing them into a shell command, even with shell-escape quoting, is fragile. Delivering them as env vars and `exec`'ing argv directly avoids the shell parser entirely. When you do need shell expansion, spell out `cmd = ["/bin/sh", "-c", "..."]` explicitly so it's visible at the call site.
 
-Every recipe below assumes the agent binary (`claude`, `codex`, `opencode`, `gemini`, `goose`, `openclaw`, `aider`) is on the `PATH` of the user running `aimx serve`. Since `aimx serve` runs as a system user under systemd/OpenRC, you will typically either install the agent CLI system-wide or set an explicit absolute path in the command.
+## Two stdin shapes
 
-## Summary table
+Recipes split into two camps depending on whether the agent reads stdin in headless mode:
 
-| Agent | MCP supported? | Hook CLI | Non-interactive / approval flag | Notes |
-|-------|----------------|----------|---------------------------------|-------|
-| Claude Code | Yes (`aimx agents setup claude-code`) | `claude -p "<prompt>"` | `--dangerously-skip-permissions` (or `--permission-mode=bypassPermissions`) | `-p` / `--print` runs headless and exits. Pipe the email via `$(cat "$AIMX_FILEPATH")`. |
-| Codex CLI | Yes (`aimx agents setup codex`) | `codex exec "<prompt>"` | `--dangerously-bypass-approvals-and-sandbox` (or `--full-auto`) | `exec` is the non-interactive subcommand. `--full-auto` enables auto-approval within sandbox. The bypass flag goes further. |
-| OpenCode | Yes (`aimx agents setup opencode`) | `opencode run "<prompt>"` | no confirmation prompts by design | `run` executes a single prompt and exits. Model selection via `-m/--model`. |
-| Gemini CLI | Yes (`aimx agents setup gemini`) | `gemini -p "<prompt>"` | `--yolo` (auto-accepts all actions) | `-p/--prompt` is the non-interactive flag. `--yolo` skips confirmations. |
-| Goose | Yes (`aimx agents setup goose`) | `goose run -t "<prompt>"` | `--no-session` (optional. Sessions default on) | `-t/--text` takes an inline prompt. `-i/--instructions` reads from a file. |
-| OpenClaw | Yes (`aimx agents setup openclaw`) | `openclaw agent --message "<prompt>" --deliver --json` | `--deliver` routes the reply back through OpenClaw. `--json` produces a stable, scriptable output envelope | The `agent` subcommand is non-interactive. See [OpenClaw](#openclaw) for a complete recipe. |
-| Hermes | Yes (`aimx agents setup hermes`) | *(no headless CLI)* | n/a | Hermes has no shell-side invocation for dispatching a one-shot prompt. Integrate via MCP instead. See [Hermes](#hermes) for the recommended pattern. |
-| Aider | No (no MCP server) | `aider --message "<prompt>"` | `--yes-always` | Aider is a code-editing agent. Recipes below pattern it as "take email, apply patch, commit." |
+- **Native-stdin** (Claude Code, Codex, Gemini, Goose, webhook): hook sets `stdin = "email"`, the daemon pipes the raw `.md` to the agent's stdin, and the prompt only tells the agent what to do with it. Smallest argv, cleanest pipeline.
+- **Inline-only** (OpenCode, Hermes): hook sets `stdin = "none"`; the `cmd` carries a fixed prompt that instructs the agent to read `$AIMX_FILEPATH` (env var set by the daemon) using its filesystem tool. argv is not shell-expanded — the literal `$AIMX_FILEPATH` token reaches the agent, which expands it via Bash/Read tooling at run time.
 
-Every agent with an `aimx agents setup <agent>` installer can ALSO be wired as a hook. MCP support and hook support are orthogonal. MCP gives the agent a way to read/send mail on demand. A hook is aimx pushing an email into the agent when it arrives.
+## Absolute paths
 
-> **Flag drift warning.** CLI flags for every agent below were verified against each project's current `--help` output and public docs at the time of writing. Agent CLIs evolve fast. Always run `<agent> --help` yourself before deploying a recipe to a production mailbox, and check the linked docs for current flag names.
+Every recipe uses `/usr/local/bin/<agent>` for `cmd[0]`. `Config::load` rejects relative paths (`hook has non-absolute cmd[0]`). Adjust the path to match your install — `which <agent>` shows where each binary lives. The `cmd[0]` literal in your `config.toml` (or in the `--cmd` argv array passed to `aimx hooks create`) must point at the binary that exists on the box.
+
+## Self-loop reminder
+
+The headless agent process runs as the **mailbox owner's uid** (the daemon `setuid`s to `mailbox.owner_uid()` before `exec`). That user must have:
+
+1. The agent binary installed and reachable at the path you reference in `cmd[0]`.
+2. The aimx skill installed (`aimx agents setup <agent>` was run as that user) so the agent loads the aimx MCP server when it starts.
+
+Without both, the headless invocation will start without the skill loaded and the agent won't know what to do with the email. `aimx doctor` could flag this gap in a future release; for now, run `aimx agents setup` as the mailbox owner before creating the hook.
 
 ## Claude Code
 
 - Docs: <https://docs.claude.com/en/docs/claude-code/cli-reference>
-- Non-interactive: `claude -p` (aliases: `--print`).
-- Bypass permissions: `--dangerously-skip-permissions` or `--permission-mode=bypassPermissions`.
-- Output: stdout by default. `--output-format text|json|stream-json` available.
+- Stdin: native (`-p` reads from stdin when `cmd[0]` is fed via pipe).
+- Bypass permissions: `--dangerously-skip-permissions` (alias `--permission-mode bypassPermissions`) is required for autonomous tool calls.
 
-### config.toml snippet
-
-```toml
-[mailboxes.inbox]
-address = "inbox@agent.yourdomain.com"
-trust = "verified"
-trusted_senders = ["*@yourcompany.com"]
-
-[[mailboxes.inbox.hooks]]
-name = "claudeinbox1"
-event = "on_receive"
-cmd = ["/bin/sh", "-c", '''
-claude -p "You received a new email. Read it and file a summary ticket.
-
-Email path: $AIMX_FILEPATH
-Subject: $AIMX_SUBJECT
-From: $AIMX_FROM
-
-Use the Read tool to open \"$AIMX_FILEPATH\", then call the appropriate MCP tool." \
-  --permission-mode=bypassPermissions \
-  >> /var/log/aimx/claude.log 2>&1
-''']
+```bash
+aimx hooks create \
+  --mailbox accounts \
+  --event on_receive \
+  --cmd '["/usr/local/bin/claude", "-p", "Read the piped email and act on it via the aimx MCP server.", "--dangerously-skip-permissions"]' \
+  --stdin email \
+  --name accounts_claude
 ```
 
-- `"$AIMX_FILEPATH"` is always safe. The shell quotes the value, so paths with spaces or unusual characters are handled correctly.
-- `claude -p` exits when the turn completes. The hook finishes quickly.
-- Redirect stdout and stderr to a log file because the hook runs detached under `aimx serve`. There is no TTY to print to.
-- Pair with `trust = "verified"` so only DKIM-passing allowlisted senders can steer Claude.
+Optional: `--mcp-config /path` + `--strict-mcp-config` to pin which MCP config Claude reads, and `--model sonnet` (or `--model opus`) to tune the routing model.
 
 ## Codex CLI
 
-- Docs: <https://github.com/openai/codex> (see `codex exec --help`).
-- Non-interactive: `codex exec "<prompt>"`.
-- Bypass approvals: `--dangerously-bypass-approvals-and-sandbox` or `--full-auto` (auto-approve within the sandbox).
+- Docs: <https://github.com/openai/codex> (run `codex exec --help`).
+- Stdin: native (the trailing `-` argument tells Codex to read stdin as the prompt — the email itself becomes Codex's task).
+- Bypass: `--full-auto` is the safe sandboxed default; `--dangerously-bypass-approvals-and-sandbox` only inside a contained host.
+- Required: `--skip-git-repo-check` because hooks fire from `/var/lib/aimx/inbox/<mailbox>/`, which is not a git repo.
 
-
-### config.toml snippet
-
-```toml
-[mailboxes.triage]
-address = "triage@agent.yourdomain.com"
-trust = "verified"
-
-[[mailboxes.triage.hooks]]
-name = "codextriage1"
-event = "on_receive"
-cmd = ["/bin/sh", "-c", '''
-codex exec "Triage this email and update the issue tracker.
-
-Email file: $AIMX_FILEPATH
-From: $AIMX_FROM
-Subject: $AIMX_SUBJECT" \
-  --full-auto \
-  >> /var/log/aimx/codex.log 2>&1
-''']
+```bash
+aimx hooks create \
+  --mailbox triage \
+  --event on_receive \
+  --cmd '["/usr/local/bin/codex", "exec", "--skip-git-repo-check", "--full-auto", "-"]' \
+  --stdin email \
+  --name triage_codex
 ```
-
-- `--full-auto` is the recommended default for hooks: Codex auto-approves tool use but stays inside its sandbox.
 
 ## OpenCode
 
 - Docs: <https://opencode.ai/docs/cli/>
-- Non-interactive: `opencode run "<prompt>"`.
-- Approval: OpenCode's `run` mode does not prompt for confirmation on tool use. Safe for hooks without a dedicated bypass flag.
+- Stdin: inline-only (`opencode run` does not read stdin in headless mode).
+- Bypass: `--dangerously-skip-permissions`.
 
-### config.toml snippet
-
-```toml
-[mailboxes.research]
-address = "research@agent.yourdomain.com"
-trust = "verified"
-
-[[mailboxes.research.hooks]]
-name = "ocresearch01"
-event = "on_receive"
-cmd = ["/bin/sh", "-c", '''
-opencode run "A new research email arrived. Read \"$AIMX_FILEPATH\" and append a digest entry to docs/digest.md.
-
-From: $AIMX_FROM
-Subject: $AIMX_SUBJECT" \
-  >> /var/log/aimx/opencode.log 2>&1
-''']
+```bash
+aimx hooks create \
+  --mailbox research \
+  --event on_receive \
+  --cmd '["/usr/local/bin/opencode", "run", "--dangerously-skip-permissions", "Read the aimx email at the path in env var AIMX_FILEPATH and act on it via the aimx MCP server (e.g. email_reply)."]' \
+  --stdin none \
+  --name research_opencode
 ```
+
+The literal token `$AIMX_FILEPATH` is **not** shell-expanded (argv is not shell-parsed). The agent sees the literal string `AIMX_FILEPATH` (or `$AIMX_FILEPATH` if you write it that way) inside its prompt and uses its Bash/Read tool to read the env var at run time. Optional: `--format json` for a structured run log.
 
 ## Gemini CLI
 
-- Docs: <https://github.com/google-gemini/gemini-cli> (see `gemini --help`).
-- Non-interactive: `gemini -p "<prompt>"` (alias `--prompt`).
-- Auto-approve: `--yolo` (accepts all tool-use confirmations).
+- Docs: <https://github.com/google-gemini/gemini-cli>
+- Stdin: native (`-p` reads from stdin when piped).
+- Bypass: `--yolo` auto-approves tool calls; required for unattended operation.
 
-### config.toml snippet
-
-```toml
-[mailboxes.notes]
-address = "notes@agent.yourdomain.com"
-trust = "verified"
-
-[[mailboxes.notes.hooks]]
-name = "geminines01"
-event = "on_receive"
-cmd = ["/bin/sh", "-c", '''
-gemini -p "A new note arrived by email. Read \"$AIMX_FILEPATH\" and file it into my notes." \
-  --yolo \
-  >> /var/log/aimx/gemini.log 2>&1
-''']
+```bash
+aimx hooks create \
+  --mailbox notes \
+  --event on_receive \
+  --cmd '["/usr/local/bin/gemini", "-p", "Read the piped email and file it into my notes via the aimx MCP server.", "--yolo"]' \
+  --stdin email \
+  --name notes_gemini
 ```
+
+Optional: `-m gemini-2.5-flash` to pin the routing model.
 
 ## Goose
 
 - Docs: <https://block.github.io/goose/docs/guides/headless-goose>
-- Non-interactive: `goose run -t "<prompt>"`.
+- Stdin: native via `--instructions -` (reads instructions from stdin; the recipe form is preferred for production).
+- Two recipes shown: ad-hoc (instructions piped via stdin) and recipe-based (the inner recipe pre-binds the `aimx mcp` extension).
 
-### config.toml snippet
+**Ad-hoc:**
 
-```toml
-[mailboxes.ops]
-address = "ops@agent.yourdomain.com"
-trust = "verified"
-
-[[mailboxes.ops.hooks]]
-name = "gooseops001"
-event = "on_receive"
-cmd = ["/bin/sh", "-c", '''
-goose run -t "Ops email arrived. Read \"$AIMX_FILEPATH\", check if action is required, and page on-call if so.
-
-Subject: $AIMX_SUBJECT
-From: $AIMX_FROM" \
-  >> /var/log/aimx/goose.log 2>&1
-''']
+```bash
+aimx hooks create \
+  --mailbox ops \
+  --event on_receive \
+  --cmd '["/usr/local/bin/goose", "run", "--instructions", "-", "--quiet"]' \
+  --stdin email \
+  --name ops_goose
 ```
+
+**Recipe-based (preferred for production):**
+
+```bash
+aimx hooks create \
+  --mailbox ops \
+  --event on_receive \
+  --cmd '["/usr/local/bin/goose", "run", "--recipe", "/etc/aimx/goose-aimx-hook.yaml"]' \
+  --stdin email \
+  --name ops_goose_recipe
+```
+
+The referenced recipe pre-binds the `aimx mcp` extension and parameterizes the inbound email path. See Goose's recipe documentation for the inner-recipe shape.
 
 ## OpenClaw
 
-- Docs: <https://docs.openclaw.ai/>
-- MCP server: `aimx agents setup openclaw` emits an `openclaw mcp set aimx '<json>'` command you paste once to register aimx's MCP tools with the OpenClaw gateway.
-- Non-interactive agent invocation: `openclaw agent --message "<prompt>" --deliver --json`.
+OpenClaw does not document a one-shot prompt mode as of Apr 2026. Its surfaces are interactive (chat-channel, Control-UI dashboard) plus admin subcommands; there is no `--prompt`-style entry point that fits the headless hook pattern.
 
-### config.toml snippet
+To use OpenClaw with aimx, treat aimx as a read source via the MCP server and trigger the agent through OpenClaw's documented interactive entry points. For shell-side notifications on new mail (so OpenClaw operators know there is mail to look at), wire a simple non-agent `on_receive` hook:
 
-```toml
-[mailboxes.inbox]
-address = "inbox@agent.yourdomain.com"
-trust = "verified"
-trusted_senders = ["*@yourcompany.com"]
-
-[[mailboxes.inbox.hooks]]
-name = "openclaw0001"
-event = "on_receive"
-cmd = ["/bin/sh", "-c", '''
-openclaw agent \
-    --message "An email arrived at $(basename \"$AIMX_FILEPATH\"). Read it at \"$AIMX_FILEPATH\", summarize the sender's request, and respond via the aimx MCP tools if a reply is appropriate." \
-    --deliver \
-    --json \
-    >> /var/log/aimx/openclaw.log 2>&1
-''']
+```bash
+aimx hooks create \
+  --mailbox openclaw \
+  --event on_receive \
+  --cmd '["/bin/sh", "-c", "ntfy pub openclaw-mail \"New email: $AIMX_SUBJECT from $AIMX_FROM\""]' \
+  --stdin none \
+  --fire-on-untrusted \
+  --name openclaw_notify
 ```
+
+When OpenClaw later publishes a one-shot CLI, this section will be updated; track upstream at <https://docs.openclaw.ai/>.
 
 ## Hermes
 
 - Docs: <https://hermes-agent.nousresearch.com/>
-- Shell-side invocation: Hermes does not currently expose a headless CLI for dispatching a one-shot prompt (the `hermes mcp serve` subcommand runs Hermes *as* an MCP server, the opposite direction). Hook-driven agent dispatch therefore uses MCP on the inbound side.
+- Stdin: inline-only (stdin handling for `hermes chat -q` is undocumented as of Apr 2026; this recipe ships the inline-only form).
+- Bypass: `--yolo` skips dangerous-command approval; `--ignore-user-config --ignore-rules` for fully isolated runs.
 
-### Recommended pattern
-
-Register aimx as an MCP server inside Hermes (`aimx agents setup hermes` plus the YAML snippet it prints. See [Agent Integration: Hermes](agent-integration.md#hermes)). Inside Hermes, use the aimx skill's `email_list` / `email_read` tools to inspect the inbox on demand.
-
-For shell-side notifications on new mail (so Hermes operators know there is mail to look at), wire a simple non-agent `on_receive` hook:
-
-```toml
-[mailboxes.hermes]
-address = "hermes@agent.yourdomain.com"
-trust = "verified"
-
-[[mailboxes.hermes.hooks]]
-# name is optional — a stable 12-char hex id is derived from event+cmd if omitted
-event = "on_receive"
-cmd = ["/bin/sh", "-c", 'ntfy pub hermes-mail "New email: $AIMX_SUBJECT from $AIMX_FROM"']
-fire_on_untrusted = true
+```bash
+aimx hooks create \
+  --mailbox hermes \
+  --event on_receive \
+  --cmd '["/usr/local/bin/hermes", "chat", "-q", "Read the aimx email at the path in env var AIMX_FILEPATH and act on it via the aimx MCP server.", "--yolo"]' \
+  --stdin none \
+  --name hermes_chat
 ```
 
-When Hermes grows a headless `--message` / `exec`-style CLI, add it here mirroring the Claude Code or Codex recipe.
+If a future Hermes release confirms that `chat -q` accepts piped stdin, switch to `--stdin email` and shorten the inline prompt to "Read the piped email and act on it via the aimx MCP server."
 
-## Aider
+## Webhook (POST to URL)
 
-- Docs: <https://aider.chat/docs/usage.html>
-- Non-interactive: `aider --message "<prompt>"` (runs once and exits).
-- Auto-approve: `--yes-always` (skips all confirmation prompts).
+A pure-curl recipe that POSTs the raw `.md` to an HTTPS endpoint. No agent required.
 
-
-### config.toml snippet
-
-```toml
-[mailboxes.bugs]
-address = "bugs@agent.yourdomain.com"
-trust = "verified"
-trusted_senders = ["*@yourcompany.com"]
-
-[[mailboxes.bugs.hooks]]
-name = "aiderbugs01"
-event = "on_receive"
-cmd = ["/bin/sh", "-c", '''
-cd /srv/repos/myapp && \
-aider --yes-always \
-      --message "Bug report arrived by email. Read \"$AIMX_FILEPATH\", reproduce the issue if possible, apply a fix, and commit." \
-      >> /var/log/aimx/aider.log 2>&1
-''']
+```bash
+aimx hooks create \
+  --mailbox alerts \
+  --event on_receive \
+  --cmd '["/usr/bin/curl", "-sS", "-X", "POST", "-H", "Content-Type: application/json", "--data-binary", "@-", "https://hooks.example.com/aimx"]' \
+  --stdin email \
+  --name alerts_webhook
 ```
+
+`--data-binary @-` tells curl to POST whatever lands on its stdin verbatim. Combined with `stdin = "email"`, the receiver gets the raw `.md` (TOML frontmatter + body) as the request body. Use `Content-Type: text/markdown` instead if your receiver expects that explicitly.
 
 ## `after_send` recipes
 
@@ -294,78 +191,80 @@ Send-side hooks run after aimx resolves the MX delivery attempt. They cannot aff
 
 ### Append to an audit log
 
-```toml
-[[mailboxes.alice.hooks]]
-name = "auditlog0001"
-event = "after_send"
-cmd = ["/bin/sh", "-c", 'printf "%s %s %s %s\n" "$AIMX_SEND_STATUS" "$AIMX_TO" "$AIMX_SUBJECT" "$AIMX_HOOK_NAME" >> /var/log/aimx/alice-sent.log']
+```bash
+aimx hooks create \
+  --mailbox alice \
+  --event after_send \
+  --cmd '["/bin/sh", "-c", "printf \"%s %s %s %s\\n\" \"$AIMX_SEND_STATUS\" \"$AIMX_TO\" \"$AIMX_SUBJECT\" \"$AIMX_HOOK_NAME\" >> /var/log/aimx/alice-sent.log"]' \
+  --stdin none \
+  --name alice_audit
 ```
 
 ### Page on failed sends
 
-```toml
-[[mailboxes.alerts.hooks]]
-name = "failedpage01"
-event = "after_send"
-cmd = ["/bin/sh", "-c", '''
-if [ "$AIMX_SEND_STATUS" != "delivered" ]; then
-  ntfy pub on-call "aimx send to $AIMX_TO $AIMX_SEND_STATUS: $AIMX_SUBJECT"
-fi
-''']
+```bash
+aimx hooks create \
+  --mailbox alerts \
+  --event after_send \
+  --cmd '["/bin/sh", "-c", "if [ \"$AIMX_SEND_STATUS\" != \"delivered\" ]; then ntfy pub on-call \"aimx send to $AIMX_TO $AIMX_SEND_STATUS: $AIMX_SUBJECT\"; fi"]' \
+  --stdin none \
+  --name alerts_failed_page
 ```
 
-### Notify only on matching recipients (shell guard)
+### Recipient-based filtering (shell guard)
 
-Filter fields on hooks have been removed — do recipient/subject matching in the `cmd` itself with a shell guard.
+`after_send` hooks have no built-in filter fields — do recipient/subject matching in the `cmd` itself with a shell guard.
 
-```toml
-[[mailboxes.marketing.hooks]]
-name = "marknotify01"
-event = "after_send"
-cmd = ["/bin/sh", "-c", '''
-case "$AIMX_TO" in
-  *@customer-co.com)
-    curl -fsS -X POST https://hooks.internal/marketing-sent \
-         -d "to=$AIMX_TO&status=$AIMX_SEND_STATUS"
-    ;;
-esac
-''']
+```bash
+aimx hooks create \
+  --mailbox marketing \
+  --event after_send \
+  --cmd '["/bin/sh", "-c", "case \"$AIMX_TO\" in *@customer-co.com) curl -fsS -X POST https://hooks.internal/marketing-sent -d \"to=$AIMX_TO&status=$AIMX_SEND_STATUS\" ;; esac"]' \
+  --stdin none \
+  --name marketing_customer_notify
 ```
 
 ## Operational tips
 
 ### Logging
 
-Every recipe above redirects stdout and stderr to a log file because `aimx serve` runs detached. Without the redirect, the agent's output is lost. aimx itself emits one structured log line per hook fire to journald:
+aimx itself emits one structured log line per hook fire to journald:
 
 ```text
-hook_name=<name> event=<on_receive|after_send> mailbox=<m> (email_id=<id>|message_id=<id>) exit_code=<n> duration_ms=<n>
+hook_name=<name> event=<on_receive|after_send> mailbox=<m> owner=<u> exit_code=<n> duration_ms=<n>
 ```
 
-Grep by `hook_name=<name>` (`journalctl -u aimx | grep hook_name=claudeinbox1`) to trace every fire of a specific hook.
+Grep by `hook_name=<name>` (`journalctl -u aimx | grep hook_name=accounts_claude`) to trace every fire of a specific hook. Hook stdout / stderr are captured by the daemon (truncated at 64 KiB each) and surfaced as `stderr_tail=...` on the structured line.
+
+If you want a separate per-agent log file too, wrap the agent invocation in `["/bin/sh", "-c", "<agent> ... >> /var/log/aimx/<agent>.log 2>&1"]`. Most operators find the journald line sufficient.
 
 ### Exit codes
 
-A non-zero exit from the hook command is logged to `aimx serve`'s stderr at `warn` but does NOT block delivery or the send. Email is always stored as a `.md` file. This is intentional: you do not want flaky agent CLIs to stall your mailbox.
+A non-zero exit from the hook command is logged at `warn` but does **not** block delivery or the send. Email is always stored as a `.md` file. This is intentional: you do not want flaky agent CLIs to stall your mailbox.
 
 ### Concurrent hooks
 
-If two emails arrive in rapid succession, `aimx serve` fires two hook shells in parallel. Agent CLIs that lock a resource (e.g. an Aider-managed git repo) can collide. Serialise with `flock`:
+If two emails arrive in rapid succession, `aimx serve` fires two hook subprocesses in parallel. Agent CLIs that lock a resource (e.g. a per-repo Aider session) can collide. Serialise inside your own wrapper using `flock`:
 
 ```bash
-flock /tmp/aider-myapp.lock aider --yes-always --message "..." ...
+aimx hooks create \
+  --mailbox bugs \
+  --event on_receive \
+  --cmd '["/usr/bin/flock", "/tmp/myapp.lock", "/usr/local/bin/claude", "-p", "Reproduce the reported bug.", "--dangerously-skip-permissions"]' \
+  --stdin email \
+  --name bugs_serialised
 ```
 
 ### Testing a recipe locally
 
-Use the integration test fixture path to simulate a real delivery without a live SMTP exchange:
+Use the `aimx ingest` CLI to simulate a real delivery without a live SMTP exchange:
 
 ```bash
-aimx --data-dir /tmp/aimx-test ingest catchall@agent.example.com \
+sudo aimx --data-dir /tmp/aimx-test ingest catchall@agent.example.com \
      < tests/fixtures/plain.eml
 ```
 
-Check your log file and confirm the agent ran with the expected template values.
+Watch journald (`aimx logs --follow`) and confirm the agent ran with the expected env vars.
 
 ---
 

--- a/book/hooks.md
+++ b/book/hooks.md
@@ -1,106 +1,66 @@
 # Hooks & Trust
 
-Hooks trigger commands on specific email events. Two events are supported today:
+Hooks trigger commands on specific email events. Two events are supported:
 
 - **`on_receive`** fires during inbound ingest, after the email is stored.
 - **`after_send`** fires during outbound delivery, after the MX attempt resolves (success, failure, or deferred).
 
-aimx supports two hook flavours:
-
-1. **Template hooks (recommended).** Per-agent templates are registered by each user who runs `aimx agents setup <agent>` (no sudo); an agent-neutral `webhook` template ships pre-bundled. Agents then pick a template and fill declared parameters via MCP. Each template's `run_as` equals the registering user's Linux username, so hook children drop into that user's uid before exec.
-2. **Raw-cmd hooks (power user).** The operator hand-writes a shell command in `config.toml` or via `sudo aimx hooks create --cmd`. Raw-cmd hooks carry an explicit `run_as` username (any existing Linux user, or the reserved `aimx-catchall` / `root`).
-
 Combined with the mailbox-level `trust` policy, hooks gate shell-side automation on DKIM-verified inbound mail and on outbound delivery outcomes.
 
-> For copy-paste agent-specific invocations (Claude Code, Codex CLI, OpenCode, Gemini CLI, Goose, OpenClaw, Hermes, Aider), see [Hook Recipes](hook-recipes.md).
+> For copy-paste agent-specific invocations (Claude Code, Codex CLI, OpenCode, Gemini CLI, Goose, OpenClaw, Hermes, webhook), see [Hook Recipes](hook-recipes.md).
 
-## Template hooks (recommended)
+## Mailbox ownership = hook authorization
 
-Templates are the agent-native way to wire up hooks. They enable the "chat with your agent to add an automation" flow: the operator picks which templates are allowed on the box during `aimx setup`, then an AI agent talks to the `aimx mcp` server and creates hooks against those templates without ever touching a shell.
+Every mailbox declares a single `owner` (a Linux user on the host). Ownership is the authorization predicate for everything that touches the mailbox:
 
-### Why templates?
+- Mailbox storage (`/var/lib/aimx/inbox/<name>/` and `/var/lib/aimx/sent/<name>/`) is `<owner>:<owner>` mode `0700`. Only the owner — and root — can read or list its contents.
+- Hooks on that mailbox can be created, listed, and deleted only by root or by the owner (via CLI as the owner's uid, or via the MCP `hook_create` / `hook_delete` tools running under the owner's uid).
+- Hooks always execute as the mailbox's owner uid. The daemon spawns the subprocess and `setuid`s to `mailbox.owner_uid()` before `exec`. There is no per-hook `run_as` override.
 
-- **No shell injection surface.** An agent that can create arbitrary `cmd` strings can escalate to local RCE. A template exposes only declared `{placeholder}` slots; parameter values substitute into argv entries but can never introduce new arguments or escape their slot (no shell is ever invoked).
-- **Sandboxed by default.** Every template hook drops to the template's `run_as` user before exec (non-root, no login shell, no access to `/etc/aimx/dkim/`). On systemd hosts the sandbox adds `ProtectSystem=strict`, `PrivateDevices=yes`, `NoNewPrivileges=yes`, and a `MemoryMax=256M` cap via `systemd-run`.
-- **Agent-friendly discovery.** MCP exposes `hook_list_templates` (filtered to the caller's visibility) so an agent can enumerate what it can wire up before asking.
+What this buys you: a hook on `alice`'s mailbox can do anything `alice` could already do (cron, `~/.bashrc`, systemd `--user`, etc.). It cannot escalate privilege, and it cannot read `bob`'s mail — `/var/lib/aimx/inbox/bob/` is `bob:bob 0700`, which `alice` cannot even traverse.
 
-### Install templates
+To run a hook as root, set `mailbox.owner = "root"` in `/etc/aimx/config.toml`. That requires editing the root-owned file directly. Catchall mailboxes are owned by the reserved `aimx-catchall` system user (created on demand by `aimx setup`); **hooks on the catchall mailbox are forbidden** at config-load time because the catchall user has no shell and no resolvable login uid that `setuid` can drop into.
 
-Per-agent templates are registered on demand by the user who wants them:
+## Hook schema
 
-```bash
-aimx agents setup claude-code     # runs as the user, no sudo
-```
-
-This probes `$PATH` for the agent binary, submits `TEMPLATE-CREATE` over the UDS, and lands a template named `invoke-<agent>-<username>` (for example `invoke-claude-alice`). The daemon hot-swaps its in-memory config so the template is live immediately — no SIGHUP, no restart. See [Agent integration](agent-integration.md) for the full flow.
-
-Only the agent-neutral `webhook` template ships pre-bundled. All other templates are user-registered.
-
-Use `aimx hooks templates` to list the templates visible on your box. An operator can always drop a `[[hook_template]]` block into `config.toml` by hand for a hand-built template — the UDS verb only accepts templates whose `run_as` matches the caller's uid, but root's `config.toml` edit can install anything (for example `run_as = "aimx-catchall"` for a catchall-bound template, or `run_as = "root"` for a rare privileged handler).
-
-### Create a template hook via MCP
-
-An agent in an `aimx mcp` session discovers and creates hooks like this (see [MCP Server](mcp.md) for the full tool reference):
-
-```json
-{"name": "hook_list_templates", "arguments": {}}
-```
-
-```json
-{"name": "hook_create", "arguments": {
-  "mailbox": "accounts",
-  "event": "on_receive",
-  "template": "invoke-claude-alice",
-  "params": {"prompt": "You are the accounts agent. File this email and draft a reply with the current balance."}
-}}
-```
-
-Template hooks created via MCP are tagged `origin = "mcp"` in `config.toml`. An agent can later `hook_list` and `hook_delete` its own hooks, but it cannot delete an operator-authored hook (`origin = "operator"`). See the [origin model](#hook-origin-mcp-vs-operator) below.
-
-### Create a template hook via CLI
-
-Operators can create template hooks from the shell too:
-
-```bash
-sudo aimx hooks create \
-  --mailbox accounts \
-  --event on_receive \
-  --template invoke-claude-alice \
-  --param prompt="You are the accounts agent..."
-```
-
-The CLI sends the request over the same UDS verb MCP uses, so the hook ends up with `origin = "mcp"` (the tag marks the submission channel, not authorship). Use raw-cmd creation when you want `origin = "operator"`.
-
-## Raw-cmd hooks (power user)
-
-Raw-cmd hooks let the operator drop an argv array directly into `config.toml`. The argv is exec'd as the mailbox's `owner` inside the privilege-dropped sandbox — there is no shell wrapping. If you need shell expansion (env-var substitution, redirection), spell out `cmd = ["/bin/sh", "-c", "..."]` explicitly.
+Hooks live as `[[mailboxes.<name>.hooks]]` arrays-of-tables in `/etc/aimx/config.toml`:
 
 ```toml
 [[mailboxes.support.hooks]]
 name = "support_notify"
 event = "on_receive"
-cmd = ["/bin/sh", "-c", 'echo "New email from $AIMX_FROM: $AIMX_SUBJECT" >> /tmp/email.log']
+cmd = ["/bin/sh", "-c", 'echo "New mail from $AIMX_FROM: $AIMX_SUBJECT" >> /tmp/email.log']
 ```
 
-### Create a raw-cmd hook
+`cmd` is exec'd directly as the mailbox owner — there is no shell wrapping. If you need shell expansion (env-var substitution, redirection, pipes), spell out `cmd = ["/bin/sh", "-c", "..."]` explicitly so it's visible at the call site.
 
-`--cmd` takes the argv as a JSON array string. The first element must be an absolute path:
+### Hook properties
+
+| Property | Type | Required | Description |
+|----------|------|----------|-------------|
+| `name` | string | no | Matches `^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$`. When omitted, aimx derives a stable 12-char hex name from `sha256(event + joined_argv + fire_on_untrusted)`. Names must be globally unique across mailboxes — including derived ones. |
+| `event` | string | yes | `"on_receive"` or `"after_send"`. |
+| `type` | string | no | Trigger kind (default `"cmd"`). Only `cmd` is supported today. |
+| `cmd` | array of strings | yes | Argv exec'd directly. Must be non-empty; `cmd[0]` must be an absolute path. No shell wrapping — wrap in `["/bin/sh", "-c", "..."]` explicitly when you need shell expansion. |
+| `stdin` | string | no | `"email"` (default) pipes the raw `.md` (frontmatter + body) to the hook's stdin; `"none"` closes stdin immediately so the hook only sees env vars. |
+| `timeout_secs` | int | no | Hard subprocess timeout in seconds. Default `60`, range `[1, 600]`. SIGTERM at the limit, SIGKILL 5s later. |
+| `fire_on_untrusted` | bool | no | `on_receive` only: when `true`, fire even if `trusted != "true"`. Default `false`. Rejected on `after_send` hooks at config load. |
+
+Multiple hooks can be defined per mailbox; each is evaluated independently. Unknown fields on a hook table are rejected at config load.
+
+## Creating hooks
+
+### Via CLI (owner or root)
 
 ```bash
-# on_receive with an explicit name (shell wrapper for env-var expansion)
-sudo aimx hooks create \
+# As the mailbox owner — uses the daemon's UDS socket; takes effect on the next event
+aimx hooks create \
   --mailbox support \
   --event on_receive \
   --cmd '["/bin/sh", "-c", "curl -fsS -X POST https://hooks.example.com/notify -d \"$AIMX_SUBJECT\""]' \
   --name support_notify
 
-# after_send: log successful deliveries
-sudo aimx hooks create \
-  --mailbox alice \
-  --event after_send \
-  --cmd '["/bin/sh", "-c", "printf \"%s -> %s: %s\\n\" \"$AIMX_FROM\" \"$AIMX_TO\" \"$AIMX_SEND_STATUS\" >> /var/log/aimx-outbound.log"]'
-
-# on_receive: direct argv exec, no shell required
+# As root — same UDS path; root passes every authorization check
 sudo aimx hooks create \
   --mailbox catchall \
   --event on_receive \
@@ -108,21 +68,25 @@ sudo aimx hooks create \
   --fire-on-untrusted
 ```
 
-Raw-cmd hook creation requires `sudo` because it writes `/etc/aimx/config.toml` directly (bypassing the UDS) and then sends SIGHUP to `aimx serve` to hot-reload. If the daemon isn't running, the CLI writes the config and prints a restart hint.
+`--cmd` takes the argv as a JSON array string. `cmd[0]` must be an absolute path.
 
-### Hook properties
+When the daemon is running, the CLI submits over `/run/aimx/aimx.sock`; the daemon hot-swaps its in-memory `Config` so the new hook is live on the very next event — **no restart required**. When the daemon is stopped, the CLI falls back to editing `config.toml` directly (root only) and prints a restart hint; non-root callers hard-error since they cannot write the root-owned config.
 
-| Property | Type | Required | Description |
-|----------|------|----------|-------------|
-| `name` | string | no | Matches `^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$`. When omitted, aimx derives a stable 12-char hex name from `sha256(event + joined_argv + fire_on_untrusted)`. Names must be globally unique across mailboxes, including derived ones. |
-| `event` | string | yes | `"on_receive"` or `"after_send"`. |
-| `type` | string | no | Trigger kind (default `"cmd"`). Only `cmd` is supported today. |
-| `cmd` | array of strings | yes | Argv exec'd directly. Must be non-empty; `cmd[0]` must be an absolute path. No shell wrapping — wrap in `["/bin/sh", "-c", "..."]` explicitly when you need shell expansion. |
-| `stdin` | string | no | `"email"` (default) pipes the raw `.md` (frontmatter + body) to the hook's stdin; `"none"` closes stdin immediately so the hook only sees env vars. |
-| `timeout_secs` | int | no | Hard subprocess timeout in seconds. Default `60`, range `[1, 600]`. SIGTERM at the limit, SIGKILL 5s later. |
-| `fire_on_untrusted` | bool | no | `on_receive` only: when `true`, fire even if `trusted != "true"`. Default `false`. |
+### Via MCP (owner's agent)
 
-Multiple hooks can be defined per mailbox; each is evaluated independently. Unknown fields on a hook table are rejected at config load.
+When `aimx mcp` runs under the mailbox owner's uid, the agent can create hooks programmatically:
+
+```json
+{"name": "hook_create", "arguments": {
+  "mailbox": "accounts",
+  "event": "on_receive",
+  "cmd": ["/usr/local/bin/claude", "-p", "Read this email and act on it.", "--dangerously-skip-permissions"],
+  "stdin": "email",
+  "fire_on_untrusted": false
+}}
+```
+
+See [MCP Server: hook_create](mcp.md#hook_create) for the full tool reference. Each agent's bundled skill ships a copy-paste `cmd` recipe — see [Hook Recipes](hook-recipes.md).
 
 ## How hooks fire
 
@@ -131,16 +95,16 @@ When an email is ingested or sent:
 1. The email is parsed/saved as a `.md` file (ingest) or the outbound MX result is known (send).
 2. aimx walks the mailbox's `hooks` array, picking entries whose `event` matches.
 3. For `on_receive`, the trust gate is applied: the hook fires iff `trusted == "true"` on the email, OR the hook sets `fire_on_untrusted = true`.
-4. The argv `cmd` is exec'd directly via `spawn_sandboxed` — there is no shell interpretation. Spell out `cmd = ["/bin/sh", "-c", "..."]` explicitly when shell expansion is required.
-5. On systemd the subprocess runs under `systemd-run` with `--uid=<owner>`, `ProtectSystem=strict`, `PrivateDevices=yes`, `NoNewPrivileges=yes`, `MemoryMax=256M`, and a 60s `RuntimeMaxSec`. On OpenRC the daemon `fork+exec`s with `setresgid/setresuid` to `<owner>` plus a manual timeout.
+4. The argv `cmd` is exec'd directly via `spawn_sandboxed`. The daemon `setuid`s to `mailbox.owner_uid()` before `exec`. `cmd` is not interpreted by a shell — wrap in `["/bin/sh", "-c", "..."]` explicitly when shell expansion is required.
+5. On systemd the subprocess runs under `systemd-run` with `--uid=<owner>`, `ProtectSystem=strict`, `PrivateDevices=yes`, `NoNewPrivileges=yes`, `MemoryMax=256M`, and `RuntimeMaxSec=<timeout_secs>`. On OpenRC the daemon `fork+exec`s with `setresgid/setresuid` to `<owner>` plus a manual timeout.
 6. stdout and stderr are captured and truncated at 64 KiB each; the daemon awaits the subprocess for predictable timing.
 7. Hook failures (non-zero exit, timeout) are logged at `warn` but **never block delivery**.
 
 Email is always stored (inbound) or attempted (outbound) regardless of whether hooks succeed or fire.
 
-## Hook context: env vars, stdin, and placeholders
+## Hook context: env vars and stdin
 
-### Env vars (raw-cmd and template hooks both receive these)
+### Env vars
 
 | Env var | Direction | Description |
 |---------|-----------|-------------|
@@ -156,7 +120,7 @@ Email is always stored (inbound) or attempted (outbound) regardless of whether h
 | `AIMX_DATE` | both | Email date (inbound) or send timestamp (outbound) |
 | `AIMX_SEND_STATUS` | after_send | `"delivered"`, `"failed"`, or `"deferred"` |
 
-Always expand env vars inside double quotes (`"$AIMX_SUBJECT"`). Values from sender-controlled headers can contain `$()`, backticks, quotes, or newlines — when you wrap your hook in `["/bin/sh", "-c", "..."]`, these pass through as literal bytes.
+Always expand env vars inside double quotes (`"$AIMX_SUBJECT"`). Values from sender-controlled headers can contain `$()`, backticks, quotes, or newlines — when you wrap your hook in `["/bin/sh", "-c", "..."]`, these pass through as literal bytes inside the quoted expansion.
 
 ### Stdin
 
@@ -165,29 +129,9 @@ Each hook declares one of two `stdin` modes:
 | Mode | Payload | Notes |
 |------|---------|-------|
 | `"email"` | The raw `.md` (frontmatter + body) | Default. Useful when piping into a CLI that takes stdin directly. |
-| `"none"` | Closed immediately | For hooks that just need env vars. |
+| `"none"` | Closed immediately | For hooks that only need env vars. Required for agent CLIs that don't read stdin in headless mode (OpenCode, Hermes). |
 
-Override per-hook with `stdin = "none"` in `config.toml`, `--stdin none` from `aimx hooks create`, or `stdin: "none"` in the MCP `hook_create` payload. Default is `"email"` when omitted.
-
-### Template placeholders
-
-Template `cmd` entries may reference `{name}` placeholders. Two categories:
-
-- **Declared params** — listed in the template's `params = [...]`. Agents fill these via `hook_create`.
-- **Built-ins** — `{event}`, `{mailbox}`, `{message_id}`, `{from}`, `{subject}`. Auto-populated at fire time; missing values become empty strings.
-
-Placeholders can only appear inside string argv entries (never as `cmd[0]` or standalone argv entries). Substituted values are always exactly one argv slot — no whitespace splitting, no shell interpretation. NUL, `\r`, and other control bytes in parameter values are rejected at fire time.
-
-## Hook origin: MCP vs operator
-
-Every hook carries an `origin` tag:
-
-- **`origin = "operator"`** — written to `config.toml` via CLI `--cmd` or hand-edit. Invisible to MCP `hook_delete` (the daemon returns `ERR origin-protected`).
-- **`origin = "mcp"`** — created over the UDS `HOOK-CREATE` verb. Visible to MCP tools; deletable via MCP `hook_delete` or `aimx hooks delete`.
-
-The tag is stamped by the daemon based on submission channel, not by the author identity. An operator who runs `aimx hooks create --template ... --param ...` traverses the UDS verb and ends up with an `origin = "mcp"` hook. Use `--cmd` when you want an UDS-protected `origin = "operator"` hook.
-
-MCP `hook_list` shows all hooks but **masks `cmd` / `params` on operator-origin entries** so agents can avoid duplicates without snooping on operator logic.
+Override per-hook with `stdin = "none"` in `config.toml`, `--stdin none` from `aimx hooks create`, or `"stdin": "none"` in the MCP `hook_create` payload. The `email_json` mode that earlier drafts shipped has been removed — `Config::load` rejects it with a clear error.
 
 ## UDS authorization (`SO_PEERCRED`)
 
@@ -198,29 +142,15 @@ MCP `hook_list` shows all hooks but **masks `cmd` / `params` on operator-origin 
 | `SEND` | Caller uid must own the mailbox resolved from the `From:` local part, OR be root. |
 | `MARK-READ` / `MARK-UNREAD` | Caller uid must own the target mailbox, OR be root. |
 | `MAILBOX-CREATE` / `MAILBOX-DELETE` | Root only. |
-| `HOOK-CREATE` | Caller uid must own the target mailbox (so alice cannot attach hooks to bob's mailbox). |
-| `HOOK-DELETE` | Caller uid must own the target mailbox. Origin-protection rules (operator-origin hooks are CLI-only to remove) still apply. |
-| `TEMPLATE-CREATE` | Caller's username must equal the submitted `run_as`. `root` and `aimx-catchall` templates can only be created by a root-executed `config.toml` edit; the UDS verb rejects those values regardless of caller. |
-| `TEMPLATE-DELETE` | Caller can delete only templates whose `run_as` equals their username. |
+| `HOOK-CREATE` / `HOOK-DELETE` | Caller uid must own the target mailbox, OR be root. |
 
-Rejected requests return an `AIMX/1 ERR` response with `code = "EACCES"` and a human-readable reason. Caller uid 0 (root) bypasses all mailbox-ownership checks and is logged at info level so `aimx logs` shows the escalation.
-
-### Reserved `run_as` values
-
-Two usernames are reserved and accepted even on hosts where no matching Linux account exists:
-
-| Reserved value | Purpose | Who can set it |
-|----------------|---------|----------------|
-| `aimx-catchall` | System user for catchall-mailbox hooks and templates. Created on demand by `aimx setup` when the operator configures a catchall mailbox. | Anyone editing `config.toml` as root; never accepted via UDS `TEMPLATE-CREATE`. |
-| `root` | Unusual: hooks that need root privileges (rare). | Operator only, via hand-edit of `config.toml`; never accepted via UDS. |
-
-All other `run_as` values must resolve via `getpwnam(3)` at `Config::load`. Unresolvable usernames are retained as orphan-flagged in the in-memory config (the daemon stays up) and soft-skipped at fire time; `aimx doctor` surfaces them.
+Rejected requests return an `AIMX/1 ERR` response with `code = "EACCES"` and the canonical reason `not authorized` (no information leakage about whether the mailbox exists). Caller uid 0 (root) bypasses all mailbox-ownership checks and is logged at info level so `aimx logs` shows the escalation.
 
 ## Trust gate (`on_receive` only)
 
-> An `on_receive` hook fires iff `email.trusted == "true"` OR the hook sets `dangerously_support_untrusted = true`.
+> An `on_receive` hook fires iff `email.trusted == "true"` OR the hook sets `fire_on_untrusted = true`.
 
-MCP-origin hooks cannot set `dangerously_support_untrusted` — if an agent could opt itself into firing on untrusted mail, the template sandbox is the only thing standing between a spoofed email and a subprocess running as the template's `run_as`. The field is only settable on operator-origin hooks in `config.toml`.
+`fire_on_untrusted` is the per-hook escape hatch. Setting it via MCP is the owner's choice — mailbox isolation (uid-scoped storage + uid-scoped exec) is the relevant defense, so an agent opting into untrusted mail on its own mailbox cannot escalate beyond what the owner already has. The flag is illegal on `after_send` hooks; `Config::load` rejects it with `ERR fire_on_untrusted is on_receive only`.
 
 `email.trusted` is computed from the mailbox's `trust` + `trusted_senders` policy and written to frontmatter at ingest:
 
@@ -231,7 +161,7 @@ MCP-origin hooks cannot set `dangerously_support_untrusted` — if an agent coul
 Recommended configuration:
 
 1. Set `trust = "verified"` + `trusted_senders = [...]` at the top level of `config.toml`.
-2. Leave per-hook `dangerously_support_untrusted` off for anything that invokes an agent or writes to the filesystem.
+2. Leave per-hook `fire_on_untrusted` off for anything that invokes an agent or writes to the filesystem in an irreversible way.
 
 ### `trust` modes
 
@@ -246,6 +176,7 @@ trusted_senders = ["*@yourcompany.com"]
 
 [mailboxes.public]
 address = "hello@agent.yourdomain.com"
+owner = "ubuntu"
 trust = "none"
 ```
 
@@ -253,7 +184,7 @@ Per-mailbox `trusted_senders` fully **replaces** the global list (no merging).
 
 ### How trust interacts with storage
 
-**Email is always stored regardless of trust result.** Trust only gates hook execution. An email from an unverified sender is still saved as a `.md` file and visible via `email_list` / `email_read`.
+**Email is always stored regardless of trust result.** Trust only gates hook execution. An email from an unverified sender is still saved as a `.md` file and visible to the mailbox owner via `email_list` / `email_read`.
 
 ### DKIM/SPF verification
 
@@ -261,24 +192,19 @@ During email ingest, aimx verifies DKIM, SPF, and DMARC. Results are stored in t
 
 ## Managing hooks via CLI
 
-All three `aimx hooks` subcommands (list/create/delete) route through the daemon's UDS socket first so newly-created hooks take effect on the very next event. **No restart required** while `aimx serve` is running. If the daemon is stopped, the CLI falls back to editing `config.toml` directly and prints a restart hint.
+All three `aimx hooks` subcommands (list/create/delete) route through the daemon's UDS socket so newly-created hooks take effect on the very next event. **No restart required** while `aimx serve` is running. If the daemon is stopped, root falls back to editing `config.toml` directly and prints a restart hint; non-root callers error out (they cannot edit the root-owned config).
 
 ### List hooks
 
 ```bash
-aimx hooks list                  # all mailboxes
-aimx hooks list --mailbox support # single mailbox
+aimx hooks list                  # mailboxes you own
+aimx hooks list --mailbox support # single mailbox you own
+sudo aimx hooks list --all       # every mailbox, root only
 ```
 
-Prints a table (`NAME`, `MAILBOX`, `EVENT`, `ORIGIN`, `CMD`). The `CMD` column is truncated to 60 chars with a `…` suffix when longer, and is blank for template hooks (see `aimx hooks templates` for their argv shape).
+For non-root callers, output is filtered to mailboxes whose owner matches your euid. `--all` is rejected for non-root with `--all requires root`.
 
-### List templates
-
-```bash
-aimx hooks templates
-```
-
-Prints a table of enabled templates (`NAME`, `DESCRIPTION`, `PARAMS`, `EVENTS`, `RUN_AS`). Empty output means no per-agent templates are registered for your user yet — run `aimx agents setup <agent>` (no sudo) for the agent you want.
+Prints a table (`NAME`, `MAILBOX`, `EVENT`, `CMD`). The `CMD` column is truncated to 60 chars with a `…` suffix when longer.
 
 ### Delete a hook
 
@@ -287,68 +213,60 @@ aimx hooks delete support_notify         # interactive prompt
 aimx hooks delete support_notify --yes   # scripted
 ```
 
-`delete` accepts either an explicit name or a derived one. Operator-origin hooks require `sudo`; MCP-origin hooks can be deleted without privilege via the UDS.
-
-### Prune orphaned templates and hooks
-
-```bash
-sudo aimx hooks prune --orphans          # print diff, ask to confirm
-sudo aimx hooks prune --orphans --yes    # scripted
-sudo aimx hooks prune --orphans --dry-run  # show what would be removed without writing
-```
-
-`hooks prune --orphans` removes every `HookTemplate` whose `run_as` user is gone, plus every `Hook` whose `run_as` user is gone or whose referenced template is gone. It is root-only, atomically rewrites `config.toml`, and prints a summary of what was removed (names plus the reason for each). To avoid cascading a half-broken config, it refuses to run if `aimx doctor` reports non-orphan issues — fix those first. Typical operator flow: delete a Linux user with `userdel alice`, run `aimx doctor` to confirm only orphan warnings remain, then `sudo aimx hooks prune --orphans` to clean up.
+`delete` accepts either an explicit name or a derived one. Authorization is the same as `create`: caller must own the target mailbox, or be root.
 
 ## Structured hook-fire logs
 
-Every hook fire emits one `info`-level log line with a stable format:
+Every hook fire emits one `info`-level log line with a stable shape:
 
 ```text
-hook_name=<name> event=<on_receive|after_send> mailbox=<m> template=<name|-> run_as=<username|root|aimx-catchall> sandbox=<systemd-run|fallback> email_id=<id> exit_code=<n> duration_ms=<n> timed_out=<true|false> stderr_tail="..."
+hook_name=<name> event=<on_receive|after_send> mailbox=<m> owner=<owner> sandbox=<systemd-run|fallback> email_id=<id> exit_code=<n> duration_ms=<n> timed_out=<true|false> stderr_tail="..."
 ```
 
-`template=-` indicates a raw-cmd hook; `run_as` reflects the configured user (resolved at fire time via `getpwnam`). When the user has been removed (`userdel alice`), the daemon soft-skips the hook with a WARN carrying `reason = "run_as_missing"` — see `aimx doctor` and `hooks prune --orphans`.
+`owner` is the resolved uid the subprocess ran as (matching `mailbox.owner` at fire time). When the configured owner has been removed (`userdel alice`), the daemon soft-skips the hook with a WARN carrying `reason = "owner-not-found"` — see `aimx doctor`.
 
-Operators can build `journalctl -u aimx | grep hook_name=<name>` workflows around it to trace every fire. `aimx doctor` parses these log lines to report 24h fire and failure counts per template.
+Operators can build `journalctl -u aimx | grep hook_name=<name>` workflows around it to trace every fire.
 
 ## Examples
 
-### Trigger Claude Code on verified mail (template hook)
+### Trigger Claude Code on verified mail
 
 ```toml
-# config.toml — alice's `aimx agents setup claude-code` writes this block over UDS
-[[hook_template]]
-name = "invoke-claude-alice"
-description = "Pipe email into Claude Code with a prompt"
-cmd = ["/home/alice/.local/bin/claude", "-p", "{prompt}"]
-params = ["prompt"]
+[mailboxes.schedule]
+address = "schedule@agent.yourdomain.com"
+owner = "alice"
+trust = "verified"
+trusted_senders = ["*@yourcompany.com"]
+
+[[mailboxes.schedule.hooks]]
+name = "schedule_claude"
+event = "on_receive"
+cmd = ["/usr/local/bin/claude", "-p", "Handle this scheduling request.", "--dangerously-skip-permissions"]
 stdin = "email"
-run_as = "alice"
-timeout_secs = 60
-allowed_events = ["on_receive", "after_send"]
 ```
 
-Then an agent binds the template to a mailbox:
+The hook fires only when the email's `trusted == "true"`. Claude runs as `alice` (matching the mailbox owner), reads the piped `.md` from stdin, and uses its own MCP tooling to reply.
 
-```bash
-# Via MCP hook_create, or from the CLI (no sudo needed — the UDS verifies the caller owns the mailbox):
-aimx hooks create \
-  --mailbox schedule \
-  --event on_receive \
-  --template invoke-claude-alice \
-  --param prompt="Handle this scheduling request."
-```
-
-### Notify via ntfy (raw-cmd, untrusted)
+### Notify via ntfy on every inbound (untrusted)
 
 ```toml
-[[mailboxes.catchall.hooks]]
+[mailboxes.catchall]
+address = "*@agent.yourdomain.com"
+owner = "aimx-catchall"
+# Note: hooks on the catchall are forbidden at config load.
+# Wire notifications via a non-catchall mailbox instead.
+
+[mailboxes.notify]
+address = "notify@agent.yourdomain.com"
+owner = "ubuntu"
+
+[[mailboxes.notify.hooks]]
 event = "on_receive"
 cmd = ["/bin/sh", "-c", 'ntfy pub agent-mail "New email: $AIMX_SUBJECT from $AIMX_FROM"']
 fire_on_untrusted = true
 ```
 
-### After-send audit log (raw-cmd)
+### After-send audit log
 
 ```toml
 [[mailboxes.alice.hooks]]
@@ -357,17 +275,17 @@ event = "after_send"
 cmd = ["/bin/sh", "-c", 'echo "$AIMX_SEND_STATUS $AIMX_TO $AIMX_SUBJECT" >> /var/log/aimx/alice-sent.log']
 ```
 
-### Webhook (template hook)
+### Webhook (POST the email body to a URL)
 
-```bash
-sudo aimx hooks create \
-  --mailbox alerts \
-  --event on_receive \
-  --template webhook \
-  --param url="https://hooks.example.com/aimx"
+```toml
+[[mailboxes.alerts.hooks]]
+name = "alerts_webhook"
+event = "on_receive"
+cmd = ["/usr/bin/curl", "-sS", "-X", "POST", "-H", "Content-Type: application/json", "--data-binary", "@-", "https://hooks.example.com/aimx"]
+stdin = "email"
 ```
 
-The `webhook` template POSTs `{"raw": "<markdown>"}` via `curl`.
+`--data-binary @-` posts whatever lands on curl's stdin verbatim, which is the raw `.md` (frontmatter + body) when `stdin = "email"`.
 
 ---
 

--- a/book/mcp.md
+++ b/book/mcp.md
@@ -22,56 +22,39 @@ The server runs in stdio mode. It reads from stdin and writes to stdout. It is l
 
 See [Agent Integration](agent-integration.md) for one-line `aimx agents setup <agent>` installers and the manual MCP wiring pattern for clients not yet in the registry.
 
-## Per-user visibility
+## Per-user authorization
 
-The MCP server inherits the uid of the user that launched the client (stdio transport — there is no server process doing multi-user auth). The daemon applies `SO_PEERCRED` on every UDS request made by the MCP server and enforces per-mailbox ownership:
+The MCP server inherits the uid of the user that launched the client (stdio transport — there is no server process doing multi-user auth). At startup the server records its euid as the authorization principal; every tool call checks the same predicate the daemon enforces over the UDS:
 
-- `mailbox_list` returns only mailboxes whose `owner` equals the caller's username. The catchall mailbox is visible because its owner is the reserved `aimx-catchall` user (visible to MCP clients regardless of caller).
-- `email_list`, `email_read`, `email_send`, `email_reply`, `email_mark_read`, `email_mark_unread` all reject with `EACCES` when the target mailbox is owned by another user.
-- `hook_list_templates` returns templates whose `run_as` equals the caller's username, plus reserved templates (`run_as = "aimx-catchall"` or `"root"`).
-- `hook_create` and `hook_delete` operate only on mailboxes the caller owns. The daemon also enforces `hook.run_as == mailbox.owner OR hook.run_as == "root"` (catchall exception: `aimx-catchall`) on every write.
+> Caller is root, or caller's uid equals the target mailbox's `owner_uid`.
+
+What that buys you per tool:
+
+- `mailbox_list` returns only mailboxes whose `owner` resolves to the caller's uid (catchalls are filtered for non-root callers since the catchall owner is `aimx-catchall`).
+- `email_list`, `email_read`, `email_mark_read`, `email_mark_unread`, `email_send`, `email_reply` all reject with `EACCES not authorized` when the target mailbox is owned by another user.
+- `hook_create`, `hook_list`, `hook_delete` operate only on mailboxes the caller owns. `hook_delete` for a hook the caller does not own collapses to `Hook '<name>' not found` so foreign mailbox names do not leak.
 
 Filesystem enforcement backs this up: every mailbox directory is `0700 <owner>:<owner>`, so even direct `.md` reads only succeed for the mailbox's owner. On a single-user box the rules are invisible (one user owns everything); on a multi-user box they give real isolation between alice and bob.
 
 Root running the MCP server bypasses mailbox-ownership checks (and is logged at info level). Non-root callers see only their own world.
 
-See [Hooks § UDS authorization (`SO_PEERCRED`)](hooks.md#uds-authorization-so_peercred) for the full per-verb authz table and the reserved `run_as` values.
+> **Removed in this release.** `mailbox_create`, `mailbox_delete`, and `hook_list_templates` are no longer MCP tools. Mailbox CRUD moves to the root-only host CLI (`sudo aimx mailboxes create | delete`); template hooks have been retired in favor of the unified plain-`cmd` model. Agents that previously called these tools will get a "tool not found" error and should call `hook_create` directly with the `cmd` argv from their bundled plugin recipe.
+
+See [Hooks § UDS authorization (`SO_PEERCRED`)](hooks.md#uds-authorization-so_peercred) for the full per-verb authz table.
 
 ## MCP tools
 
-aimx exposes 13 MCP tools organized into mailbox management, email operations, and hook templates.
+aimx exposes 10 MCP tools organized into mailbox listing, email operations, and hook management.
 
 ### Mailbox tools
 
 #### `mailbox_list`
 
-List all mailboxes with message counts.
+List mailboxes you own.
 
 **Parameters:** none
 
-**Returns:** List of mailboxes with addresses, total count, and unread count.
-
----
-
-#### `mailbox_create`
-
-Create a new mailbox.
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `name` | string | yes | Mailbox name (becomes the local part of the email address) |
-
-Creates `<name>@yourdomain.com` and the corresponding directory. No mail server restart required.
-
----
-
-#### `mailbox_delete`
-
-Delete a mailbox and all its emails.
-
-| Parameter | Type | Required | Description |
-|-----------|------|----------|-------------|
-| `name` | string | yes | Mailbox name to delete |
+**Returns:** List of mailboxes with addresses, total count, and unread count. Filtered to caller-owned mailboxes for non-root; root sees everything.
 
 ---
 
@@ -83,14 +66,14 @@ List emails in a mailbox with optional filters.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `mailbox` | string | yes | Mailbox name to list emails from |
+| `mailbox` | string | yes | Mailbox name to list emails from. Must be owned by the caller. |
 | `folder` | string | no | `"inbox"` (default) or `"sent"`. Picks which side of the mailbox to list |
 | `unread` | bool | no | Filter to only unread emails |
 | `from` | string | no | Filter by sender address (substring match) |
 | `since` | string | no | Filter to emails since this datetime (RFC 3339 format) |
 | `subject` | string | no | Filter by subject (substring match, case-insensitive) |
 
-**Returns:** Email metadata (frontmatter only, not body).
+**Returns:** Email metadata (frontmatter only, not body). Returns `EACCES not authorized` if the caller does not own the target mailbox.
 
 ---
 
@@ -104,7 +87,7 @@ Read the full content of an email.
 | `id` | string | yes | Email ID, i.e. the filename stem (e.g. `2025-01-15-103000-meeting`) |
 | `folder` | string | no | `"inbox"` (default) or `"sent"` |
 
-**Returns:** Complete `.md` file content including frontmatter and body.
+**Returns:** Complete `.md` file content including frontmatter and body. Returns `EACCES not authorized` if the caller does not own the target mailbox.
 
 ---
 
@@ -114,7 +97,7 @@ Compose and send an email with DKIM signing.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `from_mailbox` | string | yes | Mailbox name to send from |
+| `from_mailbox` | string | yes | Mailbox name to send from. Must be owned by the caller. |
 | `to` | string | yes | Recipient email address |
 | `subject` | string | yes | Email subject |
 | `body` | string | yes | Email body text |
@@ -122,7 +105,7 @@ Compose and send an email with DKIM signing.
 | `reply_to` | string | no | Message-ID of the email being replied to. Sets the `In-Reply-To` header and (when `references` is omitted) builds the `References` chain automatically. Required to enable threading. Without `reply_to`, any `references` value is silently ignored and no threading headers are emitted |
 | `references` | string | no | Full `References` header chain (space-separated Message-IDs). **Only applied when `reply_to` is also set.** Supplied alone, it is silently ignored |
 
-The MCP server composes the RFC 5322 message and submits it to `aimx serve` over the local `/run/aimx/aimx.sock` UDS. `aimx serve` DKIM-signs the message and delivers it directly to the recipient's MX server via SMTP.
+The MCP server composes the RFC 5322 message and submits it to `aimx serve` over the local `/run/aimx/aimx.sock` UDS. `aimx serve` parses `From:` from the body, validates that the caller's uid owns the resolved mailbox, DKIM-signs the message, and delivers it directly to the recipient's MX server via SMTP.
 
 For replies to a single sender, prefer `email_reply`. It handles threading headers and the `Re:` subject prefix automatically. Use `email_send` with `reply_to` / `references` only when you need to override the recipient list (e.g. reply-all) or build a custom threading chain.
 
@@ -134,7 +117,7 @@ Reply to an email with correct threading.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `mailbox` | string | yes | Mailbox name containing the email to reply to |
+| `mailbox` | string | yes | Mailbox name containing the email to reply to. Must be owned by the caller. |
 | `id` | string | yes | Email ID to reply to (e.g. `2025-01-15-001`) |
 | `body` | string | yes | Reply body text |
 
@@ -148,7 +131,7 @@ Mark an email as read.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `mailbox` | string | yes | Mailbox name |
+| `mailbox` | string | yes | Mailbox name. Must be owned by the caller. |
 | `id` | string | yes | Email ID (filename stem, e.g. `2025-01-15-103000-meeting`) |
 | `folder` | string | no | `"inbox"` (default) or `"sent"` |
 
@@ -162,7 +145,7 @@ Mark an email as unread.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `mailbox` | string | yes | Mailbox name |
+| `mailbox` | string | yes | Mailbox name. Must be owned by the caller. |
 | `id` | string | yes | Email ID (filename stem, e.g. `2025-01-15-103000-meeting`) |
 | `folder` | string | no | `"inbox"` (default) or `"sent"` |
 
@@ -170,78 +153,61 @@ Updates `read = false` in the email's frontmatter. Same daemon-mediated write pa
 
 ---
 
-### Hook template tools
+### Hook tools
 
-Four tools let agents safely self-configure hooks without shell access. See [Hooks & Trust § Template hooks](hooks.md#template-hooks-recommended) for the model and why raw `cmd` submission over MCP is rejected by design.
-
-#### `hook_list_templates`
-
-Enumerate hook templates enabled on this install.
-
-**Parameters:** none
-
-**Returns:** JSON array of template descriptors, each with `name`, `description`, `params`, and `allowed_events`. Empty `[]` when no templates are visible — for per-agent templates the caller should run `aimx agents setup <agent>` (no sudo) to register `invoke-<agent>-<username>`. Templates are filtered to the caller's visibility: only `run_as = <caller_username>` and reserved-`run_as` templates are returned.
-
-Example (for alice, after running `aimx agents setup claude-code`):
-
-```json
-[
-  {
-    "name": "invoke-claude-alice",
-    "description": "Pipe email into Claude Code with a prompt",
-    "params": ["prompt"],
-    "allowed_events": ["on_receive", "after_send"]
-  },
-  {
-    "name": "webhook",
-    "description": "POST the email as JSON to a URL",
-    "params": ["url"],
-    "allowed_events": ["on_receive", "after_send"]
-  }
-]
-```
-
----
+Three tools let agents self-configure hooks on mailboxes they own. See [Hooks & Trust](hooks.md) for the model and [Hook Recipes](hook-recipes.md) for verified per-agent `cmd` argv.
 
 #### `hook_create`
 
-Bind a template to a mailbox, creating a new hook. The daemon stamps `origin = "mcp"`.
+Create a new hook on a mailbox you own. The daemon validates the caller's uid against the mailbox's `owner_uid` via `SO_PEERCRED` and rejects with `EACCES not authorized` if the predicate fails.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `mailbox` | string | yes | Target mailbox name |
-| `event` | string | yes | `"on_receive"` or `"after_send"` (must be in the template's `allowed_events`) |
-| `template` | string | yes | Template name from `hook_list_templates` |
-| `params` | object | yes | Key/value map for the template's declared `params` |
-| `name` | string | no | Explicit hook name. When omitted, a stable 12-hex-char name is derived from `(event, template, params)` |
+| `mailbox` | string | yes | Target mailbox name. Must be owned by the caller. |
+| `event` | string | yes | `"on_receive"` or `"after_send"` |
+| `cmd` | array of strings | yes | Argv exec'd directly when the hook fires. `cmd[0]` must be an absolute path. |
+| `name` | string | no | Explicit hook name. When omitted, a stable 12-hex-char name is derived from `sha256(event + joined_argv + fire_on_untrusted)`. |
+| `stdin` | string | no | `"email"` (default) pipes the raw `.md` to the hook's stdin; `"none"` closes stdin immediately. |
+| `timeout_secs` | int | no | Hard subprocess timeout in seconds. Default `60`, range `[1, 600]`. |
+| `fire_on_untrusted` | bool | no | `on_receive` only: fire even when `trusted != "true"`. Default `false`. Rejected on `after_send`. |
 
-**Returns:** `{effective_name, substituted_argv}` — the hook name the daemon wrote and the resolved argv the sandboxed executor will run, for confirmation in the agent's UI.
+**Returns:** `{effective_name}` — the hook name the daemon wrote.
 
-Safety model: the tool refuses any request body that contains a raw `cmd`, `run_as`, `dangerously_support_untrusted`, `timeout_secs`, or `stdin` field. These are template properties, not hook properties. An agent cannot smuggle arbitrary shell past the template boundary.
+Example (Claude Code self-wiring):
+
+```json
+{"name": "hook_create", "arguments": {
+  "mailbox": "accounts",
+  "event": "on_receive",
+  "cmd": ["/usr/local/bin/claude", "-p", "Read the piped email and act on it via the aimx MCP server.", "--dangerously-skip-permissions"],
+  "stdin": "email",
+  "name": "accounts_claude"
+}}
+```
 
 **Error examples:**
 
-- `Unknown template: foo (run hook_list_templates to see enabled templates)`
-- `missing-param: prompt`
-- `event-not-allowed: after_send on template webhook_receive_only`
-- `mailbox-not-found: accounts`
+- `EACCES not authorized` — caller's uid does not own the target mailbox
+- `mailbox-not-found: <name>` — mailbox does not exist
+- `hook has non-absolute cmd[0]` — `cmd[0]` must be an absolute path
+- `fire_on_untrusted is on_receive only` — flag set on an `after_send` hook
+- `catchall does not support hooks` — target was a catchall mailbox
 
 ---
 
 #### `hook_list`
 
-List hooks visible to MCP across all (or one) mailbox.
+List hooks on mailboxes you own.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
-| `mailbox` | string | no | Filter to one mailbox; omit to list all |
+| `mailbox` | string | no | Filter to one mailbox (must be owned by the caller); omit to list every owned mailbox |
 
-**Returns:** JSON array. Each entry has `name`, `mailbox`, `event`, `origin`, and — for `origin = "mcp"` only — `template` + `params`. Operator-origin hooks have `cmd` / `params` **masked** so an agent can avoid duplicates without snooping on operator logic.
+**Returns:** JSON array. Each entry has `name`, `mailbox`, `event`, `cmd`, `stdin`, `timeout_secs`, and `fire_on_untrusted`.
 
 ```json
 [
-  {"name": "accounts-auto-reply", "mailbox": "accounts", "event": "on_receive", "origin": "mcp", "template": "invoke-claude-alice", "params": {"prompt": "..."}},
-  {"name": "op_audit", "mailbox": "accounts", "event": "on_receive", "origin": "operator"}
+  {"name": "accounts_claude", "mailbox": "accounts", "event": "on_receive", "cmd": ["/usr/local/bin/claude", "-p", "...", "--dangerously-skip-permissions"], "stdin": "email", "timeout_secs": 60, "fire_on_untrusted": false}
 ]
 ```
 
@@ -249,19 +215,13 @@ List hooks visible to MCP across all (or one) mailbox.
 
 #### `hook_delete`
 
-Delete a hook by name.
+Delete a hook by name. Caller must own the hook's mailbox.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `name` | string | yes | Effective hook name (explicit or derived) |
 
-MCP can only delete hooks whose `origin = "mcp"`. Attempts to delete an operator-origin hook return `ERR origin-protected`:
-
-```text
-ERR origin-protected: hook was created by the operator — remove via `sudo aimx hooks delete` instead
-```
-
-The agent should surface this verbatim so the user knows the hook is operator-owned.
+Returns `Hook '<name>' not found` for hooks on mailboxes the caller does not own (the lookup is filtered before the existence check, so foreign mailbox names do not leak).
 
 ---
 
@@ -298,7 +258,7 @@ See [Mailboxes: Outbound frontmatter](mailboxes.md#outbound-frontmatter) for the
 
 Two reference documents help agents understand aimx:
 
-- **`agents/common/aimx-primer.md`**: the canonical primer bundled into every agent plugin. Covers MCP tools, storage layout, frontmatter, trust model, and common workflows.
+- **`agents/common/aimx-primer.md`**: the canonical primer bundled into every agent plugin. Covers MCP tools, storage layout, frontmatter, trust model, common workflows, and a "Self-trigger as a mailbox hook" pointer to the agent's own recipe.
 - **`/var/lib/aimx/README.md`**: the runtime datadir guide written by `aimx setup` and refreshed on `aimx serve` startup. Covers the on-disk layout, file naming, slug algorithm, bundle rules, and the UDS send protocol.
 
 ## Compatible agent frameworks

--- a/book/setup.md
+++ b/book/setup.md
@@ -83,28 +83,27 @@ The MCP section prints a short summary listing the `aimx agents setup` commands 
 
 Third-party mail-client workarounds (e.g. Gmail spam-filter whitelists) are **not** part of `aimx setup`'s surface. A correct SPF / DKIM / DMARC triple plus a reverse-DNS (PTR) record at your VPS provider is the canonical deliverability story.
 
-### Mailbox-owner prompt
-
-For every mailbox you configure, setup asks which Linux user should own it:
-
-```text
-[Mailboxes]
-Which Linux user should own `alice@agent.yourdomain.com`? [alice]
-```
-
-- The default (in brackets) is the address's local part if that user exists on the host. Press Enter to accept.
-- If the default user does not exist, setup requires explicit input and rejects unknown usernames with a hint to `useradd` first.
-- The catchall mailbox (if any) is always owned by the reserved `aimx-catchall` system user.
-
-The daemon chowns `/var/lib/aimx/inbox/<mailbox>/` and `/var/lib/aimx/sent/<mailbox>/` to `<owner>:<owner>` mode `0700` at create time and keeps ownership consistent through every subsequent write (ingest, send, mark-read). Only the owner and root can read a mailbox's contents — there is no shared `aimx-hook` group in the current model.
-
 ### Catchall user (created on demand)
 
-When you configure a catchall mailbox, setup creates the `aimx-catchall` system user via `useradd --system --no-create-home --shell /usr/sbin/nologin` (or the BusyBox `adduser` equivalent on Alpine) and chowns the catchall mailbox to it. If you skip the catchall, no `aimx-catchall` user is created. The legacy `aimx-hook` shared-group model has been retired; setup does not create or chown against `aimx-hook` under any flow.
+When you configure a catchall mailbox, setup creates the `aimx-catchall` system user via `useradd --system --no-create-home --shell /usr/sbin/nologin` (or the BusyBox `adduser` equivalent on Alpine) and chowns the catchall mailbox to it. If you skip the catchall, no `aimx-catchall` user is created.
 
-### Registering agent templates
+`aimx-catchall` is the only system user that `aimx setup` creates. The catchall mailbox itself never executes hooks — `Config::load` rejects any `[[mailbox.<catchall>.hook]]` block because the catchall user has no shell and no resolvable login uid that `setuid` can drop into. To run automation on inbound mail, create a non-catchall mailbox owned by a regular Linux user and attach hooks to it after setup.
 
-Per-agent hook templates (Claude Code, Codex, OpenCode, Gemini, Goose, OpenClaw, etc.) are not ticked from a checkbox during setup. Instead, the `aimx agents setup` drop-through (step 6) runs as your regular user (not as root) and presents an interactive checkbox picker. For each selected agent, it lays down plugin files under the caller's `$HOME`, probes `$PATH` for the agent binary, and registers a matching `invoke-<agent>-<username>` template over the UDS. See [Agent integration](agent-integration.md) for the full flow and troubleshooting.
+### Provisioning your first mailbox
+
+The setup wizard does **not** prompt for a first mailbox. After setup completes, provision mailboxes from the host CLI as root:
+
+```bash
+sudo aimx mailboxes create hi --owner ubuntu
+```
+
+This registers `hi@agent.yourdomain.com`, creates `inbox/hi/` and `sent/hi/` chowned `ubuntu:ubuntu 0700`, and hot-reloads the daemon's in-memory config. The mailbox's owner (here `ubuntu`) can then read mail, send mail, and create hooks via CLI or MCP — no further root commands required.
+
+`aimx mailboxes create` and `aimx mailboxes delete` are root-only on both the CLI and the UDS (`MAILBOX-CREATE` / `MAILBOX-DELETE`). The `aimx mailboxes list` command is filtered to caller-owned mailboxes for non-root callers; `--all` is root-only.
+
+### Wiring agents
+
+The `aimx agents setup` drop-through (step 6) runs as your regular user (not as root) and presents an interactive checkbox picker. For each selected agent, it lays down plugin files under the caller's `$HOME`. The plugin teaches the agent how to call aimx's MCP tools, including a "Wiring yourself up as a mailbox hook" section with the verified `cmd` argv to use with `hook_create`. See [Agent integration](agent-integration.md) for the full flow and troubleshooting.
 
 If you logged in directly as root (no `sudo`), the wizard prints a message pointing you at the same tool. You can either re-run `aimx agents setup` as a regular user on the box, or pass `--dangerously-allow-root` if this is a single-user VPS where you genuinely want AIMX wired into `root`'s home.
 

--- a/book/troubleshooting.md
+++ b/book/troubleshooting.md
@@ -34,7 +34,7 @@ The `--verify-host` flag is also accepted by `aimx setup`, and overrides the `ve
 | Emails landing in spam | Missing DNS records, bad reverse DNS, or receiver spam filter | Add all [DNS records](setup.md#dns-configuration), configure a PTR record at your VPS provider, use a Gmail filter |
 | `aimx serve` not running | Service crashed or not started | Check status and logs (see below) |
 | Emails not delivered to mailbox | `aimx serve` not running or misconfigured | Check service status with `systemctl status aimx` |
-| Hooks not firing | Trust gate | `on_receive` hooks fire iff `trusted == "true"` OR the hook sets `dangerously_support_untrusted = true`. Check `trust` / `trusted_senders` and the email's DKIM result. See [trust gate](hooks.md#trust-gate-on_receive-only). |
+| Hooks not firing | Trust gate | `on_receive` hooks fire iff `trusted == "true"` OR the hook sets `fire_on_untrusted = true`. Check `trust` / `trusted_senders` and the email's DKIM result. See [trust gate](hooks.md#trust-gate-on_receive-only). |
 | DKIM verification failing | DNS record mismatch or key regenerated | Ensure DKIM DNS record matches current public key |
 
 ## Restarting setup from scratch
@@ -167,80 +167,78 @@ head -20 /var/lib/aimx/inbox/catchall/*.md
 
 Look at the `dkim` and `spf` fields. They should show `pass` for properly authenticated senders.
 
-## Hook templates
+## Hooks and ownership
 
-### Hook `run_as` user missing
+### Mailbox owner does not exist on the host
 
-Symptom: `aimx doctor` lists a hook under `orphan hooks` with `reason = "run_as_missing"`, or journalctl shows a WARN for a hook fire with `user-not-found`.
+Symptom: `aimx doctor` Ownership section flags a mailbox with `[FAIL] user not found` for its owner, and hook fires for that mailbox are soft-skipped with a WARN carrying `reason = "owner-not-found"`.
 
-Fix: a hook's `run_as` points at a Linux user that has been removed (for example `userdel alice` after an agent cleanup). The daemon soft-skips the hook rather than falling back to a different uid. Either recreate the missing user with `sudo useradd --system --no-create-home --shell /usr/sbin/nologin <name>` and fix up the mailbox ownership, or run `sudo aimx hooks prune --orphans` to drop the stale hook entries. The legacy shared `aimx-hook` user has been retired and `aimx setup` no longer creates it.
-
-### MCP `hook_create` returns `Unknown template`
-
-Symptom: an agent calls `hook_create` with a template name and gets `ERR unknown-template` (or the MCP-surfaced form `Unknown template: ...`).
-
-Fix: the operator never enabled that template. Run `aimx hooks templates` to list what's on this box, then `sudo aimx setup` and tick the template in the checkbox UI. Re-running `aimx setup` is idempotent — it won't overwrite unrelated config.
-
-### MCP `hook_create` returns `missing-param` or `unknown-param`
-
-Symptom: daemon rejects the hook creation with `missing-param: prompt` or `unknown-param: foo`.
-
-Fix: the agent's `params` map didn't match the template's declared `params` list. Inspect the template via `hook_list_templates` (or `aimx hooks templates`) to see the exact parameter names, then re-issue `hook_create` with the complete set.
-
-### Template hook doesn't fire on inbound mail
-
-Symptom: the hook appears in `aimx hooks list` and `origin = "mcp"`, but it never fires when email lands.
-
-Fix: MCP-origin hooks always fire only on trusted mail (`trusted == "true"` in frontmatter). Check the email's frontmatter:
-
-```bash
-grep '^trusted =' /var/lib/aimx/inbox/<mailbox>/<id>.md
-```
-
-If it reads `trusted = "false"` or `trusted = "none"`, the hook gate blocks it. Either:
-
-- Set mailbox `trust = "verified"` + `trusted_senders = [...]` so legitimate senders evaluate to `true`, or
-- Create an operator-origin raw-cmd hook with `dangerously_support_untrusted = true` (only settable in `config.toml`, not via MCP).
-
-### Sandbox denied reading stdin
-
-Symptom: hook logs show `exit_code != 0` and stderr tail like `cat: '/var/lib/aimx/inbox/...': Permission denied`.
-
-Fix: the hook's `run_as` user does not match the mailbox's owner. Each mailbox is chowned to `<owner>:<owner>` at mode `0700`, so only that owner (and root) can read the piped email content. Either fix the hook's `run_as` to equal the mailbox `owner` (the CLI/UDS verbs enforce this; a hand-edited `config.toml` can desync), or reassign the mailbox:
+Fix: the mailbox's `owner =` value points at a Linux user that does not resolve via `getpwnam(3)` on this host (typo in `config.toml`, or the user was removed via `userdel`). Either create the missing user (`sudo useradd --system --no-create-home --shell /usr/sbin/nologin <name>`) and fix up mailbox directory ownership manually:
 
 ```bash
 sudo chown -R <owner>:<owner> /var/lib/aimx/inbox/<mailbox> /var/lib/aimx/sent/<mailbox>
 sudo chmod -R u+rwX,go-rwx /var/lib/aimx/inbox/<mailbox> /var/lib/aimx/sent/<mailbox>
 ```
 
-`aimx doctor` surfaces a WARN line when mailbox ownership has drifted from the configured `owner`.
+Or re-assign the mailbox to a user that does exist by hand-editing `[mailboxes.<name>]` in `/etc/aimx/config.toml` and `sudo systemctl reload aimx`. Doctor's overall exit code is non-zero whenever any mailbox has an unresolvable owner so monitoring can detect orphans.
+
+### Hook on catchall is forbidden
+
+Symptom: `Config::load` fails on daemon startup with `catchall does not support hooks`, or `aimx hooks create --mailbox catchall` returns `EACCES catchall does not support hooks`.
+
+Fix: `aimx-catchall` has no shell and no resolvable login uid that `setuid` can drop into, so hooks on the catchall mailbox have no safe owner to execute as. Move the hook to a non-catchall mailbox owned by a regular user, or — if the goal is "notify on every inbound mail" — create a separate non-catchall mailbox (`sudo aimx mailboxes create notify --owner ubuntu`) and attach the hook there.
+
+### `fire_on_untrusted` rejected on `after_send`
+
+Symptom: `Config::load` fails on daemon startup with `fire_on_untrusted is on_receive only`, or `aimx hooks create --event after_send --fire-on-untrusted` is rejected.
+
+Fix: `fire_on_untrusted` is the trust-gate escape hatch for `on_receive` hooks (which fire only on trusted mail by default). It has no meaning on `after_send` because there is no trust gate on outbound delivery. Remove the flag from any `after_send` hook entry.
+
+### `MAILBOX-CREATE` / `MAILBOX-DELETE` rejected for non-root
+
+Symptom: a non-root call to `aimx mailboxes create` or `aimx mailboxes delete` is rejected with exit code 2, or a `MAILBOX-CREATE` / `MAILBOX-DELETE` UDS request from a non-root caller returns `EACCES not authorized`.
+
+Fix: mailbox CRUD is root-only — both verbs check the caller's uid via `SO_PEERCRED` and refuse anything other than uid 0. Provision mailboxes with `sudo aimx mailboxes create <name> --owner <user>`; the named owner can then CRUD hooks and read/send mail without further root commands. The previous "any local user can create mailboxes via UDS" stance has been retired.
+
+### `aimx send` returns `not authorized: <local_part>@<domain>`
+
+Symptom: `aimx send --from alice@agent.yourdomain.com ...` exits 1 with `not authorized: alice@agent.yourdomain.com` even though the mailbox exists.
+
+Fix: `aimx send` validates the `From:` local part against the caller's owned mailboxes. The mailbox owner (the Linux user named in `[mailboxes.<name>]` `owner =`) is the only non-root caller authorized to send as that address. Run `aimx send` as the mailbox's owner (`sudo -u <owner> aimx send ...` if you're already root), or re-assign ownership in `config.toml`. `aimx send` refuses uid 0 — root cannot run it.
+
+### Hook reads "Permission denied" on stdin
+
+Symptom: hook logs show `exit_code != 0` and stderr tail like `cat: '/var/lib/aimx/inbox/...': Permission denied`.
+
+Fix: the running subprocess is not the mailbox owner. Each mailbox directory is `<owner>:<owner> 0700`, so only the owner (and root) can read the piped email content. The daemon `setuid`s to `mailbox.owner_uid()` before `exec`, so a fresh hook should always run with the right uid; mismatches usually mean someone hand-edited `config.toml` and the on-disk perms drifted. Re-chown to match:
+
+```bash
+sudo chown -R <owner>:<owner> /var/lib/aimx/inbox/<mailbox> /var/lib/aimx/sent/<mailbox>
+sudo chmod -R u+rwX,go-rwx /var/lib/aimx/inbox/<mailbox> /var/lib/aimx/sent/<mailbox>
+```
 
 ### SIGHUP reload failed
 
-Symptom: `aimx hooks create --cmd` completes, prints `Reload:` banner, but the new hook never fires. journalctl shows a `config reloaded with error` warn line.
+Symptom: editing `config.toml` and `sudo systemctl reload aimx` reports success but the new hook never fires. journalctl shows a `config reloaded with error` warn line.
 
-Fix: the new `config.toml` failed validation (unknown field, duplicate hook name, malformed template) so the daemon kept running on the old config. Check the log:
+Fix: the new `config.toml` failed validation. Common culprits: legacy `template`, `params`, `run_as`, `origin`, or `dangerously_support_untrusted` fields on a hook (all rejected at config load with a pointer to `book/hooks.md`); duplicate hook name across mailboxes; `cmd[0]` not an absolute path; `fire_on_untrusted = true` on an `after_send` hook. Check the log:
 
 ```bash
 journalctl -u aimx --since="5 minutes ago" | grep -i reload
 ```
 
-Edit `/etc/aimx/config.toml` to fix the error, then `sudo kill -HUP $(cat /run/aimx/aimx.pid)` or `sudo systemctl reload aimx`.
+Fix the offending field in `/etc/aimx/config.toml`, then `sudo systemctl reload aimx`.
 
-### Template's `cmd[0]` binary not found
+### Hook's `cmd[0]` binary not found
 
-Symptom: `aimx doctor` flags a template with `cmd[0] (MISSING)`, or hook fires log `exit_code = -1` with `spawn-failed` kind.
+Symptom: hook fires log `exit_code = -1` with `spawn-failed` kind.
 
-Fix: the canonical path baked into the template doesn't exist on this box. Override the `cmd[0]` by editing the template in `/etc/aimx/config.toml`:
+Fix: the absolute path written into the hook's `cmd[0]` does not exist on the host. Run `which <agent>` as the mailbox owner to confirm the right path, then delete and re-create the hook with the corrected `cmd[0]`:
 
-```toml
-[[hook_template]]
-name = "invoke-claude"
-cmd = ["/home/alice/.local/bin/claude", "-p", "{prompt}"]
-# ... rest of fields unchanged
+```bash
+aimx hooks delete <name> --yes
+aimx hooks create --mailbox <m> --event on_receive --cmd '["/correct/path/to/agent", "..."]' --stdin email --name <name>
 ```
-
-SIGHUP the daemon (`sudo systemctl reload aimx`) and the new path takes effect on the next fire.
 
 ## Spam prevention
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -385,14 +385,9 @@ pub enum LoadWarning {
     /// Mailbox `owner` doesn't resolve via `getpwnam`. Mailbox is
     /// flagged inactive for the session.
     OrphanMailboxOwner { mailbox: String, owner: String },
-    /// A stale `aimx-hook` system user is present on the host. aimx no
-    /// longer creates this user; doctor notes its presence so the
-    /// operator can clean up.
-    #[allow(dead_code)]
-    LegacyAimxHookUser,
     /// Catchall mailbox is configured with `owner = "root"` and the
-    /// `allow_root_catchall = true` escape hatch (PRD §6.2). Logged at
-    /// WARN so the audit trail records the elevation.
+    /// `allow_root_catchall = true` escape hatch. Logged at WARN so the
+    /// audit trail records the elevation.
     RootCatchallAccepted { mailbox: String },
 }
 
@@ -405,15 +400,10 @@ impl LoadWarning {
                 "mailbox '{mailbox}' owner '{owner}' does not resolve via getpwnam; \
                  mailbox marked inactive — create the user or update config.toml"
             ),
-            LoadWarning::LegacyAimxHookUser => {
-                "legacy 'aimx-hook' system user present; aimx no longer \
-                 manages it — remove via 'userdel aimx-hook' when safe"
-                    .to_string()
-            }
             LoadWarning::RootCatchallAccepted { mailbox } => format!(
                 "catchall mailbox '{mailbox}' is running with owner='root' \
                  and allow_root_catchall=true; this is a documented escape \
-                 hatch (PRD §6.2) — mail lands owned by uid 0"
+                 hatch — mail lands owned by uid 0"
             ),
         }
     }
@@ -1166,7 +1156,7 @@ owner = "ops"
 
 [[mailboxes.support.hooks]]
 event = "on_receive"
-cmd = "true"
+cmd = ["/bin/true"]
 run_as = "ops"
 "#,
         );
@@ -1192,7 +1182,7 @@ owner = "ops"
 
 [[mailboxes.support.hooks]]
 event = "on_receive"
-cmd = "true"
+cmd = ["/bin/true"]
 origin = "operator"
 "#,
         );
@@ -1218,7 +1208,7 @@ owner = "ops"
 
 [[mailboxes.support.hooks]]
 event = "on_receive"
-cmd = "true"
+cmd = ["/bin/true"]
 dangerously_support_untrusted = true
 "#,
         );
@@ -1269,7 +1259,7 @@ owner = "ops"
 
 [[mailboxes.support.hooks]]
 event = "on_receive"
-cmd = "true"
+cmd = ["/bin/true"]
 stdin = "email_json"
 "#,
         );

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -849,11 +849,6 @@ pub fn translate_load_warnings(warnings: &[LoadWarning]) -> Vec<DoctorFinding> {
                     .with_fix("create the user or run `sudo aimx hooks prune --orphans`"),
                 );
             }
-            LoadWarning::LegacyAimxHookUser => {
-                // Translated separately by `check_legacy_aimx_hook_user`
-                // (probes the host directly) so the finding lands even
-                // when nobody pushed this variant onto the warning stream.
-            }
             LoadWarning::RootCatchallAccepted { mailbox } => {
                 out.push(DoctorFinding::new(
                     "ROOT-CATCHALL-ACCEPTED",


### PR DESCRIPTION
## Summary

- Rewrite every `book/` chapter that touched the legacy template-hook surface, the `aimx-hook` system user, the `--no-template` / `--redetect` flags, the deleted `hook_list_templates` / `mailbox_create` / `mailbox_delete` MCP tools, and `dangerously_support_untrusted`. The book now leads with the per-mailbox-owner model end to end.
- Drop dead `LoadWarning::LegacyAimxHookUser` variant + its match arm in `src/doctor.rs` (no producer survived the earlier sprints; the active probe lives in `doctor::check_legacy_aimx_hook_user`). Convert the `load_rejects_*` test fixtures from stale `cmd = "true"` string form to `cmd = ["/bin/true"]` argv form.
- Capture the live-host smoke results at `docs/user-root-rework-smoke-results.md` (matches the format of `docs/onboarding-smoke-results.md`). The targeted ownership / filtering / legacy-config rejection / `aimx send` ownership-mismatch checks ran on the dev host; full `aimx setup` + live daemon binding port 25 / `/run/aimx/aimx.sock` is documented as deferred to operator validation on a clean VPS, with explicit "would run" commands for each deferred row.
- Update the PRD to reflect the actual `EACCES` wire shape (the codec emits `EACCES`; earlier PRD draft used `FORBIDDEN` symbolically). Book chapters and tests are consistent.

## Book chapters touched

- `book/hooks.md` — full rewrite. Leads with mailbox-owner = hook authorization. Drops templates, `run_as`, `origin`, `dangerously_*`. Documents `fire_on_untrusted`, the structured log line, the catchall hook prohibition, the absolute-path requirement on `cmd[0]`.
- `book/hook-recipes.md` — full rewrite. Replaces every legacy recipe with a literal `aimx hooks create` invocation per agent (Claude Code, Codex, OpenCode, Gemini, Goose, OpenClaw documented gap, Hermes, webhook). Native-stdin vs. inline-only is split out; absolute paths required.
- `book/configuration.md` — `[[hook_template]]` schema removed; mailbox `owner` documented as required; reserved mailbox names called out; example block refreshed; storage layout note updated for per-owner perms.
- `book/cli.md` — `aimx hooks create` flags rewritten (`--cmd '<json-array>'`, `--stdin`, `--timeout-secs`, `--fire-on-untrusted`); template subcommands gone; `aimx mailboxes list --all` (root-only) added; `aimx send` ownership rejection documented; `aimx agents setup` loses `--no-template` / `--redetect`; `MAILBOX-CREATE` / `MAILBOX-DELETE` over UDS noted as root-only; doctor section calls out the new Ownership block.
- `book/mcp.md` — tool catalog cut to 10 (7 mail + 3 hook); per-tool authorization documented; `Removed in this release` callout for `hook_list_templates` / `mailbox_create` / `mailbox_delete`.
- `book/setup.md` — Hook Templates checkbox section dropped; `aimx-hook` references gone; first-mailbox provisioning documented as a post-setup step.
- `book/troubleshooting.md` — legacy Hook templates section replaced with new entries: orphan owner, catchall hook prohibition, `fire_on_untrusted` on `after_send`, MAILBOX-CRUD non-root rejection, `aimx send` ownership mismatch.
- `book/faq.md` — replaces template-sandbox Q&A with "what does mailbox ownership mean for security?"; updates the trust-gate Q to use `fire_on_untrusted`; refreshes MCP scoping and mailbox-tree visibility.
- `book/agent-integration.md` — drops the `TEMPLATE-CREATE` step + `invoke-<agent>-<username>` references; `--no-template` / `--redetect` flags removed; agent now reads its own bundled recipe at session start.

## Stories implemented

- S6-1 — `book/hooks.md` + `book/hook-recipes.md` rewrite. **All ACs met.**
- S6-2 — `book/configuration.md`, `book/cli.md`, `book/mcp.md` updates (incl. `book/agent-integration.md` cleanup folded in per the backlog item). **All ACs met.**
- S6-3 — `book/setup.md`, `book/troubleshooting.md`, `book/faq.md` updates. **All ACs met.**
- S6-4 — End-to-end smoke. **Partial / mixed.** Local smoke exercised on the dev host (Steps 2 / 3 / 4-negative / 6); positive paths that need a live daemon binding port 25 + `/run/aimx/aimx.sock` are deferred to a clean-VPS run with concrete replay commands captured in `docs/user-root-rework-smoke-results.md`. Step 8 (S5-2 carryover): Claude Code flag spot-check **passed** (verified `2.1.119 (Claude Code)`); the other six agents are recorded as `[N/A — agent not installed]` on this smoke host with the expected commands an operator would run. Step 9 (Hermes stdin): deferred to operator with Hermes installed.

## PRD update

`docs/user-root-rework-prd.md`: FR-3 / FR-9 / FR-15(`hook_delete`) reworded to match the actual wire shape (`EACCES`, opaque `not authorized`, `Hook '<name>' not found` on cross-owner `hook_delete`). Book chapters and `tests/uds_authz.rs` were already consistent with this.

## Backlog items addressed

- `book/cli.md` legacy hook schema (string-form `--cmd`, `--template`, `--param`, `--dangerously-support-untrusted`, `origin`).
- `book/cli.md` `email_json` stdin mode.
- `book/configuration.md` deleted `[[hook_template]]` schema (incl. defaults table).
- `book/cli.md` and `book/agent-integration.md` deleted `--no-template` / `--redetect` flags.
- `src/config.rs` `LoadWarning::LegacyAimxHookUser` variant + the message arm.
- `src/doctor.rs` orphan match arm for the deleted variant.
- `src/config.rs` stale `cmd = "true"` string-form fixtures converted to `cmd = ["/bin/true"]`.
- PRD `FORBIDDEN` vs codec `EACCES` mismatch — PRD updated.

## Concerns / deferred

- `aimx setup` end-to-end and live-daemon positive paths are deferred to operator validation on a clean VPS — captured concretely in `docs/user-root-rework-smoke-results.md` with replay commands. CI coverage (`tests/uds_authz.rs` 19 ignored UDS-authz tests, `tests/integration.rs` 88 passing, `src/*.rs` 944 passing) blankets the deferred rows so the smoke remains a packaging / UX confirmation rather than a correctness gate.
- Six of seven per-agent flag spot-checks are `[N/A — agent not installed]` on the smoke host. Recipes were verified against upstream documentation during S5-2; an operator on a multi-agent VPS can flip the rows to `[PASS]` after one `<agent> --help | rg <flag>` per agent.

## Test plan

- [x] `cargo test --bin aimx`: 944 passed, 0 failed, 6 ignored.
- [x] `cargo test --tests`: 88 integration passed, 1 mailbox-isolation ignored, 19 UDS-authz ignored (host-uid gated).
- [x] `cargo clippy --all-targets -- -D warnings` clean (main + verifier crates).
- [x] `cargo fmt -- --check` clean (main + verifier crates).
- [x] `cd services/verifier && cargo test`: 43 passed.
- [x] `mdbook build` against `website/book.toml`: book renders cleanly.
- [x] Banned-token grep (`Sprint`, `S<n>-<n>`, `FR-<n>`, `User Story`, `Acceptance criteria`) outside `docs/`: zero hits.
- [ ] Operator: replay `docs/user-root-rework-smoke-results.md` Steps 1, 4-positive, 5, 7-live on a clean Ubuntu 24.04 VPS to flip the deferred rows.