### PR TITLE
Clean up three post-rework backlog items (find_hook_owner borrow, sighup gating, mcp.md tidy)

### DIFF
--- a/book/mcp.md
+++ b/book/mcp.md
@@ -8,7 +8,7 @@ aimx includes a built-in MCP (Model Context Protocol) server that gives AI agent
 
 - **Transport:** stdio (launched on-demand, no daemon)
 - **Protocol:** Model Context Protocol (MCP)
-- **Compatible with:** Claude Code, OpenClaw, Codex, and any MCP-compatible client
+- **Compatible clients:** any MCP-compatible client — see [Compatible agent frameworks](#compatible-agent-frameworks) below for the per-agent integration matrix.
 
 ## Running the MCP server
 

--- a/src/hook_handler.rs
+++ b/src/hook_handler.rs
@@ -250,7 +250,7 @@ pub async fn handle_hook_delete(
 
     // Re-lookup against the same snapshot so the authz check sees a
     // consistent view of the mailbox's owner.
-    let mailbox_cfg = match snapshot.mailboxes.get(&mailbox_name) {
+    let mailbox_cfg = match snapshot.mailboxes.get(mailbox_name) {
         Some(m) => m.clone(),
         None => {
             return AckResponse::Err {
@@ -261,7 +261,7 @@ pub async fn handle_hook_delete(
     };
 
     if let Err(reject) =
-        enforce_mailbox_owner_or_root("HOOK-DELETE", caller, &mailbox_name, &mailbox_cfg)
+        enforce_mailbox_owner_or_root("HOOK-DELETE", caller, mailbox_name, &mailbox_cfg)
     {
         return AckResponse::Err {
             code: reject.code,
@@ -269,7 +269,7 @@ pub async fn handle_hook_delete(
         };
     }
 
-    let lock = state_ctx.lock_for(&mailbox_name);
+    let lock = state_ctx.lock_for(mailbox_name);
     let _guard = lock.lock().await;
     let _config_guard = CONFIG_WRITE_LOCK
         .lock()
@@ -279,7 +279,7 @@ pub async fn handle_hook_delete(
     // the same mailbox doesn't slip past us.
     let current = mb_ctx.config_handle.load();
     let mut new_config: Config = (*current).clone();
-    let mb = match new_config.mailboxes.get_mut(&mailbox_name) {
+    let mb = match new_config.mailboxes.get_mut(mailbox_name) {
         Some(m) => m,
         None => {
             return AckResponse::Err {
@@ -375,11 +375,11 @@ fn parse_event(s: &str) -> Result<HookEvent, String> {
     }
 }
 
-fn find_hook_owner(config: &Config, name: &str) -> Option<String> {
+fn find_hook_owner<'c>(config: &'c Config, name: &str) -> Option<&'c str> {
     for (mailbox_name, mb) in &config.mailboxes {
         for hook in &mb.hooks {
             if effective_hook_name(hook) == name {
-                return Some(mailbox_name.clone());
+                return Some(mailbox_name.as_str());
             }
         }
     }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -273,7 +273,7 @@ pub fn aimx_socket_path() -> PathBuf {
 /// hot-swaps the in-memory `Config` directly; this SIGHUP path is kept
 /// for the daemon-down fallback (root only) where the CLI rewrites
 /// `config.toml` and emits a restart hint to the operator.
-#[allow(dead_code)]
+#[cfg(test)]
 #[derive(Debug, PartialEq, Eq)]
 pub enum SighupOutcome {
     /// Delivered SIGHUP to pid `.0`.
@@ -302,7 +302,7 @@ pub enum SighupOutcome {
 ///    no `pgrep` fallback: matching by process name can return any
 ///    `aimx` binary on the host, including short-lived test
 ///    subprocesses, and SIGHUPing the wrong pid terminates it.
-#[allow(dead_code)]
+#[cfg(test)]
 pub fn sighup_running_daemon() -> SighupOutcome {
     #[cfg(unix)]
     {
@@ -382,8 +382,7 @@ pub fn reload_config(
 /// that fallback matched any `aimx` process (including short-lived
 /// test subprocesses) and could deliver SIGHUP to the wrong pid,
 /// terminating unrelated work under parallel tests.
-#[cfg(unix)]
-#[allow(dead_code)]
+#[cfg(all(unix, test))]
 fn find_daemon_pid() -> Option<i32> {
     let pid_path = runtime_dir().join("aimx.pid");
     let s = std::fs::read_to_string(&pid_path).ok()?;


### PR DESCRIPTION
## Summary

Three small, independently-scoped post-rework backlog items from `docs/user-root-rework-sprint.md`:

- **`find_hook_owner` borrow refactor** (`src/hook_handler.rs`). Changes the return type from `Option<String>` to `Option<&'c str>` borrowed off the `&Config` snapshot. Cold path (HOOK-DELETE only), but the borrow form drops a per-call allocation and reads cleaner. Caller's `mailbox_name` binding lives off the `snapshot` `Arc<Config>` for the rest of the function — verified safe because `snapshot` is never reassigned.

- **Gate `sighup_running_daemon` + helpers behind `#[cfg(test)]`** (`src/serve.rs`). After the CLI hook routing rewrite, no production path reaches for SIGHUP — the daemon-up path uses UDS hot-swap, and the daemon-down fallback only prints a "restart hint". `sighup_running_daemon`, `SighupOutcome`, and `find_daemon_pid` were tagged `#[allow(dead_code)]` and only the existing unit test exercised them. Switched the dead-code allow to `#[cfg(test)]` so the production binary doesn't carry the dead surface, but the test scaffolding survives in case a future feature wants to revive SIGHUP-based hot reload.

- **`book/mcp.md` Overview tidy.** The "Compatible with: Claude Code, OpenClaw, Codex, ..." line at the top of `book/mcp.md` listed three named agents and was slightly out of sync with the canonical "Compatible agent frameworks" table further down. Replaced with a one-liner that points at the table so we have a single source of truth.

All three are flagged in the post-rework Non-blocking Review Backlog (`docs/user-root-rework-sprint.md`).

## Test plan

- [x] `cargo build` clean
- [x] `cargo test` full suite — 944 unit + 88 integration + 1 uds_authz pass; 6 + 5 + 19 ignored (unchanged from `main`)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `services/verifier`: `cargo fmt -- --check`, `cargo clippy -- -D warnings`, `cargo test` (43 passed)
- [x] Banned-token sweep — zero hits outside `docs/`

## Out of scope

- Item 2 (`tests/uds_authz.rs` per-test socket-dir parallelism) — backlog says "defer until the matrix grows"; skipped intentionally.
- Item 3 (`aimx hooks list` non-root-filtering integration test) — needs `runuser`-style scaffolding similar to `tests/uds_authz.rs`; will follow up in a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)