### PR TITLE
[Sprint 3] MARK folder removal + hook_create stdin removal

### DIFF
--- a/agents/claude-code/skills/aimx/SKILL.md.header
+++ b/agents/claude-code/skills/aimx/SKILL.md.header
@@ -15,8 +15,7 @@ exact recipe:
 hook_create(
   mailbox: "support",
   event: "on_receive",
-  cmd: ["/usr/local/bin/claude", "-p", "<instruction-string>", "--dangerously-skip-permissions"],
-  stdin: "email"
+  cmd: ["/usr/local/bin/claude", "-p", "<instruction-string>", "--dangerously-skip-permissions"]
 )
 ```
 
@@ -33,10 +32,11 @@ email on stdin and reply via the aimx MCP server."`). Notes:
   it the headless session will block on the permission prompt and
   never call MCP. This is the documented Claude Code flag for
   unattended runs.
-- `stdin: "email"` makes the daemon pipe the raw `.md` (TOML
-  frontmatter + body) to the child process. Your `-p` prompt only
-  needs to tell the agent what to do; the email content arrives on
-  stdin.
+- The daemon always pipes the raw `.md` (TOML frontmatter + body) to
+  the child's stdin and sets `AIMX_FILEPATH` to the same path. Your
+  `-p` prompt only needs to tell the agent what to do; the email
+  content arrives on stdin. If your hook only needs the subject or
+  sender, read `$AIMX_SUBJECT` / `$AIMX_FROM` and ignore stdin.
 - Optional knobs: pass `--mcp-config <path>` together with
   `--strict-mcp-config` to pin which MCP servers the headless run
   loads, or `--model sonnet` to select a model explicitly.

--- a/agents/codex/SKILL.md.header
+++ b/agents/codex/SKILL.md.header
@@ -15,8 +15,7 @@ prompt itself:
 hook_create(
   mailbox: "support",
   event: "on_receive",
-  cmd: ["/usr/local/bin/codex", "exec", "--skip-git-repo-check", "--full-auto", "-"],
-  stdin: "email"
+  cmd: ["/usr/local/bin/codex", "exec", "--skip-git-repo-check", "--full-auto", "-"]
 )
 ```
 
@@ -37,8 +36,8 @@ Notes:
   The harsher `--dangerously-bypass-approvals-and-sandbox` is only
   appropriate inside a contained host where escape from the sandbox is
   acceptable.
-- `stdin: "email"` pipes the raw `.md` (TOML frontmatter + body) to
-  Codex.
+- The daemon always pipes the raw `.md` (TOML frontmatter + body) to
+  the child's stdin, so Codex sees the email content as its task.
 
 Note: the user the hook runs as (the mailbox's owner) must have the
 aimx skill installed too — re-run `aimx agents setup codex` as that

--- a/agents/common/aimx-primer.md
+++ b/agents/common/aimx-primer.md
@@ -100,23 +100,26 @@ does not expose `mailbox_create` or `mailbox_delete`.
   own.
 - `email_reply(mailbox, id, body)`: reply to an existing email. aimx sets
   `In-Reply-To`, `References`, and `Re:` subject automatically.
-- `email_mark_read(mailbox, id, folder?)`: mark a single email as read.
-- `email_mark_unread(mailbox, id, folder?)`: mark a single email as unread.
+- `email_mark_read(mailbox, id)`: mark a single inbox email as read.
+- `email_mark_unread(mailbox, id)`: mark a single inbox email as unread.
 
 ### Hook tools
 
 Hooks are commands the daemon fires on mail events (`on_receive`,
 `after_send`). You create a hook on a mailbox you own; the hook always
-executes as the mailbox's owning Linux user, with the email piped on
-stdin (or accessible via `$AIMX_FILEPATH` when stdin is closed). There
-is no template indirection — your `cmd` is the literal argv that runs.
+executes as the mailbox's owning Linux user, with the raw `.md`
+(frontmatter + body) piped on stdin and the same path also exposed as
+`$AIMX_FILEPATH`. There is no template indirection — your `cmd` is the
+literal argv that runs.
 
-- `hook_create(mailbox, event, cmd, name?, stdin?, timeout_secs?, fire_on_untrusted?)`:
+If your hook only needs the subject or sender, read `$AIMX_SUBJECT` /
+`$AIMX_FROM` and ignore stdin — the daemon writes the full email but
+does not require the child to consume it.
+
+- `hook_create(mailbox, event, cmd, name?, timeout_secs?, fire_on_untrusted?)`:
   attach a hook. `cmd` is an argv array (e.g. `["claude", "-p", "...",
-  "--dangerously-skip-permissions"]`). `stdin` is `"email"` (default —
-  pipes the raw `.md` to the child) or `"none"` (closes stdin; the
-  child reads `$AIMX_FILEPATH` instead). `fire_on_untrusted` defaults
-  to `false`; set `true` only on `on_receive` hooks where you want the
+  "--dangerously-skip-permissions"]`). `fire_on_untrusted` defaults to
+  `false`; set `true` only on `on_receive` hooks where you want the
   hook to fire even on `trusted = "false"` mail.
 - `hook_list(mailbox?)`: list hooks on mailboxes you own.
 - `hook_delete(name)`: delete a hook on a mailbox you own.

--- a/agents/common/references/hooks.md
+++ b/agents/common/references/hooks.md
@@ -20,7 +20,7 @@ inbox, run her own MCP server — and no more.
 
 ## The three MCP hook tools
 
-### `hook_create(mailbox, event, cmd, name?, stdin?, timeout_secs?, fire_on_untrusted?)`
+### `hook_create(mailbox, event, cmd, name?, timeout_secs?, fire_on_untrusted?)`
 
 Attach a hook to a mailbox you own.
 
@@ -32,9 +32,14 @@ Attach a hook to a mailbox you own.
 | `event`             | string            | yes      | `"on_receive"` or `"after_send"` |
 | `cmd`               | string[]          | yes      | argv array. `cmd[0]` must be an absolute path the owning user can execute |
 | `name`              | string            | no       | Explicit hook name. Omitted → daemon derives a 12-hex-char name from `(event, cmd, fire_on_untrusted)` |
-| `stdin`             | string            | no       | `"email"` (default; pipes the raw `.md` to the child) or `"none"` (closes stdin; child reads `$AIMX_FILEPATH` instead) |
 | `timeout_secs`      | u32               | no       | Per-fire timeout in seconds. Default 60, max 600. SIGTERM at expiry, SIGKILL +5s |
 | `fire_on_untrusted` | bool              | no       | Default `false`. Legal only on `on_receive`. When `true`, the hook fires on any inbound mail regardless of `trusted` |
+
+The raw `.md` (frontmatter + body) is always piped on stdin and the
+same path is also exposed as `$AIMX_FILEPATH`. If your hook only needs
+the subject or sender, read `$AIMX_SUBJECT` / `$AIMX_FROM` and ignore
+stdin — the daemon writes the full email but does not require the
+child to consume it.
 
 **Returns:** confirmation containing the effective name and the argv
 that will run.
@@ -72,7 +77,6 @@ List hooks on mailboxes you own.
   "mailbox": "support",
   "event": "on_receive",
   "cmd": ["/usr/local/bin/claude", "-p", "You are the support agent...", "--dangerously-skip-permissions"],
-  "stdin": "email",
   "timeout_secs": 60,
   "fire_on_untrusted": false
 }
@@ -127,9 +131,10 @@ below).
 - `AIMX_FROM`: sender address (header `From:`).
 - `AIMX_SUBJECT`: subject line.
 
-When `stdin = "email"` (the default) the same `.md` file is also
-piped to the child's stdin. When `stdin = "none"` stdin is closed
-and the child must use `$AIMX_FILEPATH` to read the email.
+The raw `.md` (frontmatter + body) is always piped to the child's
+stdin. The same path is exposed as `$AIMX_FILEPATH` so a hook that
+only needs select fields (or that uses an agent which does not read
+stdin in headless mode) can ignore stdin and act on env vars only.
 
 ### Per-agent recipes
 
@@ -139,15 +144,15 @@ flags depend on the agent's own headless-run contract. Look for the
 "Wiring yourself up as a mailbox hook" section in your agent's
 `SKILL.md`. As of Apr 2026 the supported set is:
 
-| Agent        | stdin       | Notes |
-|--------------|-------------|-------|
-| Claude Code  | `"email"`   | `claude -p <instruction> --dangerously-skip-permissions` |
-| Codex CLI    | `"email"`   | `codex exec --skip-git-repo-check --full-auto -` (trailing `-` reads stdin as the prompt) |
-| Gemini CLI   | `"email"`   | `gemini -p <instruction> --yolo` |
-| Goose        | `"email"`   | `goose run --recipe <path>` (preferred) or `goose run --instructions - --quiet` |
-| OpenCode     | `"none"`    | `opencode run --dangerously-skip-permissions <inline-prompt>` (reads `$AIMX_FILEPATH`) |
-| Hermes       | `"none"`    | `hermes chat -q <inline-prompt> --yolo` (reads `$AIMX_FILEPATH`; switch to `"email"` if a current install confirms `-q` accepts piped stdin) |
-| OpenClaw     | n/a         | No documented headless CLI as of Apr 2026 — see the OpenClaw skill |
+| Agent        | Notes |
+|--------------|-------|
+| Claude Code  | `claude -p <instruction> --dangerously-skip-permissions` (reads piped email on stdin) |
+| Codex CLI    | `codex exec --skip-git-repo-check --full-auto -` (trailing `-` reads stdin as the prompt) |
+| Gemini CLI   | `gemini -p <instruction> --yolo` (reads piped email on stdin) |
+| Goose        | `goose run --recipe <path>` (preferred) or `goose run --instructions - --quiet` |
+| OpenCode     | `opencode run --dangerously-skip-permissions <inline-prompt>` (reads `$AIMX_FILEPATH`; ignores stdin) |
+| Hermes       | `hermes chat -q <inline-prompt> --yolo` (reads `$AIMX_FILEPATH`; ignores stdin) |
+| OpenClaw     | No documented headless CLI as of Apr 2026 — see the OpenClaw skill |
 
 ## Example: "file + reply" hook on an accounts mailbox
 

--- a/agents/common/references/mcp-tools.md
+++ b/agents/common/references/mcp-tools.md
@@ -270,14 +270,15 @@ email_reply(
 
 ### `email_mark_read`
 
-Mark a single email as read (sets `read = true` in frontmatter).
+Mark a single inbox email as read (sets `read = true` in
+frontmatter). Sent-mail mark has no agent use case and is not
+supported.
 
 **Parameters:**
 | Name      | Type   | Required | Description |
 |-----------|--------|----------|-------------|
 | `mailbox` | string | yes      | Mailbox name (must be owned by you) |
 | `id`      | string | yes      | Email ID |
-| `folder`  | string | no       | `"inbox"` (default) or `"sent"` |
 
 **Returns:** Confirmation string.
 
@@ -291,14 +292,15 @@ email_mark_read(mailbox: "agent", id: "2026-04-15-143022-meeting-notes")
 
 ### `email_mark_unread`
 
-Mark a single email as unread (sets `read = false` in frontmatter).
+Mark a single inbox email as unread (sets `read = false` in
+frontmatter). Sent-mail mark has no agent use case and is not
+supported.
 
 **Parameters:**
 | Name      | Type   | Required | Description |
 |-----------|--------|----------|-------------|
 | `mailbox` | string | yes      | Mailbox name (must be owned by you) |
 | `id`      | string | yes      | Email ID |
-| `folder`  | string | no       | `"inbox"` (default) or `"sent"` |
 
 **Returns:** Confirmation string.
 
@@ -311,9 +313,12 @@ email_mark_unread(mailbox: "agent", id: "2026-04-15-143022-meeting-notes")
 ## Hook tools
 
 Hooks fire commands on mail events. You create hooks on mailboxes you
-own; the hook always executes as the mailbox's owning Linux user, with
-the email piped on stdin (or accessible via `$AIMX_FILEPATH` when
-stdin is closed). There is no template indirection — your `cmd` is
+own; the hook always executes as the mailbox's owning Linux user. The
+raw `.md` (frontmatter + body) is always piped on stdin and the same
+path is exposed as `$AIMX_FILEPATH`. If your hook only needs the
+subject or sender, read `$AIMX_SUBJECT` / `$AIMX_FROM` and ignore
+stdin — the daemon writes the full email but does not require the
+child to consume it. There is no template indirection — your `cmd` is
 the literal argv that runs. See `references/hooks.md` for the full
 model, worked examples, and troubleshooting.
 
@@ -328,7 +333,6 @@ Attach a hook to a mailbox you own.
 | `event`             | string   | yes      | `"on_receive"` or `"after_send"` |
 | `cmd`               | string[] | yes      | argv array. `cmd[0]` must be an absolute path the owning user can execute |
 | `name`              | string   | no       | Optional explicit name; derived from `(event, cmd, fire_on_untrusted)` when omitted |
-| `stdin`             | string   | no       | `"email"` (default; pipes raw `.md`) or `"none"` (closes stdin; child reads `$AIMX_FILEPATH` instead) |
 | `timeout_secs`      | u32      | no       | Per-fire timeout in seconds. Default 60, max 600 |
 | `fire_on_untrusted` | bool     | no       | Default `false`. Legal only on `on_receive`; when `true`, fires regardless of `trusted` |
 
@@ -340,8 +344,7 @@ that will run.
 hook_create(
   mailbox: "support",
   event: "on_receive",
-  cmd: ["/usr/local/bin/claude", "-p", "You are the support agent.", "--dangerously-skip-permissions"],
-  stdin: "email"
+  cmd: ["/usr/local/bin/claude", "-p", "You are the support agent.", "--dangerously-skip-permissions"]
 )
 → "Hook 'support-replier' created on mailbox 'support'. argv=['/usr/local/bin/claude', '-p', 'You are the support agent.', '--dangerously-skip-permissions']"
 ```
@@ -372,7 +375,7 @@ List hooks on mailboxes you own (or one when `mailbox` is set).
 hook_list()
 → [{"name":"support-replier","mailbox":"support","event":"on_receive",
     "cmd":["/usr/local/bin/claude","-p","...","--dangerously-skip-permissions"],
-    "stdin":"email","timeout_secs":60,"fire_on_untrusted":false}]
+    "timeout_secs":60,"fire_on_untrusted":false}]
 ```
 
 ---

--- a/agents/gemini/SKILL.md.header
+++ b/agents/gemini/SKILL.md.header
@@ -14,8 +14,7 @@ hook that re-launches `gemini` with the email piped on stdin:
 hook_create(
   mailbox: "support",
   event: "on_receive",
-  cmd: ["/usr/local/bin/gemini", "-p", "<instruction-string>", "--yolo"],
-  stdin: "email"
+  cmd: ["/usr/local/bin/gemini", "-p", "<instruction-string>", "--yolo"]
 )
 ```
 
@@ -33,7 +32,8 @@ arrives on stdin. Reply via the aimx MCP server."`). Notes:
 - The `cat file | gemini -p "..."` pipe-from-stdin pattern is the
   official non-interactive contract — Gemini reads the piped content
   as additional context alongside the `-p` prompt. The aimx daemon
