### PR TITLE
[Sprint 4] Param reorder + release notes + final docs sweep

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2342,6 +2342,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap",
  "itoa",
  "memchr",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,7 +39,7 @@ tokio-rustls = "0.26"
 rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "std"] }
 rustls-pemfile = "2"
 serde_json = "1.0.149"
-schemars = "1.2.1"
+schemars = { version = "1.2.1", features = ["preserve_order"] }
 glob-match = "0.2"
 libc = "0.2"
 nix = { version = "0.31", default-features = false, features = ["fs", "user"] }

--- a/agents/common/references/hooks.md
+++ b/agents/common/references/hooks.md
@@ -167,8 +167,7 @@ hook_create(
     "/usr/local/bin/claude", "-p",
     "You are the accounts agent. Read the email on stdin. If it is from the bank, mark it read via email_mark_read and reply via email_reply with the current balance from the local ledger. Otherwise mark it read and do nothing.",
     "--dangerously-skip-permissions"
-  ],
-  stdin: "email"
+  ]
 )
 ```
 
@@ -190,15 +189,15 @@ hook_create(
     "-H", "Content-Type: text/markdown",
     "--data-binary", "@-",
     "https://ops.example.com/log"
-  ],
-  stdin: "email"
+  ]
 )
 ```
 
 The remote endpoint receives the raw `.md` (frontmatter + body) on
 the request body. If the user needs JSON specifically, ask them to
-pre-process the file from a small wrapper script — the daemon ships
-no JSON-mode `stdin` variant; only `"email"` (raw) and `"none"`.
+pre-process the file from a small wrapper script — the daemon always
+pipes the raw email to the hook's stdin and there is no JSON-mode
+variant.
 
 ## Trust gate
 

--- a/agents/common/references/mcp-tools.md
+++ b/agents/common/references/mcp-tools.md
@@ -181,9 +181,9 @@ directly to the recipient's MX server.
 | `from_mailbox` | string   | yes      | Mailbox name to send from (local part only); must be owned by you |
 | `to`           | string   | yes      | Recipient email address |
 | `subject`      | string   | yes      | Email subject |
+| `reply_to`     | string   | no       | Message-ID of the email being replied to. Sets `In-Reply-To`. When `references` is omitted, `References` is built automatically from this value. Required to enable threading. Without `reply_to`, any `references` value is silently ignored and no threading headers are emitted |
 | `body`         | string   | yes      | Email body text |
 | `attachments`  | string[] | no       | Absolute file paths to attach |
-| `reply_to`     | string   | no       | Message-ID of the email being replied to. Sets `In-Reply-To`. When `references` is omitted, `References` is built automatically from this value. Required to enable threading. Without `reply_to`, any `references` value is silently ignored and no threading headers are emitted |
 | `references`   | string   | no       | Full `References` header chain (space-separated Message-IDs). **Only applied when `reply_to` is also set.** Supplied alone, it is silently ignored |
 
 For simple replies to a single sender, prefer `email_reply`. It reads the
@@ -228,8 +228,8 @@ email_send(
   from_mailbox: "agent",
   to: "alice@example.com, bob@example.com, carol@example.com",
   subject: "Re: Status Update",
-  body: "Looping everyone in.",
   reply_to: "<abc@example.com>",
+  body: "Looping everyone in.",
   references: "<prev@example.com> <abc@example.com>"
 )
 ```

--- a/agents/common/references/workflows.md
+++ b/agents/common/references/workflows.md
@@ -130,8 +130,8 @@ email_send(
   from_mailbox: "agent",
   to: "<original-from>, <original-to>, <original-cc>",
   subject: "Re: <original-subject>",
-  body: "<reply-body>",
   reply_to: "<original-message-id>",
+  body: "<reply-body>",
   references: "<original-references> <original-message-id>"
 )
 ```

--- a/book/mcp.md
+++ b/book/mcp.md
@@ -117,9 +117,9 @@ Compose and send an email with DKIM signing.
 | `from_mailbox` | string | yes | Mailbox name to send from. Must be owned by the caller. |
 | `to` | string | yes | Recipient email address |
 | `subject` | string | yes | Email subject |
+| `reply_to` | string | no | Message-ID of the email being replied to. Sets the `In-Reply-To` header and (when `references` is omitted) builds the `References` chain automatically. Required to enable threading. Without `reply_to`, any `references` value is silently ignored and no threading headers are emitted |
 | `body` | string | yes | Email body text |
 | `attachments` | array of strings | no | File paths to attach |
