### PR TITLE
[Sprint 1] MAILBOX-LIST UDS verb + non-root mailbox_list

### DIFF
--- a/agents/common/aimx-primer.md
+++ b/agents/common/aimx-primer.md
@@ -19,15 +19,23 @@ startup.
 
 ## Two access surfaces
 
+Mail is stored as `.md` files for a reason — when you do not need a
+mutation, read mailbox files directly with your filesystem tools
+(`Read` / `Glob` / `Grep` / equivalent). MCP is the surface for
+*changes*: send, reply, mark, hook CRUD.
+
 aimx gives you two complementary ways to interact with email:
 
-1. **MCP tools** for all mutations (send, reply, mark read/unread, create
-   hooks). The `aimx` MCP server runs over stdio and is launched
-   on-demand by your MCP client.
-2. **Direct filesystem reads** for reading `.md` email files, scanning
-   directories, or bulk-processing. Mailbox directories are mode `0700`
-   and owned by the mailbox's Linux owner, so you see only the mailboxes
-   owned by the user running your MCP process.
+1. **Direct filesystem reads** for inspecting `.md` email files,
+   scanning directories, or bulk-processing. Mailbox directories are
+   mode `0700` and owned by the mailbox's Linux owner, so you see
+   only the mailboxes owned by the user running your MCP process.
+   `mailbox_list` returns absolute `inbox_path` / `sent_path` values
+   precisely so you can hand them to your filesystem tools without
+   another round-trip.
+2. **MCP tools** for all mutations (send, reply, mark read/unread,
+   create hooks). The `aimx` MCP server runs over stdio and is
+   launched on-demand by your MCP client.
 
 Writes always go through MCP. Never create, modify, or delete `.md` files
 directly. The daemon owns those paths.

--- a/agents/common/references/mcp-tools.md
+++ b/agents/common/references/mcp-tools.md
@@ -36,23 +36,50 @@ are invisible. On a multi-user box they give real isolation.
 
 ### `mailbox_list`
 
-List mailboxes you own with total and unread message counts.
+List mailboxes you own with absolute filesystem paths and message
+counts.
 
 **Parameters:** None.
 
-**Returns:** Formatted list of mailboxes with counts.
+**Returns:** JSON array. One row per visible mailbox with these
+fields:
+
+| Field         | Type   | Description                                                                  |
+|---------------|--------|------------------------------------------------------------------------------|
+| `name`        | string | Mailbox name (the local part).                                               |
+| `inbox_path`  | string | Absolute path to the inbox directory (`/var/lib/aimx/inbox/<name>`).         |
+| `sent_path`   | string | Absolute path to the sent directory (`/var/lib/aimx/sent/<name>`).           |
+| `total`       | number | Total emails in the inbox.                                                   |
+| `unread`      | number | Number of inbox emails with `read = false` in the frontmatter.               |
+| `sent_count`  | number | Total emails in the sent folder.                                             |
+| `registered`  | bool   | `true` for mailboxes in `config.toml`; `false` for stray on-disk dirs only.  |
+
+The empty case returns `[]` (a JSON empty array), never a "no
+mailboxes" string. Mailboxes you do not own are simply absent from
+the array. To create or delete mailboxes, ask the operator to run
+`sudo aimx mailboxes create <name> --owner <user>` or
+`sudo aimx mailboxes delete <name>` on the host.
 
 **Example:**
 ```
 mailbox_list()
-→ "agent (inbox: 12 total, 3 unread; sent: 5 total)
-   reports (inbox: 0 total, 0 unread; sent: 0 total)"
+→ [
+    {
+      "name": "agent",
+      "inbox_path": "/var/lib/aimx/inbox/agent",
+      "sent_path": "/var/lib/aimx/sent/agent",
+      "total": 12,
+      "unread": 3,
+      "sent_count": 5,
+      "registered": true
+    }
+  ]
 ```
 
-Mailboxes you do not own do not appear. To create or delete
-mailboxes, ask the operator to run
-`sudo aimx mailboxes create <name> --owner <user>` or
-`sudo aimx mailboxes delete <name>` on the host.
+**Next step:** read messages directly from disk. Take an `id` from
+`email_list(mailbox: "agent")` (or list the inbox dir) and `Read`
+`<inbox_path>/<id>.md` — no need for `email_read` unless you need
+the daemon to enforce path canonicalisation for you.
 
 ---
 

--- a/book/mcp.md
+++ b/book/mcp.md
@@ -54,7 +54,19 @@ List mailboxes you own.
 
 **Parameters:** none
 
-**Returns:** List of mailboxes with addresses, total count, and unread count. Filtered to caller-owned mailboxes for non-root; root sees everything.
+**Returns:** JSON array. One row per visible mailbox with these fields:
+
+| Field         | Type   | Description                                                                  |
+|---------------|--------|------------------------------------------------------------------------------|
+| `name`        | string | Mailbox name (the local part).                                               |
+| `inbox_path`  | string | Absolute path to the inbox directory (`/var/lib/aimx/inbox/<name>`).         |
+| `sent_path`   | string | Absolute path to the sent directory (`/var/lib/aimx/sent/<name>`).           |
+| `total`       | number | Total emails in the inbox.                                                   |
+| `unread`      | number | Inbox emails with `read = false`.                                            |
+| `sent_count`  | number | Total emails in the sent folder.                                             |
+| `registered`  | bool   | `true` for mailboxes in `config.toml`; `false` for stray on-disk dirs only.  |
+
+The empty case returns `[]`. Filtered to caller-owned mailboxes for non-root callers; root sees everything. The MCP process resolves the listing through the daemon over `/run/aimx/aimx.sock`, so it works without read access to root-owned `config.toml`.
 
 ---
 