-  performs the same pipe automatically when `stdin: "email"` is set.
+  always pipes the raw `.md` to the child's stdin so this happens
+  automatically.
 - Optional: pass `-m gemini-2.5-flash` (or another model) to pin the
   model explicitly.
 

--- a/agents/goose/aimx.yaml.header
+++ b/agents/goose/aimx.yaml.header
@@ -31,8 +31,7 @@ prompt: |
   hook_create(
     mailbox: "support",
     event: "on_receive",
-    cmd: ["/usr/local/bin/goose", "run", "--recipe", "/etc/aimx/goose-aimx-hook.yaml"],
-    stdin: "email"
+    cmd: ["/usr/local/bin/goose", "run", "--recipe", "/etc/aimx/goose-aimx-hook.yaml"]
   )
   ```
 
@@ -65,15 +64,14 @@ prompt: |
   hook_create(
     mailbox: "support",
     event: "on_receive",
-    cmd: ["/usr/local/bin/goose", "run", "--instructions", "-", "--quiet"],
-    stdin: "email"
+    cmd: ["/usr/local/bin/goose", "run", "--instructions", "-", "--quiet"]
   )
   ```
 
-  `--instructions -` reads the prompt from stdin; the daemon pipes the
-  raw email `.md` into that channel when `stdin: "email"` is set.
-  `--quiet` keeps the run free of progress chatter that would otherwise
-  pollute the structured log.
+  `--instructions -` reads the prompt from stdin; the daemon always
+  pipes the raw email `.md` into that channel. `--quiet` keeps the run
+  free of progress chatter that would otherwise pollute the structured
+  log.
 
   Note: the user the hook runs as (the mailbox's owner) must have the
   aimx skill installed too — re-run `aimx agents setup goose` as that

--- a/agents/hermes/SKILL.md.header
+++ b/agents/hermes/SKILL.md.header
@@ -21,8 +21,7 @@ prompt that tells the agent to fetch the email itself:
 hook_create(
   mailbox: "support",
   event: "on_receive",
-  cmd: ["/usr/local/bin/hermes", "chat", "-q", "Read the aimx email at the path in env var AIMX_FILEPATH and act on it via the aimx MCP server.", "--yolo"],
-  stdin: "none"
+  cmd: ["/usr/local/bin/hermes", "chat", "-q", "Read the aimx email at the path in env var AIMX_FILEPATH and act on it via the aimx MCP server.", "--yolo"]
 )
 ```
 
@@ -37,16 +36,13 @@ Notes:
 - `--yolo` bypasses dangerous-command approval, which is required for
   unattended runs. Without it the headless invocation blocks on
   approvals and never calls MCP.
-- The daemon sets `AIMX_FILEPATH` to the absolute path of the
-  inbound email's `.md` file before spawning the hook; Hermes's
-  filesystem tooling expands it at run time. argv itself is not
-  shell-expanded — the literal token `AIMX_FILEPATH` reaches the
-  agent verbatim.
-- Stdin handling for `hermes chat -q` is undocumented as of Apr 2026;
-  this recipe ships the inline-only form (`stdin: "none"`). If a
-  current install confirms `-q` accepts piped stdin, switch to
-  `stdin: "email"` and shorten the inline prompt to just the
-  instruction (the daemon will pipe the raw `.md` directly).
+- The daemon always pipes the raw `.md` to the child's stdin and sets
+  `AIMX_FILEPATH` to the same path. `hermes chat -q` does not read
+  stdin in headless mode as of Apr 2026, so this recipe instructs it
+  to read `$AIMX_FILEPATH` instead. If your hook only needs select
+  fields, the daemon also exposes `AIMX_SUBJECT`, `AIMX_FROM`,
+  `AIMX_MAILBOX`, etc. argv itself is not shell-expanded — the
+  literal token `AIMX_FILEPATH` reaches the agent verbatim.
 - Optional: pass `--ignore-user-config --ignore-rules` for fully
   isolated runs that ignore the operator's personal config.
 

--- a/agents/opencode/SKILL.md.header
+++ b/agents/opencode/SKILL.md.header
@@ -15,8 +15,7 @@ that tells the agent to fetch the email itself:
 hook_create(
   mailbox: "support",
   event: "on_receive",
-  cmd: ["/usr/local/bin/opencode", "run", "--dangerously-skip-permissions", "Read the aimx email at the path in env var AIMX_FILEPATH and act on it via the aimx MCP server (e.g., email_reply)."],
-  stdin: "none"
+  cmd: ["/usr/local/bin/opencode", "run", "--dangerously-skip-permissions", "Read the aimx email at the path in env var AIMX_FILEPATH and act on it via the aimx MCP server (e.g., email_reply)."]
 )
 ```
 
@@ -28,13 +27,14 @@ Notes:
   host if the binary lives elsewhere (e.g. `/usr/bin/opencode`). The
   inline-prompt argv element is ~200 chars; well under
   `MAX_ARG_STRLEN` (128 KiB on Linux).
-- `opencode run` does not read stdin in headless mode, so we use
-  `stdin: "none"` and embed the entire instruction as the final argv
-  element. The daemon sets the `AIMX_FILEPATH` environment variable
-  to the absolute path of the inbound email's `.md` file before
-  spawning the hook; OpenCode's filesystem/Bash tools expand it at
-  run time. argv itself is not shell-expanded — the literal token
-  `AIMX_FILEPATH` reaches the agent verbatim.
+- The daemon always pipes the raw `.md` to the child's stdin and sets
+  `AIMX_FILEPATH` to the same path. `opencode run` does not read
+  stdin in headless mode, so this recipe instructs it to read
+  `$AIMX_FILEPATH` instead. OpenCode's filesystem/Bash tools expand
+  the env var at run time. argv itself is not shell-expanded — the
+  literal token `AIMX_FILEPATH` reaches the agent verbatim. If your
+  hook only needs select fields, the daemon also exposes
+  `AIMX_SUBJECT`, `AIMX_FROM`, etc.
 - `--dangerously-skip-permissions` is required for unattended tool
   calls. Without it the headless run blocks on permission prompts.
 - Optional: pass `--format json` to get machine-readable output (the

--- a/book/cli.md
+++ b/book/cli.md
@@ -161,10 +161,11 @@ Create a hook. `--cmd` takes the argv as a JSON array string; `cmd[0]` must be a
 | `--mailbox <name>` | Owning mailbox. Must already exist and be owned by the caller (or caller is root). |
 | `--event <event>` | `on_receive` or `after_send`. |
 | `--cmd <json-array>` | Argv exec'd directly when the hook fires. Required. JSON array string with `cmd[0]` as an absolute path. No shell wrapping — wrap in `["/bin/sh", "-c", "..."]` explicitly when you need shell expansion. |
-| `--stdin <mode>` | `email` (default) pipes the raw `.md` to the hook's stdin; `none` closes stdin immediately. |
 | `--timeout-secs <N>` | Hard subprocess timeout. Default `60`, range `[1, 600]`. SIGTERM at the limit, SIGKILL 5s later. |
 | `--fire-on-untrusted` | Fire even when `trusted != "true"`. Only valid on `--event on_receive`. Rejected on `--event after_send`. |
 | `--name <name>` | Optional. Matches `^[a-zA-Z0-9_][a-zA-Z0-9_.-]{0,127}$`. Must be globally unique across all mailboxes. When omitted, a derived 12-char hex name is used. |
+
+The raw `.md` (frontmatter + body) is always piped to the hook's stdin and the same path is also exposed as `$AIMX_FILEPATH`. If your hook only needs the subject or sender, read `$AIMX_SUBJECT` / `$AIMX_FROM` and ignore stdin — the daemon writes the full email but does not require the child to consume it.
 
 Example (as the mailbox owner — no sudo needed when the daemon is running):
 
@@ -173,7 +174,6 @@ aimx hooks create \
   --mailbox accounts \
   --event on_receive \
   --cmd '["/usr/local/bin/claude", "-p", "Read the piped email and act on it.", "--dangerously-skip-permissions"]' \
-  --stdin email \
   --name accounts_claude
 ```
 

--- a/book/configuration.md
+++ b/book/configuration.md
@@ -112,11 +112,12 @@ Hooks are defined as `[[mailboxes.<name>.hooks]]` arrays. `cmd` is an argv array
 | `event` | string | `"on_receive"` or `"after_send"` |
 | `type` | string | Hook kind, default `"cmd"` (only `cmd` is supported today) |
 | `cmd` | array of strings | Argv exec'd directly. Required and non-empty; `cmd[0]` must be an absolute path. There is no shell wrapping — spell out `["/bin/sh", "-c", "..."]` explicitly when you need shell expansion. |
-| `stdin` | string | `"email"` (default) pipes the raw `.md` (frontmatter + body) to the hook's stdin; `"none"` closes stdin immediately so the hook only sees env vars. |
 | `timeout_secs` | int | Hard subprocess timeout in seconds. Default `60`, range `[1, 600]`. SIGTERM at the limit, SIGKILL 5s later. |
 | `fire_on_untrusted` | bool | `on_receive` only: fire even when `trusted != "true"`. Rejected on `after_send` hooks at config load with `ERR fire_on_untrusted is on_receive only`. |
 
-Unknown fields on a hook table are rejected at config load. The legacy fields `template`, `params`, `run_as`, `origin`, and `dangerously_support_untrusted` are also rejected with a pointer to `book/hooks.md` — the template-hook surface and `aimx-hook` shared-uid sandbox have been retired in favor of the per-mailbox owner model. See [Hooks & Trust](hooks.md) for full details on events and trust policies.
+The raw `.md` (frontmatter + body) is always piped to the hook's stdin and the same path is also exposed as `$AIMX_FILEPATH`. If your hook only needs the subject or sender, read `$AIMX_SUBJECT` / `$AIMX_FROM` and ignore stdin — the daemon writes the full email but does not require the child to consume it.
+
+Unknown fields on a hook table are rejected at config load. The legacy fields `stdin`, `template`, `params`, `run_as`, `origin`, and `dangerously_support_untrusted` are also rejected with a pointer to `book/hooks.md` — the template-hook surface, `aimx-hook` shared-uid sandbox, and the per-hook stdin opt-out have been retired in favor of the per-mailbox owner model with an unconditional pipe. See [Hooks & Trust](hooks.md) for full details on events and trust policies.
 
 ## Storage layout
 
@@ -247,7 +248,6 @@ cmd = ["/bin/sh", "-c", 'echo "$AIMX_DATE | $AIMX_FROM | $AIMX_SUBJECT" >> /var/
 name = "support_agent"
 event = "on_receive"
 cmd = ["/usr/local/bin/claude", "-p", "Read the piped email and act on it via the aimx MCP server.", "--dangerously-skip-permissions"]
-stdin = "email"
 
 # ----------------------------
 # Another mailbox

--- a/book/hook-recipes.md
+++ b/book/hook-recipes.md
@@ -12,18 +12,20 @@ A hook recipe is a `[[mailboxes.<name>.hooks]]` block (or the equivalent `aimx h
 
 1. Email lands in the mailbox, aimx writes the `.md` file to disk.
 2. aimx evaluates the trust gate. A hook fires iff `trusted == "true"` on the email OR the hook sets `fire_on_untrusted = true`.
-3. aimx exec's the argv directly as the mailbox's owner. There is no `/bin/sh` between aimx and the agent. The piped email body (`stdin = "email"`) or the `$AIMX_FILEPATH` env var (`stdin = "none"`) hands the agent the email content.
-4. The agent reads the email and takes action: replying, filing a ticket, updating a calendar, whatever.
+3. aimx exec's the argv directly as the mailbox's owner. There is no `/bin/sh` between aimx and the agent. The raw `.md` is always piped to the child's stdin and the same path is exposed as `$AIMX_FILEPATH`.
+4. The agent reads the email — either off stdin or by opening `$AIMX_FILEPATH` — and takes action: replying, filing a ticket, updating a calendar, whatever.
 5. Exit code is logged (one structured line per fire) but does not block delivery.
 
 > **Why argv and not shell?** User-controlled fields like `From:` and `Subject:` can contain arbitrary bytes, including shell metacharacters (`$()`, backticks, `;`, quotes). Splicing them into a shell command, even with shell-escape quoting, is fragile. Delivering them as env vars and `exec`'ing argv directly avoids the shell parser entirely. When you do need shell expansion, spell out `cmd = ["/bin/sh", "-c", "..."]` explicitly so it's visible at the call site.
 
-## Two stdin shapes
+## Two consumption shapes
 
-Recipes split into two camps depending on whether the agent reads stdin in headless mode:
+The daemon always pipes the raw `.md` to a hook's stdin, but recipes still split into two camps depending on whether the agent reads stdin in headless mode:
 
-- **Native-stdin** (Claude Code, Codex, Gemini, Goose, webhook): hook sets `stdin = "email"`, the daemon pipes the raw `.md` to the agent's stdin, and the prompt only tells the agent what to do with it. Smallest argv, cleanest pipeline.
-- **Inline-only** (OpenCode, Hermes): hook sets `stdin = "none"`; the `cmd` carries a fixed prompt that instructs the agent to read `$AIMX_FILEPATH` (env var set by the daemon) using its filesystem tool. argv is not shell-expanded — the literal `$AIMX_FILEPATH` token reaches the agent, which expands it via Bash/Read tooling at run time.
+- **Native-stdin** (Claude Code, Codex, Gemini, Goose, webhook): the agent reads the piped email straight off its stdin; the prompt only tells it what to do with the content.
+- **Filepath-only** (OpenCode, Hermes): the agent does not read stdin in headless mode, so the `cmd` carries a fixed prompt that instructs it to read `$AIMX_FILEPATH` (env var set by the daemon) using its filesystem tool. argv is not shell-expanded — the literal `$AIMX_FILEPATH` token reaches the agent, which expands it via Bash/Read tooling at run time.
+
+If your hook only needs the subject or sender, read `$AIMX_SUBJECT` / `$AIMX_FROM` and ignore stdin — the daemon writes the full email but does not require the child to consume it.
 
 ## Absolute paths
 
@@ -49,7 +51,6 @@ aimx hooks create \
   --mailbox accounts \
   --event on_receive \
   --cmd '["/usr/local/bin/claude", "-p", "Read the piped email and act on it via the aimx MCP server.", "--dangerously-skip-permissions"]' \
-  --stdin email \
   --name accounts_claude
 ```
 
@@ -67,7 +68,6 @@ aimx hooks create \
   --mailbox triage \
   --event on_receive \
   --cmd '["/usr/local/bin/codex", "exec", "--skip-git-repo-check", "--full-auto", "-"]' \
-  --stdin email \
   --name triage_codex
 ```
 
@@ -82,7 +82,6 @@ aimx hooks create \
   --mailbox research \
   --event on_receive \
   --cmd '["/usr/local/bin/opencode", "run", "--dangerously-skip-permissions", "Read the aimx email at the path in env var AIMX_FILEPATH and act on it via the aimx MCP server (e.g. email_reply)."]' \
-  --stdin none \
   --name research_opencode
 ```
 
@@ -99,7 +98,6 @@ aimx hooks create \
   --mailbox notes \
   --event on_receive \
   --cmd '["/usr/local/bin/gemini", "-p", "Read the piped email and file it into my notes via the aimx MCP server.", "--yolo"]' \
-  --stdin email \
   --name notes_gemini
 ```
 
@@ -118,7 +116,6 @@ aimx hooks create \
   --mailbox ops \
   --event on_receive \
   --cmd '["/usr/local/bin/goose", "run", "--instructions", "-", "--quiet"]' \
-  --stdin email \
   --name ops_goose
 ```
 
@@ -129,7 +126,6 @@ aimx hooks create \
   --mailbox ops \
   --event on_receive \
   --cmd '["/usr/local/bin/goose", "run", "--recipe", "/etc/aimx/goose-aimx-hook.yaml"]' \
-  --stdin email \
   --name ops_goose_recipe
 ```
 
@@ -146,7 +142,6 @@ aimx hooks create \
   --mailbox openclaw \
   --event on_receive \
   --cmd '["/bin/sh", "-c", "ntfy pub openclaw-mail \"New email: $AIMX_SUBJECT from $AIMX_FROM\""]' \
-  --stdin none \
   --fire-on-untrusted \
   --name openclaw_notify
 ```
@@ -164,11 +159,10 @@ aimx hooks create \
   --mailbox hermes \
   --event on_receive \
   --cmd '["/usr/local/bin/hermes", "chat", "-q", "Read the aimx email at the path in env var AIMX_FILEPATH and act on it via the aimx MCP server.", "--yolo"]' \
-  --stdin none \
   --name hermes_chat
 ```
 
-If a future Hermes release confirms that `chat -q` accepts piped stdin, switch to `--stdin email` and shorten the inline prompt to "Read the piped email and act on it via the aimx MCP server."
+If a future Hermes release confirms that `chat -q` accepts piped stdin, shorten the inline prompt to "Read the piped email and act on it via the aimx MCP server." — the daemon already pipes the email regardless.
 
 ## Webhook (POST to URL)
 
@@ -179,11 +173,10 @@ aimx hooks create \
   --mailbox alerts \
   --event on_receive \
   --cmd '["/usr/bin/curl", "-sS", "-X", "POST", "-H", "Content-Type: application/json", "--data-binary", "@-", "https://hooks.example.com/aimx"]' \
-  --stdin email \
   --name alerts_webhook
 ```
 
-`--data-binary @-` tells curl to POST whatever lands on its stdin verbatim. Combined with `stdin = "email"`, the receiver gets the raw `.md` (TOML frontmatter + body) as the request body. Use `Content-Type: text/markdown` instead if your receiver expects that explicitly.
+`--data-binary @-` tells curl to POST whatever lands on its stdin verbatim. Since the daemon always pipes the email to the hook, the receiver gets the raw `.md` (TOML frontmatter + body) as the request body. Use `Content-Type: text/markdown` instead if your receiver expects that explicitly.
 
 ## `after_send` recipes
 
@@ -196,7 +189,6 @@ aimx hooks create \
   --mailbox alice \
   --event after_send \
   --cmd '["/bin/sh", "-c", "printf \"%s %s %s %s\\n\" \"$AIMX_SEND_STATUS\" \"$AIMX_TO\" \"$AIMX_SUBJECT\" \"$AIMX_HOOK_NAME\" >> /var/log/aimx/alice-sent.log"]' \
-  --stdin none \
   --name alice_audit
 ```
 
@@ -207,7 +199,6 @@ aimx hooks create \
   --mailbox alerts \
   --event after_send \
   --cmd '["/bin/sh", "-c", "if [ \"$AIMX_SEND_STATUS\" != \"delivered\" ]; then ntfy pub on-call \"aimx send to $AIMX_TO $AIMX_SEND_STATUS: $AIMX_SUBJECT\"; fi"]' \
-  --stdin none \
   --name alerts_failed_page
 ```
 
@@ -220,7 +211,6 @@ aimx hooks create \
   --mailbox marketing \
   --event after_send \
   --cmd '["/bin/sh", "-c", "case \"$AIMX_TO\" in *@customer-co.com) curl -fsS -X POST https://hooks.internal/marketing-sent -d \"to=$AIMX_TO&status=$AIMX_SEND_STATUS\" ;; esac"]' \
-  --stdin none \
   --name marketing_customer_notify
 ```
 
@@ -251,7 +241,6 @@ aimx hooks create \
   --mailbox bugs \
   --event on_receive \
   --cmd '["/usr/bin/flock", "/tmp/myapp.lock", "/usr/local/bin/claude", "-p", "Reproduce the reported bug.", "--dangerously-skip-permissions"]' \
-  --stdin email \
   --name bugs_serialised
 ```
 

--- a/book/hooks.md
+++ b/book/hooks.md
@@ -42,7 +42,6 @@ cmd = ["/bin/sh", "-c", 'echo "New mail from $AIMX_FROM: $AIMX_SUBJECT" >> /tmp/
 | `event` | string | yes | `"on_receive"` or `"after_send"`. |
 | `type` | string | no | Trigger kind (default `"cmd"`). Only `cmd` is supported today. |
 | `cmd` | array of strings | yes | Argv exec'd directly. Must be non-empty; `cmd[0]` must be an absolute path. No shell wrapping — wrap in `["/bin/sh", "-c", "..."]` explicitly when you need shell expansion. |
-| `stdin` | string | no | `"email"` (default) pipes the raw `.md` (frontmatter + body) to the hook's stdin; `"none"` closes stdin immediately so the hook only sees env vars. |
 | `timeout_secs` | int | no | Hard subprocess timeout in seconds. Default `60`, range `[1, 600]`. SIGTERM at the limit, SIGKILL 5s later. |
 | `fire_on_untrusted` | bool | no | `on_receive` only: when `true`, fire even if `trusted != "true"`. Default `false`. Rejected on `after_send` hooks at config load. |
 
@@ -81,7 +80,6 @@ When `aimx mcp` runs under the mailbox owner's uid, the agent can create hooks p
   "mailbox": "accounts",
   "event": "on_receive",
   "cmd": ["/usr/local/bin/claude", "-p", "Read this email and act on it.", "--dangerously-skip-permissions"],
-  "stdin": "email",
   "fire_on_untrusted": false
 }}
 ```
@@ -124,14 +122,11 @@ Always expand env vars inside double quotes (`"$AIMX_SUBJECT"`). Values from sen
 
 ### Stdin
 
-Each hook declares one of two `stdin` modes:
+The raw `.md` (frontmatter + body) is always piped to the hook's stdin. The same path is also exposed as `$AIMX_FILEPATH`.
 
-| Mode | Payload | Notes |
-|------|---------|-------|
-| `"email"` | The raw `.md` (frontmatter + body) | Default. Useful when piping into a CLI that takes stdin directly. |
-| `"none"` | Closed immediately | For hooks that only need env vars. Required for agent CLIs that don't read stdin in headless mode (OpenCode, Hermes). |
+If your hook only needs the subject or sender, read `$AIMX_SUBJECT` / `$AIMX_FROM` and ignore stdin — the daemon writes the full email but does not require the child to consume it. Agent CLIs that don't read stdin in headless mode (OpenCode, Hermes) use `$AIMX_FILEPATH` to open the file directly.
 
-Override per-hook with `stdin = "none"` in `config.toml`, `--stdin none` from `aimx hooks create`, or `"stdin": "none"` in the MCP `hook_create` payload. The `email_json` mode that earlier drafts shipped has been removed — `Config::load` rejects it with a clear error.
+The earlier per-hook `stdin = "email" | "none"` knob has been removed; `Config::load` rejects any `stdin` line in `[[mailboxes.<name>.hooks]]` with an error that names the offending hook.
 
 ## UDS authorization (`SO_PEERCRED`)
 
@@ -242,7 +237,6 @@ trusted_senders = ["*@yourcompany.com"]
 name = "schedule_claude"
 event = "on_receive"
 cmd = ["/usr/local/bin/claude", "-p", "Handle this scheduling request.", "--dangerously-skip-permissions"]
-stdin = "email"
 ```
 
 The hook fires only when the email's `trusted == "true"`. Claude runs as `alice` (matching the mailbox owner), reads the piped `.md` from stdin, and uses its own MCP tooling to reply.
@@ -282,10 +276,9 @@ cmd = ["/bin/sh", "-c", 'echo "$AIMX_SEND_STATUS $AIMX_TO $AIMX_SUBJECT" >> /var
 name = "alerts_webhook"
 event = "on_receive"
 cmd = ["/usr/bin/curl", "-sS", "-X", "POST", "-H", "Content-Type: application/json", "--data-binary", "@-", "https://hooks.example.com/aimx"]
-stdin = "email"
 ```
 
-`--data-binary @-` posts whatever lands on curl's stdin verbatim, which is the raw `.md` (frontmatter + body) when `stdin = "email"`.
+`--data-binary @-` posts whatever lands on curl's stdin verbatim, which is the raw `.md` (frontmatter + body) — the daemon always pipes the email to a hook's stdin.
 
 ---
 

--- a/book/mcp.md
+++ b/book/mcp.md
@@ -144,13 +144,12 @@ Automatically sets `In-Reply-To` and `References` headers from the original emai
 
 #### `email_mark_read`
 
-Mark an email as read.
+Mark an inbox email as read. Sent-mail mark has no agent use case and is not supported.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `mailbox` | string | yes | Mailbox name. Must be owned by the caller. |
 | `id` | string | yes | Email ID (filename stem, e.g. `2025-01-15-103000-meeting`) |
-| `folder` | string | no | `"inbox"` (default) or `"sent"` |
 
 Updates `read = true` in the email's frontmatter. The MCP server is non-root so it routes the write through `aimx serve` over the local UDS (`/run/aimx/aimx.sock`) rather than touching the root-owned mailbox file directly. If `aimx serve` is not running the tool returns an error hint to start the daemon.
 
@@ -158,13 +157,12 @@ Updates `read = true` in the email's frontmatter. The MCP server is non-root so 
 
 #### `email_mark_unread`
 
-Mark an email as unread.
+Mark an inbox email as unread. Sent-mail mark has no agent use case and is not supported.
 
 | Parameter | Type | Required | Description |
 |-----------|------|----------|-------------|
 | `mailbox` | string | yes | Mailbox name. Must be owned by the caller. |
 | `id` | string | yes | Email ID (filename stem, e.g. `2025-01-15-103000-meeting`) |
-| `folder` | string | no | `"inbox"` (default) or `"sent"` |
 
 Updates `read = false` in the email's frontmatter. Same daemon-mediated write path as `email_mark_read`. Requires a running `aimx serve`.
 
@@ -184,9 +182,10 @@ Create a new hook on a mailbox you own. The daemon validates the caller's uid ag
 | `event` | string | yes | `"on_receive"` or `"after_send"` |
 | `cmd` | array of strings | yes | Argv exec'd directly when the hook fires. `cmd[0]` must be an absolute path. |
 | `name` | string | no | Explicit hook name. When omitted, a stable 12-hex-char name is derived from `sha256(event + joined_argv + fire_on_untrusted)`. |
-| `stdin` | string | no | `"email"` (default) pipes the raw `.md` to the hook's stdin; `"none"` closes stdin immediately. |
 | `timeout_secs` | int | no | Hard subprocess timeout in seconds. Default `60`, range `[1, 600]`. |
 | `fire_on_untrusted` | bool | no | `on_receive` only: fire even when `trusted != "true"`. Default `false`. Rejected on `after_send`. |
+
+The raw `.md` (frontmatter + body) is always piped to the hook's stdin and the same path is exposed as `$AIMX_FILEPATH`. If your hook only needs the subject or sender, read `$AIMX_SUBJECT` / `$AIMX_FROM` and ignore stdin — the daemon writes the full email but does not require the child to consume it.
 
 **Returns:** `{effective_name}` — the hook name the daemon wrote.
 
@@ -197,7 +196,6 @@ Example (Claude Code self-wiring):
   "mailbox": "accounts",
   "event": "on_receive",
   "cmd": ["/usr/local/bin/claude", "-p", "Read the piped email and act on it via the aimx MCP server.", "--dangerously-skip-permissions"],
-  "stdin": "email",
   "name": "accounts_claude"
 }}
 ```
@@ -220,11 +218,11 @@ List hooks on mailboxes you own.
 |-----------|------|----------|-------------|
 | `mailbox` | string | no | Filter to one mailbox (must be owned by the caller); omit to list every owned mailbox |
 
-**Returns:** JSON array. Each entry has `name`, `mailbox`, `event`, `cmd`, `stdin`, `timeout_secs`, and `fire_on_untrusted`.
+**Returns:** JSON array. Each entry has `name`, `mailbox`, `event`, `cmd`, `timeout_secs`, and `fire_on_untrusted`.
 
 ```json
 [
-  {"name": "accounts_claude", "mailbox": "accounts", "event": "on_receive", "cmd": ["/usr/local/bin/claude", "-p", "...", "--dangerously-skip-permissions"], "stdin": "email", "timeout_secs": 60, "fire_on_untrusted": false}
+  {"name": "accounts_claude", "mailbox": "accounts", "event": "on_receive", "cmd": ["/usr/local/bin/claude", "-p", "...", "--dangerously-skip-permissions"], "timeout_secs": 60, "fire_on_untrusted": false}
 ]
 ```
 

--- a/book/troubleshooting.md
+++ b/book/troubleshooting.md
@@ -221,7 +221,7 @@ sudo chmod -R u+rwX,go-rwx /var/lib/aimx/inbox/<mailbox> /var/lib/aimx/sent/<mai
 
 Symptom: editing `config.toml` and `sudo systemctl reload aimx` reports success but the new hook never fires. journalctl shows a `config reloaded with error` warn line.
 
-Fix: the new `config.toml` failed validation. Common culprits: legacy `template`, `params`, `run_as`, `origin`, or `dangerously_support_untrusted` fields on a hook (all rejected at config load with a pointer to `book/hooks.md`); duplicate hook name across mailboxes; `cmd[0]` not an absolute path; `fire_on_untrusted = true` on an `after_send` hook. Check the log:
+Fix: the new `config.toml` failed validation. Common culprits: a `stdin` line on a hook (the field was removed; `Config::load` now refuses any value with `hook '<name>' carries removed field 'stdin' — remove this line and restart aimx serve; the email is always piped to hooks`); legacy `template`, `params`, `run_as`, `origin`, or `dangerously_support_untrusted` fields on a hook (all rejected at config load with a pointer to `book/hooks.md`); duplicate hook name across mailboxes; `cmd[0]` not an absolute path; `fire_on_untrusted = true` on an `after_send` hook. Check the log:
 
 ```bash
 journalctl -u aimx --since="5 minutes ago" | grep -i reload