-| `reply_to` | string | no | Message-ID of the email being replied to. Sets the `In-Reply-To` header and (when `references` is omitted) builds the `References` chain automatically. Required to enable threading. Without `reply_to`, any `references` value is silently ignored and no threading headers are emitted |
 | `references` | string | no | Full `References` header chain (space-separated Message-IDs). **Only applied when `reply_to` is also set.** Supplied alone, it is silently ignored |
 
 The MCP server composes the RFC 5322 message and submits it to `aimx serve` over the local `/run/aimx/aimx.sock` UDS. `aimx serve` parses `From:` from the body, validates that the caller's uid owns the resolved mailbox, DKIM-signs the message, and delivers it directly to the recipient's MX server via SMTP.

--- a/book/release-notes.md
+++ b/book/release-notes.md
@@ -2,6 +2,59 @@
 
 Version-by-version changelog of operator-visible behavior changes. Use this as the canonical source for "what changed" between aimx releases; individual book chapters describe the current behavior only.
 
+## Unreleased — MCP surface cleanup
+
+Three hard breaks tighten the MCP tool surface around aimx's "no index, no scan" design. Canonical tool docs live in [MCP Server](mcp.md); the new hook model lives in [Hooks & Trust](hooks.md).
+
+### Removed `email_list` filters
+
+- **What was removed:** the `unread`, `from`, `since`, and `subject` parameters on `email_list`.
+- **Rationale:** aimx ships no index. Server-side filters silently forced an O(N) scan of every frontmatter block in the mailbox — the opposite of the design intent. The new shape lists a page of metadata (cheap, bounded by `limit`) and the agent filters client-side.
+- **New call shape:**
+
+  ```
+  email_list(mailbox="alice", limit=50)   # then filter rows where read == false
+  ```
+
+`email_list` now returns a JSON array (one row per email) with `id`, `from`, `to`, `subject`, `date`, plus `read` on inbox rows or `delivery_status` on sent rows. Pass `offset` to page past already-seen rows.
+
+### Removed `email_mark_*` `folder` parameter
+
+- **What was removed:** the `folder` parameter on `email_mark_read` and `email_mark_unread` (and its `Folder:` header on the underlying UDS verb).
+- **Rationale:** there is no agent workflow that benefits from marking sent copies read or unread. Inbox is the only meaningful target; the `"sent"` value was dead weight. The `MarkFolder::Sent` variant has also been deleted from the codebase.
+- **New call shape:**
+
+  ```
+  email_mark_read(mailbox="alice", id="2025-06-15-120000-hello")
+  ```
+
+The MCP schema rejects a stale `folder` argument with an `unknown field` parse error rather than silently mutating inbox.
+
+### Removed `hook_create` / `config.toml` `stdin`
+
+- **What was removed:** the `stdin` parameter on the `hook_create` MCP tool, and the `stdin` field on `[[mailbox.<name>.hook]]` blocks in `config.toml`. The daemon now always pipes the raw `.md` source to every hook command.
+- **Rationale:** closing stdin to a hook gave no real benefit — `$AIMX_FROM`, `$AIMX_SUBJECT`, and `$AIMX_FILEPATH` already cover the "metadata only" case, and the child process is free to ignore stdin.
+- **Upgrade-time validation error.** `aimx serve` will refuse to start if any hook block in `config.toml` still carries a `stdin` line. The error names the offending hook so you can grep your logs against it:
+
+  ```
+  hook 'X' carries removed field 'stdin' — remove this line and restart aimx serve; the email is always piped to hooks
+  ```
+
+  Remediation: open `/etc/aimx/config.toml`, delete every `stdin = "…"` line under your `[[mailbox.*.hook]]` blocks, then `sudo systemctl restart aimx`.
+- **New call shape:**
+
+  ```
+  hook_create(mailbox="alice", event="on_receive", cmd=["/usr/local/bin/notify"])
+  ```
+
+  Selectivity guidance: if your hook only needs the subject or sender, read `$AIMX_SUBJECT` / `$AIMX_FROM` and ignore stdin — the daemon writes the full email to stdin but does not require the child to consume it.
+
+### Soft change — `mailbox_list` and `email_list` now return JSON
+
+`mailbox_list` and `email_list` now return JSON arrays instead of plain-text listings. Existing agents using the bundled skills are already updated. Any custom MCP client that parsed the old plain-text output must switch to a JSON parser; nothing fails at startup, but the next call will surface the shape change.
+
+`mailbox_list` rows: `{ name, inbox_path, sent_path, total, unread, sent_count, registered }`. `email_list` rows on inbox: `{ id, from, to, subject, date, read }`; on sent: `{ id, from, to, subject, date, delivery_status }`.
+
 ## 0.1.0 — first public release
 
 aimx ships as a single prebuilt binary for Linux on four targets: `x86_64-unknown-linux-gnu`, `aarch64-unknown-linux-gnu`, `x86_64-unknown-linux-musl`, `aarch64-unknown-linux-musl` (canonical Rust target triples; tarball filenames drop the `-unknown-` vendor field, e.g. `aimx-0.1.0-x86_64-linux-gnu.tar.gz`). One-line install:

--- a/book/security.md
+++ b/book/security.md
@@ -174,7 +174,7 @@ So the socket is the signing oracle. What it can do is deliberately narrow. The 
 - `SEND` — submit an unsigned RFC 5322 message for DKIM signing and MX delivery.
 - `MARK-READ` / `MARK-UNREAD` — rewrite the `read` field in an email's frontmatter under a per-mailbox lock.
 - `MAILBOX-CREATE` / `MAILBOX-DELETE` — add or remove a configured mailbox, hot-swapping the in-memory `Arc<Config>`.
-- `HOOK-CREATE` — create a **template-bound** hook. The handler rejects any body that carries `cmd`, `run_as`, `timeout_secs`, `stdin`, or `dangerously_support_untrusted`. These fields are *template* properties — they live on `[[hook_template]]` entries the operator installs — and are unreachable through the socket. Tests (`hook_create_rejects_body_with_cmd`, `…_run_as`, `…_dangerously_support_untrusted`) assert the rejection explicitly.
+- `HOOK-CREATE` — create a **template-bound** hook. The handler rejects any body that carries `cmd`, `run_as`, `timeout_secs`, or `dangerously_support_untrusted` — these are *template* properties, living on `[[hook_template]]` entries the operator installs, and are unreachable through the socket. The handler also rejects a stale `stdin` field with the canonical "always piped" hint so an upgraded agent client still sees a clear error. Tests (`hook_create_rejects_body_with_cmd`, `…_run_as`, `…_dangerously_support_untrusted`, `create_rejects_stdin_field`) assert each rejection explicitly.
 - `HOOK-DELETE` — remove an existing hook, subject to origin protection (see below).
 
 The explicit non-list matters as much as the list. There is no verb over the socket that:

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -71,16 +71,16 @@ pub struct EmailSendParams {
     pub to: String,
     #[schemars(description = "Email subject")]
     pub subject: String,
-    #[schemars(description = "Email body text")]
-    pub body: String,
-    #[schemars(description = "File paths to attach")]
-    pub attachments: Option<Vec<String>>,
     #[schemars(
         description = "Message-ID of the email being replied to (sets In-Reply-To header for threading). \
                        Required to enable threading: without reply_to, the references field is silently ignored and no threading headers are emitted. \
                        When set, References is built automatically unless overridden by the references field."
     )]
     pub reply_to: Option<String>,
+    #[schemars(description = "Email body text")]
+    pub body: String,
+    #[schemars(description = "File paths to attach")]
+    pub attachments: Option<Vec<String>>,
     #[schemars(
         description = "Full References header chain (space-separated Message-IDs) for threading. \
                        Only applied when reply_to is also set. Supplied alone, it is silently ignored."