--- a/src/mailbox_list_handler.rs
+++ b/src/mailbox_list_handler.rs
@@ -1,0 +1,353 @@
+//! Daemon-side handler for the `MAILBOX-LIST` verb of the `AIMX/1`
+//! UDS protocol.
+//!
+//! The MCP `mailbox_list` tool used to read `/etc/aimx/config.toml`
+//! directly from a non-root process and would always fail on the
+//! `0640 root:root` permission. After this rework the MCP tool is a
+//! thin UDS client: it ships `AIMX/1 MAILBOX-LIST`, the daemon
+//! resolves the caller via `SO_PEERCRED`, and answers with a JSON
+//! array filtered to mailboxes the caller owns.
+//!
+//! Filtering rules (mirror the previous MCP-side semantics):
+//!
+//! - Root sees every mailbox the daemon knows about, including the
+//!   catchall and every stray on-disk directory.
+//! - A non-root caller sees only the mailboxes whose configured
+//!   `owner` resolves to the caller's uid. Stray on-disk directories
+//!   appear only when the directory's owning uid matches the caller.
+//! - The catchall is owned by the dedicated `aimx-catchall` system
+//!   user; non-root callers who are not that user do not see it.
+//!
+//! No locks are taken: the response reads from the in-memory
+//! `Arc<Config>` snapshot via [`ConfigHandle::load`] plus a single
+//! pass over the on-disk inbox/sent counters. A concurrent
+//! `MAILBOX-CREATE` / `MAILBOX-DELETE` may swap the snapshot in
+//! between two MAILBOX-LIST calls, but each individual call observes
+//! a consistent snapshot.
+
+use std::os::unix::fs::MetadataExt;
+use std::path::Path;
+
+#[cfg(test)]
+use serde::Deserialize;
+use serde::Serialize;
+
+use crate::config::Config;
+use crate::mailbox;
+use crate::send_protocol::{ErrCode, JsonAckResponse};
+use crate::state_handler::StateContext;
+use crate::uds_authz::Caller;
+
+/// One row of the JSON array returned by `MAILBOX-LIST`. Field order
+/// matches the PRD: identity → paths → counts → registration flag.
+#[derive(Debug, Serialize)]
+#[cfg_attr(test, derive(Deserialize))]
+pub struct MailboxListRow {
+    pub name: String,
+    pub inbox_path: String,
+    pub sent_path: String,
+    pub total: usize,
+    pub unread: usize,
+    pub sent_count: usize,
+    pub registered: bool,
+}
+
+/// Build the JSON ack response for an `AIMX/1 MAILBOX-LIST` request.
+pub async fn handle_mailbox_list(state_ctx: &StateContext, caller: &Caller) -> JsonAckResponse {
+    let config = state_ctx.config_handle.load();
+    let rows = collect_rows(&config, caller.uid);
+    let body = match serde_json::to_vec(&rows) {
+        Ok(b) => b,
+        Err(e) => {
+            return JsonAckResponse::Err {
+                code: ErrCode::Io,
+                reason: format!("failed to serialize mailbox list: {e}"),
+            };
+        }
+    };
+    JsonAckResponse::Ok { body }
+}
+
+/// Pure helper: walk `discover_mailbox_names`, count messages, and
+/// keep only the rows visible to `caller_uid`. Extracted for unit
+/// testing without spinning up a real `Caller` / `StateContext`.
+fn collect_rows(config: &Config, caller_uid: u32) -> Vec<MailboxListRow> {
+    let names = mailbox::discover_mailbox_names(config);
+    let mut rows: Vec<MailboxListRow> = Vec::with_capacity(names.len());
+    for name in names {
+        if !is_visible_to(config, &name, caller_uid) {
+            continue;
+        }
+        let inbox_dir = config.inbox_dir(&name);
+        let sent_dir = config.sent_dir(&name);
+        let (total, unread) = count_inbox(&inbox_dir);
+        let sent_count = mailbox::count_messages(&sent_dir);
+        rows.push(MailboxListRow {
+            name: name.clone(),
+            inbox_path: inbox_dir.to_string_lossy().into_owned(),
+            sent_path: sent_dir.to_string_lossy().into_owned(),
+            total,
+            unread,
+            sent_count,
+            registered: mailbox::is_registered(config, &name),
+        });
+    }
+    rows.sort_by(|a, b| a.name.cmp(&b.name));
+    rows
+}
+
+/// Visibility rule for the listing. Root sees every mailbox. A non-
+/// root caller sees a mailbox when:
+///
+/// - The mailbox is registered in `config.mailboxes` and its `owner`
+///   resolves to the caller's uid; or
+/// - The mailbox is a stray on-disk directory (no config entry) and
+///   the inbox directory's filesystem owner matches the caller.
+fn is_visible_to(config: &Config, name: &str, caller_uid: u32) -> bool {
+    if caller_uid == 0 {
+        return true;
+    }
+    if mailbox::is_registered(config, name) {
+        return mailbox::caller_owns(config, name, caller_uid);
+    }
+    // Unregistered stray dir: trust the inbox dir's filesystem owner.
+    let inbox_dir = config.inbox_dir(name);
+    inbox_owner_uid(&inbox_dir).is_some_and(|uid| uid == caller_uid)
+}
+
+fn inbox_owner_uid(dir: &Path) -> Option<u32> {
+    std::fs::symlink_metadata(dir).ok().map(|m| m.uid())
+}
+
+fn count_inbox(dir: &Path) -> (usize, usize) {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return (0, 0),
+    };
+    let mut total = 0usize;
+    let mut unread = 0usize;
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        let md_path = if path.is_dir() {
+            let stem = match path.file_name().and_then(|f| f.to_str()) {
+                Some(s) => s.to_string(),
+                None => continue,
+            };
+            let inner = path.join(format!("{stem}.md"));
+            if !inner.exists() {
+                continue;
+            }
+            inner
+        } else if path.extension().is_some_and(|ext| ext == "md") {
+            path
+        } else {
+            continue;
+        };
+        total += 1;
+        if !is_marked_read(&md_path) {
+            unread += 1;
+        }
+    }
+    (total, unread)
+}
+
+/// Cheap "is this email already marked read?" check that parses the
+/// frontmatter just enough to find the `read = true|false` line.
+/// Avoids the full TOML decode that `crate::mcp::list_emails` did —
+/// the listing path stays cheap on huge mailboxes.
+fn is_marked_read(md_path: &Path) -> bool {
+    let content = match std::fs::read_to_string(md_path) {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    let parts: Vec<&str> = content.splitn(3, "+++").collect();
+    if parts.len() < 3 {
+        return false;
+    }
+    for line in parts[1].lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("read") {
+            let rest = rest.trim_start();
+            if let Some(value) = rest.strip_prefix('=') {
+                return value.trim() == "true";
+            }
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Config, ConfigHandle, MailboxConfig};
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    /// Map `"alice"` to uid/gid 4242 (and `"root"` to 0). Static fn
+    /// because the user_resolver test seam takes a function pointer,
+    /// not a closure.
+    fn fake_resolver(name: &str) -> Option<crate::user_resolver::ResolvedUser> {
+        match name {
+            "alice" => Some(crate::user_resolver::ResolvedUser {
+                name: "alice".to_string(),
+                uid: 4242,
+                gid: 4242,
+            }),
+            "root" => Some(crate::user_resolver::ResolvedUser {
+                name: "root".to_string(),
+                uid: 0,
+                gid: 0,
+            }),
+            _ => None,
+        }
+    }
+
+    fn install_tester_resolver() -> crate::user_resolver::test_resolver::ResolverOverride {
+        crate::user_resolver::set_test_resolver(fake_resolver)
+    }
+
+    fn base_config(data_dir: &Path, owner: &str) -> Config {
+        let mut mailboxes = HashMap::new();
+        mailboxes.insert(
+            "catchall".to_string(),
+            MailboxConfig {
+                address: "*@example.com".to_string(),
+                owner: "aimx-catchall".to_string(),
+                hooks: vec![],
+                trust: None,
+                trusted_senders: None,
+                allow_root_catchall: false,
+            },
+        );
+        mailboxes.insert(
+            "alice".to_string(),
+            MailboxConfig {
+                address: "alice@example.com".to_string(),
+                owner: owner.to_string(),
+                hooks: vec![],
+                trust: None,
+                trusted_senders: None,
+                allow_root_catchall: false,
+            },
+        );
+        Config {
+            domain: "example.com".to_string(),
+            data_dir: data_dir.to_path_buf(),
+            dkim_selector: "aimx".to_string(),
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            mailboxes,
+            verify_host: None,
+            enable_ipv6: false,
+            upgrade: None,
+        }
+    }
+
+    fn seed_dirs(tmp: &Path) {
+        for sub in [
+            "inbox/catchall",
+            "sent/catchall",
+            "inbox/alice",
+            "sent/alice",
+        ] {
+            std::fs::create_dir_all(tmp.join(sub)).unwrap();
+        }
+    }
+
+    /// Root sees every mailbox in the configured set.
+    #[tokio::test]
+    async fn root_sees_every_mailbox() {
+        let tmp = TempDir::new().unwrap();
+        seed_dirs(tmp.path());
+        let config = base_config(tmp.path(), "alice");
+        let handle = ConfigHandle::new(config);
+        let state_ctx = StateContext::new(tmp.path().to_path_buf(), handle);
+
+        let resp = handle_mailbox_list(&state_ctx, &Caller::internal_root()).await;
+        let body = match resp {
+            JsonAckResponse::Ok { body } => body,
+            other => panic!("expected Ok, got {other:?}"),
+        };
+        let rows: Vec<MailboxListRow> = serde_json::from_slice(&body).unwrap();
+        let names: Vec<String> = rows.iter().map(|r| r.name.clone()).collect();
+        assert!(names.contains(&"catchall".to_string()));
+        assert!(names.contains(&"alice".to_string()));
+    }
+
+    /// A non-root caller whose uid matches `alice`'s owner sees alice
+    /// but does not see the catchall (different owner).
+    #[tokio::test]
+    async fn non_root_owner_sees_only_owned_mailboxes() {
+        let tmp = TempDir::new().unwrap();
+        seed_dirs(tmp.path());
+        let _r = install_tester_resolver();
+        let config = base_config(tmp.path(), "alice");
+        let handle = ConfigHandle::new(config);
+        let state_ctx = StateContext::new(tmp.path().to_path_buf(), handle);
+
+        let caller = Caller::new(4242, 4242, None);
+        let resp = handle_mailbox_list(&state_ctx, &caller).await;
+        let body = match resp {
+            JsonAckResponse::Ok { body } => body,
+            other => panic!("expected Ok, got {other:?}"),
+        };
+        let rows: Vec<MailboxListRow> = serde_json::from_slice(&body).unwrap();
+        let names: Vec<String> = rows.iter().map(|r| r.name.clone()).collect();
+        assert_eq!(names, vec!["alice".to_string()]);
+        assert!(rows[0].registered);
+        assert!(rows[0].inbox_path.ends_with("/inbox/alice"));
+        assert!(rows[0].sent_path.ends_with("/sent/alice"));
+    }
+
+    /// A stranger uid sees an empty array — never `null` and never a
+    /// human-readable "no mailboxes" string.
+    #[tokio::test]
+    async fn stranger_sees_empty_array() {
+        let tmp = TempDir::new().unwrap();
+        seed_dirs(tmp.path());
+        let _r = install_tester_resolver();
+        let config = base_config(tmp.path(), "alice");
+        let handle = ConfigHandle::new(config);
+        let state_ctx = StateContext::new(tmp.path().to_path_buf(), handle);
+
+        let stranger = Caller::new(99999, 99999, None);
+        let resp = handle_mailbox_list(&state_ctx, &stranger).await;
+        let body = match resp {
+            JsonAckResponse::Ok { body } => body,
+            other => panic!("expected Ok, got {other:?}"),
+        };
+        assert_eq!(body, b"[]");
+    }
+
+    /// Inbox total / unread counts populate from on-disk `.md` files
+    /// even when frontmatter parsing finds the `read = true` line via
+    /// the cheap line-scan.
+    #[tokio::test]
+    async fn counts_match_on_disk_state() {
+        let tmp = TempDir::new().unwrap();
+        seed_dirs(tmp.path());
+        let _r = install_tester_resolver();
+
+        // Two emails: one read, one unread.
+        let inbox = tmp.path().join("inbox").join("alice");
+        let unread = "+++\nid = \"2025-06-01-001\"\nread = false\n+++\n\nbody\n";
+        let read = "+++\nid = \"2025-06-02-002\"\nread = true\n+++\n\nbody\n";
+        std::fs::write(inbox.join("2025-06-01-001.md"), unread).unwrap();
+        std::fs::write(inbox.join("2025-06-02-002.md"), read).unwrap();
+
+        let config = base_config(tmp.path(), "alice");
+        let handle = ConfigHandle::new(config);
+        let state_ctx = StateContext::new(tmp.path().to_path_buf(), handle);
+        let caller = Caller::new(4242, 4242, None);
+        let resp = handle_mailbox_list(&state_ctx, &caller).await;
+        let body = match resp {
+            JsonAckResponse::Ok { body } => body,
+            other => panic!("expected Ok, got {other:?}"),
+        };
+        let rows: Vec<MailboxListRow> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].name, "alice");
+        assert_eq!(rows[0].total, 2);
+        assert_eq!(rows[0].unread, 1);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ mod logging;
 mod logs;
 mod mailbox;
 mod mailbox_handler;
+mod mailbox_list_handler;
 mod mailbox_locks;
 mod mcp;
 mod mx;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -215,34 +215,13 @@ impl AimxMcpServer {
                        Mailboxes the caller does not own are absent — root sees all."
     )]
     fn mailbox_list(&self) -> Result<String, String> {
-        let config = self.load_config()?;
-        let mailboxes = list_mailboxes_with_unread(&config);
-
-        // Filter to caller-owned mailboxes for non-root callers.
-        // Mailboxes the caller doesn't own are simply absent from the
-        // output rather than returned with a "denied" tag. Root sees
-        // the full set.
-        let filtered: Vec<_> = if self.caller_uid == 0 {
-            mailboxes
-        } else {
-            mailboxes
-                .into_iter()
-                .filter(|(name, _, _, _, _)| mailbox::caller_owns(&config, name, self.caller_uid))
-                .collect()
-        };
-
-        if filtered.is_empty() {
-            return Ok("No mailboxes configured.".to_string());
-        }
-
-        let result: Vec<String> = filtered
-            .iter()
-            .map(|(name, total, unread, sent_count, registered)| {
-                let suffix = if *registered { "" } else { " (unregistered)" };
-                format!("{name}: {total} messages ({unread} unread), {sent_count} sent{suffix}")
-            })
-            .collect();
-        Ok(result.join("\n"))
+        // The daemon is the single source of truth: it resolves the
+        // caller via `SO_PEERCRED` and returns a JSON array of
+        // mailboxes the uid owns. The MCP process never reads
+        // root-owned `config.toml` and never runs its own authz
+        // pre-flight — there are no mailboxes to authorize against
+        // until the daemon answers.
+        submit_mailbox_list_via_daemon()
     }
 
     #[tool(
