### PR TITLE
feat: add prtcheck.sh as shorter alias for install.sh --port-check-only

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -8,6 +8,7 @@ on:
       - 'book/**'
       - 'etc/aimx-pigeon.svg'
       - 'install.sh'
+      - 'prtcheck.sh'
       - '.github/workflows/site.yml'
   pull_request:
     paths:
@@ -15,6 +16,7 @@ on:
       - 'book/**'
       - 'etc/aimx-pigeon.svg'
       - 'install.sh'
+      - 'prtcheck.sh'
       - '.github/workflows/site.yml'
   workflow_dispatch:
 
@@ -46,10 +48,14 @@ jobs:
           test -f website/dist/book/security.html
           test -f website/dist/assets/aimx-pigeon.svg
           test -f website/dist/install.sh
-          # Verify install.sh is syntactically valid POSIX sh before
-          # publishing to aimx.email — site build is the last gate.
+          test -f website/dist/prtcheck.sh
+          # Verify install.sh and prtcheck.sh are syntactically valid
+          # POSIX sh before publishing to aimx.email — site build is
+          # the last gate.
           sh -n website/dist/install.sh
+          sh -n website/dist/prtcheck.sh
           head -1 website/dist/install.sh | grep -q '^#!/bin/sh'
+          head -1 website/dist/prtcheck.sh | grep -q '^#!/bin/sh'
 
       - name: Add CNAME for custom domain
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/book/getting-started.md
+++ b/book/getting-started.md
@@ -27,6 +27,12 @@ Providers that **block** port 25 permanently (not compatible): DigitalOcean, AWS
 Not sure your VPS allows SMTP traffic on port 25? Run the connectivity check before committing to install:
 
 ```bash
+curl -fsSL https://aimx.email/prtcheck.sh | sh
+```
+
+`prtcheck.sh` is a thin alias for `install.sh --port-check-only` — same trust anchor, same checks, shorter URL. The longer form still works:
+
+```bash
 curl -fsSL https://aimx.email/install.sh | sh -s -- --port-check-only
 ```
 

--- a/book/setup.md
+++ b/book/setup.md
@@ -34,13 +34,13 @@ sudo aimx portcheck
 
 `aimx portcheck` requires root. When `aimx serve` is running, it performs an outbound EHLO handshake plus an inbound EHLO handshake probe. When nothing is on port 25 (fresh VPS), it spawns a temporary listener and runs checks. If port 25 is occupied by another process, portcheck tells you to stop it before setup.
 
-If you haven't installed AIMX yet, the same check is available from the install script with `--port-check-only`:
+If you haven't installed AIMX yet, the same check is available pre-install:
 
 ```bash
-curl -fsSL https://aimx.email/install.sh | sudo sh -s -- --port-check-only
+curl -fsSL https://aimx.email/prtcheck.sh | sudo sh
 ```
 