@@ -237,7 +237,7 @@ Fix: the absolute path written into the hook's `cmd[0]` does not exist on the ho
 
 ```bash
 aimx hooks delete <name> --yes
-aimx hooks create --mailbox <m> --event on_receive --cmd '["/correct/path/to/agent", "..."]' --stdin email --name <name>
+aimx hooks create --mailbox <m> --event on_receive --cmd '["/correct/path/to/agent", "..."]' --name <name>
 ```
 
 ## Spam prevention

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -435,12 +435,6 @@ pub struct HookCreateArgs {
     #[arg(long)]
     pub name: Option<String>,
 
-    /// Stdin delivery mode. `email` (default) pipes the raw `.md`
-    /// (frontmatter + body) into the hook's stdin. `none` closes
-    /// stdin immediately so the hook only sees env vars.
-    #[arg(long, value_parser = ["email", "none"])]
-    pub stdin: Option<String>,
-
     /// Hard subprocess timeout in seconds. Default 60, max 600.
     /// SIGTERM at the limit, SIGKILL 5s later.
     #[arg(long)]

--- a/src/config.rs
+++ b/src/config.rs
@@ -521,11 +521,10 @@ fn reject_legacy_schema(toml_text: &str) -> Result<(), Box<dyn std::error::Error
             continue;
         }
 