@@ -1111,26 +1090,122 @@ pub async fn run(data_dir: Option<&std::path::Path>) -> Result<(), Box<dyn std::
     Ok(())
 }
 
-/// Return `(name, total, unread, sent_count, registered)` for every mailbox
-/// the daemon knows about: both registered ones in `config.mailboxes` and
-/// stray `inbox/<name>/` directories left by backup restores or
-/// out-of-band tooling. Sorted by name.
-fn list_mailboxes_with_unread(config: &Config) -> Vec<(String, usize, usize, usize, bool)> {
-    let mut result: Vec<(String, usize, usize, usize, bool)> =
-        mailbox::discover_mailbox_names(config)
-            .into_iter()
-            .map(|name| {
-                let dir = config.inbox_dir(&name);
-                let emails = list_emails(&dir).unwrap_or_default();
-                let total = emails.len();
-                let unread = emails.iter().filter(|e| !e.read).count();
-                let sent_count = mailbox::count_messages(&config.sent_dir(&name));
-                let registered = mailbox::is_registered(config, &name);
-                (name, total, unread, sent_count, registered)
-            })
-            .collect();
-    result.sort_by(|a, b| a.0.cmp(&b.0));
-    result
+/// Submit an `AIMX/1 MAILBOX-LIST` to the daemon and return the JSON
+/// body verbatim. The schema-mandated string output for the tool is
+/// the JSON itself; no re-formatting happens here.
+fn submit_mailbox_list_via_daemon() -> Result<String, String> {
+    let socket = crate::serve::aimx_socket_path();
+
+    let rt = tokio::runtime::Handle::try_current();
+    let io_result: Result<Vec<u8>, std::io::Error> = match rt {
+        Ok(handle) => {
+            tokio::task::block_in_place(|| handle.block_on(submit_mailbox_list_request(&socket)))
+        }
+        Err(_) => {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| format!("Failed to create tokio runtime: {e}"))?;
+            rt.block_on(submit_mailbox_list_request(&socket))
+        }
+    };
+
+    let raw = io_result.map_err(|e| {
+        if is_socket_missing(&e) {
+            "aimx daemon not running. Start with 'sudo systemctl start aimx'".to_string()
+        } else {
+            format!(
+                "Failed to connect to aimx daemon at {}: {e}",
+                socket.display()
+            )
+        }
+    })?;
+
+    decode_mailbox_list_response(&raw)
+}
+
+/// Open the UDS, ship `AIMX/1 MAILBOX-LIST`, and return the raw
+/// daemon response bytes. Parsing happens in
+/// [`decode_mailbox_list_response`] so the I/O and codec layers stay
+/// independently testable.
+async fn submit_mailbox_list_request(
+    socket_path: &std::path::Path,
+) -> Result<Vec<u8>, std::io::Error> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let stream = tokio::net::UnixStream::connect(socket_path).await?;
+    let (mut reader, mut writer) = stream.into_split();
+
+    send_protocol::write_mailbox_list_request(&mut writer).await?;
+    writer.shutdown().await.ok();
+
+    let mut buf = Vec::with_capacity(1024);
+    reader.read_to_end(&mut buf).await?;
+    Ok(buf)
+}
+
+/// Decode the daemon's `MAILBOX-LIST` response. On `OK` returns the
+/// raw JSON body string; on `ERR` formats the wire reason verbatim
+/// the way every other MCP tool surfaces daemon-side errors.
+fn decode_mailbox_list_response(buf: &[u8]) -> Result<String, String> {
+    let text = std::str::from_utf8(buf).map_err(|_| "response is not UTF-8".to_string())?;
+    let header_end = text
+        .find("\n\n")
+        .or_else(|| text.find("\r\n\r\n"))
+        .ok_or_else(|| format!("malformed response (no header terminator): {text:?}"))?;
+    // Locate body start (covers both `\n\n` and `\r\n\r\n`).
+    let body_start = if text[header_end..].starts_with("\r\n\r\n") {
+        header_end + 4
+    } else {
+        header_end + 2
+    };
+    let header_block = &text[..header_end];
+
+    let mut lines = header_block.lines();
+    let status_line = lines
+        .next()
+        .ok_or_else(|| "empty response from daemon".to_string())?
+        .trim_end_matches('\r');
+    let rest = status_line
+        .strip_prefix("AIMX/1 ")
+        .ok_or_else(|| format!("unexpected response: {status_line:?}"))?;
+
+    if rest == "OK" {
+        // OK frame must carry a Content-Length header and a body.
+        let mut content_length: Option<usize> = None;
+        for line in lines {
+            let line = line.trim_end_matches('\r');
+            if let Some(v) = line.strip_prefix("Content-Length:") {
+                content_length = v
+                    .trim()
+                    .parse::<usize>()
+                    .map(Some)
+                    .map_err(|_| format!("invalid Content-Length: {line:?}"))?;
+            }
+        }
+        let n =
+            content_length.ok_or_else(|| "missing Content-Length on OK response".to_string())?;
+        let body_bytes = &buf[body_start..];
+        if body_bytes.len() < n {
+            return Err(format!(
+                "truncated body: expected {n} bytes, got {}",
+                body_bytes.len()
+            ));
+        }
+        return std::str::from_utf8(&body_bytes[..n])
+            .map(|s| s.to_string())
+            .map_err(|_| "JSON body is not UTF-8".to_string());
+    }
+
+    if let Some(err_body) = rest.strip_prefix("ERR ") {
+        let (code_str, reason) = err_body.split_once(' ').unwrap_or((err_body, ""));
+        let code = ErrCode::from_str(code_str)
+            .map(|c| c.as_str().to_string())
+            .unwrap_or_else(|| code_str.to_string());
+        return Err(format!("[{code}] {}", reason.trim()));
+    }
+
+    Err(format!("unexpected response: {status_line:?}"))
 }
 
 /// List the emails in a single folder. Handles both flat `<stem>.md`

