### PR TITLE
feat: add --port-check-only flag to install.sh

### DIFF
--- a/book/getting-started.md
+++ b/book/getting-started.md
@@ -22,6 +22,16 @@ AIMX requires direct SMTP access on port 25. Not all cloud providers allow this.
 
 Providers that **block** port 25 permanently (not compatible): DigitalOcean, AWS EC2, Azure VMs, GCP.
 
+## Pre-install: check port 25
+
+Not sure your VPS allows SMTP traffic on port 25? Run the connectivity check before committing to install:
+
+```bash
+curl -fsSL https://aimx.email/install.sh | sh -s -- --port-check-only
+```
+
+This runs the same outbound + inbound port-25 checks as `aimx portcheck`, then exits without installing anything. Run it as `sudo` for the inbound check (otherwise inbound is reported as `[skip]` and only outbound is verified). Exits `0` on pass-or-skip, `1` on fail, `2` if a required tool (curl, python3/nc/bash) is missing. Use `--verify-host <URL>` (or `AIMX_VERIFY_HOST`) to point at a self-hosted verifier instead of the default `https://check.aimx.email`.
+
 ## Install
 
 ```bash

--- a/book/setup.md
+++ b/book/setup.md
@@ -34,6 +34,14 @@ sudo aimx portcheck
 
 `aimx portcheck` requires root. When `aimx serve` is running, it performs an outbound EHLO handshake plus an inbound EHLO handshake probe. When nothing is on port 25 (fresh VPS), it spawns a temporary listener and runs checks. If port 25 is occupied by another process, portcheck tells you to stop it before setup.
 
+If you haven't installed AIMX yet, the same check is available from the install script with `--port-check-only`:
+
+```bash
+curl -fsSL https://aimx.email/install.sh | sudo sh -s -- --port-check-only
+```
+
+It exits without installing. See [Getting Started: Pre-install](getting-started.md#pre-install-check-port-25).
+
 | Check | What it does | Fix if it fails |
 |-------|-------------|-----------------|
 | Outbound port 25 | Performs EHLO handshake to `check.aimx.email` on port 25 | Ask VPS provider to unblock outbound SMTP |

--- a/book/troubleshooting.md
+++ b/book/troubleshooting.md
@@ -297,6 +297,14 @@ sudo chmod 600 /etc/aimx/dkim/private.key
 
 If portcheck fails with EHLO probe after setup, the issue is likely in the `aimx serve` configuration rather than firewall/port access. Run `sudo systemctl status aimx` to check.
 
+Before installing AIMX, you can run the same connectivity probe from the install script (no install side effects):
+
+```bash
+curl -fsSL https://aimx.email/install.sh | sudo sh -s -- --port-check-only
+```
+
+See [Getting Started: Pre-install check](getting-started.md#pre-install-check-port-25).
+
 ## Useful commands reference
 
 | Command | Purpose |

--- a/install.sh
+++ b/install.sh
@@ -734,7 +734,10 @@ while time.time() < deadline:
     try:
         c, _ = s.accept()
     except socket.timeout:
-        break
+        # Idle window expired but the deadline still bounds the loop.
+        # Continue so a second probe attempt within the deadline still
+        # gets served (mirrors src/portcheck.rs:73-82).
+        continue
     except Exception:
         break
     try:
@@ -805,8 +808,11 @@ port_check_inbound() {
     _listener_pid=""
 
     if [ "${_occ}" = "occupied" ]; then
-        # Existing daemon will reply to /probe.
-        :
+        # Existing daemon will reply to /probe. Warn the operator —
+        # /probe can't tell aimx apart from Postfix/Sendmail/Exim, so a
+        # green [ok] here is only meaningful if the holder is aimx.
+        # Mirrors `aimx portcheck`'s Port25Status::OtherProcess handling.
+        ui_warn "port 25 is held by another process; verify it's aimx before running setup"
     else
         # Free or unknown: spawn a temp Python listener if available.
         if ! port_check_have_python3; then
@@ -817,6 +823,17 @@ port_check_inbound() {
         _listener_pid="$(port_check_listener_start)"
         # Give the listener a moment to bind before /probe fires.
         sleep 1
+        # Liveness probe: if the python child died (bind() failed —
+        # race / EACCES / port stolen), surface that as a distinct
+        # error rather than letting /probe report a generic
+        # "unreachable". Mirrors the synchronous bind+error in
+        # src/portcheck.rs:44-53.
+        if ! kill -0 "${_listener_pid}" 2>/dev/null; then
+            _PORT_CHECK_INBOUND_STATE="fail"
+            _PORT_CHECK_INBOUND_MSG="failed to spawn temp listener on :25 (bind failed; another binder won the race?)"
+            _listener_pid=""
+            return 0
+        fi
     fi
 
     _body="$(port_check_probe)"
@@ -842,7 +859,13 @@ port_check_inbound() {
 port_check_main() {
     print_port_check_banner
 
-    need curl
+    # Required tool: curl. Exit 2 (missing required tool) per the
+    # documented contract — `need` exits 1, which is wrong here.
+    if ! command -v curl >/dev/null 2>&1; then
+        ui_error "required command not found: curl"
+        ui_info "  install curl and re-run"
+        return 2
+    fi
 
     _host="$(derive_smtp_host "${VERIFY_HOST}")"
     if [ -z "${_host}" ]; then
@@ -1026,15 +1049,15 @@ main() {
         PREFIX="${DEFAULT_PREFIX}"
     fi
 
-    # Resolve + validate verify-host (used by --port-check-only). Done
-    # before the short-circuit so a bad value rejects fast either way.
-    resolve_verify_host
-    validate_verify_host
-
     # --port-check-only short-circuit. Branches here, BEFORE any
     # privileged or networked install code (no ensure_sudo, no GitHub
-    # API call, no filesystem writes).
+    # API call, no filesystem writes). The verify-host env var is
+    # specific to the port-check path; gate resolve+validate behind the
+    # flag so a stray AIMX_VERIFY_HOST in the operator's shell doesn't
+    # block a regular install.
     if [ "${PORT_CHECK_ONLY}" = "1" ]; then
+        resolve_verify_host
+        validate_verify_host
         port_check_main
         exit $?
     fi

--- a/install.sh
+++ b/install.sh
@@ -118,6 +118,15 @@ print_install_banner() {
     printf '\n' >&2
 }
 
+# Port-check banner. Replaces the install banner when --port-check-only
+# is set, so it is visually obvious nothing is installing.
+print_port_check_banner() {
+    printf '\n' >&2
+    printf '%s\n' "$(_ui_paint '1;35' 'aimx port 25 connectivity check')" >&2
+    printf '%s\n' "$(_ui_paint 2 '  no install will be performed')" >&2
+    printf '\n' >&2
+}
+
 # download <url> <path>
 #   Prefers curl; falls back to wget. Refuses non-HTTPS URLs. Honors
 #   GITHUB_TOKEN for api.github.com calls so rate-limited CI runs succeed.
@@ -177,12 +186,19 @@ FLAGS:
         --to <DIR>           Install binary into DIR (default /usr/local/bin);
                              overrides AIMX_PREFIX env var
         --force              Re-install even if target version already present
+        --port-check-only    Run port-25 outbound + inbound connectivity checks
+                             then exit; no install is performed
+        --verify-host <URL>  Verifier base URL for the inbound /probe call
+                             (default https://check.aimx.email); overrides
+                             AIMX_VERIFY_HOST env var
 
 ENVIRONMENT:
     AIMX_VERSION             Release tag to install (e.g. 1.2.3)
     AIMX_PREFIX              Install directory (default /usr/local/bin)
     AIMX_DRY_RUN=1           Print every step without downloading or installing
     AIMX_VERBOSE=1           Trace HTTP requests and filesystem actions
+    AIMX_VERIFY_HOST         Verifier base URL for --port-check-only (default
+                             https://check.aimx.email)
     GITHUB_TOKEN             Token for rate-limited GitHub API calls
 
 EXAMPLES:
@@ -194,6 +210,9 @@ EXAMPLES:
 
     # Dry-run: see what would happen without installing
     curl -fsSL https://aimx.email/install.sh | AIMX_DRY_RUN=1 sh
+
+    # Port-25 connectivity check only (no install)
+    curl -fsSL https://aimx.email/install.sh | sh -s -- --port-check-only
 
 Trust anchor is HTTPS on the GitHub Releases domain. No signature or
 checksum verification in this script; skeptical operators can verify
@@ -543,6 +562,352 @@ detect_manual_aimx_serve() {
 }
 
 # ---------------------------------------------------------------------------
+# Port-25 connectivity check (--port-check-only)
+# ---------------------------------------------------------------------------
+#
+# Mirrors `aimx portcheck` semantics for evaluators who want to verify a VPS
+# can reach SMTP before installing. Outbound: TCP-connect to <host>:25,
+# expect 220 banner, send EHLO, accept on 250 SP, send QUIT. Inbound: GET
+# ${VERIFY_HOST}/probe; loose substring match for "reachable":true.
+
+# Strip scheme + path/port from a verify-host URL → bare hostname.
+derive_smtp_host() {
+    _vh="$1"
+    case "${_vh}" in
+        https://*) _vh="${_vh#https://}" ;;
+        http://*) _vh="${_vh#http://}" ;;
+    esac
+    # Drop trailing path.
+    _vh="${_vh%%/*}"
+    # Drop trailing :port (IPv6 in brackets is out of scope per plan).
+    _vh="${_vh%%:*}"
+    printf '%s' "${_vh}"
+}
+
+port_check_have_python3() {
+    command -v python3 >/dev/null 2>&1
+}
+
+port_check_have_nc() {
+    command -v nc >/dev/null 2>&1
+}
+
+port_check_have_bash() {
+    command -v bash >/dev/null 2>&1
+}
+
+# Outbound EHLO via python3. Returns 0 on success, 1 on protocol fail.
+port_check_outbound_python() {
+    _h="$1"
+    _p="$2"
+    python3 - "${_h}" "${_p}" <<'PYEOF'
+import socket, sys
+host, port = sys.argv[1], int(sys.argv[2])
+try:
+    s = socket.create_connection((host, port), timeout=10)
+except Exception:
+    sys.exit(1)
+s.settimeout(5)
+try:
+    f = s.makefile('rwb', buffering=0)
+    banner = f.readline().decode('latin-1', 'replace')
+    if not banner.startswith('220'):
+        sys.exit(1)
+    f.write(b'EHLO aimx\r\n'); f.flush()
+    while True:
+        line = f.readline().decode('latin-1', 'replace')
+        if not line:
+            sys.exit(1)
+        if line.startswith('250 '):
+            break
+        if not line.startswith('250-'):
+            sys.exit(1)
+    try:
+        f.write(b'QUIT\r\n'); f.flush()
+    except Exception:
+        pass
+finally:
+    try: s.close()
+    except Exception: pass
+sys.exit(0)
+PYEOF
+}
+
+# Outbound EHLO via nc. Stream-based; tolerates BSD/GNU/ncat quirks by
+# avoiding -q / -N / -c entirely.
+port_check_outbound_nc() {
+    _h="$1"
+    _p="$2"
+    { printf 'EHLO aimx\r\n'; sleep 1; printf 'QUIT\r\n'; sleep 1; } \
+        | nc -w 5 "${_h}" "${_p}" 2>/dev/null \
+        | awk 'BEGIN{seen=0; ok=0}
+               /^220 /{seen=1}
+               /^220-/{seen=1}
+               /^250 /{if(seen)ok=1}
+               END{exit ok?0:1}'
+}
+
+# Outbound EHLO via bash /dev/tcp. Last resort; uses bash -c so the rest of
+# the script stays POSIX sh.
+port_check_outbound_bash() {
+    _h="$1"
+    _p="$2"
+    bash -c '
+exec 3<>"/dev/tcp/$1/$2" || exit 1
+read -r -t 5 banner <&3 || exit 1
+case "$banner" in 220*) ;; *) exit 1 ;; esac
+printf "EHLO aimx\r\n" >&3
+ok=0
+while read -r -t 5 line <&3; do
+  case "$line" in
+    250\ *) ok=1; break ;;
+    250-*) ;;
+    *) exit 1 ;;
+  esac
+done
+[ "$ok" = "1" ] || exit 1
+printf "QUIT\r\n" >&3 2>/dev/null || true
+exit 0
+' _ "${_h}" "${_p}"
+}
+
+# Run outbound check via the first available tool. Sets _PORT_CHECK_NO_TOOL=1
+# when no usable tool is on PATH (caller maps that to exit 2).
+_PORT_CHECK_NO_TOOL=0
+port_check_outbound() {
+    _h="$1"
+    _p="${2:-25}"
+    _PORT_CHECK_NO_TOOL=0
+    if port_check_have_python3; then
+        port_check_outbound_python "${_h}" "${_p}"
+        return $?
+    fi
+    if port_check_have_nc; then
+        port_check_outbound_nc "${_h}" "${_p}"
+        return $?
+    fi
+    if port_check_have_bash; then
+        port_check_outbound_bash "${_h}" "${_p}"
+        return $?
+    fi
+    _PORT_CHECK_NO_TOOL=1
+    return 1
+}
+
+# Detect whether port 25 is already bound on this host.
+# Echoes "free" | "occupied" | "unknown".
+port_check_detect_occupancy() {
+    if command -v ss >/dev/null 2>&1; then
+        if ss -tln 2>/dev/null | awk '{print $4}' | grep -E ':25$' >/dev/null 2>&1; then
+            printf 'occupied'
+        else
+            printf 'free'
+        fi
+        return 0
+    fi
+    if command -v netstat >/dev/null 2>&1; then
+        if netstat -tln 2>/dev/null | awk '{print $4}' | grep -E ':25$' >/dev/null 2>&1; then
+            printf 'occupied'
+        else
+            printf 'free'
+        fi
+        return 0
+    fi
+    printf 'unknown'
+}
+
+# Spawn a temp Python SMTP listener on :25. Echoes the PID on stdout so the
+# caller can kill it after /probe returns. Mirrors src/portcheck.rs:69-129.
+port_check_listener_start() {
+    python3 - <<'PYEOF' &
+import socket, sys, time
+s = socket.socket()
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+try:
+    s.bind(('0.0.0.0', 25))
+except Exception:
+    sys.exit(1)
+s.listen(8)
+deadline = time.time() + 30
+while time.time() < deadline:
+    s.settimeout(max(0.5, deadline - time.time()))
+    try:
+        c, _ = s.accept()
+    except socket.timeout:
+        break
+    except Exception:
+        break
+    try:
+        c.settimeout(10)
+        c.sendall(b'220 chkport25 ESMTP\r\n')
+        while True:
+            data = c.recv(1024)
+            if not data:
+                break
+            up = data.upper()
+            if up.startswith(b'EHLO') or up.startswith(b'HELO'):
+                c.sendall(b'250 chkport25\r\n')
+            elif up.startswith(b'QUIT'):
+                c.sendall(b'221 Bye\r\n'); break
+            else:
+                c.sendall(b'502 Not implemented\r\n')
+    except Exception:
+        pass
+    finally:
+        try: c.close()
+        except Exception: pass
+PYEOF
+    printf '%s' "$!"
+}
+
+port_check_listener_stop() {
+    _pid="$1"
+    if [ -n "${_pid}" ] && kill -0 "${_pid}" 2>/dev/null; then
+        kill "${_pid}" 2>/dev/null || true
+        wait "${_pid}" 2>/dev/null || true
+    fi
+}
+
+# Run the inbound /probe call against ${VERIFY_HOST}. Honors http:// for
+# self-hosted dev verifiers (matches validate_verify_host in src/setup.rs).
+# Echoes the response body on stdout; caller parses it.
+port_check_probe() {
+    _url="${VERIFY_HOST}/probe"
+    case "${VERIFY_HOST}" in
+        https://*)
+            curl --proto '=https' --tlsv1.2 -fsS -m 60 "${_url}" 2>/dev/null || true
+            ;;
+        *)
+            curl -fsS -m 60 "${_url}" 2>/dev/null || true
+            ;;
+    esac
+}
+
+# Orchestrate the inbound check. Sets _PORT_CHECK_INBOUND_STATE to one of:
+#   pass | fail | skip
+# When pass, _PORT_CHECK_INBOUND_IP holds the verifier-detected IP if any.
+_PORT_CHECK_INBOUND_STATE=""
+_PORT_CHECK_INBOUND_IP=""
+_PORT_CHECK_INBOUND_MSG=""
+port_check_inbound() {
+    _PORT_CHECK_INBOUND_STATE=""
+    _PORT_CHECK_INBOUND_IP=""
+    _PORT_CHECK_INBOUND_MSG=""
+
+    _euid="$(id -u 2>/dev/null || echo 0)"
+    if [ "${_euid}" -ne 0 ]; then
+        _PORT_CHECK_INBOUND_STATE="skip"
+        _PORT_CHECK_INBOUND_MSG="inbound check requires root (re-run with sudo)"
+        return 0
+    fi
+
+    _occ="$(port_check_detect_occupancy)"
+    _listener_pid=""
+
+    if [ "${_occ}" = "occupied" ]; then
+        # Existing daemon will reply to /probe.
+        :
+    else
+        # Free or unknown: spawn a temp Python listener if available.
+        if ! port_check_have_python3; then
+            _PORT_CHECK_INBOUND_STATE="skip"
+            _PORT_CHECK_INBOUND_MSG="install python3 or run 'aimx portcheck' after install"
+            return 0
+        fi
+        _listener_pid="$(port_check_listener_start)"
+        # Give the listener a moment to bind before /probe fires.
+        sleep 1
+    fi
+
+    _body="$(port_check_probe)"
+
+    if [ -n "${_listener_pid}" ]; then
+        port_check_listener_stop "${_listener_pid}"
+    fi
+
+    case "${_body}" in
+        *'"reachable":true'* | *'"reachable": true'*)
+            _PORT_CHECK_INBOUND_STATE="pass"
+            _PORT_CHECK_INBOUND_IP="$(printf '%s' "${_body}" \
+                | sed -n 's/.*"ip"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+            ;;
+        *)
+            _PORT_CHECK_INBOUND_STATE="fail"
+            _PORT_CHECK_INBOUND_MSG="verifier reported port 25 unreachable from the public internet"
+            ;;
+    esac
+}
+
+# Main entry for --port-check-only. Returns the right exit code.
+port_check_main() {
+    print_port_check_banner
+
+    need curl
+
+    _host="$(derive_smtp_host "${VERIFY_HOST}")"
+    if [ -z "${_host}" ]; then
+        ui_error "could not derive SMTP host from verify-host: ${VERIFY_HOST}"
+        return 2
+    fi
+
+    # Outbound.
+    printf '  Outbound port 25 ... ' >&2
+    _ob_rc=0
+    port_check_outbound "${_host}" 25 || _ob_rc=$?
+    if [ "${_PORT_CHECK_NO_TOOL}" = "1" ]; then
+        printf '%s\n' "$(_ui_paint 31 '[fail]')" >&2
+        ui_error "no usable outbound tool (need python3, nc, or bash)"
+        ui_info "  install python3 or nc and re-run"
+        return 2
+    fi
+    if [ "${_ob_rc}" -eq 0 ]; then
+        printf '%s\n' "$(_ui_paint 32 '[ok]')" >&2
+        _outbound_ok=1
+    else
+        printf '%s\n' "$(_ui_paint 31 '[fail]')" >&2
+        printf '    %s\n' "could not complete EHLO handshake to ${_host}:25" >&2
+        _outbound_ok=0
+    fi
+
+    # Inbound.
+    printf '  Inbound port 25 .... ' >&2
+    port_check_inbound
+    case "${_PORT_CHECK_INBOUND_STATE}" in
+        pass)
+            if [ -n "${_PORT_CHECK_INBOUND_IP}" ]; then
+                printf '%s   detected ip: %s\n' "$(_ui_paint 32 '[ok]')" "${_PORT_CHECK_INBOUND_IP}" >&2
+            else
+                printf '%s\n' "$(_ui_paint 32 '[ok]')" >&2
+            fi
+            _inbound_ok=1
+            ;;
+        skip)
+            printf '%s   %s\n' "$(_ui_paint 33 '[skip]')" "${_PORT_CHECK_INBOUND_MSG}" >&2
+            _inbound_ok=skip
+            ;;
+        *)
+            printf '%s\n' "$(_ui_paint 31 '[fail]')" >&2
+            if [ -n "${_PORT_CHECK_INBOUND_MSG}" ]; then
+                printf '    %s\n' "${_PORT_CHECK_INBOUND_MSG}" >&2
+            fi
+            _inbound_ok=0
+            ;;
+    esac
+
+    printf '\n' >&2
+    if [ "${_outbound_ok}" -eq 1 ] && [ "${_inbound_ok}" = "1" ]; then
+        ui_success "Port 25 reachable. Run 'curl -fsSL https://aimx.email/install.sh | sh' to install."
+        return 0
+    fi
+    if [ "${_outbound_ok}" -eq 1 ] && [ "${_inbound_ok}" = "skip" ]; then
+        ui_info "Outbound OK; inbound check skipped."
+        return 0
+    fi
+    ui_error "Port 25 connectivity check failed."
+    return 1
+}
+
+# ---------------------------------------------------------------------------
 # Install / upgrade
 # ---------------------------------------------------------------------------
 
@@ -551,6 +916,13 @@ TARGET=""
 PREFIX=""
 FORCE=0
 DRY_RUN="${AIMX_DRY_RUN:-0}"
+
+# Port-check mode: when set, run the same outbound + inbound port-25 checks
+# as `aimx portcheck` then exit. No install side effects. Resolved against
+# AIMX_VERIFY_HOST and DEFAULT_VERIFY_HOST in main() / resolve_verify_host.
+PORT_CHECK_ONLY=0
+VERIFY_HOST=""
+DEFAULT_VERIFY_HOST="https://check.aimx.email"
 
 parse_args() {
     while [ "$#" -gt 0 ]; do
@@ -590,11 +962,46 @@ parse_args() {
                 FORCE=1
                 shift
                 ;;
+            --port-check-only)
+                PORT_CHECK_ONLY=1
+                shift
+                ;;
+            --verify-host)
+                [ "$#" -ge 2 ] || err "--verify-host requires a value"
+                VERIFY_HOST="$2"
+                shift 2
+                ;;
+            --verify-host=*)
+                VERIFY_HOST="${1#--verify-host=}"
+                shift
+                ;;
             *)
                 err "unknown argument: $1 (try --help)"
                 ;;
         esac
     done
+}
+
+# resolve_verify_host — apply env-var → default fallback for VERIFY_HOST.
+# Flag (set by parse_args) wins, AIMX_VERIFY_HOST next, DEFAULT_VERIFY_HOST last.
+resolve_verify_host() {
+    if [ -z "${VERIFY_HOST}" ] && [ -n "${AIMX_VERIFY_HOST:-}" ]; then
+        VERIFY_HOST="${AIMX_VERIFY_HOST}"
+    fi
+    if [ -z "${VERIFY_HOST}" ]; then
+        VERIFY_HOST="${DEFAULT_VERIFY_HOST}"
+    fi
+}
+
+# validate_verify_host — reject empty / non-http(s) URLs.
+validate_verify_host() {
+    if [ -z "${VERIFY_HOST}" ]; then
+        err "verify-host cannot be empty"
+    fi
+    case "${VERIFY_HOST}" in
+        https://* | http://*) : ;;
+        *) err "verify-host must start with http:// or https:// (got: ${VERIFY_HOST})" ;;
+    esac
 }
 
 # ---------------------------------------------------------------------------
@@ -617,6 +1024,19 @@ main() {
     fi
     if [ -z "${PREFIX}" ]; then
         PREFIX="${DEFAULT_PREFIX}"
+    fi
+
+    # Resolve + validate verify-host (used by --port-check-only). Done
+    # before the short-circuit so a bad value rejects fast either way.
+    resolve_verify_host
+    validate_verify_host
+
+    # --port-check-only short-circuit. Branches here, BEFORE any
+    # privileged or networked install code (no ensure_sudo, no GitHub
+    # API call, no filesystem writes).
+    if [ "${PORT_CHECK_ONLY}" = "1" ]; then
+        port_check_main
+        exit $?
     fi
 
     # Thin install banner. Full six-step wizard checklist is the binary's job.

--- a/tests/install_sh.sh
+++ b/tests/install_sh.sh
@@ -560,6 +560,180 @@ assert_contains "parse_args --to=VAL"  "${_out}" "PREFIX=/tmp/x"
 assert_contains "parse_args --target=VAL" "${_out}" "TARGET=x86_64-unknown-linux-gnu"
 
 # ---------------------------------------------------------------------------
+# 7b. parse_args --port-check-only / --verify-host
+# ---------------------------------------------------------------------------
+
+echo "# parse_args (port-check)"
+
+# --port-check-only sets PORT_CHECK_ONLY=1 and leaves other flags untouched.
+_out="$(
+    INSTALL_SH_TEST=1 sh -c '
+        . "'"${INSTALL_SH}"'"
+        parse_args --port-check-only
+        printf "PORT_CHECK_ONLY=%s TAG=[%s] PREFIX=[%s] FORCE=%s VERIFY_HOST=[%s]" \
+            "${PORT_CHECK_ONLY}" "${TAG}" "${PREFIX}" "${FORCE}" "${VERIFY_HOST}"
+    '
+)"
+assert_contains "parse_args --port-check-only sets PORT_CHECK_ONLY=1" "${_out}" "PORT_CHECK_ONLY=1"
+assert_contains "parse_args --port-check-only leaves TAG empty" "${_out}" "TAG=[]"
+assert_contains "parse_args --port-check-only leaves PREFIX empty" "${_out}" "PREFIX=[]"
+assert_contains "parse_args --port-check-only leaves FORCE=0" "${_out}" "FORCE=0"
+assert_contains "parse_args --port-check-only leaves VERIFY_HOST empty" "${_out}" "VERIFY_HOST=[]"
+
+# Negative case: unrelated flag combos must NOT set PORT_CHECK_ONLY=1.
+_out="$(
+    INSTALL_SH_TEST=1 sh -c '
+        . "'"${INSTALL_SH}"'"
+        parse_args --tag 1.2.3 --to /tmp/x
+        printf "PORT_CHECK_ONLY=%s" "${PORT_CHECK_ONLY}"
+    '
+)"
+assert_contains "negative: --tag/--to does NOT set PORT_CHECK_ONLY" "${_out}" "PORT_CHECK_ONLY=0"
+
+# --verify-host space form.
+_out="$(
+    INSTALL_SH_TEST=1 sh -c '
+        . "'"${INSTALL_SH}"'"
+        parse_args --verify-host https://x.example
+        printf "VERIFY_HOST=%s" "${VERIFY_HOST}"
+    '
+)"
+assert_contains "parse_args --verify-host VAL" "${_out}" "VERIFY_HOST=https://x.example"
+
+# --verify-host=VAL equals form.
+_out="$(
+    INSTALL_SH_TEST=1 sh -c '
+        . "'"${INSTALL_SH}"'"
+        parse_args --verify-host=https://x.example
+        printf "VERIFY_HOST=%s" "${VERIFY_HOST}"
+    '
+)"
+assert_contains "parse_args --verify-host=VAL" "${_out}" "VERIFY_HOST=https://x.example"
+
+# --verify-host with no value → err (non-zero exit).
+_rc=0
+INSTALL_SH_TEST=1 sh -c '
+    . "'"${INSTALL_SH}"'"
+    parse_args --verify-host
+' >/dev/null 2>&1 || _rc=$?
+if [ "${_rc}" -ne 0 ]; then
+    PASS=$((PASS + 1))
+    printf '  ok  parse_args --verify-host (no value) errors out\n'
+else
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES="${FAILED_NAMES} verify-host-missing-value"
+    printf '  FAIL parse_args --verify-host (no value) should have errored\n' >&2
+fi
+
+# validate_verify_host rejects non-http(s) schemes (call helper directly).
+_rc=0
+INSTALL_SH_TEST=1 sh -c '
+    . "'"${INSTALL_SH}"'"
+    parse_args --verify-host ftp://x
+    validate_verify_host
+' >/dev/null 2>&1 || _rc=$?
+if [ "${_rc}" -ne 0 ]; then
+    PASS=$((PASS + 1))
+    printf '  ok  validate_verify_host rejects ftp://\n'
+else
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES="${FAILED_NAMES} verify-host-bad-scheme"
+    printf '  FAIL validate_verify_host should reject ftp://\n' >&2
+fi
+
+# Default DEFAULT_VERIFY_HOST.
+_out="$(
+    INSTALL_SH_TEST=1 sh -c '
+        . "'"${INSTALL_SH}"'"
+        printf "DEFAULT_VERIFY_HOST=%s" "${DEFAULT_VERIFY_HOST}"
+    '
+)"
+assert_contains "default verify-host is check.aimx.email" "${_out}" "DEFAULT_VERIFY_HOST=https://check.aimx.email"
+
+# resolve_verify_host: flag wins over env var.
+_out="$(
+    INSTALL_SH_TEST=1 AIMX_VERIFY_HOST=https://env.example sh -c '
+        . "'"${INSTALL_SH}"'"
+        parse_args --verify-host https://flag.example
+        resolve_verify_host
+        printf "VERIFY_HOST=%s" "${VERIFY_HOST}"
+    '
+)"
+assert_contains "flag wins over env var" "${_out}" "VERIFY_HOST=https://flag.example"
+
+# resolve_verify_host: env var wins over default.
+_out="$(
+    INSTALL_SH_TEST=1 AIMX_VERIFY_HOST=https://env.example sh -c '
+        . "'"${INSTALL_SH}"'"
+        resolve_verify_host
+        printf "VERIFY_HOST=%s" "${VERIFY_HOST}"
+    '
+)"
+assert_contains "env var wins over default" "${_out}" "VERIFY_HOST=https://env.example"
+
+# resolve_verify_host: neither flag nor env → default.
+_out="$(
+    INSTALL_SH_TEST=1 sh -c '
+        unset AIMX_VERIFY_HOST
+        . "'"${INSTALL_SH}"'"
+        resolve_verify_host
+        printf "VERIFY_HOST=%s" "${VERIFY_HOST}"
+    '
+)"
+assert_contains "default applies when nothing set" "${_out}" "VERIFY_HOST=https://check.aimx.email"
+
+# --help text must mention the new flag and env var.
+_helpout="$(
+    INSTALL_SH_TEST=1 sh -c '
+        . "'"${INSTALL_SH}"'"
+        help
+    '
+)"
+assert_contains "help mentions --port-check-only" "${_helpout}" "--port-check-only"
+assert_contains "help mentions --verify-host" "${_helpout}" "--verify-host"
+assert_contains "help mentions AIMX_VERIFY_HOST" "${_helpout}" "AIMX_VERIFY_HOST"
+
+# `install.sh --port-check-only --help` exits 0 and prints help.
+_rc=0
+_out="$(
+    sh "${INSTALL_SH}" --port-check-only --help 2>&1
+)" || _rc=$?
+assert_zero "--port-check-only --help exits 0" "${_rc}"
+assert_contains "--port-check-only --help prints help" "${_out}" "aimx install script"
+
+# `install.sh --help` mentions port-check-only.
+_rc=0
+sh "${INSTALL_SH}" --help 2>&1 | grep -q port-check-only || _rc=$?
+assert_zero "install.sh --help | grep -q port-check-only" "${_rc}"
+
+# derive_smtp_host extracts host[:port]-stripped host from a verify-host URL.
+_out="$(
+    INSTALL_SH_TEST=1 sh -c '
+        . "'"${INSTALL_SH}"'"
+        derive_smtp_host https://check.aimx.email/probe
+    '
+)"
+assert_eq "derive_smtp_host strips scheme + path" "check.aimx.email" "${_out}"
+
+_out="$(
+    INSTALL_SH_TEST=1 sh -c '
+        . "'"${INSTALL_SH}"'"
+        derive_smtp_host https://check.aimx.email:3025
+    '
+)"
+assert_eq "derive_smtp_host strips :port" "check.aimx.email" "${_out}"
+
+# print_port_check_banner exists and prints the connectivity-check title.
+_out="$(
+    INSTALL_SH_TEST=1 NO_COLOR=1 sh -c '
+        . "'"${INSTALL_SH}"'"
+        print_port_check_banner
+    ' 2>&1
+)"
+assert_contains "port-check banner shows connectivity title" "${_out}" "aimx port 25 connectivity check"
+assert_contains "port-check banner notes no install" "${_out}" "no install will be performed"
+
+# ---------------------------------------------------------------------------
 # 7c. SUDO prefix resolution — root-without-sudo path must succeed
 # ---------------------------------------------------------------------------
 
@@ -645,6 +819,10 @@ assert_contains "dry-run notes no FS changes" "${_out}" "no filesystem changes"
 # are the binary's job. The thin banner is just two lines.
 assert_not_contains "shell does not print checklist" "${_out}" "Preflight checks on port 25"
 assert_not_contains "shell does not print step 6 title" "${_out}" "Set up MCP for agent"
+
+# Dry-run must NOT run a port check (no port-check banner emitted).
+assert_not_contains "dry-run does not switch to port-check banner" "${_out}" "aimx port 25 connectivity check"
+assert_not_contains "dry-run does not show outbound check line" "${_out}" "Outbound port 25"
 
 # ---------------------------------------------------------------------------
 # Report

--- a/tests/install_sh.sh
+++ b/tests/install_sh.sh
@@ -734,6 +734,205 @@ assert_contains "port-check banner shows connectivity title" "${_out}" "aimx por
 assert_contains "port-check banner notes no install" "${_out}" "no install will be performed"
 
 # ---------------------------------------------------------------------------
+# 7d. AIMX_VERIFY_HOST gating — env var only validates on port-check path
+# ---------------------------------------------------------------------------
+#
+# Regression for review #6: `validate_verify_host` ran unconditionally in
+# main(), so a regular install with AIMX_VERIFY_HOST=garbage exported in
+# the operator's shell would fail before any install side effect even
+# though the env var only gates the port-check path.
+
+echo "# AIMX_VERIFY_HOST gating"
+
+# Regular install (dry-run) must NOT validate AIMX_VERIFY_HOST.
+_rc=0
+_out="$(
+    AIMX_DRY_RUN=1 \
+    AIMX_VERIFY_HOST=garbage \
+    AIMX_PREFIX="${_tmp}/bin" \
+    PATH="${_tmp}/bin:${PATH}" \
+    NO_COLOR=1 \
+    sh "${INSTALL_SH}" --target x86_64-unknown-linux-gnu --tag 0.1.0 2>&1
+)" || _rc=$?
+assert_zero "regular install ignores AIMX_VERIFY_HOST=garbage" "${_rc}"
+assert_not_contains "regular install does not run validate_verify_host" "${_out}" "verify-host must start with"
+
+# Port-check path WITH AIMX_VERIFY_HOST=garbage SHOULD fail validation.
+_rc=0
+_out="$(
+    AIMX_VERIFY_HOST=garbage \
+    sh "${INSTALL_SH}" --port-check-only 2>&1
+)" || _rc=$?
+if [ "${_rc}" -ne 0 ]; then
+    PASS=$((PASS + 1))
+    printf '  ok  --port-check-only validates AIMX_VERIFY_HOST (rc=%s)\n' "${_rc}"
+else
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES="${FAILED_NAMES} port-check-validates-env"
+    printf '  FAIL --port-check-only with AIMX_VERIFY_HOST=garbage should fail\n' >&2
+fi
+assert_contains "--port-check-only error names verify-host scheme" "${_out}" "verify-host must start with"
+
+# ---------------------------------------------------------------------------
+# 7e. Listener loop continue-on-timeout (review #2)
+# ---------------------------------------------------------------------------
+#
+# The Python listener heredoc must use `continue` (not `break`) on
+# socket.timeout so the deadline still bounds the loop while a second
+# probe attempt within the deadline is still served. Source-grep for the
+# guard rather than spawn a real listener.
+
+echo "# listener continue-on-timeout"
+
+# Pull lines after `except socket.timeout:` and look for `continue` (not `break`)
+# before the next `except` clause.
+_timeout_block="$(awk '
+    /except socket.timeout:/ {found=1; next}
+    found && /except / {found=0}
+    found {print}
+' "${INSTALL_SH}")"
+case "${_timeout_block}" in
+    *continue*)
+        PASS=$((PASS + 1))
+        printf '  ok  listener loop uses continue on socket.timeout\n'
+        ;;
+    *)
+        FAIL=$((FAIL + 1))
+        FAILED_NAMES="${FAILED_NAMES} listener-continue-on-timeout"
+        printf '  FAIL listener loop should `continue` on socket.timeout, not `break`\n' >&2
+        ;;
+esac
+case "${_timeout_block}" in
+    *break*)
+        FAIL=$((FAIL + 1))
+        FAILED_NAMES="${FAILED_NAMES} listener-no-break-on-timeout"
+        printf '  FAIL listener loop still has `break` in socket.timeout handler\n' >&2
+        ;;
+    *)
+        PASS=$((PASS + 1))
+        printf '  ok  listener loop has no `break` in socket.timeout handler\n'
+        ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 7f. Listener bind liveness probe (review #1)
+# ---------------------------------------------------------------------------
+#
+# When the temp listener fails to bind (bind() race / EACCES), python
+# exits 1 silently. The shell must `kill -0 ${_listener_pid}` after the
+# bind delay and surface a distinct error rather than letting /probe
+# report a generic "unreachable".
+
+echo "# listener bind liveness"
+
+if grep -q 'kill -0 "\${_listener_pid}"' "${INSTALL_SH}"; then
+    PASS=$((PASS + 1))
+    printf '  ok  port_check_inbound has kill -0 liveness probe on listener pid\n'
+else
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES="${FAILED_NAMES} listener-liveness-probe"
+    printf '  FAIL port_check_inbound missing kill -0 liveness probe on listener pid\n' >&2
+fi
+if grep -q 'failed to spawn temp listener on :25' "${INSTALL_SH}"; then
+    PASS=$((PASS + 1))
+    printf '  ok  liveness probe surfaces a distinct bind-failed message\n'
+else
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES="${FAILED_NAMES} listener-bind-msg"
+    printf '  FAIL bind-failed listener path missing distinct error message\n' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# 7g. Occupancy warning (review #4)
+# ---------------------------------------------------------------------------
+#
+# When port 25 is held by another process (Postfix/Sendmail/Exim), /probe
+# will report success against THAT daemon's banner. The shell must warn
+# operators that the green [ok] is only meaningful if the holder is aimx.
+
+echo "# occupancy warning"
+
+if grep -q "port 25 is held by another process" "${INSTALL_SH}"; then
+    PASS=$((PASS + 1))
+    printf '  ok  port_check_inbound warns when port 25 is occupied\n'
+else
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES="${FAILED_NAMES} occupancy-warning"
+    printf '  FAIL port_check_inbound missing occupancy warning\n' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# 7h. Missing-curl exit code is 2 (review #5)
+# ---------------------------------------------------------------------------
+#
+# port_check_main MUST exit 2 when curl is missing (documented contract:
+# 0 pass-or-skip, 1 fail, 2 missing required tool). The previous
+# implementation used `need curl`, which exits 1 — wrong for this path.
+# Source-grep proves the explicit `return 2` is in place; the previous
+# `need curl` line must be gone from port_check_main.
+
+echo "# missing-curl exits 2"
+
+# Find port_check_main body (between its opening and closing brace).
+_pc_main_start="$(grep -n '^port_check_main()' "${INSTALL_SH}" | head -n1 | cut -d: -f1)"
+if [ -n "${_pc_main_start}" ]; then
+    # Everything from port_check_main() until the next top-level `}` line.
+    _pc_main_body="$(awk '
+        $0 ~ /^port_check_main\(\)/ {inside=1}
+        inside {print}
+        inside && /^}/ {inside=0}
+    ' "${INSTALL_SH}")"
+    case "${_pc_main_body}" in
+        *"required command not found: curl"*)
+            PASS=$((PASS + 1))
+            printf '  ok  port_check_main uses explicit curl check\n'
+            ;;
+        *)
+            FAIL=$((FAIL + 1))
+            FAILED_NAMES="${FAILED_NAMES} missing-curl-explicit-check"
+            printf '  FAIL port_check_main missing explicit curl check\n' >&2
+            ;;
+    esac
+    case "${_pc_main_body}" in
+        *"need curl"*)
+            FAIL=$((FAIL + 1))
+            FAILED_NAMES="${FAILED_NAMES} missing-curl-old-need"
+            printf '  FAIL port_check_main still calls `need curl` (exits 1, should exit 2)\n' >&2
+            ;;
+        *)
+            PASS=$((PASS + 1))
+            printf '  ok  port_check_main no longer calls `need curl`\n'
+            ;;
+    esac
+else
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES="${FAILED_NAMES} port-check-main-missing"
+    printf '  FAIL could not locate port_check_main() in install.sh\n' >&2
+fi
+
+# Live test: with curl scrubbed from PATH, --port-check-only must exit 2.
+_isobin2="${_tmp}/iso-bin-no-curl"
+mkdir -p "${_isobin2}"
+for _t in uname tar mkdir rm install awk sed grep cat date mktemp sh head cut sort dirname basename id; do
+    for _d in /usr/bin /bin; do
+        if [ -x "${_d}/$_t" ]; then
+            ln -sf "${_d}/$_t" "${_isobin2}/$_t"
+            break
+        fi
+    done
+done
+
+_rc=0
+_out="$(
+    PATH="${_isobin2}" \
+        sh "${INSTALL_SH}" --port-check-only 2>&1
+)" || _rc=$?
+assert_eq "--port-check-only without curl exits 2" "2" "${_rc}"
+assert_contains "--port-check-only without curl names curl" "${_out}" "curl"
+
+rm -rf "${_isobin2}"
+
+# ---------------------------------------------------------------------------
 # 7c. SUDO prefix resolution — root-without-sudo path must succeed
 # ---------------------------------------------------------------------------
 

--- a/website/public/index.html
+++ b/website/public/index.html
@@ -454,7 +454,11 @@ footer a:hover {
 <pre class="code">curl -fsSL https://aimx.email/install.sh | sh
 sudo aimx setup</pre>
       <p class="prose" style="margin-top: 1.1em;">
-        You need sudo — port 25 is privileged. A VPS with port 25 open (inbound and outbound) and a domain you control are the only requirements. Want to see the script before running it? <a href="/install.sh">Read <code>install.sh</code></a>.
+        You need sudo — port 25 is privileged. A VPS with port 25 open (inbound and outbound) and a domain you control are the only requirements. Not sure your VPS allows port 25? Check first, no install:
+      </p>
+<pre class="code">curl -fsSL https://aimx.email/install.sh | sh -s -- --port-check-only</pre>
+      <p class="prose" style="margin-top: 1.1em;">
+        Want to see the script before running it? <a href="/install.sh">Read <code>install.sh</code></a>.
       </p>
     </section>
 


### PR DESCRIPTION
## Summary
Add `--port-check-only` flag to install.sh that runs the same outbound + inbound port-25 checks as `aimx portcheck`, then exits without installing. Lets evaluators verify a VPS can reach SMTP before committing to install/setup.

One-liner:
```sh
curl -fsSL https://aimx.email/install.sh | sh -s -- --port-check-only
```

## Requirements
- [x] `--port-check-only` flag short-circuits before install path
- [x] `--verify-host <URL>` flag + `AIMX_VERIFY_HOST` env var override default `https://check.aimx.email`
- [x] `--help` text lists new flag, env var, and a curl-pipe example
- [x] Outbound EHLO via TCP+EHLO, mirroring `RealNetworkOps::check_outbound_port25` (src/setup.rs:829-876)
- [x] Outbound implementation ladder: python3 → nc → bash /dev/tcp; exit 2 with hint when none available
- [x] Inbound `/probe` call via curl with loose `"reachable":true` substring match (src/setup.rs:774-787)
- [x] Non-root → inbound `[skip]` (does NOT fail exit code); root + occupied → call /probe directly; root + free → spawn temp Python listener; root + free + no python3 → `[skip]`
- [x] Banner switches to "aimx port 25 connectivity check (no install will be performed)" when --port-check-only set
- [x] Output styling reuses ui_info / ui_success / ui_warn / ui_error helpers
- [x] Exit codes: 0 pass-or-skip, 1 fail, 2 missing required tool
- [x] Cannot trigger any install side-effect (branches before ensure_sudo / network / fs writes)
- [x] POSIX sh, `sh -n install.sh` passes
- [x] tests/install_sh.sh extended with parse_args + verify-host validation cases
- [x] Existing `AIMX_DRY_RUN=1` behavior unchanged