@@ -2034,5 +2034,99 @@ mod email_list_tests {
             serde_json::from_value(json).expect("canonical mark params must parse");
         assert_eq!(params.mailbox, "alice");
         assert_eq!(params.id, "2025-06-15-120000-hello");
+    }
+}
+
+#[cfg(test)]
+mod schema_order_tests {
+    //! Snapshot tests pinning the JSON-schema property order for every
+    //! tool's `*Params` struct. `schemars` emits `properties` in struct
+    //! declaration order, so reordering struct fields reorders the
+    //! schema. Each test here asserts the exact key order an agent sees
+    //! in the tool list — wire compatibility is unaffected (JSON params
+    //! are name-keyed) but agents read these schemas top-to-bottom.
+
+    use super::*;
+    use schemars::schema_for;
+    use serde_json::Value;
+
+    fn property_keys<T: schemars::JsonSchema>() -> Vec<String> {
+        let schema = schema_for!(T);
+        let value: Value = serde_json::to_value(schema).expect("schema serializes to JSON");
+        let props = value
+            .get("properties")
+            .and_then(|p| p.as_object())
+            .expect("schema has a properties object");
+        props.keys().cloned().collect()
+    }
+
+    #[test]
+    fn email_list_params_property_order() {
+        assert_eq!(
+            property_keys::<EmailListParams>(),
+            vec!["mailbox", "folder", "limit", "offset"],
+        );
+    }
+
+    #[test]
+    fn email_read_params_property_order() {
+        assert_eq!(
+            property_keys::<EmailReadParams>(),
+            vec!["mailbox", "id", "folder"],
+        );
+    }
+
+    #[test]
+    fn email_send_params_property_order() {
+        assert_eq!(
+            property_keys::<EmailSendParams>(),
+            vec![
+                "from_mailbox",
+                "to",
+                "subject",
+                "reply_to",
+                "body",
+                "attachments",
+                "references",
+            ],
+        );
+    }
+
+    #[test]
+    fn email_reply_params_property_order() {
+        assert_eq!(
+            property_keys::<EmailReplyParams>(),
+            vec!["mailbox", "id", "body"],
+        );
+    }
+
+    #[test]
+    fn email_mark_params_property_order() {
+        assert_eq!(property_keys::<EmailMarkParams>(), vec!["mailbox", "id"]);
+    }
+
+    #[test]
+    fn hook_create_params_property_order() {
+        assert_eq!(
+            property_keys::<HookCreateParams>(),
+            vec![
+                "mailbox",
+                "event",
+                "cmd",
+                "name",
+                "timeout_secs",
+                "fire_on_untrusted",
+            ],
+        );
+    }
+
+    #[test]
+    fn hook_list_params_property_order() {
+        assert_eq!(property_keys::<HookListParams>(), vec!["mailbox"]);
+    }
+
+    #[test]
+    fn hook_delete_params_property_order() {
+        assert_eq!(property_keys::<HookDeleteParams>(), vec!["name"]);
     }
 }


### PR DESCRIPTION
## Summary

Final sprint of the mcp-update track. Cosmetic field reordering across every `*Params` struct, release notes for the three hard breaks the prior sprints landed, and the final consistency sweep across `book/`, `agents/common/`, and the per-agent skill bundles.

### Changes

- **Param reorder.** Reordered `EmailSendParams` to `from_mailbox, to, subject, reply_to, body, attachments, references` so the schema reads like an email composition. Every other `*Params` struct was already in the target order from prior sprints; verified each via a new `schema_order_tests` module that snapshots the `properties` key order via `schemars::schema_for!`.
- **schemars `preserve_order`.** `serde_json::Map` is `BTreeMap`-backed in this crate, which alphabetises schema properties. Enabled `schemars`' `preserve_order` feature (which transitively enables `serde_json/preserve_order`) so the JSON Schema served to MCP clients reflects struct declaration order. Without this, struct field order is invisible to agents.
- **Release notes.** New `Unreleased — MCP surface cleanup` section in `book/release-notes.md` with subsections for each hard break (`email_list` filters, `email_mark_*` `folder`, `hook_create` / `config.toml` `stdin`) plus a "Soft change" note covering the `mailbox_list` / `email_list` JSON-shape switch. The `stdin` section quotes the canonical `Config::load` wording verbatim so operators can grep failing-startup logs.
- **Final docs sweep.** Dropped two stale `stdin: "email"` examples in `agents/common/references/hooks.md` (the only remaining hits anywhere in `book/` or `agents/`). Reordered the `email_send` parameter table and threaded-reply example in `book/mcp.md` and `agents/common/references/{mcp-tools,workflows}.md` to match the new schema order. Reworded the HOOK-CREATE bullet in `book/security.md` so `stdin` is named as a stale-field rejection rather than a template property.

### Verification

- `cargo test`: 973 + 91 passed; 0 failed.
- `cargo clippy --all-targets -- -D warnings`: clean.
- `cargo fmt -- --check`: clean.
- `services/verifier`: clippy + fmt clean.
- Ran `aimx agents setup <agent> --print` for every supported agent — no remaining `stdin: "email"` lines, no remaining `email_list(unread:|since:|from:|subject:)` filters, no `email_mark_*(folder:)` references.
- Repo-wide planning-doc cross-reference grep returns zero hits outside `docs/`.

## Test plan

- [x] `cargo test` (full suite)
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cd services/verifier && cargo clippy -- -D warnings && cargo fmt -- --check`
- [x] Visual check of `aimx agents setup <agent> --print` output for every bundled agent
- [x] Schema property-order snapshots for all 8 multi-field tools