### PR TITLE
Clean up post-mcp-update backlog (4 items)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -563,7 +563,7 @@ fn reject_legacy_schema(toml_text: &str) -> Result<(), Box<dyn std::error::Error
 ///
 /// The error names the hook by its explicit `name` if set, otherwise by
 /// the derived sha256-based effective name (matches `effective_hook_name`).
-fn reject_removed_stdin_field(parsed: &toml::Value) -> Result<(), String> {
+fn reject_removed_stdin_field(parsed: &toml::Value) -> Result<(), Box<dyn std::error::Error>> {
     let Some(mailboxes) = parsed.get("mailboxes").and_then(|v| v.as_table()) else {
         return Ok(());
     };
@@ -591,7 +591,8 @@ fn reject_removed_stdin_field(parsed: &toml::Value) -> Result<(), String> {
             return Err(format!(
                 "hook '{name}' carries removed field 'stdin' — remove this line and \
                  restart aimx serve; the email is always piped to hooks"
-            ));
+            )
+            .into());
         }
     }
     Ok(())
@@ -911,8 +912,7 @@ impl Config {
         // reject the removed `stdin` field with a hook-named error
         // before the structural deserializer trips on its absence.
         let raw_value: toml::Value = toml::from_str(&content)?;
-        reject_removed_stdin_field(&raw_value)
-            .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+        reject_removed_stdin_field(&raw_value)?;
         let config: Config = raw_value.try_into()?;
         for (name, mb) in &config.mailboxes {
             if mb.owner.trim().is_empty() {

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -639,7 +639,7 @@ fn submit_via_daemon(args: &SendArgs) -> Result<String, String> {
     };
 
     let outcome = outcome.map_err(|e| {
-        if e.kind() == std::io::ErrorKind::NotFound {
+        if is_socket_missing(&e) {
             "aimx daemon not running. Start with 'sudo systemctl start aimx'".to_string()
         } else {
             format!(
@@ -689,7 +689,7 @@ fn submit_mark_via_daemon(mailbox: &str, id: &str, read: bool) -> Result<(), Str
     };
 
     let outcome = outcome.map_err(|e| {
-        if e.kind() == std::io::ErrorKind::NotFound {
+        if is_socket_missing(&e) {
             "aimx daemon not running. Start with 'sudo systemctl start aimx'".to_string()
         } else {
             format!(
@@ -1211,8 +1211,6 @@ struct SentListRow {
 #[derive(Deserialize)]
 struct EmailListFm {
     #[serde(default)]
-    id: String,
-    #[serde(default)]
     from: String,
     #[serde(default)]
     to: String,
@@ -1303,7 +1301,7 @@ fn list_email_page_json(
                     continue;
                 };
                 rows.push(InboxListRow {
-                    id: choose_id(id, &fm.id),
+                    id: id.clone(),
                     from: fm.from,
                     to: fm.to,
                     subject: fm.subject,
@@ -1320,7 +1318,7 @@ fn list_email_page_json(
                     continue;
                 };
                 rows.push(SentListRow {
-                    id: choose_id(id, &fm.id),
+                    id: id.clone(),
                     from: fm.from,
                     to: fm.to,
                     subject: fm.subject,
@@ -1330,18 +1328,6 @@ fn list_email_page_json(
             }
             Ok(serde_json::to_string(&rows)?)
         }
-    }
-}
-
-/// Prefer the on-disk filename stem as the canonical id (it is the
-/// value the agent passes to `email_read` / `email_mark_*`). Fall back
-/// to the frontmatter `id` only when the filename could not be decoded
-/// — protects the response shape against unicode-broken filenames.
-fn choose_id(filename_stem: &str, fm_id: &str) -> String {
-    if !filename_stem.is_empty() {
-        filename_stem.to_string()
-    } else {
-        fm_id.to_string()
     }
 }
 
@@ -2128,5 +2114,39 @@ mod schema_order_tests {
     #[test]
     fn hook_delete_params_property_order() {
         assert_eq!(property_keys::<HookDeleteParams>(), vec!["name"]);
+    }
+}
+
+#[cfg(test)]
+mod socket_missing_tests {
+    use super::is_socket_missing;
+    use std::io::{Error, ErrorKind};
+
+    #[test]
+    fn flags_not_found_connection_refused_and_permission_denied() {
+        for kind in [
+            ErrorKind::NotFound,
+            ErrorKind::ConnectionRefused,
+            ErrorKind::PermissionDenied,
+        ] {
+            assert!(
+                is_socket_missing(&Error::from(kind)),
+                "expected {kind:?} to count as socket-missing"
+            );
+        }
+    }
+
+    #[test]
+    fn rejects_other_io_errors() {
+        for kind in [
+            ErrorKind::TimedOut,
+            ErrorKind::ConnectionReset,
+            ErrorKind::Other,
+        ] {
+            assert!(
+                !is_socket_missing(&Error::from(kind)),
+                "expected {kind:?} to NOT count as socket-missing"
+            );
+        }
     }
 }

--- a/src/platform.rs
+++ b/src/platform.rs
@@ -69,14 +69,12 @@ pub const DEFAULT_MEMORY_MAX: &str = "256M";
 /// Stdin delivery policy. The daemon writes the chosen payload to the
 /// child's stdin before starting the timeout clock, then closes stdin —
 /// no hook blocks mid-run on a stdin `read()`.
-#[allow(dead_code)]
 pub enum SandboxStdin {
     /// Raw `.md` bytes (TOML frontmatter + body) written to stdin.
     Email(Vec<u8>),
-    /// JSON object `{ "frontmatter": {...}, "body": "..." }` written to
-    /// stdin. Retained for the sprint-rework but not constructed today.
-    EmailJson(Vec<u8>),
-    /// Close stdin immediately (no payload).
+    /// Close stdin immediately (no payload). Constructed only by
+    /// `run_fallback` tests that exercise non-payload paths.
+    #[allow(dead_code)]
     None,
 }
 
@@ -393,7 +391,7 @@ fn run_child_with_timeout(
     let stdin_handle = thread::spawn(move || {
         if let Some(mut pipe) = child_stdin {
             let payload: &[u8] = match &stdin {
-                SandboxStdin::Email(b) | SandboxStdin::EmailJson(b) => b.as_slice(),
+                SandboxStdin::Email(b) => b.as_slice(),
                 SandboxStdin::None => &[],
             };
             if !payload.is_empty() {


### PR DESCRIPTION
## Summary

Four small backlog items from `docs/mcp-update-sprint.md` Improvements section addressed in one PR. All four are cosmetic / consistency cleanups; no behaviour change in the operator-visible surface.

- **`is_socket_missing` migration (`src/mcp.rs`)** — `submit_via_daemon` and `submit_mark_via_daemon` now call the shared `is_socket_missing` helper instead of hand-checking `ErrorKind::NotFound`, so all MCP UDS clients show the same "aimx daemon not running" message when the socket exists but is unreachable (`ConnectionRefused` / `PermissionDenied`), matching `submit_mailbox_list_via_daemon`'s behaviour. Added a unit test that pins the predicate's accept/reject sets.
- **Delete `SandboxStdin::EmailJson` (`src/platform.rs`)** — the variant had no construction site (`rg EmailJson` confirmed only the declaration). Removed it and its `Email | EmailJson` match arm. Kept a narrow `#[allow(dead_code)]` on `None`, which is constructed only in `run_fallback` tests.
- **`reject_removed_stdin_field` error type (`src/config.rs`)** — function now returns `Result<(), Box<dyn std::error::Error>>` directly so the call site in `Config::load` can drop its `.map_err(|e| -> Box<dyn std::error::Error> { e.into() })?` for symmetry with the surrounding error path. Existing rejection tests pass with the same error wording.
- **`choose_id` comment fix (`src/mcp.rs`)** — chose deletion over rewording. The frontmatter-id fallback was unreachable from `enumerate_email_ids` (only valid UTF-8 stems are pushed). Inlined `id.clone()` at both call sites, dropped the helper, and removed the now-unused `EmailListFm.id` field.

## Test plan

- [x] `cargo test` — 975 unit + 91 integration tests pass.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt -- --check` clean.
- [x] No banned planning-doc tokens in the diff.