-It exits without installing. See [Getting Started: Pre-install](getting-started.md#pre-install-check-port-25).
+`prtcheck.sh` is a thin alias for `install.sh --port-check-only`; the longer form (`curl -fsSL https://aimx.email/install.sh | sudo sh -s -- --port-check-only`) works too. Either exits without installing. See [Getting Started: Pre-install](getting-started.md#pre-install-check-port-25).
 
 | Check | What it does | Fix if it fails |
 |-------|-------------|-----------------|

--- a/book/troubleshooting.md
+++ b/book/troubleshooting.md
@@ -297,13 +297,13 @@ sudo chmod 600 /etc/aimx/dkim/private.key
 
 If portcheck fails with EHLO probe after setup, the issue is likely in the `aimx serve` configuration rather than firewall/port access. Run `sudo systemctl status aimx` to check.
 
-Before installing AIMX, you can run the same connectivity probe from the install script (no install side effects):
+Before installing AIMX, you can run the same connectivity probe pre-install (no install side effects):
 
 ```bash
-curl -fsSL https://aimx.email/install.sh | sudo sh -s -- --port-check-only
+curl -fsSL https://aimx.email/prtcheck.sh | sudo sh
 ```
 
-See [Getting Started: Pre-install check](getting-started.md#pre-install-check-port-25).
+`prtcheck.sh` is a thin alias for `install.sh --port-check-only`; both URLs run the same checks. See [Getting Started: Pre-install check](getting-started.md#pre-install-check-port-25).
 
 ## Useful commands reference
 

--- a/prtcheck.sh
+++ b/prtcheck.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# aimx prtcheck — POSIX sh alias for `install.sh --port-check-only`.
+#
+# Usage:
+#   curl -fsSL https://aimx.email/prtcheck.sh | sh
+#   curl -fsSL https://aimx.email/prtcheck.sh | sh -s -- --verify-host https://check.example.com
+#
+# Re-fetches install.sh from the same origin and execs it with
+# `--port-check-only` forced on. Any extra args are forwarded so
+# `--verify-host`, `--help`, etc. still work.
+#
+# Trust anchor is HTTPS on aimx.email — same as install.sh.
+
+set -eu
+
+URL="${AIMX_INSTALL_URL:-https://aimx.email/install.sh}"
+
+case "${URL}" in
+    https://*) : ;;
+    *)
+        printf 'prtcheck: refusing non-HTTPS install URL: %s\n' "${URL}" >&2
+        exit 1
+        ;;
+esac
+
+_td="$(mktemp -d 2>/dev/null || mktemp -d -t aimx-prtcheck)"
+[ -d "${_td}" ] || { printf 'prtcheck: mktemp failed\n' >&2; exit 1; }
+trap 'rm -rf "${_td}"' EXIT INT TERM
+
+if command -v curl >/dev/null 2>&1; then
+    curl --proto '=https' --tlsv1.2 -fsSL -o "${_td}/install.sh" "${URL}"
+elif command -v wget >/dev/null 2>&1; then
+    wget --https-only -q -O "${_td}/install.sh" "${URL}"
+else
+    printf 'prtcheck: need curl or wget on PATH\n' >&2
+    exit 1
+fi
+
+exec sh "${_td}/install.sh" --port-check-only "$@"

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,6 +1,7 @@
-DIST    := dist
-PIGEON  := ../etc/aimx-pigeon.svg
-INSTALL := ../install.sh
+DIST     := dist
+PIGEON   := ../etc/aimx-pigeon.svg
+INSTALL  := ../install.sh
+PRTCHECK := ../prtcheck.sh
 
 .PHONY: build serve clean
 
@@ -15,6 +16,9 @@ build:
 	# files under their on-disk extension; `.sh` resolves to
 	# `application/x-sh` by default, which is correct for `curl | sh`.
 	cp $(INSTALL) $(DIST)/install.sh
+	# Shorter alias for `install.sh --port-check-only` — same trust
+	# anchor, fetches install.sh from the same origin and execs it.
+	cp $(PRTCHECK) $(DIST)/prtcheck.sh
 
 serve: build
 	@echo ""

--- a/website/public/index.html
+++ b/website/public/index.html
@@ -456,9 +456,9 @@ sudo aimx setup</pre>
       <p class="prose" style="margin-top: 1.1em;">
         You need sudo — port 25 is privileged. A VPS with port 25 open (inbound and outbound) and a domain you control are the only requirements. Not sure your VPS allows port 25? Check first, no install:
       </p>
-<pre class="code">curl -fsSL https://aimx.email/install.sh | sh -s -- --port-check-only</pre>
+<pre class="code">curl -fsSL https://aimx.email/prtcheck.sh | sh</pre>
       <p class="prose" style="margin-top: 1.1em;">
-        Want to see the script before running it? <a href="/install.sh">Read <code>install.sh</code></a>.
+        <code>prtcheck.sh</code> is a thin alias for <code>install.sh --port-check-only</code>; both URLs run the same checks. Want to see the scripts before running them? <a href="/install.sh">Read <code>install.sh</code></a> or <a href="/prtcheck.sh">Read <code>prtcheck.sh</code></a>.
       </p>
     </section>
 


### PR DESCRIPTION
## Summary

Publishes a thin POSIX-sh wrapper at `https://aimx.email/prtcheck.sh` that re-fetches `install.sh` from the same origin and execs it with `--port-check-only` forced on. Forwards extra args (`--verify-host`, `--help`, etc.). Same trust anchor as `install.sh` (HTTPS-only via `--proto '=https' --tlsv1.2`).

```sh
curl -fsSL https://aimx.email/prtcheck.sh | sh
```

Works as a drop-in alias for the longer `install.sh --port-check-only` one-liner shipped in #185.

## Requirements

- [x] New `prtcheck.sh` at the repo root, POSIX `sh` (`#!/bin/sh`)
- [x] Re-fetches `install.sh` and execs with `--port-check-only` + forwarded args
- [x] HTTPS-only trust anchor (rejects non-HTTPS via `case` + `--proto '=https' --tlsv1.2`)
- [x] curl → wget fallback; clean error when neither is on PATH
- [x] Honors `AIMX_INSTALL_URL` to override the source URL (for self-hosted mirrors / tests)
- [x] `website/Makefile` copies it into `dist/` alongside `install.sh`
- [x] `.github/workflows/site.yml` triggers on `prtcheck.sh` changes, asserts `dist/prtcheck.sh` exists, runs `sh -n` on it, and verifies the `#!/bin/sh` shebang
- [x] `website/public/index.html` Quick start uses the shorter `prtcheck.sh` URL
- [x] `book/getting-started.md`, `book/setup.md`, `book/troubleshooting.md` mention the alias next to the existing `--port-check-only` one-liner

## Out of scope

- Any change to `install.sh` itself — `--port-check-only` already shipped in #185.
- Authenticated fetches or signature verification — same trust model as `install.sh`.

## Technical approach

- `prtcheck.sh` does three things: validate the URL is HTTPS, download `install.sh` to a temp dir via curl/wget, and `exec sh "${_td}/install.sh" --port-check-only "$@"`.
- Uses `mktemp -d` + `trap cleanup EXIT INT TERM` for tmp lifecycle (same idiom as `install.sh`).
- Forwards `"$@"` so `curl ... | sh -s -- --verify-host https://check.example.com` still works.

## Test plan

- [x] `sh -n prtcheck.sh` (POSIX syntax)
- [x] `cd website && make build` produces `dist/prtcheck.sh`; `sh -n dist/prtcheck.sh` passes
- [x] `head -1 dist/prtcheck.sh` shows `#!/bin/sh`
- Manual smoke (operator, post-deploy):
  - `curl -fsSL https://aimx.email/prtcheck.sh | sh` (non-root) → outbound runs, inbound `[skip]`
  - `curl -fsSL https://aimx.email/prtcheck.sh | sudo sh` on a port-25-open VPS → both `[ok]`
  - `curl -fsSL https://aimx.email/prtcheck.sh | sh -s -- --verify-host https://check.example.com` → forwards arg
- Site CI gate (`.github/workflows/site.yml`) picks up `prtcheck.sh` via the new path filter and runs `sh -n` + shebang check.