-        let Some((key, value)) = trimmed.split_once('=') else {
+        let Some((key, _value)) = trimmed.split_once('=') else {
             continue;
         };
         let key = key.trim();
-        let value = value.trim();
 
         match key {
             "run_as" => {
@@ -552,15 +551,75 @@ fn reject_legacy_schema(toml_text: &str) -> Result<(), Box<dyn std::error::Error
                 )
                 .into());
             }
-            "stdin" if value.contains("email_json") => {
-                return Err("email_json stdin mode was removed; use stdin = \"email\""
-                    .to_string()
-                    .into());
-            }
             _ => {}
         }
     }
     Ok(())
+}
+
+/// Pre-`from_value` check: reject any `[[mailbox.<name>.hooks]]` block
+/// carrying a `stdin = ...` key. The field was removed and the email is
+/// always piped to hooks now.
+///
+/// The error names the hook by its explicit `name` if set, otherwise by
+/// the derived sha256-based effective name (matches `effective_hook_name`).
+fn reject_removed_stdin_field(parsed: &toml::Value) -> Result<(), String> {
+    let Some(mailboxes) = parsed.get("mailboxes").and_then(|v| v.as_table()) else {
+        return Ok(());
+    };
+    for (_mb_name, mb) in mailboxes {
+        let Some(mb_tbl) = mb.as_table() else {
+            continue;
+        };
+        let Some(hooks) = mb_tbl.get("hooks").and_then(|v| v.as_array()) else {
+            continue;
+        };
+        for hook in hooks {
+            let Some(tbl) = hook.as_table() else {
+                continue;
+            };
+            if !tbl.contains_key("stdin") {
+                continue;
+            }
+            // Resolve the effective name. Explicit `name` wins; otherwise
+            // derive from `(event, cmd, fire_on_untrusted)` so the error
+            // is greppable against `aimx hooks list` output.
+            let name = match tbl.get("name").and_then(|v| v.as_str()) {
+                Some(n) => n.to_string(),
+                None => derive_hook_name_from_toml(tbl),
+            };
+            return Err(format!(
+                "hook '{name}' carries removed field 'stdin' — remove this line and \
+                 restart aimx serve; the email is always piped to hooks"
+            ));
+        }
+    }
+    Ok(())
+}
+
+/// Derive the effective hook name from a raw `toml::Table`. Mirrors
+/// `crate::hook::effective_hook_name` for the no-explicit-name case so
+/// the rejection error can name the hook by its derived sha256 stem.
+/// Best-effort: missing or wrong-typed fields fall back to defaults.
+fn derive_hook_name_from_toml(tbl: &toml::value::Table) -> String {
+    let event = match tbl.get("event").and_then(|v| v.as_str()) {
+        Some("after_send") => HookEvent::AfterSend,
+        _ => HookEvent::OnReceive,
+    };
+    let cmd: Vec<String> = tbl
+        .get("cmd")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                .collect()
+        })
+        .unwrap_or_default();
+    let fire = tbl
+        .get("fire_on_untrusted")
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false);
+    crate::hook::derive_hook_name(event, &cmd, fire)
 }
 
 /// Reject `fire_on_untrusted = true` on `after_send` hooks, and any hook
@@ -848,7 +907,13 @@ impl Config {
             }
         })?;
         reject_legacy_schema(&content)?;