## Out of scope
- No new website asset (no `chkport25.sh`); folded into install.sh by explicit decision
- No changes to the `aimx portcheck` Rust subcommand
- No authenticated /probe calls or rate-limit handling
- Best-effort dual-stack handling for IPv6-only environments

## Technical approach
- New top-level state vars `PORT_CHECK_ONLY=0`, `VERIFY_HOST=""`, `DEFAULT_VERIFY_HOST="https://check.aimx.email"`.
- parse_args adds `--port-check-only`, `--verify-host`, and `--verify-host=<URL>` cases.
- main() resolves env-var precedence (flag → AIMX_VERIFY_HOST → default), validates the scheme, then short-circuits to `port_check_main` before any privileged or networked work.
- Outbound EHLO mirrors `check_outbound_port25` byte-for-byte (220 banner, EHLO aimx, consume 250- continuations, accept on 250 SP, QUIT).
- Temp listener is Python-only (matches `with_temp_smtp_listener` in src/portcheck.rs:69-129); nc -l semantics vary too widely between BSD/GNU/ncat to support reliably.
- /probe parsing is loose `"reachable":true` substring match (same as src/setup.rs:783) plus a sed extraction for the `ip` field.

## Test plan
- [x] `sh -n install.sh` (POSIX syntax)
- [x] `sh tests/install_sh.sh` (existing + new assertions all pass)
- [x] `sh install.sh --port-check-only --help` exits 0
- [x] `sh install.sh --help | grep -q port-check-only` exits 0
- [x] `AIMX_DRY_RUN=1 sh install.sh` still produces the existing dry-run output (no port check)
- Manual smoke (operator): `sh install.sh --port-check-only` non-root → outbound runs, inbound [skip]; `sudo sh install.sh --port-check-only` on a port-25-open VPS → both [ok]
- Site CI gate: `.github/workflows/site.yml:51` already runs `sh -n website/dist/install.sh` after `make build`; no change needed there

## Notes
- Honors HTTPS-only trust anchor for the verify-host when scheme is https; allows http only for self-hosted dev verifiers (matches `validate_verify_host` in src/setup.rs:790-801).
- Listener lifecycle: spawned with `&`, PID captured, killed after /probe returns; SO_REUSEADDR set so re-runs don't TIME_WAIT-block.