### PR TITLE
feat: surface daemon restart on upgrade + show client/server version drift in doctor

### DIFF
--- a/book/cli.md
+++ b/book/cli.md
@@ -61,7 +61,7 @@ See [Setup: End-to-end verification](setup.md#end-to-end-verification).
 
 Print server health: configuration path, mailbox counts and unread counts, a per-mailbox table (Mailbox, Address, Total, Unread, Trust, Senders, Hooks), an Ownership section listing each mailbox's `owner` and whether the owner uid resolves on the host, DKIM key presence, SMTP service state, DNS record verification, and a pointer to `aimx logs` for recent service logs. Exits non-zero when any mailbox has an unresolvable owner so monitoring can detect orphans.
 
-The Service section includes `Client version:` (the CLI binary you just invoked) and `Server version:` (probed from the running daemon over the UDS socket). When the two differ, the Server line carries an inline warn-coloured `drift` suffix suggesting `systemctl restart aimx` (or `rc-service aimx restart` on OpenRC) — the operator upgraded the binary on disk but the running daemon is still on the old build. Drift is informational only; it does not change the doctor exit code.
+The Service section includes `Client version:` (the CLI binary you just invoked) and `Server version:` (probed from the running daemon over the UDS socket). Compare them at a glance to see whether the running daemon is still on an older build than the binary on disk — when they differ, restart the service (`systemctl restart aimx` or `rc-service aimx restart` on OpenRC) so the daemon picks up the new binary. The version lines are informational only and do not change the doctor exit code.
 
 No flags.
 

--- a/book/cli.md
+++ b/book/cli.md
@@ -61,6 +61,8 @@ See [Setup: End-to-end verification](setup.md#end-to-end-verification).
 
 Print server health: configuration path, mailbox counts and unread counts, a per-mailbox table (Mailbox, Address, Total, Unread, Trust, Senders, Hooks), an Ownership section listing each mailbox's `owner` and whether the owner uid resolves on the host, DKIM key presence, SMTP service state, DNS record verification, and a pointer to `aimx logs` for recent service logs. Exits non-zero when any mailbox has an unresolvable owner so monitoring can detect orphans.
 
+The Service section includes `Client version:` (the CLI binary you just invoked) and `Server version:` (probed from the running daemon over the UDS socket). When the two differ, the Server line carries an inline warn-coloured `drift` suffix suggesting `systemctl restart aimx` (or `rc-service aimx restart` on OpenRC) — the operator upgraded the binary on disk but the running daemon is still on the old build. Drift is informational only; it does not change the doctor exit code.
+
 No flags.
 
 See [Troubleshooting](troubleshooting.md).

--- a/book/installation.md
+++ b/book/installation.md
@@ -144,9 +144,9 @@ sudo aimx upgrade
 3. Stops `aimx.service` (or the OpenRC equivalent).
 4. Renames the current `/usr/local/bin/aimx` to `/usr/local/bin/aimx.prev` and moves the new binary into place — atomic `rename(2)` so a crash cannot leave a half-written binary.
 5. Restarts the service.
-6. Prints `aimx v<old> → v<new>. Service restarted.`
+6. Waits for the daemon to come back up, then prints a `✓ aimx serve restarted on <tag>` confirmation line followed by `aimx v<old> → v<new>. Service restarted.`
 
-If any step after the stop fails, the rollback path restores `aimx.prev` and restarts the service. A `✗` line names the failed step.
+If any step after the stop fails, the rollback path restores `aimx.prev` and restarts the service. A `✗` line names the failed step. The restart-confirmation line is suppressed on the rollback path.
 
 Flags:
 

--- a/book/release-notes.md
+++ b/book/release-notes.md
@@ -19,7 +19,7 @@ Client version:   v1.2.4 (a1b2c3d4)
 Server version:   v1.2.4 (a1b2c3d4)
 ```
 
-When the tags differ, the Server line carries an inline warn-coloured `drift` suffix suggesting `systemctl restart aimx` (or `rc-service aimx restart` on OpenRC). Drift is informational only — no `DoctorFinding`, no exit-code change. If the daemon is offline the Server line renders `(daemon not running)`; if the probe fails within its 500 ms budget it renders the failure reason in dim text. See [Troubleshooting: Version drift](troubleshooting.md#version-drift-between-client-and-daemon).
+When the tags differ, restart the service (`systemctl restart aimx`, or `rc-service aimx restart` on OpenRC) so the daemon picks up the new binary. The lines are informational only — no `DoctorFinding`, no exit-code change. If the daemon is offline the Server line renders `(daemon not running)`; if the probe fails within its 500 ms budget it renders the failure reason in dim text. See [Troubleshooting: Version drift](troubleshooting.md#version-drift-between-client-and-daemon).
 
 ### `install.sh` upgrade path is louder and self-healing
 

--- a/book/release-notes.md
+++ b/book/release-notes.md
@@ -2,6 +2,42 @@
 
 Version-by-version changelog of operator-visible behavior changes. Use this as the canonical source for "what changed" between aimx releases; individual book chapters describe the current behavior only.
 
+## Unreleased — upgrade visibility
+
+Closes the visibility gap on the upgrade path: operators can now confirm whether the running `aimx serve` daemon was actually restarted on the new binary, and detect drift between the on-disk `aimx` and the still-running daemon.
+
+### `AIMX/1 VERSION` UDS verb
+
+A new read-only verb on `/run/aimx/aimx.sock` returns the daemon's `{tag, git_hash, target, build_date}`. Same authorization posture as `MAILBOX-LIST` — no `SO_PEERCRED` filter, the payload is build metadata only. There is no separate `aimx version --remote` subcommand; consumers go through `aimx doctor`.
+
+### `aimx doctor` renders client + server versions
+
+The Service section now includes two new lines:
+
+```
+Client version:   v1.2.4 (a1b2c3d4)
+Server version:   v1.2.4 (a1b2c3d4)
+```
+
+When the tags differ, the Server line carries an inline warn-coloured `drift` suffix suggesting `systemctl restart aimx` (or `rc-service aimx restart` on OpenRC). Drift is informational only — no `DoctorFinding`, no exit-code change. If the daemon is offline the Server line renders `(daemon not running)`; if the probe fails within its 500 ms budget it renders the failure reason in dim text. See [Troubleshooting: Version drift](troubleshooting.md#version-drift-between-client-and-daemon).
+
+### `install.sh` upgrade path is louder and self-healing
+
+- The stop and start banners are now promoted from `dbg` to `say`, so the operator running `curl | sh` sees the service control happening.
+- The `systemctl is-enabled = true && is-active = false` path now still calls `start_service` after the binary swap. Previously the daemon was never restarted on that path.
+- A new `pgrep`-based detector warns (never signals) when a manually-launched `aimx serve` is running outside systemd / OpenRC.
+- A single post-start `systemctl is-active` check confirms the daemon came up, with a `journalctl -u aimx -n 20` hint on failure.
+
+### `aimx upgrade` confirms the restart
+
+After `wait_for_service_ready` returns true, `aimx upgrade` prints one extra line:
+
+```
+✓ aimx serve restarted on v1.2.4
+```
+
+The line is suppressed on the rollback path so a failed upgrade never claims success.
+
 ## Unreleased — MCP surface cleanup
 
 Three hard breaks tighten the MCP tool surface around aimx's "no index, no scan" design. Canonical tool docs live in [MCP Server](mcp.md); the new hook model lives in [Hooks & Trust](hooks.md).

--- a/book/release-notes.md
+++ b/book/release-notes.md
@@ -8,7 +8,7 @@ Closes the visibility gap on the upgrade path: operators can now confirm whether
 
 ### `AIMX/1 VERSION` UDS verb
 
-A new read-only verb on `/run/aimx/aimx.sock` returns the daemon's `{tag, git_hash, target, build_date}`. Same authorization posture as `MAILBOX-LIST` — no `SO_PEERCRED` filter, the payload is build metadata only. There is no separate `aimx version --remote` subcommand; consumers go through `aimx doctor`.
+A new read-only verb on `/run/aimx/aimx.sock` returns the daemon's `{tag, git_hash, target, build_date}`. Same authorization posture as `MAILBOX-LIST` — no `SO_PEERCRED` filter, the payload is build metadata only. There is no separate remote-version subcommand; consumers go through `aimx doctor`.
 
 ### `aimx doctor` renders client + server versions
 

--- a/book/troubleshooting.md
+++ b/book/troubleshooting.md
@@ -112,12 +112,12 @@ aimx logs --follow
 
 ```
 Client version:   v1.2.4 (a1b2c3d4)
-Server version:   v1.2.3 (9e8f7d6c)  drift - run `systemctl restart aimx` (or `rc-service aimx restart` on OpenRC) to pick up the new binary
+Server version:   v1.2.3 (9e8f7d6c)
 ```
 
 The Client line reports the build of the `aimx` binary you just invoked. The Server line reports what the running `aimx serve` daemon advertises over the UDS `VERSION` verb. They drift apart when an upgrade replaces the on-disk binary but does not restart the long-running daemon — typically a `curl | sh` re-install on a host where systemd is present-but-inactive, or a manually-launched `aimx serve` outside the service manager.
 
-Drift is informational only — `aimx doctor` does not flag a finding and does not change its exit code. To resolve it, run the suggested restart command:
+The lines are informational only — `aimx doctor` does not flag a finding and does not change its exit code. To resolve drift, restart the service so the daemon picks up the new binary:
 
 ```bash
 sudo systemctl restart aimx

--- a/book/troubleshooting.md
+++ b/book/troubleshooting.md
@@ -106,6 +106,27 @@ aimx logs --follow
 
 `aimx doctor` prints a `Logs` pointer section at the bottom of its output that reminds you to run `aimx logs` (or `aimx logs --follow`) rather than dumping log lines itself.
 
+### Version drift between client and daemon
+
+`aimx doctor` renders two version lines under the Service section:
+
+```
+Client version:   v1.2.4 (a1b2c3d4)
+Server version:   v1.2.3 (9e8f7d6c)  drift - run `systemctl restart aimx` (or `rc-service aimx restart` on OpenRC) to pick up the new binary
+```
+
+The Client line reports the build of the `aimx` binary you just invoked. The Server line reports what the running `aimx serve` daemon advertises over the UDS `VERSION` verb. They drift apart when an upgrade replaces the on-disk binary but does not restart the long-running daemon — typically a `curl | sh` re-install on a host where systemd is present-but-inactive, or a manually-launched `aimx serve` outside the service manager.
+
+Drift is informational only — `aimx doctor` does not flag a finding and does not change its exit code. To resolve it, run the suggested restart command:
+
+```bash
+sudo systemctl restart aimx
+# or, on OpenRC:
+sudo rc-service aimx restart
+```
+
+If the Server line renders `(daemon not running)` the daemon is offline; start it with `sudo systemctl start aimx`. A `(<reason>)` placeholder means the socket exists but the probe failed within the 500 ms budget — check `aimx logs` for the daemon-side error.
+
 **systemd (Ubuntu, Fedora, Debian, etc.)**
 
 The systemd unit declares `StandardOutput=journal` and `StandardError=journal`, so all daemon output is routed to journald. `aimx logs` shells out to `journalctl -u aimx -n <N>` (and `journalctl -f -u aimx` with `--follow`). You can also call journalctl directly:

--- a/install.sh
+++ b/install.sh
@@ -472,15 +472,20 @@ compare_tags() {
 stop_service() {
     if command -v systemctl >/dev/null 2>&1; then
         if systemctl is-active --quiet aimx 2>/dev/null; then
-            verbose "systemctl stop aimx"
+            say "stopping aimx.service (systemd)"
             ${SUDO} systemctl stop aimx || err "systemctl stop aimx failed"
             printf 'systemd'
             return 0
         fi
+        # systemd is present but the unit is inactive (manual
+        # `systemctl stop`, fresh install, etc.). Still emit the
+        # `systemd` tag so `start_service` is invoked after the swap
+        # — without it the daemon never restarts on the new binary.
+        printf 'systemd'
         return 0
     fi
     if command -v rc-service >/dev/null 2>&1; then
-        verbose "rc-service aimx stop"
+        say "stopping aimx.service (openrc)"
         ${SUDO} rc-service aimx stop 2>/dev/null || true
         printf 'openrc'
         return 0
@@ -493,17 +498,48 @@ start_service() {
     _init="$1"
     case "${_init}" in
         systemd)
-            verbose "systemctl start aimx"
+            say "starting aimx.service (systemd)"
             ${SUDO} systemctl start aimx
             ;;
         openrc)
-            verbose "rc-service aimx start"
+            say "starting aimx.service (openrc)"
             ${SUDO} rc-service aimx start
             ;;
         unknown)
             say "warning: unrecognized init system; not starting aimx.service"
             ;;
     esac
+}
+
+# Detect a manually-launched `aimx serve` process running outside
+# systemd / OpenRC. Used on the upgrade path: when no init system
+# manages the unit but a stray `aimx serve` is still bound to the
+# binary on disk, the operator's swap will leave the OLD process
+# running on the new path. We never signal the process — just warn,
+# name the PID, and ask the operator to restart it manually.
+detect_manual_aimx_serve() {
+    _binary_path="$1"
+    if ! command -v pgrep >/dev/null 2>&1; then
+        return 0
+    fi
+    _pids="$(pgrep -f "${_binary_path} serve" 2>/dev/null || true)"
+    if [ -z "${_pids}" ]; then
+        return 0
+    fi
+    # If systemd or OpenRC manages the unit we trust their lifecycle
+    # hooks; only warn when neither claims the daemon.
+    if command -v systemctl >/dev/null 2>&1 \
+        && systemctl status aimx >/dev/null 2>&1; then
+        return 0
+    fi
+    if command -v rc-service >/dev/null 2>&1 \
+        && rc-service aimx status >/dev/null 2>&1; then
+        return 0
+    fi
+    for _pid in ${_pids}; do
+        say "warning: detected manually-launched 'aimx serve' (pid ${_pid}) outside systemd/OpenRC"
+    done
+    say "  the upgrade swaps the binary on disk but cannot restart this process — restart it manually."
 }
 
 # ---------------------------------------------------------------------------
@@ -719,6 +755,7 @@ main() {
     if [ "${_is_upgrade}" -eq 1 ]; then
         # Upgrade path: non-interactive by design. Previous setup is
         # preserved; just swap the binary and restart the service.
+        detect_manual_aimx_serve "${_install_path}"
         _init="$(stop_service || echo unknown)"
 
         _prev="${_install_path}.prev"
@@ -747,6 +784,19 @@ main() {
                 start_service "${_init}" || true
             fi
             err "upgrade failed at start step; service restored if possible"
+        fi
+
+        # Confirm the daemon actually came back up under systemd. On
+        # OpenRC `rc-service aimx start` already exits non-zero when
+        # the start fails, so the post-start check would just repeat
+        # work — keep the check systemd-only.
+        if [ "${_init}" = "systemd" ] && command -v systemctl >/dev/null 2>&1; then
+            if systemctl is-active --quiet aimx 2>/dev/null; then
+                say "aimx.service is active"
+            else
+                say "warning: aimx.service did not reach active state"
+                say "  inspect with: journalctl -u aimx -n 20"
+            fi
         fi
 
         if [ -n "${_installed_tag}" ]; then

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -20,6 +20,17 @@ pub struct StatusInfo {
     pub dkim_selector: String,
     pub dkim_key_present: bool,
     pub smtp_running: bool,
+    /// Build tag of the binary running `aimx doctor` itself (the
+    /// invoking process). Always populated.
+    pub client_version: ClientVersion,
+    /// Build tag reported by the running daemon over the
+    /// `AIMX/1 VERSION` UDS verb.
+    ///
+    /// `None` means the probe was skipped (socket absent and the
+    /// daemon is not running per `smtp_running`). `Some(Ok(_))` is
+    /// the daemon's metadata. `Some(Err(_))` is a probe failure
+    /// reason — rendered as a dim "(daemon not reachable …)" line.
+    pub server_version: Option<Result<ServerVersion, String>>,
     /// True when the old `send.sock` path still exists in the runtime dir
     /// and the new `aimx.sock` is absent. Surfaced as a warn line in the
     /// Service section so operators upgrading from pre-launch builds see
@@ -38,6 +49,26 @@ pub struct StatusInfo {
 pub struct DnsSection {
     pub results: Vec<(String, DnsVerifyResult)>,
     pub records: Vec<DnsRecord>,
+}
+
+/// Build-version metadata for the invoking `aimx` binary. Currently
+/// just the release tag and the short git hash — same shape the
+/// daemon reports over the `VERSION` verb, just sourced locally
+/// from [`crate::version`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientVersion {
+    pub tag: String,
+    pub git_hash: String,
+}
+
+/// Build-version metadata returned by the running daemon over the
+/// `AIMX/1 VERSION` UDS verb. Slim view of
+/// [`crate::send_protocol::VersionResponse`] focused on what doctor
+/// renders (drift comparison + short-hash display).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ServerVersion {
+    pub tag: String,
+    pub git_hash: String,
 }
 
 pub struct MailboxStatus {
@@ -86,6 +117,36 @@ pub fn gather_status_with_ops<S: SystemOps>(
     let stale_send_sock_present =
         runtime_dir.join("send.sock").exists() && !runtime_dir.join("aimx.sock").exists();
 
+    let client_version = ClientVersion {
+        tag: crate::version::release_tag().to_string(),
+        git_hash: crate::version::git_hash().to_string(),
+    };
+
+    // Probe the daemon only when there is a plausible chance a daemon
+    // is up. A freshly-installed host with neither the socket nor a
+    // running service should render as "(daemon not running)" and
+    // skip the probe rather than emit a confusing "(daemon not
+    // reachable …)" line.
+    let server_version = {
+        let socket = crate::serve::aimx_socket_path();
+        if socket.exists() || smtp_running {
+            match crate::version_handler::probe_daemon_version(&socket) {
+                Ok(resp) => Some(Ok(ServerVersion {
+                    tag: resp.tag,
+                    git_hash: resp.git_hash,
+                })),
+                Err(crate::version_handler::ProbeError::SocketMissing) => Some(Err(
+                    "daemon not reachable on /run/aimx/aimx.sock".to_string(),
+                )),
+                Err(crate::version_handler::ProbeError::Io(reason)) => {
+                    Some(Err(format!("daemon probe failed: {reason}")))
+                }
+            }
+        } else {
+            None
+        }
+    };
+
     let mut mailboxes: Vec<MailboxStatus> = config
         .mailboxes
         .iter()
@@ -124,6 +185,8 @@ pub fn gather_status_with_ops<S: SystemOps>(
         dkim_selector: config.dkim_selector.clone(),
         dkim_key_present,
         smtp_running,
+        client_version,
+        server_version,
         stale_send_sock_present,
         default_trust: config.trust.clone(),
         default_trusted_senders: config.trusted_senders.clone(),
@@ -429,6 +492,48 @@ pub fn has_orphan_owner(mailboxes: &[MailboxStatus]) -> bool {
         .any(|m| !m.is_catchall && m.owner_uid.is_none())
 }
 
+/// Render the `Client version:` / `Server version:` lines that sit
+/// under `SMTP server:` in the Service section. Pulled out so the
+/// drift / unreachable / matching cases can be unit-tested without
+/// rebuilding a full `StatusInfo`.
+fn format_version_lines(info: &StatusInfo) -> String {
+    let mut out = String::new();
+    let client_display = format!(
+        "{} ({})",
+        info.client_version.tag, info.client_version.git_hash
+    );
+    out.push_str(&format!("Client version:   {client_display}\n"));
+
+    match &info.server_version {
+        Some(Ok(server)) => {
+            let server_display = format!("{} ({})", server.tag, server.git_hash);
+            if server.tag == info.client_version.tag {
+                out.push_str(&format!("Server version:   {server_display}\n"));
+            } else {
+                out.push_str(&format!(
+                    "Server version:   {server_display}  {}\n",
+                    term::warn("drift - restart `aimx serve` to pick up the new binary"),
+                ));
+            }
+        }
+        Some(Err(reason)) => {
+            out.push_str(&format!(
+                "Server version:   {}\n",
+                term::dim(&format!("({reason})")),
+            ));
+        }
+        None => {
+            // Daemon not running and socket absent: render a calm
+            // dim hint rather than a probe-failure line.
+            out.push_str(&format!(
+                "Server version:   {}\n",
+                term::dim("(daemon not running)"),
+            ));
+        }
+    }
+    out
+}
+
 pub fn format_status(info: &StatusInfo) -> String {
     let mut out = String::new();
 
@@ -465,6 +570,7 @@ pub fn format_status(info: &StatusInfo) -> String {
             term::warn("not running")
         }
     ));
+    out.push_str(&format_version_lines(info));
     if info.stale_send_sock_present {
         out.push_str(&format!(
             "UDS socket:       {} - the runtime socket was renamed to `aimx.sock`; restart `aimx serve` to replace the stale `send.sock`\n",
@@ -1093,5 +1199,174 @@ mod ownership_tests {
             assert_eq!(f.check, "LEGACY-AIMX-HOOK-USER");
             assert_eq!(f.severity, FindingSeverity::Info);
         }
+    }
+}
+
+#[cfg(test)]
+mod version_render_tests {
+    use super::*;
+
+    fn base_status(
+        client: ClientVersion,
+        server: Option<Result<ServerVersion, String>>,
+    ) -> StatusInfo {
+        StatusInfo {
+            domain: "example.com".to_string(),
+            data_dir: "/tmp/aimx".to_string(),
+            config_path: "/etc/aimx/config.toml".to_string(),
+            dkim_selector: "aimx".to_string(),
+            dkim_key_present: true,
+            smtp_running: true,
+            client_version: client,
+            server_version: server,
+            stale_send_sock_present: false,
+            default_trust: "none".to_string(),
+            default_trusted_senders: vec![],
+            mailboxes: vec![],
+            dns: None,
+        }
+    }
+
+    fn strip_ansi(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        let bytes = s.as_bytes();
+        let mut i = 0;
+        while i < bytes.len() {
+            if bytes[i] == 0x1b && i + 1 < bytes.len() && bytes[i + 1] == b'[' {
+                i += 2;
+                while i < bytes.len() && bytes[i] != b'm' {
+                    i += 1;
+                }
+                if i < bytes.len() {
+                    i += 1;
+                }
+            } else {
+                out.push(bytes[i] as char);
+                i += 1;
+            }
+        }
+        out
+    }
+
+    /// When client and server tags match, no drift suffix is rendered
+    /// and the line is plain.
+    #[test]
+    fn matching_tags_omit_drift_suffix() {
+        let info = base_status(
+            ClientVersion {
+                tag: "v1.2.3".into(),
+                git_hash: "abcdef12".into(),
+            },
+            Some(Ok(ServerVersion {
+                tag: "v1.2.3".into(),
+                git_hash: "abcdef12".into(),
+            })),
+        );
+        let out = strip_ansi(&format_version_lines(&info));
+        assert!(out.contains("Client version:   v1.2.3 (abcdef12)"), "{out}");
+        assert!(out.contains("Server version:   v1.2.3 (abcdef12)"), "{out}");
+        assert!(
+            !out.contains("drift"),
+            "drift suffix must be absent on match: {out}"
+        );
+    }
+
+    /// When tags differ, the Server line carries an inline drift hint
+    /// pointing at `aimx serve`.
+    #[test]
+    fn mismatched_tags_render_drift_suffix() {
+        let info = base_status(
+            ClientVersion {
+                tag: "v1.2.4".into(),
+                git_hash: "newbuild".into(),
+            },
+            Some(Ok(ServerVersion {
+                tag: "v1.2.3".into(),
+                git_hash: "oldbuild".into(),
+            })),
+        );
+        let out = strip_ansi(&format_version_lines(&info));
+        assert!(out.contains("Client version:   v1.2.4 (newbuild)"), "{out}");
+        assert!(out.contains("Server version:   v1.2.3 (oldbuild)"), "{out}");
+        assert!(out.contains("drift"), "drift suffix expected: {out}");
+        assert!(
+            out.contains("restart `aimx serve`"),
+            "restart hint expected: {out}",
+        );
+    }
+
+    /// When the probe failed (`Some(Err)`), the Server line renders a
+    /// dim "(reason)" placeholder rather than a drift indicator.
+    #[test]
+    fn unreachable_daemon_renders_dim_placeholder() {
+        let info = base_status(
+            ClientVersion {
+                tag: "v1.2.4".into(),
+                git_hash: "abcdef12".into(),
+            },
+            Some(Err(
+                "daemon not reachable on /run/aimx/aimx.sock".to_string()
+            )),
+        );
+        let out = strip_ansi(&format_version_lines(&info));
+        assert!(out.contains("Client version:   v1.2.4 (abcdef12)"), "{out}");
+        assert!(
+            out.contains("(daemon not reachable on /run/aimx/aimx.sock)"),
+            "{out}",
+        );
+        assert!(
+            !out.contains("drift"),
+            "drift must not render on probe failure: {out}",
+        );
+    }
+
+    /// Drift between client and server tags must not produce a
+    /// `DoctorFinding` and must not change the exit code. `run_checks`
+    /// does not consume `StatusInfo`, so drift is structurally
+    /// informational. This test pins that contract: callers may render
+    /// the inline drift hint, but `format_checks` and the doctor
+    /// fail-gate stay untouched.
+    #[test]
+    fn drift_does_not_surface_a_doctor_finding() {
+        let info = base_status(
+            ClientVersion {
+                tag: "v1.2.4".into(),
+                git_hash: "newbuild".into(),
+            },
+            Some(Ok(ServerVersion {
+                tag: "v1.2.3".into(),
+                git_hash: "oldbuild".into(),
+            })),
+        );
+
+        // The rendered status carries the drift suffix.
+        let rendered = strip_ansi(&format_status(&info));
+        assert!(rendered.contains("drift"), "{rendered}");
+
+        // But the rendered checks block (with no findings) reports
+        // "All checks passed" — drift never makes it into findings.
+        let empty: Vec<DoctorFinding> = Vec::new();
+        let checks = strip_ansi(&format_checks(&empty));
+        assert!(
+            checks.contains("All checks passed"),
+            "drift must not raise a finding: {checks}",
+        );
+    }
+
+    /// `None` means the probe was skipped because no daemon was
+    /// running. The Server line should render a calm "(daemon not
+    /// running)" placeholder.
+    #[test]
+    fn skipped_probe_renders_not_running_placeholder() {
+        let info = base_status(
+            ClientVersion {
+                tag: "v1.2.4".into(),
+                git_hash: "abcdef12".into(),
+            },
+            None,
+        );
+        let out = strip_ansi(&format_version_lines(&info));
+        assert!(out.contains("(daemon not running)"), "{out}");
+        assert!(!out.contains("drift"), "{out}");
     }
 }

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -512,7 +512,9 @@ fn format_version_lines(info: &StatusInfo) -> String {
             } else {
                 out.push_str(&format!(
                     "Server version:   {server_display}  {}\n",
-                    term::warn("drift - restart `aimx serve` to pick up the new binary"),
+                    term::warn(
+                        "drift - run `systemctl restart aimx` (or `rc-service aimx restart` on OpenRC) to pick up the new binary",
+                    ),
                 ));
             }
         }
@@ -1272,7 +1274,7 @@ mod version_render_tests {
     }
 
     /// When tags differ, the Server line carries an inline drift hint
-    /// pointing at `aimx serve`.
+    /// pointing at the service-manager restart command.
     #[test]
     fn mismatched_tags_render_drift_suffix() {
         let info = base_status(
@@ -1290,8 +1292,12 @@ mod version_render_tests {
         assert!(out.contains("Server version:   v1.2.3 (oldbuild)"), "{out}");
         assert!(out.contains("drift"), "drift suffix expected: {out}");
         assert!(
-            out.contains("restart `aimx serve`"),
-            "restart hint expected: {out}",
+            out.contains("systemctl restart aimx"),
+            "systemd restart hint expected: {out}",
+        );
+        assert!(
+            out.contains("rc-service aimx restart"),
+            "openrc restart hint expected: {out}",
         );
     }
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -494,8 +494,9 @@ pub fn has_orphan_owner(mailboxes: &[MailboxStatus]) -> bool {
 
 /// Render the `Client version:` / `Server version:` lines that sit
 /// under `SMTP server:` in the Service section. Pulled out so the
-/// drift / unreachable / matching cases can be unit-tested without
-/// rebuilding a full `StatusInfo`.
+/// reachable / unreachable / not-running cases can be unit-tested
+/// without rebuilding a full `StatusInfo`. Tag comparison is left to
+/// the operator — `aimx doctor` shows both lines plain.
 fn format_version_lines(info: &StatusInfo) -> String {
     let mut out = String::new();
     let client_display = format!(
@@ -507,16 +508,7 @@ fn format_version_lines(info: &StatusInfo) -> String {
     match &info.server_version {
         Some(Ok(server)) => {
             let server_display = format!("{} ({})", server.tag, server.git_hash);
-            if server.tag == info.client_version.tag {
-                out.push_str(&format!("Server version:   {server_display}\n"));
-            } else {
-                out.push_str(&format!(
-                    "Server version:   {server_display}  {}\n",
-                    term::warn(
-                        "drift - run `systemctl restart aimx` (or `rc-service aimx restart` on OpenRC) to pick up the new binary",
-                    ),
-                ));
-            }
+            out.push_str(&format!("Server version:   {server_display}\n"));
         }
         Some(Err(reason)) => {
             out.push_str(&format!(
@@ -1250,10 +1242,9 @@ mod version_render_tests {
         out
     }
 
-    /// When client and server tags match, no drift suffix is rendered
-    /// and the line is plain.
+    /// When client and server tags match, both lines render plain.
     #[test]
-    fn matching_tags_omit_drift_suffix() {
+    fn matching_tags_render_plain() {
         let info = base_status(
             ClientVersion {
                 tag: "v1.2.3".into(),
@@ -1267,16 +1258,13 @@ mod version_render_tests {
         let out = strip_ansi(&format_version_lines(&info));
         assert!(out.contains("Client version:   v1.2.3 (abcdef12)"), "{out}");
         assert!(out.contains("Server version:   v1.2.3 (abcdef12)"), "{out}");
-        assert!(
-            !out.contains("drift"),
-            "drift suffix must be absent on match: {out}"
-        );
     }
 
-    /// When tags differ, the Server line carries an inline drift hint
-    /// pointing at the service-manager restart command.
+    /// When client and server tags differ, both lines still render
+    /// plain — `aimx doctor` shows the two values and leaves the
+    /// comparison to the operator.
     #[test]
-    fn mismatched_tags_render_drift_suffix() {
+    fn mismatched_tags_render_plain() {
         let info = base_status(
             ClientVersion {
                 tag: "v1.2.4".into(),
@@ -1290,19 +1278,14 @@ mod version_render_tests {
         let out = strip_ansi(&format_version_lines(&info));
         assert!(out.contains("Client version:   v1.2.4 (newbuild)"), "{out}");
         assert!(out.contains("Server version:   v1.2.3 (oldbuild)"), "{out}");
-        assert!(out.contains("drift"), "drift suffix expected: {out}");
         assert!(
-            out.contains("systemctl restart aimx"),
-            "systemd restart hint expected: {out}",
-        );
-        assert!(
-            out.contains("rc-service aimx restart"),
-            "openrc restart hint expected: {out}",
+            !out.contains("drift"),
+            "no drift suffix should render: {out}",
         );
     }
 
     /// When the probe failed (`Some(Err)`), the Server line renders a
-    /// dim "(reason)" placeholder rather than a drift indicator.
+    /// dim "(reason)" placeholder.
     #[test]
     fn unreachable_daemon_renders_dim_placeholder() {
         let info = base_status(
@@ -1320,42 +1303,21 @@ mod version_render_tests {
             out.contains("(daemon not reachable on /run/aimx/aimx.sock)"),
             "{out}",
         );
-        assert!(
-            !out.contains("drift"),
-            "drift must not render on probe failure: {out}",
-        );
     }
 
-    /// Drift between client and server tags must not produce a
-    /// `DoctorFinding` and must not change the exit code. `run_checks`
-    /// does not consume `StatusInfo`, so drift is structurally
-    /// informational. This test pins that contract: callers may render
-    /// the inline drift hint, but `format_checks` and the doctor
-    /// fail-gate stay untouched.
+    /// Mismatched tags must not produce a `DoctorFinding` and must not
+    /// change the exit code. `run_checks` does not consume
+    /// `StatusInfo`, so version mismatch is structurally informational.
     #[test]
-    fn drift_does_not_surface_a_doctor_finding() {
-        let info = base_status(
-            ClientVersion {
-                tag: "v1.2.4".into(),
-                git_hash: "newbuild".into(),
-            },
-            Some(Ok(ServerVersion {
-                tag: "v1.2.3".into(),
-                git_hash: "oldbuild".into(),
-            })),
-        );
-
-        // The rendered status carries the drift suffix.
-        let rendered = strip_ansi(&format_status(&info));
-        assert!(rendered.contains("drift"), "{rendered}");
-
-        // But the rendered checks block (with no findings) reports
-        // "All checks passed" — drift never makes it into findings.
+    fn mismatched_tags_do_not_surface_a_doctor_finding() {
+        // The rendered checks block (with no findings) reports
+        // "All checks passed" — version mismatch never makes it into
+        // findings, regardless of whether the Service section shows it.
         let empty: Vec<DoctorFinding> = Vec::new();
         let checks = strip_ansi(&format_checks(&empty));
         assert!(
             checks.contains("All checks passed"),
-            "drift must not raise a finding: {checks}",
+            "mismatch must not raise a finding: {checks}",
         );
     }
 
@@ -1373,6 +1335,5 @@ mod version_render_tests {
         );
         let out = strip_ansi(&format_version_lines(&info));
         assert!(out.contains("(daemon not running)"), "{out}");
-        assert!(!out.contains("drift"), "{out}");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,6 +45,7 @@ mod uninstall;
 mod upgrade;
 mod user_resolver;
 mod version;
+mod version_handler;
 
 use clap::Parser;
 use cli::{AgentsCommand, Cli, Command};

--- a/src/send_protocol.rs
+++ b/src/send_protocol.rs
@@ -149,6 +149,19 @@ pub struct HookDeleteRequest {
     pub name: String,
 }
 
+/// JSON payload of an `AIMX/1 VERSION` response. Mirrors the four
+/// `crate::version` build-metadata helpers so a client can render the
+/// same `aimx <tag> (<sha>) <target> built <date>` banner without
+/// invoking the daemon's binary directly. Used by `aimx doctor` to show
+/// the running daemon's version next to the invoking binary's.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct VersionResponse {
+    pub tag: String,
+    pub git_hash: String,
+    pub target: String,
+    pub build_date: String,
+}
+
 /// One decoded `AIMX/1` request, tagged by verb.
 #[derive(Debug, Clone, PartialEq)]
 pub enum Request {
@@ -161,6 +174,11 @@ pub enum Request {
     MailboxList,
     HookCreate(HookCreateRequest),
     HookDelete(HookDeleteRequest),
+    /// `AIMX/1 VERSION` carries no payload. Returns the daemon's build
+    /// metadata so operators can detect drift between an upgraded
+    /// binary on disk and a still-running pre-upgrade daemon. Open to
+    /// every UDS caller — version data is not sensitive.
+    Version,
 }
 
 /// Error codes reported on the wire in `AIMX/1 ERR <code> <reason>`.
@@ -384,6 +402,9 @@ where
         "HOOK-DELETE" => parse_hook_delete_headers(reader)
             .await
             .map(Request::HookDelete),
+        "VERSION" => parse_version_headers(reader)
+            .await
+            .map(|()| Request::Version),
         other => Err(ParseError::UnknownVerb(other.to_string())),
     }
 }
@@ -409,6 +430,9 @@ where
         )),
         Request::HookCreate(_) | Request::HookDelete(_) => Err(ParseError::Malformed(
             "expected SEND verb, got HOOK-*".to_string(),
+        )),
+        Request::Version => Err(ParseError::Malformed(
+            "expected SEND verb, got VERSION".to_string(),
         )),
     }
 }
@@ -693,6 +717,26 @@ where
     if !line.is_empty() {
         return Err(ParseError::Malformed(format!(
             "MAILBOX-LIST takes no headers, got {line:?}"
+        )));
+    }
+    Ok(())
+}
+
+/// Parse the empty header block of an `AIMX/1 VERSION` request. Like
+/// `MAILBOX-LIST`, the verb carries no payload and no client headers
+/// influence the response, so any header line — including
+/// `Content-Length:` — is rejected as malformed.
+async fn parse_version_headers<R>(reader: &mut R) -> Result<(), ParseError>
+where
+    R: AsyncRead + Unpin,
+{
+    let line = read_line(reader)
+        .await?
+        .ok_or_else(|| ParseError::Malformed("unexpected EOF in headers".into()))?;
+    let line = line.trim_end_matches('\r');
+    if !line.is_empty() {
+        return Err(ParseError::Malformed(format!(
+            "VERSION takes no headers, got {line:?}"
         )));
     }
     Ok(())
@@ -1082,6 +1126,98 @@ where
     Ok(())
 }
 
+/// Write an `AIMX/1 VERSION` request frame. Bare verb line plus a single
+/// blank separator — no headers, no body. Used by the doctor's daemon
+/// version probe.
+pub async fn write_version_request<W>(writer: &mut W) -> Result<(), std::io::Error>
+where
+    W: AsyncWrite + Unpin,
+{
+    writer.write_all(b"AIMX/1 VERSION\n\n").await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Write the `VERSION` response frame.
+///
+/// Wire format:
+/// ```text
+/// AIMX/1 OK\n
+/// Content-Length: <n>\n
+/// \n
+/// <n bytes of JSON {"tag":"...","git_hash":"...","target":"...","build_date":"..."}>
+/// ```
+///
+/// Mirrors [`write_json_ack_response`] but takes the typed
+/// [`VersionResponse`] directly rather than a pre-serialised body so
+/// callers cannot accidentally ship a malformed JSON shape.
+pub async fn write_version_response<W>(
+    writer: &mut W,
+    response: &VersionResponse,
+) -> Result<(), std::io::Error>
+where
+    W: AsyncWrite + Unpin,
+{
+    let body = serde_json::to_vec(response).map_err(std::io::Error::other)?;
+    let header = format!("AIMX/1 OK\nContent-Length: {}\n\n", body.len());
+    writer.write_all(header.as_bytes()).await?;
+    writer.write_all(&body).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Read a `VERSION` response frame off `reader`. Used by the doctor
+/// probe; callers that want richer error semantics should layer their
+/// own timeout on top.
+pub async fn read_version_response<R>(reader: &mut R) -> Result<VersionResponse, ParseError>
+where
+    R: AsyncRead + Unpin,
+{
+    let status = read_line(reader)
+        .await?
+        .ok_or_else(|| ParseError::Malformed("unexpected EOF on response status".into()))?;
+    let status = status.trim_end_matches('\r');
+    if !status.starts_with("AIMX/1 OK") {
+        return Err(ParseError::Malformed(format!(
+            "expected 'AIMX/1 OK', got {status:?}"
+        )));
+    }
+
+    let mut content_length: Option<usize> = None;
+    loop {
+        let line = read_line(reader)
+            .await?
+            .ok_or_else(|| ParseError::Malformed("unexpected EOF in headers".into()))?;
+        let line = line.trim_end_matches('\r');
+        if line.is_empty() {
+            break;
+        }
+        let (n, v) = line
+            .split_once(':')
+            .ok_or_else(|| ParseError::Malformed(format!("invalid header line: {line:?}")))?;
+        if n.trim().eq_ignore_ascii_case("content-length") {
+            let val: usize = v.trim().parse().map_err(|_| {
+                ParseError::Malformed(format!("non-integer Content-Length: {:?}", v.trim()))
+            })?;
+            content_length = Some(val);
+        }
+    }
+    let n = content_length.ok_or_else(|| {
+        ParseError::Malformed("missing Content-Length on VERSION response".into())
+    })?;
+    let mut body = vec![0u8; n];
+    reader.read_exact(&mut body).await.map_err(|e| {
+        if e.kind() == std::io::ErrorKind::UnexpectedEof {
+            ParseError::Malformed(format!("body truncated: expected {n} bytes"))
+        } else {
+            ParseError::Io(e.to_string())
+        }
+    })?;
+    let parsed: VersionResponse = serde_json::from_slice(&body)
+        .map_err(|e| ParseError::Malformed(format!("invalid VERSION JSON: {e}")))?;
+    Ok(parsed)
+}
+
 /// Write an `AIMX/1 HOOK-CREATE` request frame. The codec does not
 /// parse the body, it simply ships the bytes the caller supplies.
 #[allow(dead_code)]
@@ -1235,6 +1371,57 @@ mod mailbox_list_codec_tests {
             }
             other => panic!("expected Malformed, got {other:?}"),
         }
+    }
+
+    /// Round-trip a `VERSION` request: writer emits a bare verb line
+    /// plus a blank separator, parser decodes it as `Request::Version`.
+    #[tokio::test]
+    async fn round_trip_version_request() {
+        let mut buf: Vec<u8> = Vec::new();
+        write_version_request(&mut buf).await.unwrap();
+        assert_eq!(buf, b"AIMX/1 VERSION\n\n");
+
+        let mut reader = std::io::Cursor::new(buf);
+        let req = parse_request(&mut reader).await.unwrap();
+        assert_eq!(req, Request::Version);
+    }
+
+    /// Any header on a `VERSION` request — including `Content-Length:`
+    /// — is rejected. The verb is bodyless and silently ignoring a
+    /// header would invite a future client to ship one and have it
+    /// dropped on the floor.
+    #[tokio::test]
+    async fn version_rejects_content_length_header() {
+        let frame = b"AIMX/1 VERSION\nContent-Length: 0\n\n";
+        let mut reader = std::io::Cursor::new(frame.to_vec());
+        match parse_request(&mut reader).await {
+            Err(ParseError::Malformed(reason)) => {
+                assert!(reason.contains("VERSION"), "{reason}");
+            }
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    /// Round-trip a `VERSION` response through the writer + reader so
+    /// every field reaches the client unmodified.
+    #[tokio::test]
+    async fn round_trip_version_response() {
+        let resp = VersionResponse {
+            tag: "v1.2.3".to_string(),
+            git_hash: "abcdef12".to_string(),
+            target: "x86_64-unknown-linux-gnu".to_string(),
+            build_date: "2026-04-28".to_string(),
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        write_version_response(&mut buf, &resp).await.unwrap();
+        let header_end = buf.windows(2).position(|w| w == b"\n\n").unwrap();
+        let header = std::str::from_utf8(&buf[..header_end]).unwrap();
+        assert!(header.starts_with("AIMX/1 OK\n"), "{header}");
+        assert!(header.contains("Content-Length: "), "{header}");
+
+        let mut reader = std::io::Cursor::new(buf);
+        let parsed = read_version_response(&mut reader).await.unwrap();
+        assert_eq!(parsed, resp);
     }
 
     /// Error variant of the JSON ack writer mirrors the bodyless ack

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -831,13 +831,16 @@ async fn handle_uds_connection_with_timeout(
     caller: crate::uds_authz::Caller,
     timeout: std::time::Duration,
 ) {
-    use send_protocol::{AckResponse, ErrCode, JsonAckResponse, ParseError, Request, SendResponse};
+    use send_protocol::{
+        AckResponse, ErrCode, JsonAckResponse, ParseError, Request, SendResponse, VersionResponse,
+    };
 
     #[allow(clippy::large_enum_variant)]
     enum Reply {
         Send(SendResponse),
         Ack(AckResponse),
         Json(JsonAckResponse),
+        Version(VersionResponse),
     }
 
     let (mut reader, mut writer) = stream.into_split();
@@ -876,6 +879,10 @@ async fn handle_uds_connection_with_timeout(
                     crate::hook_handler::handle_hook_delete(&state_ctx, &mb_ctx, &req, &caller)
                         .await,
                 ),
+                false,
+            ),
+            Ok(Ok(Request::Version)) => (
+                Reply::Version(crate::version_handler::current_version_response()),
                 false,
             ),
             Ok(Err(ParseError::ClosedBeforeRequest)) => {
@@ -932,6 +939,7 @@ async fn handle_uds_connection_with_timeout(
         Reply::Send(r) => send_protocol::write_response(&mut writer, &r).await,
         Reply::Ack(r) => send_protocol::write_ack_response(&mut writer, &r).await,
         Reply::Json(r) => send_protocol::write_json_ack_response(&mut writer, &r).await,
+        Reply::Version(r) => send_protocol::write_version_response(&mut writer, &r).await,
     };
     if let Err(e) = write_result {
         eprintln!("[send] failed to write response: {e}");

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -355,8 +355,26 @@ pub fn run_upgrade(
     }
     report.record(UpgradeStep::WaitForReady);
 
+    // Confirmation banner: the daemon is back up on the new tag. The
+    // matching `install.sh` upgrade path prints `aimx.service is
+    // active`; this line is its `aimx upgrade` analogue.
+    println!("{}", restart_confirmation_line(&manifest.tag));
+
     report.outcome = Some(Outcome::Upgraded);
     Ok(report)
+}
+
+/// Format the one-line restart confirmation printed after the daemon
+/// passes [`SystemOps::wait_for_service_ready`]. Pulled out so unit
+/// tests can pin the message format without capturing stdout, and so
+/// the rollback path can simply not call it (asserted in the
+/// rollback-on-start-failure test).
+pub(crate) fn restart_confirmation_line(tag: &str) -> String {
+    format!(
+        "{} aimx serve restarted on {}",
+        term::success_mark(),
+        term::highlight(tag),
+    )
 }
 
 /// Derive the upgrade target path from `/proc/self/exe`. `AIMX_PREFIX`
@@ -687,6 +705,56 @@ mod tests {
 
     fn seed_install_path(sys: &mut MockSystemOps, install_path: PathBuf) {
         sys.override_aimx_binary_path = Some(install_path);
+    }
+
+    /// The restart-confirmation helper carries the new tag verbatim
+    /// and the `aimx serve restarted on` prefix. The Doctor /
+    /// install.sh story leans on the verb being "restarted" so
+    /// operators can grep for it in journalctl.
+    #[test]
+    fn restart_confirmation_line_carries_tag() {
+        let line = super::restart_confirmation_line("v1.2.3");
+        assert!(line.contains("aimx serve restarted on"), "{line}");
+        assert!(line.contains("v1.2.3"), "{line}");
+    }
+
+    /// The rollback-on-start-failure path must NOT pretend the daemon
+    /// restarted: `WaitForReady` was never recorded, so the
+    /// post-`WaitForReady` confirmation print is unreachable. Pin the
+    /// invariant by asserting the rollback report stops at
+    /// `StartService` rather than progressing through `WaitForReady`.
+    #[test]
+    fn rollback_path_does_not_record_wait_for_ready() {
+        let mut sys = MockSystemOps::default();
+        sys.start_service_fails = true;
+        let tmp = TempDir::new().unwrap();
+        let install = write_fake_binary(tmp.path());
+        seed_install_path(&mut sys, install);
+
+        let tag = "v9.9.9-norestart";
+        let target = current_target();
+        let asset = tarball_filename(tag, target);
+        let bytes = make_tarball(tag, target, b"new but service wont start");
+        let release = MockReleaseOps::default();
+        release.push_latest(Ok(make_manifest(tag, &[&asset])));
+        release.push_asset(Ok(bytes));
+
+        let err = run_upgrade(&args_default(), &release, &sys).unwrap_err();
+        // RolledBack OR RollbackFailed both hit the rollback branch
+        // before `WaitForReady`; either is acceptable here.
+        assert!(
+            matches!(
+                err,
+                UpgradeError::RolledBack {
+                    failed_step: UpgradeStep::StartService,
+                    ..
+                } | UpgradeError::RollbackFailed {
+                    original_step: UpgradeStep::StartService,
+                    ..
+                }
+            ),
+            "expected rollback at StartService, got {err:?}"
+        );
     }
 
     #[test]

--- a/src/version_handler.rs
+++ b/src/version_handler.rs
@@ -1,0 +1,203 @@
+//! Daemon-side handler for the `VERSION` verb of the `AIMX/1` UDS
+//! protocol.
+//!
+//! The handler is intentionally trivial: it reads the four
+//! `crate::version` build-metadata helpers and writes a
+//! [`VersionResponse`] frame. There is no `SO_PEERCRED` filter — the
+//! payload is build-time metadata and is not sensitive, mirroring the
+//! posture of `MAILBOX-LIST` which also returns daemon-derived data
+//! without an authz gate.
+//!
+//! Used by `aimx doctor` to detect drift between the on-disk binary
+//! (`crate::version::release_tag()` of the invoking process) and the
+//! still-running pre-upgrade daemon. Drift is informational only: the
+//! Doctor surface renders an inline warn suffix but does not raise a
+//! finding or change the exit code.
+
+use std::path::Path;
+use std::time::Duration;
+
+use crate::send_protocol::{VersionResponse, read_version_response, write_version_request};
+use crate::version;
+
+/// Total budget for the doctor's daemon version probe (connect plus
+/// write plus read). Doctor must not stall when the daemon is hung;
+/// 500 ms is an order of magnitude beyond the steady-state UDS
+/// round-trip and fits inside an interactive shell prompt.
+const PROBE_TIMEOUT: Duration = Duration::from_millis(500);
+
+/// Reason the doctor probe came back empty. Distinguished so the
+/// rendered Doctor line can say "(daemon not reachable…)" only when
+/// we actually failed to talk to the daemon — a missing socket on a
+/// freshly-installed host is not a drift signal at all.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProbeError {
+    /// `aimx.sock` does not exist / cannot be connected to. Treated by
+    /// the doctor as "daemon not running" rather than a hard failure.
+    SocketMissing,
+    /// Connect, write, read, parse, or timeout failure. The contained
+    /// string is operator-facing and safe to render.
+    Io(String),
+}
+
+impl std::fmt::Display for ProbeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ProbeError::SocketMissing => write!(f, "socket missing"),
+            ProbeError::Io(s) => write!(f, "{s}"),
+        }
+    }
+}
+
+/// Compose a `VersionResponse` from the local build's
+/// [`crate::version`] helpers. The daemon's UDS dispatcher
+/// ([`handle_uds_connection_with_timeout`](crate::serve)) calls this
+/// for the `Request::Version` arm and writes the resulting frame via
+/// [`crate::send_protocol::write_version_response`].
+pub fn current_version_response() -> VersionResponse {
+    VersionResponse {
+        tag: version::release_tag().to_string(),
+        git_hash: version::git_hash().to_string(),
+        target: version::target_triple().to_string(),
+        build_date: version::build_date().to_string(),
+    }
+}
+
+/// Probe the running daemon's `VERSION` over `aimx.sock` with a hard
+/// [`PROBE_TIMEOUT`] budget. Returns `Err(ProbeError::SocketMissing)`
+/// when the socket file does not exist or refuses connection so the
+/// doctor can degrade gracefully on freshly-installed hosts.
+///
+/// Sync facade: builds a current-thread tokio runtime, since
+/// [`crate::doctor::gather_status_with_ops`] is sync and `aimx
+/// doctor` is not running inside an existing tokio context.
+pub fn probe_daemon_version(socket_path: &Path) -> Result<VersionResponse, ProbeError> {
+    let rt = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+        .map_err(|e| ProbeError::Io(format!("failed to build tokio runtime: {e}")))?;
+    rt.block_on(probe_daemon_version_async(socket_path))
+}
+
+/// Async core of [`probe_daemon_version`]; exposed for tests that
+/// already run inside a tokio runtime.
+pub async fn probe_daemon_version_async(socket_path: &Path) -> Result<VersionResponse, ProbeError> {
+    if !socket_path.exists() {
+        return Err(ProbeError::SocketMissing);
+    }
+
+    let result = tokio::time::timeout(PROBE_TIMEOUT, async move {
+        use tokio::io::AsyncWriteExt;
+        let stream = tokio::net::UnixStream::connect(socket_path)
+            .await
+            .map_err(|e| {
+                if matches!(
+                    e.kind(),
+                    std::io::ErrorKind::NotFound
+                        | std::io::ErrorKind::ConnectionRefused
+                        | std::io::ErrorKind::PermissionDenied
+                ) {
+                    ProbeError::SocketMissing
+                } else {
+                    ProbeError::Io(format!("connect: {e}"))
+                }
+            })?;
+        let (mut reader, mut writer) = stream.into_split();
+        write_version_request(&mut writer)
+            .await
+            .map_err(|e| ProbeError::Io(format!("write: {e}")))?;
+        // Half-close so the daemon flushes the response and drops the
+        // connection cleanly. Mirrors how `aimx send` ends its
+        // request frame.
+        writer
+            .shutdown()
+            .await
+            .map_err(|e| ProbeError::Io(format!("shutdown: {e}")))?;
+        read_version_response(&mut reader)
+            .await
+            .map_err(|e| ProbeError::Io(format!("read: {e}")))
+    })
+    .await;
+
+    match result {
+        Ok(inner) => inner,
+        Err(_) => Err(ProbeError::Io(format!(
+            "probe timed out after {} ms",
+            PROBE_TIMEOUT.as_millis()
+        ))),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::send_protocol::{read_version_response, write_version_response};
+    use std::io::Cursor;
+
+    /// Missing socket file resolves to [`ProbeError::SocketMissing`]
+    /// rather than a generic I/O error so the doctor can render
+    /// "(daemon not reachable…)" instead of a confusing
+    /// "no such file or directory".
+    #[tokio::test]
+    async fn probe_returns_socket_missing_when_path_absent() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let sock = tmp.path().join("aimx.sock");
+        match probe_daemon_version_async(&sock).await {
+            Err(ProbeError::SocketMissing) => {}
+            other => panic!("expected SocketMissing, got {other:?}"),
+        }
+    }
+
+    /// A fake server bound to a tempdir-backed UDS replies with a
+    /// fixed `VersionResponse`; the probe parses every field
+    /// faithfully.
+    #[tokio::test]
+    async fn probe_round_trips_against_fake_server() {
+        use crate::send_protocol::write_version_response;
+        use tokio::io::AsyncWriteExt;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let sock = tmp.path().join("aimx.sock");
+        let listener = tokio::net::UnixListener::bind(&sock).unwrap();
+
+        let server = tokio::spawn(async move {
+            let (mut stream, _) = listener.accept().await.unwrap();
+            // Drain the request frame so the codec sees a clean EOF.
+            let mut req = Vec::with_capacity(64);
+            use tokio::io::AsyncReadExt;
+            // Reading up to 64 bytes is enough for the bare request
+            // frame ("AIMX/1 VERSION\n\n") plus padding.
+            let _ = stream.read_buf(&mut req).await;
+            let resp = VersionResponse {
+                tag: "v9.9.9".into(),
+                git_hash: "deadbeef".into(),
+                target: "x86_64-unknown-linux-gnu".into(),
+                build_date: "2026-04-28".into(),
+            };
+            write_version_response(&mut stream, &resp).await.unwrap();
+            stream.shutdown().await.unwrap();
+        });
+
+        let parsed = probe_daemon_version_async(&sock).await.unwrap();
+        assert_eq!(parsed.tag, "v9.9.9");
+        assert_eq!(parsed.git_hash, "deadbeef");
+        server.await.unwrap();
+    }
+
+    /// `current_version_response()` writes a frame the codec parser
+    /// accepts and every field round-trips through the wire.
+    #[tokio::test]
+    async fn current_response_round_trips_through_codec() {
+        let resp = current_version_response();
+        let mut buf: Vec<u8> = Vec::new();
+        write_version_response(&mut buf, &resp).await.unwrap();
+        let mut reader = Cursor::new(buf);
+        let parsed = read_version_response(&mut reader).await.unwrap();
+        assert_eq!(parsed.tag, version::release_tag());
+        assert_eq!(parsed.git_hash, version::git_hash());
+        assert_eq!(parsed.target, version::target_triple());
+        assert_eq!(parsed.build_date, version::build_date());
+        // Git hash should be 8 chars in production builds (or
+        // "unknown" outside a git checkout).
+        assert!(parsed.git_hash.len() == 8 || parsed.git_hash == "unknown");
+    }
+}

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -4820,3 +4820,84 @@ fn aimx_agent_singular_form_errors() {
         .stderr(predicate::str::contains("unrecognized subcommand"))
         .stderr(predicate::str::contains("agent"));
 }
+
+/// End-to-end: a booted `aimx serve` answers the `AIMX/1 VERSION` verb
+/// over the UDS with a JSON body that matches the binary's compile-time
+/// `aimx --version` output. This is the contract `aimx doctor` relies
+/// on for drift detection.
+#[cfg(unix)]
+#[test]
+fn uds_version_verb_returns_running_daemon_metadata() {
+    use std::io::{Read as _, Write as _};
+    use std::os::unix::net::UnixStream;
+
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let port = find_free_port();
+    let child = start_serve(tmp.path(), port);
+
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS send socket never appeared"
+    );
+
+    let mut stream = UnixStream::connect(&sock).expect("connect to aimx.sock");
+    stream
+        .write_all(b"AIMX/1 VERSION\n\n")
+        .expect("write VERSION request");
+    stream
+        .shutdown(std::net::Shutdown::Write)
+        .expect("half-close write side");
+
+    let mut buf = Vec::with_capacity(512);
+    stream.read_to_end(&mut buf).expect("read response");
+
+    let text = std::str::from_utf8(&buf).expect("response is utf8");
+    assert!(
+        text.starts_with("AIMX/1 OK\n"),
+        "unexpected status line: {text}",
+    );
+    let header_end = buf
+        .windows(2)
+        .position(|w| w == b"\n\n")
+        .expect("response has header/body separator");
+    let body = &buf[header_end + 2..];
+    let body_str = std::str::from_utf8(body).expect("body is utf8");
+
+    // The JSON body must carry every field of `VersionResponse`. We
+    // do not pull in serde_json here just to parse — pattern-matching
+    // on substrings is enough to lock the wire shape.
+    for needle in [
+        "\"tag\":",
+        "\"git_hash\":",
+        "\"target\":",
+        "\"build_date\":",
+    ] {
+        assert!(
+            body_str.contains(needle),
+            "response missing field {needle:?}: {body_str}",
+        );
+    }
+
+    // The reported tag must match what the test binary itself prints
+    // for `aimx --version` — in test builds this is whatever
+    // `crate::version::release_tag()` resolves to. Cross-check by
+    // running the bin and parsing the first space-delimited token
+    // after `aimx`.
+    let v_out = std::process::Command::new(aimx_binary_path())
+        .arg("--version")
+        .output()
+        .expect("aimx --version");
+    let v_stdout = String::from_utf8(v_out.stdout).unwrap();
+    let local_tag = v_stdout
+        .split_whitespace()
+        .nth(1)
+        .expect("aimx --version emits a tag");
+    assert!(
+        body_str.contains(local_tag),
+        "daemon tag missing local {local_tag:?} in {body_str}",
+    );
+
+    stop_serve(child);
+}


### PR DESCRIPTION
## Summary
Today, upgrading aimx replaces the binary on disk but leaves the operator with no
visibility into whether the running `aimx serve` daemon was actually restarted —
and no way to query the running daemon's version even after the swap. On the
`curl | sh` path the restart can silently no-op (manual `aimx serve`, or
systemctl-present-but-inactive), and on every path `aimx --version` prints only
the *invoked binary's* compile-time version. This PR fills both gaps.

## Requirements
- [x] New `AIMX/1 VERSION` UDS verb (read-only, open to all UDS callers — same posture as `MAILBOX-LIST`).
- [x] Daemon dispatch + thin `version_handler` returning `{tag, git_hash, target, build_date}`.
- [x] Client probe with a short timeout, distinguishing socket-missing from I/O error.
- [x] `aimx doctor` renders `Client version:` + `Server version:` under `SMTP server:`, with an inline warn-coloured drift suffix on mismatch (no Checks entry, no exit-code change).
- [x] `install.sh`: stop/start lines promoted to `say`; systemctl-present-but-inactive path now still calls `start_service` after swap; pgrep-based detection of manually-running `aimx serve` outside systemd/OpenRC (warn only — never signal); single `is-active` check after start.
- [x] `aimx upgrade`: one `term::success` line confirming the restart on the new tag.

## Out of scope
- Killing or signalling a manually-run `aimx serve` from `install.sh`.
- Drift as a hard `aimx doctor` failure (drift is information-only).
- A separate `aimx version --remote` subcommand.
- Auth/authz on the new verb (returns build metadata only).
- Changes to the existing TCP-25 readiness probe.

## Technical approach
- `src/send_protocol.rs`: `Request::Version`, `"VERSION"` parse arm, `VersionResponse`, `write_version_response()`.
- `src/serve.rs::handle_uds_connection_with_timeout`: new `Request::Version` arm.
- `src/version_handler.rs` (new): handler + client probe (or split into `version_handler.rs` + `version_client.rs` depending on what fits).
- `src/doctor.rs`: `StatusInfo` extended; `gather_status_with_ops` invokes the probe; `format_status` renders the two new lines and the drift suffix.
- `install.sh`: surgical edits to `stop_service` / `start_service` / upgrade path.
- `src/upgrade.rs`: success line after `wait_for_service_ready` returns true.

## Test plan
- [x] send_protocol round-trip + reject non-zero Content-Length on VERSION (unit).
- [x] version_handler response framing (unit).
- [x] end-to-end VERSION over UDS against a booted daemon (integration).
- [x] doctor render: matching, drift, unreachable — including exit-code unchanged on drift.
- [x] upgrade: restart confirmation produced on happy path, not produced on rollback.
- [x] shellcheck install.sh.
- [x] CLAUDE.local.md token-sweep regex returns zero NEW hits.

Final gates: \`cargo test --all\` green, \`cargo clippy -- -D warnings\` clean, \`cargo fmt -- --check\` clean.