--- a/src/send_protocol.rs
+++ b/src/send_protocol.rs
@@ -30,6 +30,10 @@
 //!   Content-Length: 0\n
 //!   \n
 //!
+//! Client → Server (MAILBOX-LIST):
+//!   AIMX/1 MAILBOX-LIST\n
+//!   \n
+//!
 //! Client → Server (HOOK-CREATE):
 //!   AIMX/1 HOOK-CREATE\n
 //!   Mailbox: <mailbox-name>\n
@@ -175,6 +179,10 @@ pub enum Request {
     Send(SendRequest),
     Mark(MarkRequest),
     MailboxCrud(MailboxCrudRequest),
+    /// `AIMX/1 MAILBOX-LIST` carries no payload. The daemon resolves
+    /// the caller via `SO_PEERCRED` and returns the mailboxes the uid
+    /// owns; root sees every mailbox.
+    MailboxList,
     HookCreate(HookCreateRequest),
     HookDelete(HookDeleteRequest),
 }
@@ -288,6 +296,27 @@ pub enum AckResponse {
     Err { code: ErrCode, reason: String },
 }
 
+/// Response emitted by the daemon after processing a `MAILBOX-LIST`
+/// request. The `Ok` variant carries the JSON body the daemon
+/// renders from its `Arc<Config>` snapshot plus the on-disk inbox /
+/// sent counts.
+///
+/// Wire format on success:
+/// ```text
+/// AIMX/1 OK\n
+/// Content-Length: <n>\n
+/// \n
+/// <n bytes of JSON>
+/// ```
+///
+/// The error form mirrors the other ack responses
+/// (`AIMX/1 ERR <code> <reason>\nCode: <code>\n\n`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum JsonAckResponse {
+    Ok { body: Vec<u8> },
+    Err { code: ErrCode, reason: String },
+}
+
 /// Codec error. Kept separate from `std::error::Error` so the daemon's
 /// handler can map `ParseError` values into wire-level `ErrCode::Malformed`
 /// responses without rebuilding the information.