-        let config: Config = toml::from_str(&content)?;
+        // Peek at the parsed TOML value before `from_value` so we can
+        // reject the removed `stdin` field with a hook-named error
+        // before the structural deserializer trips on its absence.
+        let raw_value: toml::Value = toml::from_str(&content)?;
+        reject_removed_stdin_field(&raw_value)
+            .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+        let config: Config = raw_value.try_into()?;
         for (name, mb) in &config.mailboxes {
             if mb.owner.trim().is_empty() {
                 return Err(format!(
@@ -1244,8 +1309,44 @@ template = "invoke-claude"
         );
     }
 
+    /// Any `stdin = ...` value (including the legacy `email_json`)
+    /// rejects with the unified "always piped" error. The `stdin` field
+    /// was removed; its mere presence is the error.
     #[test]
-    fn load_rejects_email_json_stdin() {
+    fn load_rejects_stdin_field_for_every_value() {
+        for value in ["none", "email", "email_json"] {
+            let tmp = TempDir::new().unwrap();
+            let path = tmp.path().join("config.toml");
+            write_cfg(
+                &path,
+                &format!(
+                    r#"
+domain = "test.com"
+
+[mailboxes.support]
+address = "support@test.com"
+owner = "ops"
+
+[[mailboxes.support.hooks]]
+name = "named_hook"
+event = "on_receive"
+cmd = ["/bin/true"]
+stdin = "{value}"
+"#
+                ),
+            );
+            let err = Config::load(&path).unwrap_err().to_string();
+            assert!(err.contains("named_hook"), "value={value}: {err}");
+            assert!(err.contains("stdin"), "value={value}: {err}");
+            assert!(err.contains("always piped"), "value={value}: {err}");
+        }
+    }
+
+    /// When the hook has no explicit `name`, the rejection error names
+    /// it by the derived sha256 effective name so operators can grep
+    /// the failing line against `aimx hooks list` output.
+    #[test]
+    fn load_rejects_stdin_field_with_derived_name_when_unnamed() {
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("config.toml");
         write_cfg(
@@ -1260,14 +1361,18 @@ owner = "ops"
 [[mailboxes.support.hooks]]
 event = "on_receive"
 cmd = ["/bin/true"]
-stdin = "email_json"
+stdin = "none"
 "#,
         );
         let err = Config::load(&path).unwrap_err().to_string();
-        assert!(
-            err.contains("email_json"),
-            "error should mention email_json: {err}"
+        let derived = crate::hook::derive_hook_name(
+            crate::hook::HookEvent::OnReceive,
+            &["/bin/true".to_string()],
+            false,
         );
+        assert!(err.contains(&derived), "{err}");
+        assert!(err.contains("stdin"), "{err}");
+        assert!(err.contains("always piped"), "{err}");
     }
 
     #[test]
@@ -1369,33 +1474,6 @@ timeout_secs = 600
         );
         let (_cfg, _warnings) =
             Config::load(&path).expect("config with timeout_secs=600 must load");
-    }
-
-    #[test]
-    fn load_accepts_stdin_none() {
-        let _g = ConfigDirOverride::set(Path::new("/tmp"));
-        let tmp = TempDir::new().unwrap();
-        let path = tmp.path().join("config.toml");
-        write_cfg(
-            &path,
-            r#"
-domain = "test.com"
-
-[mailboxes.support]
-address = "support@test.com"
-owner = "ops"
-
-[[mailboxes.support.hooks]]
-event = "on_receive"
-cmd = ["/bin/true"]
-stdin = "none"
-"#,
-        );
-        let (cfg, _warnings) = Config::load(&path).expect("config with stdin=none must load");
-        assert_eq!(
-            cfg.mailboxes["support"].hooks[0].stdin,
-            crate::hook::HookStdin::None
-        );
     }
 
     #[test]

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -4,11 +4,13 @@
 //! One `Hook` entry in `config.toml` carries an `event`
 //! (`on_receive` | `after_send`), a `cmd` argv array, an opt-in
 //! `fire_on_untrusted` flag that lets `on_receive` hooks fire on
-//! non-trusted email, an optional `name`, and per-hook `stdin`
-//! (`email` default; `none` closes stdin) and `timeout_secs` (60s
-//! default; 1..=600 range, validated at config load) overrides. Hooks
-//! fire on every event of their configured type; the only gate is the
-//! `on_receive` trust check.
+//! non-trusted email, an optional `name`, and a per-hook `timeout_secs`
+//! (60s default; 1..=600 range, validated at config load) override.
+//! Hooks fire on every event of their configured type; the only gate
+//! is the `on_receive` trust check. The raw `.md` (frontmatter + body)
+//! is always piped to the child's stdin — there is no opt-out. Hooks
+//! that only need select fields can read `$AIMX_FROM` /
+//! `$AIMX_SUBJECT` / `$AIMX_FILEPATH` and ignore stdin.
 //!
 //! `name` is optional. When omitted, the effective name is derived
 //! deterministically from
@@ -55,38 +57,6 @@ pub const MAX_HOOK_TIMEOUT_SECS: u32 = 600;
 pub enum HookEvent {
     OnReceive,
     AfterSend,
-}
-
-/// Stdin delivery mode for a hook. `Email` (default) pipes the raw `.md`
-/// (frontmatter + body) into the child's stdin. `None` closes stdin
-/// immediately so the hook only sees env vars.
-///
-/// Legacy `email_json` is rejected pre-parse (see `reject_legacy_schema`).
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
-#[serde(rename_all = "snake_case")]
-pub enum HookStdin {
-    #[default]
-    Email,
-    None,
-}
-
-impl HookStdin {
-    pub fn as_str(&self) -> &'static str {
-        match self {
-            HookStdin::Email => "email",
-            HookStdin::None => "none",
-        }
-    }
-
-    pub fn parse(s: &str) -> Result<Self, String> {
-        match s {
-            "email" => Ok(HookStdin::Email),
-            "none" => Ok(HookStdin::None),
-            other => Err(format!(
-                "invalid stdin mode '{other}': expected 'email' or 'none'"
-            )),
-        }
-    }
 }
 
 impl HookEvent {
@@ -140,12 +110,6 @@ pub struct Hook {
     /// `trusted` value is not `"true"`.
     #[serde(default, skip_serializing_if = "is_false")]
     pub fire_on_untrusted: bool,
-
-    /// Stdin delivery mode. `email` (default) pipes the raw `.md` body
-    /// to the child's stdin; `none` closes stdin immediately. Validated
-    /// at config load: legacy `"email_json"` is rejected pre-parse.
-    #[serde(default, skip_serializing_if = "is_default_stdin")]
-    pub stdin: HookStdin,
 
     /// Hard subprocess timeout in seconds. Default 60, max 600.
     /// Validated at config load (`Config::load`) so out-of-range values
@@ -208,10 +172,6 @@ fn default_hook_timeout_secs() -> u32 {
 
 fn is_false(b: &bool) -> bool {
     !*b
-}
-
-fn is_default_stdin(s: &HookStdin) -> bool {
-    matches!(s, HookStdin::Email)
 }
 
 fn is_default_hook_timeout_secs(t: &u32) -> bool {
@@ -511,15 +471,16 @@ fn run_and_log(
         }
     };
 
-    // --- Resolve owner / timeout / stdin mode ------------------------------
-    // With the legacy schema gone, hooks always run as the mailbox's
-    // owner. The auth predicate will gate this in a later pass; for
-    // now this is the simple single-line rule.
+    // --- Resolve owner / timeout / stdin -----------------------------------
+    // Hooks always run as the mailbox's owner. The raw `.md` (frontmatter
+    // + body) is always piped on stdin — hooks that only need select
+    // fields read `$AIMX_FROM` / `$AIMX_SUBJECT` / `$AIMX_FILEPATH` and
+    // ignore stdin.
     let owner: String = mailbox_config.owner.clone();
 
     let timeout = Duration::from_secs(hook.timeout_secs as u64);
 
-    let stdin_payload = build_stdin(hook.stdin, stdin_source);
+    let stdin_payload = SandboxStdin::Email(read_stdin_source(stdin_source));
 
     tracing::info!(
         target: "aimx::hook",
@@ -623,19 +584,10 @@ fn run_and_log(
     }
 }
 
-/// Build the stdin payload for a hook fire. When `mode == Email`, the
-/// raw `.md` file is piped into the hook's child process. If the file
-/// doesn't exist (e.g. TEMP failures on `after_send` where persistence
-/// was skipped) we pipe an empty payload rather than failing the hook.
-/// A real read error (EACCES etc.) is logged at WARN. When `mode == None`,
-/// stdin is closed immediately and `source` is not read.
-fn build_stdin(mode: HookStdin, source: Option<&Path>) -> SandboxStdin {
-    match mode {
-        HookStdin::Email => SandboxStdin::Email(read_stdin_source(source)),
-        HookStdin::None => SandboxStdin::None,
-    }
-}
-
+/// Read the raw `.md` payload that gets piped to a hook's stdin. If the
+/// file doesn't exist (e.g. TEMP failures on `after_send` where
+/// persistence was skipped) we pipe an empty payload rather than failing
+/// the hook. A real read error (EACCES etc.) is logged at WARN.
 fn read_stdin_source(source: Option<&Path>) -> Vec<u8> {
     let Some(p) = source else {
         return Vec::new();
@@ -767,7 +719,6 @@ mod tests {
             r#type: "cmd".to_string(),
             cmd: vec!["/bin/true".to_string()],
             fire_on_untrusted: false,
-            stdin: HookStdin::Email,
             timeout_secs: DEFAULT_HOOK_TIMEOUT_SECS,
         }
     }
@@ -994,34 +945,6 @@ mod tests {
     }
 
     #[test]
-    fn execute_on_receive_with_stdin_none_pipes_empty_stdin() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let out = tmp.path().join("stdin.out");
-        let mut hook = basic_hook("h_stdin_none");
-        hook.fire_on_untrusted = true;
-        hook.stdin = HookStdin::None;
-        // The script writes whatever it reads from stdin to a file.
-        // With stdin = "none" the file must be empty.
-        hook.cmd = shell_argv(format!("cat > {}", out.display()));
-        let mailbox = regular_mailbox(vec![hook]);
-        let mut meta = sample_metadata();
-        meta.trusted = "true".to_string();
-        let filepath = tmp.path().join("source.md");
-        std::fs::write(&filepath, b"original markdown body\n").ok();
-        let ctx = OnReceiveContext {
-            filepath: &filepath,
-            metadata: &meta,
-        };
-        execute_on_receive(&sample_config(), &mailbox, &ctx);
-        let content = std::fs::read(&out).unwrap();
-        assert!(
-            content.is_empty(),
-            "stdin = none must close stdin immediately; got {} bytes",
-            content.len()
-        );
-    }
-
-    #[test]
     fn execute_on_receive_with_short_timeout_kills_long_running_hook() {
         let tmp = tempfile::TempDir::new().unwrap();
         let marker = tmp.path().join("after_sleep");
@@ -1066,7 +989,6 @@ mod tests {
                 out.display()
             )),
             fire_on_untrusted: true,
-            stdin: HookStdin::Email,
             timeout_secs: DEFAULT_HOOK_TIMEOUT_SECS,
         };
         let derived = derive_hook_name(HookEvent::OnReceive, &hook.cmd, true);
@@ -1149,7 +1071,6 @@ mod tests {
                 out.display()
             )),
             fire_on_untrusted: false,
-            stdin: HookStdin::Email,
             timeout_secs: DEFAULT_HOOK_TIMEOUT_SECS,
         };
         let mailbox = alice_mailbox(vec![hook]);
@@ -1190,7 +1111,6 @@ mod tests {
             r#type: "cmd".to_string(),
             cmd: vec!["/bin/false".to_string()],
             fire_on_untrusted: false,
-            stdin: HookStdin::Email,
             timeout_secs: DEFAULT_HOOK_TIMEOUT_SECS,
         };
         let mailbox = alice_mailbox(vec![hook]);
@@ -1214,7 +1134,6 @@ mod tests {
             r#type: "cmd".to_string(),
             cmd: argv(&["/bin/echo", "hi"]),
             fire_on_untrusted: false,
-            stdin: HookStdin::Email,
             timeout_secs: DEFAULT_HOOK_TIMEOUT_SECS,
         };
         let s = toml::to_string(&hook).unwrap();
@@ -1239,29 +1158,22 @@ cmd = ["/bin/echo", "hi"]
         assert_eq!(hook.event, HookEvent::OnReceive);
         assert_eq!(hook.cmd, vec!["/bin/echo", "hi"]);
         assert!(!hook.fire_on_untrusted);
-        assert_eq!(hook.stdin, HookStdin::Email);
         assert_eq!(hook.timeout_secs, DEFAULT_HOOK_TIMEOUT_SECS);
     }
 
+    /// `stdin` is no longer a recognized field; `deny_unknown_fields`
+    /// rejects it at parse time. The load-time check in `Config::load`
+    /// produces a more actionable error (see config.rs tests); this
+    /// pins the lower-level shape.
     #[test]
-    fn hook_stdin_parses_email_and_none() {
-        assert_eq!(HookStdin::parse("email").unwrap(), HookStdin::Email);
-        assert_eq!(HookStdin::parse("none").unwrap(), HookStdin::None);
-        assert!(HookStdin::parse("email_json").is_err());
-        assert!(HookStdin::parse("anything").is_err());
-    }
-
-    #[test]
-    fn hook_toml_with_explicit_stdin_and_timeout_loads() {
+    fn hook_toml_with_stdin_field_is_rejected() {
         let src = r#"
 event = "on_receive"
 cmd = ["/bin/echo", "hi"]
 stdin = "none"
-timeout_secs = 5
 "#;
-        let hook: Hook = toml::from_str(src).unwrap();
-        assert_eq!(hook.stdin, HookStdin::None);
-        assert_eq!(hook.timeout_secs, 5);
+        let err = toml::from_str::<Hook>(src).unwrap_err().to_string();
+        assert!(err.contains("stdin"), "{err}");
     }
 
     #[test]
@@ -1413,7 +1325,6 @@ timeout_secs = 5
             r#type: "cmd".to_string(),
             cmd: vec!["/bin/touch".to_string(), marker.display().to_string()],
             fire_on_untrusted: false,
-            stdin: HookStdin::Email,
             timeout_secs: DEFAULT_HOOK_TIMEOUT_SECS,
         };
         let mailbox = MailboxConfig {

--- a/src/hook_handler.rs
+++ b/src/hook_handler.rs
@@ -21,7 +21,7 @@ use serde::Deserialize;
 
 use crate::config::{Config, validate_hooks, validate_single_hook};
 use crate::hook::{
-    DEFAULT_HOOK_TIMEOUT_SECS, Hook, HookEvent, HookStdin, effective_hook_name, is_valid_hook_name,
+    DEFAULT_HOOK_TIMEOUT_SECS, Hook, HookEvent, effective_hook_name, is_valid_hook_name,
 };
 use crate::mailbox_handler::{CONFIG_WRITE_LOCK, MailboxContext, write_config_atomic};
 use crate::send_protocol::{AckResponse, ErrCode, HookCreateRequest, HookDeleteRequest};
@@ -30,10 +30,10 @@ use crate::uds_authz::{Caller, enforce_mailbox_owner_or_root};
 
 /// Wire-shape of the `HOOK-CREATE` JSON body. Mirrors the trimmed
 /// `Hook` schema in `src/hook.rs` minus the `event` and `name` fields,
-/// which travel as request headers. `deny_unknown_fields` causes a
-/// legacy `template` / `params` / `run_as` / `origin` /
-/// `dangerously_support_untrusted` to reject at body-parse time, before
-/// the handler ever touches `config.toml`.
+/// which travel as request headers. `deny_unknown_fields` causes
+/// any removed field (`stdin`, legacy `template` / `params` / `run_as`
+/// / `origin` / `dangerously_support_untrusted`) to reject at
+/// body-parse time, before the handler ever touches `config.toml`.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct HookCreateBody {
@@ -42,11 +42,6 @@ struct HookCreateBody {
     fire_on_untrusted: bool,
     #[serde(default = "default_hook_type")]
     r#type: String,
-    /// Optional stdin mode override. Defaults to `email`. The legacy
-    /// `email_json` value is rejected by `Config::load`'s pre-parse hook
-    /// for `[[hooks]]` blocks; the wire-level rejection runs here too.
-    #[serde(default)]
-    stdin: Option<String>,
     /// Optional subprocess timeout override. Defaults to 60s. Range
     /// [1, 600] is enforced by `validate_single_hook`.
     #[serde(default)]
@@ -144,26 +139,12 @@ pub async fn handle_hook_create(
         }
     };
 
-    let stdin_mode = match body.stdin.as_deref() {
-        None => HookStdin::Email,
-        Some(s) => match HookStdin::parse(s) {
-            Ok(v) => v,
-            Err(reason) => {
-                return AckResponse::Err {
-                    code: ErrCode::Validation,
-                    reason,
-                };
-            }
-        },
-    };
-
     let hook = Hook {
         name: req.name.clone(),
         event,
         r#type: body.r#type,
         cmd: body.cmd,
         fire_on_untrusted: body.fire_on_untrusted,
-        stdin: stdin_mode,
         timeout_secs: body.timeout_secs.unwrap_or(DEFAULT_HOOK_TIMEOUT_SECS),
     };
 
@@ -357,10 +338,12 @@ fn reject_legacy_body_fields(body: &[u8]) -> Result<(), String> {
                 .to_string(),
         );
     }