@@ -370,6 +399,9 @@ where
         "MAILBOX-DELETE" => parse_mailbox_crud_headers(reader, false)
             .await
             .map(Request::MailboxCrud),
+        "MAILBOX-LIST" => parse_mailbox_list_headers(reader)
+            .await
+            .map(|()| Request::MailboxList),
         "HOOK-CREATE" => parse_hook_create_headers_and_body(reader, max_body)
             .await
             .map(Request::HookCreate),
@@ -396,7 +428,7 @@ where
         Request::Mark(_) => Err(ParseError::Malformed(
             "expected SEND verb, got MARK-*".to_string(),
         )),
-        Request::MailboxCrud(_) => Err(ParseError::Malformed(
+        Request::MailboxCrud(_) | Request::MailboxList => Err(ParseError::Malformed(
             "expected SEND verb, got MAILBOX-*".to_string(),
         )),
         Request::HookCreate(_) | Request::HookDelete(_) => Err(ParseError::Malformed(
@@ -675,6 +707,27 @@ where
         create,
         owner,
     })
+}
+
+/// Parse the empty body of an `AIMX/1 MAILBOX-LIST` request. The verb
+/// carries no headers — the parser reads exactly one blank line and
+/// rejects any header line (including `Content-Length:`) so a future
+/// rev cannot silently smuggle a forged owner header past the
+/// `SO_PEERCRED` filter.
+async fn parse_mailbox_list_headers<R>(reader: &mut R) -> Result<(), ParseError>
+where
+    R: AsyncRead + Unpin,
+{
+    let line = read_line(reader)
+        .await?
+        .ok_or_else(|| ParseError::Malformed("unexpected EOF in headers".into()))?;
+    let line = line.trim_end_matches('\r');
+    if !line.is_empty() {
+        return Err(ParseError::Malformed(format!(
+            "MAILBOX-LIST takes no headers, got {line:?}"
+        )));
+    }
+    Ok(())
 }
 
 async fn parse_hook_create_headers_and_body<R>(
@@ -956,6 +1009,36 @@ where
     Ok(())
 }
 
+/// Write a `JsonAckResponse` frame. Used by the daemon-side
+/// `MAILBOX-LIST` handler so non-root callers receive a JSON body
+/// listing the mailboxes they own. On error the wire shape matches
+/// [`write_ack_response`].
+pub async fn write_json_ack_response<W>(
+    writer: &mut W,
+    response: &JsonAckResponse,
+) -> Result<(), std::io::Error>
+where
+    W: AsyncWrite + Unpin,
+{
+    match response {
+        JsonAckResponse::Ok { body } => {
+            let header = format!("AIMX/1 OK\nContent-Length: {}\n\n", body.len());
+            writer.write_all(header.as_bytes()).await?;
+            writer.write_all(body).await?;
+        }
+        JsonAckResponse::Err { code, reason } => {
+            let r = sanitize_inline(reason);
+            let payload = format!(
+                "AIMX/1 ERR {code} {r}\nCode: {code}\n\n",
+                code = code.as_str()
+            );
+            writer.write_all(payload.as_bytes()).await?;
+        }
+    }
+    writer.flush().await?;
+    Ok(())
+}
+
 /// Write an `AIMX/1 SEND` request frame to `writer`. Used by the client
 /// (`aimx send`) and by tests that exercise `parse_request` over a paired
 /// AsyncRead/AsyncWrite harness.
@@ -1021,6 +1104,17 @@ where
     Ok(())
 }
 
+/// Write an `AIMX/1 MAILBOX-LIST` request frame. Bare verb line plus
+/// a single blank separator — no headers, no body.
+pub async fn write_mailbox_list_request<W>(writer: &mut W) -> Result<(), std::io::Error>
+where
+    W: AsyncWrite + Unpin,
+{
+    writer.write_all(b"AIMX/1 MAILBOX-LIST\n\n").await?;
+    writer.flush().await?;
+    Ok(())
+}
+
 /// Write an `AIMX/1 HOOK-CREATE` request frame. The codec does not
 /// parse the body, it simply ships the bytes the caller supplies.
 #[allow(dead_code)]
@@ -1068,4 +1162,103 @@ where
 /// LF inside a reason or message-ID or the framer ambiguates the next line.
 fn sanitize_inline(s: &str) -> String {
     s.chars().filter(|c| *c != '\n' && *c != '\r').collect()
+}
+
+#[cfg(test)]
+mod mailbox_list_codec_tests {
+    use super::*;
+    use tokio::io::AsyncWriteExt;
+
+    /// Round-trip a `MAILBOX-LIST` frame: writer emits the bare verb +
+    /// blank separator, parser decodes it as `Request::MailboxList`.
+    #[tokio::test]
+    async fn round_trip_mailbox_list_request() {
+        let mut buf: Vec<u8> = Vec::new();
+        write_mailbox_list_request(&mut buf).await.unwrap();
+        assert_eq!(buf, b"AIMX/1 MAILBOX-LIST\n\n");
+
+        let mut reader = std::io::Cursor::new(buf);
+        let req = parse_request(&mut reader).await.unwrap();
+        assert_eq!(req, Request::MailboxList);
+    }
+
+    /// Any header on a `MAILBOX-LIST` frame is rejected. The verb
+    /// resolves the caller via `SO_PEERCRED`; client-supplied owner
+    /// hints would defeat that and must be a hard parse error.
+    #[tokio::test]
+    async fn mailbox_list_rejects_owner_header() {
+        let frame = b"AIMX/1 MAILBOX-LIST\nOwner: alice\n\n";
+        let mut reader = std::io::Cursor::new(frame.to_vec());
+        match parse_request(&mut reader).await {
+            Err(ParseError::Malformed(reason)) => {
+                assert!(reason.contains("MAILBOX-LIST"), "{reason}");
+            }
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    /// `Content-Length:` headers are also rejected — `MAILBOX-LIST`
+    /// has no body, and silently ignoring the header would invite a
+    /// future caller to send one and have it skipped.
+    #[tokio::test]
+    async fn mailbox_list_rejects_content_length_header() {
+        let frame = b"AIMX/1 MAILBOX-LIST\nContent-Length: 0\n\n";
+        let mut reader = std::io::Cursor::new(frame.to_vec());
+        match parse_request(&mut reader).await {
+            Err(ParseError::Malformed(_)) => {}
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    /// The JSON ack response writer round-trips: the frame carries
+    /// `AIMX/1 OK`, a `Content-Length:` header, and the JSON body.
+    #[tokio::test]
+    async fn json_ack_response_writer_emits_content_length_and_body() {
+        let body = br#"[{"name":"alice","total":1,"unread":0}]"#;
+        let mut buf: Vec<u8> = Vec::new();
+        write_json_ack_response(
+            &mut buf,
+            &JsonAckResponse::Ok {
+                body: body.to_vec(),
+            },
+        )
+        .await
+        .unwrap();
+        let header_end = buf.windows(2).position(|w| w == b"\n\n").unwrap();
+        let header = std::str::from_utf8(&buf[..header_end]).unwrap();
+        assert!(header.starts_with("AIMX/1 OK\n"));
+        assert!(
+            header.contains(&format!("Content-Length: {}", body.len())),
+            "{header}"
+        );
+        assert_eq!(&buf[header_end + 2..], &body[..]);
+    }
+
+    /// Error variant of the JSON ack writer mirrors the bodyless ack
+    /// shape exactly so clients can share one parser.
+    #[tokio::test]
+    async fn json_ack_response_writer_error_form_matches_bodyless_ack() {
+        let mut json_buf: Vec<u8> = Vec::new();
+        write_json_ack_response(
+            &mut json_buf,
+            &JsonAckResponse::Err {
+                code: ErrCode::Eaccess,
+                reason: "denied".into(),
+            },
+        )
+        .await
+        .unwrap();
+        let mut bare_buf: Vec<u8> = Vec::new();
+        write_ack_response(
+            &mut bare_buf,
+            &AckResponse::Err {
+                code: ErrCode::Eaccess,
+                reason: "denied".into(),
+            },
+        )
+        .await
+        .unwrap();
+        bare_buf.flush().await.unwrap();
+        assert_eq!(json_buf, bare_buf);
+    }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -831,12 +831,13 @@ async fn handle_uds_connection_with_timeout(
     caller: crate::uds_authz::Caller,
     timeout: std::time::Duration,
 ) {
-    use send_protocol::{AckResponse, ErrCode, ParseError, Request, SendResponse};
+    use send_protocol::{AckResponse, ErrCode, JsonAckResponse, ParseError, Request, SendResponse};
 
     #[allow(clippy::large_enum_variant)]
     enum Reply {
         Send(SendResponse),
         Ack(AckResponse),
+        Json(JsonAckResponse),
     }
 
     let (mut reader, mut writer) = stream.into_split();
@@ -854,6 +855,12 @@ async fn handle_uds_connection_with_timeout(
                 Reply::Ack(
                     crate::mailbox_handler::handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &caller)
                         .await,
+                ),
+                false,
+            ),
+            Ok(Ok(Request::MailboxList)) => (
+                Reply::Json(
+                    crate::mailbox_list_handler::handle_mailbox_list(&state_ctx, &caller).await,
                 ),
                 false,
             ),
@@ -924,6 +931,7 @@ async fn handle_uds_connection_with_timeout(
     let write_result = match reply {
         Reply::Send(r) => send_protocol::write_response(&mut writer, &r).await,
         Reply::Ack(r) => send_protocol::write_ack_response(&mut writer, &r).await,
+        Reply::Json(r) => send_protocol::write_json_ack_response(&mut writer, &r).await,
     };
     if let Err(e) = write_result {
         eprintln!("[send] failed to write response: {e}");

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -753,28 +753,128 @@ fn mcp_list_tools() {
     client.shutdown();
 }
 
+#[cfg(unix)]
 #[test]
 fn mcp_mailbox_list_returns_caller_owned() {
-    // After the CLI/MCP rework `mailbox_create` / `mailbox_delete` are
-    // gone from the MCP surface (moved to root-only CLI). What remains
-    // is `mailbox_list`, which returns mailboxes the caller owns. The
-    // shared fixture sets every mailbox to the test runner's own
-    // username so the listing is non-empty under non-root `cargo test`.
+    // `mailbox_list` is now a thin UDS client: it ships
+    // `AIMX/1 MAILBOX-LIST`, the daemon resolves the caller via
+    // `SO_PEERCRED`, and the response is a JSON array of mailboxes
+    // the caller owns. The shared fixture sets every mailbox owner
+    // to the test runner's username so a non-root `cargo test`
+    // sees both alice and catchall through the daemon.
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
 
-    let mut client = McpClient::spawn(tmp.path());
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS send socket never appeared"
+    );
+
+    let runtime = tmp.path().join("run");
+    let mut child = StdCommand::new(aimx_binary_path())
+        .env("AIMX_CONFIG_DIR", tmp.path())
+        .env("AIMX_RUNTIME_DIR", &runtime)
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("mcp")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn aimx mcp");
+    let stdin = child.stdin.take().unwrap();
+    let stdout = child.stdout.take().unwrap();
+    let mut client = McpClient {
+        child,
+        stdin,
+        reader: BufReader::new(stdout),
+        id: 0,
+    };
+    client.initialize();
+
+    let resp = client.call_tool("mailbox_list", serde_json::json!({}));
+    let text = get_tool_text(&resp);
+    let rows: serde_json::Value =
+        serde_json::from_str(&text).unwrap_or_else(|e| panic!("response not JSON: {text}: {e}"));
+    let arr = rows.as_array().expect("expected JSON array");
+    let names: Vec<&str> = arr
+        .iter()
+        .filter_map(|row| row.get("name").and_then(|v| v.as_str()))
+        .collect();
+    assert!(names.contains(&"alice"), "expected alice in {names:?}");
+    assert!(
+        names.contains(&"catchall"),
+        "expected catchall in {names:?}"
+    );
+
+    let alice = arr
+        .iter()
+        .find(|row| row.get("name").and_then(|v| v.as_str()) == Some("alice"))
+        .unwrap();
+    assert!(
+        alice
+            .get("inbox_path")
+            .and_then(|v| v.as_str())
+            .is_some_and(|p| p.ends_with("/inbox/alice")),
+        "alice row missing inbox_path: {alice}"
+    );
+    assert!(
+        alice
+            .get("sent_path")
+            .and_then(|v| v.as_str())
+            .is_some_and(|p| p.ends_with("/sent/alice")),
+        "alice row missing sent_path: {alice}"
+    );
+    assert_eq!(
+        alice.get("registered"),
+        Some(&serde_json::Value::Bool(true))
+    );
+
+    client.shutdown();
+    stop_serve(daemon);
+}
+
+/// Without a running daemon, `mailbox_list` surfaces the canonical
+/// "aimx daemon not running" message that `email_send` and
+/// `hook_create` already use.
+#[cfg(unix)]
+#[test]
+fn mcp_mailbox_list_without_daemon_reports_missing_socket() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+
+    let runtime = tmp.path().join("run");
+    std::fs::create_dir_all(&runtime).ok();
+
+    let mut child = StdCommand::new(aimx_binary_path())
+        .env("AIMX_CONFIG_DIR", tmp.path())
+        .env("AIMX_RUNTIME_DIR", &runtime)
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("mcp")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("Failed to spawn aimx mcp");
+    let stdin = child.stdin.take().unwrap();
+    let stdout = child.stdout.take().unwrap();
+    let mut client = McpClient {
+        child,
+        stdin,
+        reader: BufReader::new(stdout),
+        id: 0,
+    };
     client.initialize();
 
     let resp = client.call_tool("mailbox_list", serde_json::json!({}));
     let text = get_tool_text(&resp);
     assert!(
-        text.contains("alice"),
-        "expected alice in list, got: {text}"
-    );
-    assert!(
-        text.contains("catchall"),
-        "expected catchall in list, got: {text}"
+        text.contains("aimx daemon not running"),
+        "expected canonical missing-daemon message, got: {text}"
     );
 
     client.shutdown();


### PR DESCRIPTION
## Summary

- Add `AIMX/1 MAILBOX-LIST` UDS verb. The daemon resolves the caller via `SO_PEERCRED` and answers with a JSON array of mailboxes the uid owns; root sees everything.
- New `mailbox_list_handler` reads from the in-memory `Arc<Config>` snapshot and returns rows of `{ name, inbox_path, sent_path, total, unread, sent_count, registered }`. Empty result is `[]`.
- MCP `mailbox_list` becomes a thin UDS client. It no longer reads `/etc/aimx/config.toml` and no longer runs its own authz pre-flight, so non-root agents can enumerate their own mailboxes without `sudo`.
- Daemon-not-running surfaces the canonical `aimx daemon not running. Start with 'sudo systemctl start aimx'` message.
- Codec hardening: `MAILBOX-LIST` rejects any header (including `Owner:` and `Content-Length:`) so a forged owner header cannot defeat the `SO_PEERCRED` filter.
- New `JsonAckResponse` shape for verbs that ship a JSON body alongside the bare-ack response variant.
- Primer + `references/mcp-tools.md` now lead with "read `.md` files directly when you don't need a mutation"; the `mailbox_list` row documents the new JSON shape with a worked next-step example.

## Test plan

- [x] `cargo test` (959 tests) — green
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] Verifier service `cargo build` / `clippy` / `fmt` — clean
- [x] New unit tests in `mailbox_list_handler::tests` cover root, owner, stranger, and on-disk count visibility paths.
- [x] New codec tests round-trip `MAILBOX-LIST`, reject `Owner:` and `Content-Length:` headers, and pin the JSON-ack writer wire shape.
- [x] New integration test spawns `aimx serve` + `aimx mcp` and parses the JSON response from `mailbox_list`. A second integration test asserts the canonical missing-socket message when the daemon is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)