-    if let Some(stdin) = obj.get("stdin").and_then(|v| v.as_str())
-        && stdin == "email_json"
-    {
-        return Err("email_json stdin mode was removed; use stdin = \"email\"".to_string());
+    if obj.contains_key("stdin") {
+        return Err(
+            "hook sets removed field 'stdin' — the email is always piped to hooks; \
+             remove this key from the request"
+                .to_string(),
+        );
     }
     Ok(())
 }
@@ -915,31 +898,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_accepts_stdin_none() {
-        let _r = install_tester_resolver();
-        let tmp = TempDir::new().unwrap();
-        let (state_ctx, mb_ctx) = contexts(&tmp);
-        let body = serde_json::to_vec(&serde_json::json!({
-            "cmd": ["/bin/true"],
-            "stdin": "none",
-        }))
-        .unwrap();
-        let req = HookCreateRequest {
-            mailbox: "alice".into(),
-            event: "on_receive".into(),
-            name: Some("stdinhook".into()),
-            body,
-        };
-        let resp = handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await;
-        assert!(matches!(resp, AckResponse::Ok), "{resp:?}");
-        let cfg = mb_ctx.config_handle.load();
-        assert_eq!(
-            cfg.mailboxes["alice"].hooks[0].stdin,
-            crate::hook::HookStdin::None
-        );
-    }
-
-    #[tokio::test]
     async fn create_accepts_explicit_timeout_secs() {
         let _r = install_tester_resolver();
         let tmp = TempDir::new().unwrap();
@@ -961,53 +919,35 @@ mod tests {
         assert_eq!(cfg.mailboxes["alice"].hooks[0].timeout_secs, 5);
     }
 
+    /// `stdin` is a removed field. Any value (including the legacy
+    /// `"email_json"`, the previously valid `"email"` / `"none"`, or
+    /// gibberish) reject at the legacy-field pre-screen with the
+    /// "always piped" hint.
     #[tokio::test]
-    async fn create_rejects_invalid_stdin_value() {
+    async fn create_rejects_stdin_field() {
         let _r = install_tester_resolver();
         let tmp = TempDir::new().unwrap();
         let (state_ctx, mb_ctx) = contexts(&tmp);
-        let body = serde_json::to_vec(&serde_json::json!({
-            "cmd": ["/bin/true"],
-            "stdin": "bogus",
-        }))
-        .unwrap();
-        let req = HookCreateRequest {
-            mailbox: "alice".into(),
-            event: "on_receive".into(),
-            name: None,
-            body,
-        };
-        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
-            AckResponse::Err { code, reason } => {
-                assert_eq!(code, ErrCode::Validation);
-                assert!(reason.contains("stdin"), "{reason}");
+        for value in ["none", "email", "email_json", "bogus"] {
+            let body = serde_json::to_vec(&serde_json::json!({
+                "cmd": ["/bin/true"],
+                "stdin": value,
+            }))
+            .unwrap();
+            let req = HookCreateRequest {
+                mailbox: "alice".into(),
+                event: "on_receive".into(),
+                name: None,
+                body,
+            };
+            match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
+                AckResponse::Err { code, reason } => {
+                    assert_eq!(code, ErrCode::Protocol, "value={value}: {reason}");
+                    assert!(reason.contains("stdin"), "value={value}: {reason}");
+                    assert!(reason.contains("always piped"), "value={value}: {reason}");
+                }
+                other => panic!("value={value}: expected PROTOCOL, got {other:?}"),
             }
-            other => panic!("expected VALIDATION, got {other:?}"),
-        }
-    }
-
-    #[tokio::test]
-    async fn create_rejects_legacy_email_json_stdin() {
-        let _r = install_tester_resolver();
-        let tmp = TempDir::new().unwrap();
-        let (state_ctx, mb_ctx) = contexts(&tmp);
-        let body = serde_json::to_vec(&serde_json::json!({
-            "cmd": ["/bin/true"],
-            "stdin": "email_json",
-        }))
-        .unwrap();
-        let req = HookCreateRequest {
-            mailbox: "alice".into(),
-            event: "on_receive".into(),
-            name: None,
-            body,
-        };
-        match handle_hook_create(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
-            AckResponse::Err { code, reason } => {
-                assert_eq!(code, ErrCode::Protocol);
-                assert!(reason.contains("email_json"), "{reason}");
-            }
-            other => panic!("expected PROTOCOL, got {other:?}"),
         }
     }
 

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -25,7 +25,7 @@ use crate::auth::{Action, AuthError, authorize};
 use crate::cli::{HookCommand, HookCreateArgs};
 use crate::config::{Config, validate_hooks};
 use crate::hook::{
-    DEFAULT_HOOK_TIMEOUT_SECS, Hook, HookEvent, HookStdin, effective_hook_name, is_valid_hook_name,
+    DEFAULT_HOOK_TIMEOUT_SECS, Hook, HookEvent, effective_hook_name, is_valid_hook_name,
 };
 use crate::mcp::{HookCrudFallback, submit_hook_create_via_daemon, submit_hook_delete_via_daemon};
 use crate::platform::{current_euid, is_root};
@@ -69,21 +69,19 @@ fn list(config: &Config, filter_mailbox: Option<&str>) -> Result<(), Box<dyn std
     }
 
     println!(
-        "{} {} {} {} {} {}",
+        "{} {} {} {} {}",
         term::header("NAME                        "),
         term::header("MAILBOX             "),
         term::header("EVENT       "),
-        term::header("STDIN  "),
         term::header("TIMEOUT"),
         term::header("CMD"),
     );
     for row in rows {
         println!(
-            "{:<28.28} {:<20.20} {:<11} {:<6} {:>7} {}",
+            "{:<28.28} {:<20.20} {:<11} {:>7} {}",
             term::highlight(&row.name).to_string(),
             row.mailbox,
             row.event,
-            row.stdin.as_str(),
             row.timeout_secs,
             truncate_with_ellipsis(&row.cmd, 60),
         );
@@ -96,7 +94,6 @@ struct HookRow {
     mailbox: String,
     event: &'static str,
     cmd: String,
-    stdin: HookStdin,
     timeout_secs: u32,
 }
 
@@ -122,7 +119,6 @@ fn gather_rows(config: &Config, filter_mailbox: Option<&str>) -> Vec<HookRow> {
                 mailbox: mailbox_name.clone(),
                 event: hook.event.as_str(),
                 cmd: format_argv_for_display(&hook.cmd),
-                stdin: hook.stdin,
                 timeout_secs: hook.timeout_secs,
             });
         }
@@ -179,10 +175,6 @@ fn create(config: &Config, args: HookCreateArgs) -> Result<(), Box<dyn std::erro
     }
     let cmd = parse_cmd_argv(&args.cmd)?;
 
-    let stdin_mode = match args.stdin.as_deref() {
-        None => HookStdin::Email,
-        Some(s) => HookStdin::parse(s)?,
-    };
     let timeout_secs = args.timeout_secs.unwrap_or(DEFAULT_HOOK_TIMEOUT_SECS);
 
     let hook = Hook {
@@ -191,7 +183,6 @@ fn create(config: &Config, args: HookCreateArgs) -> Result<(), Box<dyn std::erro
         r#type: "cmd".to_string(),
         cmd: cmd.clone(),
         fire_on_untrusted: args.fire_on_untrusted,
-        stdin: stdin_mode,
         timeout_secs,
     };
     let effective = effective_hook_name(&hook);
@@ -199,7 +190,7 @@ fn create(config: &Config, args: HookCreateArgs) -> Result<(), Box<dyn std::erro
     // Try the UDS path first. The daemon authorizes via SO_PEERCRED +
     // auth::authorize so the same gate runs whether the caller used CLI
     // or MCP, and the running Config hot-swaps without a restart.
-    let body = build_hook_create_body(&cmd, args.fire_on_untrusted, stdin_mode, timeout_secs)?;
+    let body = build_hook_create_body(&cmd, args.fire_on_untrusted, timeout_secs)?;
     match submit_hook_create_via_daemon(&args.mailbox, &args.event, args.name.as_deref(), body) {
         Ok(()) => {
             println!(
@@ -244,13 +235,12 @@ fn format_hook_auth_error(err: &AuthError, verb: &str) -> String {
 
 /// Build the JSON body the daemon's `HookCreateBody` deserializer
 /// expects: `{"cmd": [...], "fire_on_untrusted": <bool>, "type": "cmd"}`.
-/// `stdin` and `timeout_secs` are emitted only when they differ from the
-/// schema defaults so existing callers (and round-tripped configs) round
+/// `timeout_secs` is emitted only when it differs from the schema
+/// default so existing callers (and round-tripped configs) round
 /// through unchanged.
 fn build_hook_create_body(
     cmd: &[String],
     fire_on_untrusted: bool,
-    stdin: HookStdin,
     timeout_secs: u32,
 ) -> Result<Vec<u8>, Box<dyn std::error::Error>> {
     let mut body = serde_json::json!({
@@ -258,9 +248,6 @@ fn build_hook_create_body(
         "fire_on_untrusted": fire_on_untrusted,
         "type": "cmd",
     });
-    if !matches!(stdin, HookStdin::Email) {
-        body["stdin"] = serde_json::Value::String(stdin.as_str().to_string());
-    }
     if timeout_secs != DEFAULT_HOOK_TIMEOUT_SECS {
         body["timeout_secs"] = serde_json::Value::Number(timeout_secs.into());
     }
@@ -278,7 +265,6 @@ fn delete(config: &Config, name: &str, yes: bool) -> Result<(), Box<dyn std::err
         println!("  {}   {}", term::header("name:   "), term::highlight(name));
         println!("  {}   {}", term::header("mailbox:"), mailbox);
         println!("  {}   {}", term::header("event:  "), hook.event);
-        println!("  {}   {}", term::header("stdin:  "), hook.stdin.as_str());
         println!("  {}   {}", term::header("timeout:"), hook.timeout_secs);
         println!(
             "  {}   {}",
@@ -434,7 +420,6 @@ mod tests {
         let body = build_hook_create_body(
             &["/bin/echo".to_string(), "hi".to_string()],
             true,
-            HookStdin::Email,
             DEFAULT_HOOK_TIMEOUT_SECS,
         )
         .unwrap();
@@ -444,31 +429,27 @@ mod tests {
         assert_eq!(parsed["fire_on_untrusted"], true);
         assert_eq!(parsed["type"], "cmd");
         // Defaults are not serialized so the wire stays stable across
-        // operators that don't touch stdin/timeout_secs.
+        // operators that don't touch timeout_secs. `stdin` is no
+        // longer a recognized field.
         assert!(parsed.get("stdin").is_none(), "{parsed}");
         assert!(parsed.get("timeout_secs").is_none(), "{parsed}");
     }
 
     #[test]
     fn build_hook_create_body_default_fire_on_untrusted_is_false() {
-        let body = build_hook_create_body(
-            &["/bin/true".to_string()],
-            false,
-            HookStdin::Email,
-            DEFAULT_HOOK_TIMEOUT_SECS,
-        )
-        .unwrap();
+        let body =
+            build_hook_create_body(&["/bin/true".to_string()], false, DEFAULT_HOOK_TIMEOUT_SECS)
+                .unwrap();
         let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(parsed["fire_on_untrusted"], false);
     }
 
     #[test]
-    fn build_hook_create_body_emits_stdin_and_timeout_when_non_default() {
-        let body =
-            build_hook_create_body(&["/bin/true".to_string()], false, HookStdin::None, 5).unwrap();
+    fn build_hook_create_body_emits_timeout_when_non_default() {
+        let body = build_hook_create_body(&["/bin/true".to_string()], false, 5).unwrap();
         let parsed: serde_json::Value = serde_json::from_slice(&body).unwrap();
-        assert_eq!(parsed["stdin"], "none");
         assert_eq!(parsed["timeout_secs"], 5);
+        assert!(parsed.get("stdin").is_none(), "{parsed}");
     }
 
     #[test]

--- a/src/mailbox_handler.rs
+++ b/src/mailbox_handler.rs
@@ -956,7 +956,6 @@ mod tests {
         let mark_req = crate::send_protocol::MarkRequest {
             mailbox: "alice".into(),
             id: "2025-06-01-001".into(),
-            folder: crate::send_protocol::MarkFolder::Inbox,
             read: true,
         };
         let resp = crate::state_handler::handle_mark(

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -55,6 +55,7 @@ pub struct EmailReadParams {
 }
 
 #[derive(Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
 pub struct EmailMarkParams {
     #[schemars(description = "Mailbox name")]
     pub mailbox: String,
@@ -2000,5 +2001,38 @@ mod email_list_tests {
         let rows = rows.as_array().unwrap();
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0]["delivery_status"], "");
+    }
+
+    #[test]
+    fn email_mark_params_rejects_stale_folder_arg() {
+        // Symmetric to how `hook_create` hard-rejects a removed `stdin`
+        // arg: a stale `folder` field on `email_mark_*` must surface as
+        // a parse error, not a silent drop that mutates inbox while the
+        // agent thinks it touched sent.
+        let json = serde_json::json!({
+            "mailbox": "alice",
+            "id": "2025-06-15-120000-hello",
+            "folder": "sent",
+        });
+        let err = match serde_json::from_value::<EmailMarkParams>(json) {
+            Ok(_) => panic!("expected unknown-field error, got Ok"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string().contains("unknown field"),
+            "expected unknown-field error, got {err}"
+        );
+    }
+
+    #[test]
+    fn email_mark_params_accepts_canonical_shape() {
+        let json = serde_json::json!({
+            "mailbox": "alice",
+            "id": "2025-06-15-120000-hello",
+        });
+        let params: EmailMarkParams =
+            serde_json::from_value(json).expect("canonical mark params must parse");
+        assert_eq!(params.mailbox, "alice");
+        assert_eq!(params.id, "2025-06-15-120000-hello");
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -4,8 +4,8 @@ use crate::frontmatter::InboundFrontmatter;
 use crate::mailbox;
 use crate::send;
 use crate::send_protocol::{
-    self, ErrCode, HookCreateRequest, HookDeleteRequest, MailboxCrudRequest, MarkFolder,
-    MarkRequest, SendRequest,
+    self, ErrCode, HookCreateRequest, HookDeleteRequest, MailboxCrudRequest, MarkRequest,
+    SendRequest,
 };
 
 use rmcp::handler::server::router::tool::ToolRouter;
@@ -60,8 +60,6 @@ pub struct EmailMarkParams {
     pub mailbox: String,
     #[schemars(description = "Email ID (e.g. 2025-06-15-120000-hello)")]
     pub id: String,
-    #[schemars(description = "Which folder to target: \"inbox\" (default) or \"sent\"")]
-    pub folder: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, schemars::JsonSchema)]
@@ -116,11 +114,6 @@ pub struct HookCreateParams {
                        12-char hex name is derived from (event, cmd, \
                        fire_on_untrusted).")]
     pub name: Option<String>,
-    #[schemars(description = "Stdin delivery mode. \"email\" (default) pipes the \
-                       raw .md (frontmatter + body) into the child's stdin. \
-                       \"none\" closes stdin immediately so the hook only \
-                       sees env vars.")]
-    pub stdin: Option<String>,
     #[schemars(description = "Hard subprocess timeout in seconds. Default 60, \
                        max 600. SIGTERM at the limit, SIGKILL 5s later.")]
     pub timeout_secs: Option<u32>,
@@ -288,7 +281,11 @@ impl AimxMcpServer {
         std::fs::read_to_string(&filepath).map_err(|e| format!("Failed to read email: {e}"))
     }
 
-    #[tool(name = "email_mark_read", description = "Mark an email as read")]
+    #[tool(
+        name = "email_mark_read",
+        description = "Mark an inbox email as read. Sent-mail mark has no \
+                       agent use case and is not supported."
+    )]
     fn email_mark_read(
         &self,
         Parameters(params): Parameters<EmailMarkParams>,
@@ -299,16 +296,19 @@ impl AimxMcpServer {
             crate::auth::Action::MarkReadWrite(params.mailbox.clone()),
             &config,
         )?;
-        let folder = resolve_folder(params.folder.as_deref())?;
         // Route through the daemon; mailbox files are root-owned and
         // the MCP process runs as the invoking user. The daemon
         // re-checks via SO_PEERCRED, so MCP's pre-flight authz is
         // defense in depth, not the security boundary.
-        submit_mark_via_daemon(&params.mailbox, &params.id, folder, true)?;
+        submit_mark_via_daemon(&params.mailbox, &params.id, true)?;
         Ok(format!("Email '{}' marked as read.", params.id))
     }
 
-    #[tool(name = "email_mark_unread", description = "Mark an email as unread")]
+    #[tool(
+        name = "email_mark_unread",
+        description = "Mark an inbox email as unread. Sent-mail mark has no \
+                       agent use case and is not supported."
+    )]
     fn email_mark_unread(
         &self,
         Parameters(params): Parameters<EmailMarkParams>,
@@ -319,8 +319,7 @@ impl AimxMcpServer {
             crate::auth::Action::MarkReadWrite(params.mailbox.clone()),
             &config,
         )?;
-        let folder = resolve_folder(params.folder.as_deref())?;
-        submit_mark_via_daemon(&params.mailbox, &params.id, folder, false)?;
+        submit_mark_via_daemon(&params.mailbox, &params.id, false)?;
         Ok(format!("Email '{}' marked as unread.", params.id))
     }
 
@@ -460,23 +459,11 @@ impl AimxMcpServer {
         }
         let fire_on_untrusted = params.fire_on_untrusted.unwrap_or(false);
 
-        // Validate stdin at the MCP layer so callers get a precise error
-        // before any wire I/O. The daemon would re-validate on the wire,
-        // but the local check produces a more actionable message.
-        if let Some(s) = params.stdin.as_deref()
-            && let Err(e) = crate::hook::HookStdin::parse(s)
-        {
-            return Err(e);
-        }
-
         let mut body = serde_json::json!({
             "cmd": params.cmd,
             "fire_on_untrusted": fire_on_untrusted,
             "type": "cmd",
         });
-        if let Some(stdin) = params.stdin.as_deref() {
-            body["stdin"] = serde_json::Value::String(stdin.to_string());
-        }
         if let Some(t) = params.timeout_secs {
             body["timeout_secs"] = serde_json::Value::Number(t.into());
         }
@@ -532,7 +519,6 @@ impl AimxMcpServer {
                     "event": hook.event.as_str(),
                     "cmd": hook.cmd,
                     "fire_on_untrusted": hook.fire_on_untrusted,
-                    "stdin": hook.stdin.as_str(),
                     "timeout_secs": hook.timeout_secs,
                 }));
             }
@@ -677,21 +663,12 @@ fn submit_via_daemon(args: &SendArgs) -> Result<String, String> {
 /// Submit a `MARK-READ` or `MARK-UNREAD` request to the daemon over UDS.
 /// MCP's `email_mark_read` / `email_mark_unread` tools route through this
 /// path so the non-root MCP process doesn't need write access to the
-/// root-owned mailbox files.
-fn submit_mark_via_daemon(
-    mailbox: &str,
-    id: &str,
-    folder: Folder,
-    read: bool,
-) -> Result<(), String> {
-    let folder = match folder {
-        Folder::Inbox => MarkFolder::Inbox,
-        Folder::Sent => MarkFolder::Sent,
-    };
+/// root-owned mailbox files. Targets the inbox unconditionally; the
+/// sent folder has no agent use case.
+fn submit_mark_via_daemon(mailbox: &str, id: &str, read: bool) -> Result<(), String> {
     let request = MarkRequest {
         mailbox: mailbox.to_string(),
         id: id.to_string(),
-        folder,
         read,
     };
     let socket = crate::serve::aimx_socket_path();

--- a/src/send_protocol.rs
+++ b/src/send_protocol.rs
@@ -20,7 +20,6 @@
 //!   AIMX/1 MARK-READ\n
 //!   Mailbox: <name>\n
 //!   Id: <id>\n
-//!   Folder: inbox|sent\n
 //!   Content-Length: 0\n
 //!   \n
 //!
@@ -100,36 +99,13 @@ pub struct SendRequest {
     pub body: Vec<u8>,
 }
 
-/// Which on-disk folder a MARK request targets.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum MarkFolder {
-    Inbox,
-    Sent,
-}
-
-impl MarkFolder {
-    pub fn as_str(self) -> &'static str {
-        match self {
-            MarkFolder::Inbox => "inbox",
-            MarkFolder::Sent => "sent",
-        }
-    }
-
-    pub fn parse(s: &str) -> Option<Self> {
-        match s {
-            "inbox" => Some(MarkFolder::Inbox),
-            "sent" => Some(MarkFolder::Sent),
-            _ => None,
-        }
-    }
-}
-
-/// Decoded `AIMX/1 MARK-READ` or `AIMX/1 MARK-UNREAD` request.
+/// Decoded `AIMX/1 MARK-READ` or `AIMX/1 MARK-UNREAD` request. Targets
+/// the inbox folder unconditionally — sent-mail mark has no agent use
+/// case and was removed from the wire.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct MarkRequest {
     pub mailbox: String,
     pub id: String,
-    pub folder: MarkFolder,
     pub read: bool,
 }
 
@@ -513,7 +489,6 @@ where
 {
     let mut mailbox: Option<String> = None;
     let mut id: Option<String> = None;
-    let mut folder: Option<MarkFolder> = None;
     let mut content_length: Option<usize> = None;
 
     loop {
@@ -557,15 +532,15 @@ where
                 id = Some(value);
             }
             "folder" => {
-                if folder.is_some() {
-                    return Err(ParseError::Malformed("duplicate Folder header".into()));
-                }
-                let parsed = MarkFolder::parse(&value).ok_or_else(|| {
-                    ParseError::Malformed(format!(
-                        "invalid Folder '{value}', expected 'inbox' or 'sent'"
-                    ))
-                })?;
-                folder = Some(parsed);
+                // The `Folder:` header was removed; MARK targets the
+                // inbox unconditionally. Reject rather than silently
+                // dropping so a stale client cannot believe it
+                // selected the sent folder.
+                return Err(ParseError::Malformed(
+                    "Folder header is not allowed on MARK verbs (sent-mail \
+                     mark removed; inbox is the only target)"
+                        .into(),
+                ));
             }
             "content-length" => {
                 if content_length.is_some() {
@@ -592,19 +567,12 @@ where
     let mailbox =
         mailbox.ok_or_else(|| ParseError::Malformed("missing required header: Mailbox".into()))?;
     let id = id.ok_or_else(|| ParseError::Malformed("missing required header: Id".into()))?;
-    let folder =
-        folder.ok_or_else(|| ParseError::Malformed("missing required header: Folder".into()))?;
     // Content-Length is optional for MARK verbs but if present must be 0.
     // The `!= 0` branch above already rejects otherwise. Accept the missing
     // case as "implicitly 0" to keep clients terse.
     let _ = content_length;
 
-    Ok(MarkRequest {
-        mailbox,
-        id,
-        folder,
-        read,
-    })
+    Ok(MarkRequest { mailbox, id, read })
 }
 
 async fn parse_mailbox_crud_headers<R>(
@@ -1068,10 +1036,9 @@ where
         "MARK-UNREAD"
     };
     let header = format!(
-        "AIMX/1 {verb}\nMailbox: {}\nId: {}\nFolder: {}\nContent-Length: 0\n\n",
+        "AIMX/1 {verb}\nMailbox: {}\nId: {}\nContent-Length: 0\n\n",
         sanitize_inline(&request.mailbox),
         sanitize_inline(&request.id),
-        request.folder.as_str(),
     );
     writer.write_all(header.as_bytes()).await?;
     writer.flush().await?;
@@ -1232,6 +1199,42 @@ mod mailbox_list_codec_tests {
             "{header}"
         );
         assert_eq!(&buf[header_end + 2..], &body[..]);
+    }
+
+    /// Round-trip a `MARK-READ` frame: writer emits the verb plus the
+    /// mailbox / id headers, parser decodes back to a `MarkRequest`.
+    /// `Folder:` is no longer emitted or accepted.
+    #[tokio::test]
+    async fn round_trip_mark_request_omits_folder() {
+        let req = MarkRequest {
+            mailbox: "alice".into(),
+            id: "2025-06-01-001".into(),
+            read: true,
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        write_mark_request(&mut buf, &req).await.unwrap();
+        let text = std::str::from_utf8(&buf).unwrap();
+        assert!(text.starts_with("AIMX/1 MARK-READ\n"), "{text}");
+        assert!(!text.to_ascii_lowercase().contains("folder:"), "{text}");
+
+        let mut reader = std::io::Cursor::new(buf);
+        let parsed = parse_request(&mut reader).await.unwrap();
+        assert_eq!(parsed, Request::Mark(req));
+    }
+
+    /// A `Folder:` header on MARK is a hard parse error — silently
+    /// dropping it would let a stale client believe it had selected the
+    /// sent folder.
+    #[tokio::test]
+    async fn mark_rejects_folder_header() {
+        let frame = b"AIMX/1 MARK-READ\nMailbox: alice\nId: 2025-06-01-001\nFolder: sent\nContent-Length: 0\n\n";
+        let mut reader = std::io::Cursor::new(frame.to_vec());
+        match parse_request(&mut reader).await {
+            Err(ParseError::Malformed(reason)) => {
+                assert!(reason.contains("Folder"), "{reason}");
+            }
+            other => panic!("expected Malformed, got {other:?}"),
+        }
     }
 
     /// Error variant of the JSON ack writer mirrors the bodyless ack

--- a/src/state_handler.rs
+++ b/src/state_handler.rs
@@ -32,7 +32,7 @@ use crate::frontmatter::InboundFrontmatter;
 use crate::mailbox_locks::MailboxLocks;
 use crate::mcp::resolve_email_path_strict;
 use crate::ownership::chown_as_owner;
-use crate::send_protocol::{AckResponse, ErrCode, MarkFolder, MarkRequest};
+use crate::send_protocol::{AckResponse, ErrCode, MarkRequest};
 use crate::uds_authz::{Caller, enforce_mailbox_owner_or_root};
 
 /// Per-connection shared state for the MARK verbs (and the MAILBOX-CRUD
@@ -109,12 +109,8 @@ fn validate_id(id: &str) -> Result<(), AckResponse> {
     Ok(())
 }
 
-fn folder_dir(data_dir: &Path, mailbox: &str, folder: MarkFolder) -> PathBuf {
-    let sub = match folder {
-        MarkFolder::Inbox => "inbox",
-        MarkFolder::Sent => "sent",
-    };
-    data_dir.join(sub).join(mailbox)
+fn inbox_dir(data_dir: &Path, mailbox: &str) -> PathBuf {
+    data_dir.join("inbox").join(mailbox)
 }
 
 /// Handle a `MARK-READ` / `MARK-UNREAD` request. Takes the shared
@@ -159,7 +155,7 @@ pub async fn handle_mark(ctx: &StateContext, req: &MarkRequest, caller: &Caller)
     let lock = ctx.lock_for(&req.mailbox);
     let _guard = lock.lock().await;
 
-    let mailbox_dir = folder_dir(&ctx.data_dir, &req.mailbox, req.folder);
+    let mailbox_dir = inbox_dir(&ctx.data_dir, &req.mailbox);
     let filepath = match resolve_email_path_strict(&mailbox_dir, &req.id) {
         Some(p) => p,
         None => {
@@ -176,17 +172,11 @@ pub async fn handle_mark(ctx: &StateContext, req: &MarkRequest, caller: &Caller)
                 reason = "symlink_or_escape",
                 mailbox = %req.mailbox,
                 id = %req.id,
-                folder = req.folder.as_str(),
                 "MARK rejected: email not resolvable under mailbox dir"
             );
             return AckResponse::Err {
                 code: ErrCode::NotFound,
-                reason: format!(
-                    "email '{}' not found in {}/{}",
-                    req.id,
-                    req.folder.as_str(),
-                    req.mailbox
-                ),
+                reason: format!("email '{}' not found in inbox/{}", req.id, req.mailbox),
             };
         }
     };
@@ -388,7 +378,6 @@ mod tests {
         let req = MarkRequest {
             mailbox: "alice".to_string(),
             id: "2025-06-01-001".to_string(),
-            folder: MarkFolder::Inbox,
             read: true,
         };
         match handle_mark(&sctx, &req, &Caller::internal_root()).await {
@@ -415,7 +404,6 @@ mod tests {
         let req = MarkRequest {
             mailbox: "alice".to_string(),
             id: "2025-06-01-001".to_string(),
-            folder: MarkFolder::Inbox,
             read: false,
         };
         assert!(matches!(
@@ -436,7 +424,6 @@ mod tests {
         let req = MarkRequest {
             mailbox: "ghost".to_string(),
             id: "2025-06-01-001".to_string(),
-            folder: MarkFolder::Inbox,
             read: true,
         };
         match handle_mark(&sctx, &req, &Caller::internal_root()).await {
@@ -458,7 +445,6 @@ mod tests {
         let req = MarkRequest {
             mailbox: "alice".to_string(),
             id: "2099-01-01-missing".to_string(),
-            folder: MarkFolder::Inbox,
             read: true,
         };
         match handle_mark(&sctx, &req, &Caller::internal_root()).await {
@@ -474,7 +460,6 @@ mod tests {
         let req = MarkRequest {
             mailbox: "alice".to_string(),
             id: "../../etc/passwd".to_string(),
-            folder: MarkFolder::Inbox,
             read: true,
         };
         match handle_mark(&sctx, &req, &Caller::internal_root()).await {
@@ -484,37 +469,6 @@ mod tests {
             }
             other => panic!("expected Err, got {other:?}"),
         }
-    }
-
-    #[tokio::test]
-    async fn mark_read_in_sent_folder() {
-        let tmp = TempDir::new().unwrap();
-        let meta = sample_meta("2025-06-02-001", false);
-        let sent = tmp.path().join("sent").join("alice");
-        write_email(&sent, "2025-06-02-001", &meta);
-
-        let sctx = ctx(tmp.path());
-        let req = MarkRequest {
-            mailbox: "alice".to_string(),
-            id: "2025-06-02-001".to_string(),
-            folder: MarkFolder::Sent,
-            read: true,
-        };
-        assert!(matches!(
-            handle_mark(&sctx, &req, &Caller::internal_root()).await,
-            AckResponse::Ok
-        ));
-
-        let fm: InboundFrontmatter = toml::from_str(
-            std::fs::read_to_string(sent.join("2025-06-02-001.md"))
-                .unwrap()
-                .split("+++")
-                .nth(1)
-                .unwrap()
-                .trim(),
-        )
-        .unwrap();
-        assert!(fm.read);
     }
 
     #[tokio::test]
@@ -533,7 +487,6 @@ mod tests {
         let req = MarkRequest {
             mailbox: "alice".to_string(),
             id: "2025-06-03-001".to_string(),
-            folder: MarkFolder::Inbox,
             read: true,
         };
         assert!(matches!(
@@ -566,7 +519,6 @@ mod tests {
         let req = MarkRequest {
             mailbox: "alice".to_string(),
             id: "2025-06-01-002".to_string(),
-            folder: MarkFolder::Inbox,
             read: true,
         };
         match handle_mark(&sctx, &req, &Caller::internal_root()).await {
@@ -592,7 +544,6 @@ mod tests {
         let req = MarkRequest {
             mailbox: "alice".to_string(),
             id: "2025-06-01-001".to_string(),
-            folder: MarkFolder::Inbox,
             read: true,
         };
         let before = chrono::Utc::now();
@@ -625,7 +576,6 @@ mod tests {
         let req = MarkRequest {
             mailbox: "alice".to_string(),
             id: "2025-06-01-001".to_string(),
-            folder: MarkFolder::Inbox,
             read: false,
         };
         assert!(matches!(
@@ -658,7 +608,6 @@ mod tests {
         let req_read = MarkRequest {
             mailbox: "alice".to_string(),
             id: "2025-06-01-001".to_string(),
-            folder: MarkFolder::Inbox,
             read: true,
         };
         let req_unread = MarkRequest {
@@ -766,7 +715,6 @@ mod tests {
         let req = MarkRequest {
             mailbox: "alice".to_string(),
             id: "2025-06-01-001".to_string(),
-            folder: MarkFolder::Inbox,
             read: true,
         };
         assert!(matches!(
@@ -859,7 +807,6 @@ mod tests {
         let req = MarkRequest {
             mailbox: "alice".to_string(),
             id: "2025-06-01-001".to_string(),
-            folder: MarkFolder::Inbox,
             read: true,
         };
         // chown will fail (EPERM) but the handler must still return Ok.
@@ -972,7 +919,6 @@ mod tests {
         let req = MarkRequest {
             mailbox: "alice".to_string(),
             id: "2025-06-01-777".to_string(),
-            folder: MarkFolder::Inbox,
             read: true,
         };
         match handle_mark(&sctx, &req, &Caller::internal_root()).await {
@@ -1051,7 +997,6 @@ mod tests {
         let req = MarkRequest {
             mailbox: "alice".to_string(),
             id: id.to_string(),
-            folder: MarkFolder::Inbox,
             read: true,
         };
         match handle_mark(&sctx, &req, &Caller::internal_root()).await {
@@ -1083,7 +1028,6 @@ mod tests {
         let req = MarkRequest {
             mailbox: "alice".to_string(),
             id: "2025-06-01-003".to_string(),
-            folder: MarkFolder::Inbox,
             read: true,
         };
         match handle_mark(&sctx, &req, &Caller::internal_root()).await {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3974,11 +3974,12 @@ fn hooks_create_and_list_roundtrip_direct_edit() {
     );
 }
 
-/// `aimx hooks create --stdin none --timeout-secs 5` round-trips
-/// through the direct-edit fallback into `config.toml` and shows up in
-/// `aimx hooks list`.
+/// `aimx hooks create --timeout-secs 5` round-trips through the
+/// direct-edit fallback into `config.toml` and shows up in
+/// `aimx hooks list`. The `--stdin` flag is gone; the email is always
+/// piped to hooks.
 #[test]
-fn hooks_create_with_stdin_and_timeout_flags_persists_to_config() {
+fn hooks_create_with_timeout_flag_persists_to_config() {
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
 
@@ -3995,9 +3996,7 @@ fn hooks_create_with_stdin_and_timeout_flags_persists_to_config() {
             "--cmd",
             r#"["/bin/echo", "noinput"]"#,
             "--name",
-            "stdinhook",
-            "--stdin",
-            "none",
+            "timeouthook",
             "--timeout-secs",
             "5",
         ])
@@ -4008,8 +4007,8 @@ fn hooks_create_with_stdin_and_timeout_flags_persists_to_config() {
 
     let toml_contents = std::fs::read_to_string(tmp.path().join("config.toml")).unwrap();
     assert!(
-        toml_contents.contains("stdin = \"none\""),
-        "stdin override missing from config.toml: {toml_contents}"
+        !toml_contents.contains("stdin"),
+        "stdin field must not appear in config.toml: {toml_contents}"
     );
     assert!(
         toml_contents.contains("timeout_secs = 5"),
@@ -4023,8 +4022,7 @@ fn hooks_create_with_stdin_and_timeout_flags_persists_to_config() {
         .assert()
         .success();
     let list_out = String::from_utf8_lossy(&list.get_output().stdout).to_string();
-    assert!(list_out.contains("stdinhook"), "{list_out}");
-    assert!(list_out.contains("none"), "{list_out}");
+    assert!(list_out.contains("timeouthook"), "{list_out}");
     assert!(list_out.contains("5"), "{list_out}");
 }
 

--- a/tests/uds_authz.rs
+++ b/tests/uds_authz.rs
@@ -103,9 +103,7 @@ fn raw_send_frame(from: &str, to: &str) -> String {
 }
 
 fn raw_mark_frame(verb: &str, mailbox: &str, id: &str) -> String {
-    format!(
-        "AIMX/1 {verb}\r\nMailbox: {mailbox}\r\nId: {id}\r\nFolder: inbox\r\nContent-Length: 0\r\n\r\n"
-    )
+    format!("AIMX/1 {verb}\r\nMailbox: {mailbox}\r\nId: {id}\r\nContent-Length: 0\r\n\r\n")
 }
 
 fn raw_hook_create_frame(mailbox: &str, name: &str, cmd: &[&str]) -> String {


### PR DESCRIPTION
## Summary

Two parallel surface narrows that go down to the codec layer with no shim.

### MARK folder removal
- `MarkFolder` enum and `MarkRequest.folder` field deleted. The codec stops emitting the `Folder:` header and rejects an incoming one with `ParseError` (round-trip test pins the new shape; another test pins the rejection).
- `state_handler.rs` `match folder` branch is gone — the inbox path is the only path. The per-mailbox `RwLock` continues to guard the rewrite. Sent-folder mark test deleted (no replacement behaviour).
- MCP-side `EmailMarkParams` loses `folder`; `submit_mark_via_daemon` signature loses `folder`; `email_mark_read` / `email_mark_unread` tool descriptions explicitly call out that sent-mail mark is unsupported.

### `hook_create` stdin removal
- `HookStdin` enum and `Hook.stdin` field deleted. `build_stdin` / `read_stdin_source` collapse to a single inline call that always pipes the `.md`.
- CLI `--stdin` flag, MCP `HookCreateParams.stdin`, and the UDS body parser's `stdin` key are gone. UDS `HOOK-CREATE` pre-screen now rejects any `stdin` value (legacy `email_json`, the previously valid `email` / `none`, or anything else) with the unified "always piped" hint.
- Tests setting `stdin = "none"` deleted — no replacement to test.

### `Config::load` unified rejection
- `Config::load` peeks at the parsed `toml::Value` before `from_value` and refuses any `[[mailboxes.<name>.hooks]]` block carrying a `stdin` key with the canonical wording: `"hook 'X' carries removed field 'stdin' — remove this line and restart aimx serve; the email is always piped to hooks"`. Hook name is the explicit `name` if set, otherwise the derived sha256 effective name (reuses `derive_hook_name`).
- Replaces the old separate `email_json`-only rejection.
- Tests pin the wording for `none`, `email_json`, `email`, and the no-explicit-name derived case.

### Docs sweep
- `agents/common/aimx-primer.md` "Creating hooks" drops `stdin` and adds the verbatim selectivity guidance ("If your hook only needs the subject or sender, read `$AIMX_SUBJECT` / `$AIMX_FROM` and ignore stdin — the daemon writes the full email but does not require the child to consume it").
- `agents/common/references/hooks.md`, `mcp-tools.md` `hook_create` row, and every per-agent `SKILL.md.header` drop the `stdin` parameter.
- `book/hooks.md`, `book/hook-recipes.md`, `book/configuration.md`, `book/cli.md`, `book/troubleshooting.md` drop the `stdin` field; the selectivity guidance is mirrored in the operator-facing chapter.
- `book/mcp.md` `email_mark_*` rows drop the `folder` parameter (the docs counterpart to S3-1).

## Test plan

- [x] `cargo test` — all 1055+ tests pass (963 binary + 91 integration + smaller suites).
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt -- --check` clean.
- [x] Round-trip test exercises the new `MarkRequest` wire shape (no `Folder:`).
- [x] Header-rejection test pins `Folder:` on `MARK-READ` / `MARK-UNREAD` as `ParseError::Malformed`.
- [x] Three new `Config::load` tests pin the unified `stdin` rejection wording (`none`, `email_json`, `email`, and the derived-name case).
- [x] UDS handler test pins the four `stdin` values rejecting at the legacy-field pre-screen with the "always piped" hint.
- [x] `rg 'stdin\s*=' book/ agents/` returns one expected hit (the removal documentation paragraph in `book/hooks.md`).
- [x] Planning-doc cross-reference grep returns zero hits.