### PR TITLE
fix: rename prtcheck.sh to portcheck.sh (typo)

### DIFF
--- a/.github/workflows/site.yml
+++ b/.github/workflows/site.yml
@@ -8,7 +8,7 @@ on:
       - 'book/**'
       - 'etc/aimx-pigeon.svg'
       - 'install.sh'
-      - 'prtcheck.sh'
+      - 'portcheck.sh'
       - '.github/workflows/site.yml'
   pull_request:
     paths:
@@ -16,7 +16,7 @@ on:
       - 'book/**'
       - 'etc/aimx-pigeon.svg'
       - 'install.sh'
-      - 'prtcheck.sh'
+      - 'portcheck.sh'
       - '.github/workflows/site.yml'
   workflow_dispatch:
 
@@ -48,14 +48,14 @@ jobs:
           test -f website/dist/book/security.html
           test -f website/dist/assets/aimx-pigeon.svg
           test -f website/dist/install.sh
-          test -f website/dist/prtcheck.sh
-          # Verify install.sh and prtcheck.sh are syntactically valid
+          test -f website/dist/portcheck.sh
+          # Verify install.sh and portcheck.sh are syntactically valid
           # POSIX sh before publishing to aimx.email — site build is
           # the last gate.
           sh -n website/dist/install.sh
-          sh -n website/dist/prtcheck.sh
+          sh -n website/dist/portcheck.sh
           head -1 website/dist/install.sh | grep -q '^#!/bin/sh'
-          head -1 website/dist/prtcheck.sh | grep -q '^#!/bin/sh'
+          head -1 website/dist/portcheck.sh | grep -q '^#!/bin/sh'
 
       - name: Add CNAME for custom domain
         if: github.event_name == 'push' && github.ref == 'refs/heads/main'

--- a/book/getting-started.md
+++ b/book/getting-started.md
@@ -27,10 +27,10 @@ Providers that **block** port 25 permanently (not compatible): DigitalOcean, AWS
 Not sure your VPS allows SMTP traffic on port 25? Run the connectivity check before committing to install:
 
 ```bash
-curl -fsSL https://aimx.email/prtcheck.sh | sh
+curl -fsSL https://aimx.email/portcheck.sh | sh
 ```
 
-`prtcheck.sh` is a thin alias for `install.sh --port-check-only` — same trust anchor, same checks, shorter URL. The longer form still works:
+`portcheck.sh` is a thin alias for `install.sh --port-check-only` — same trust anchor, same checks, shorter URL. The longer form still works:
 
 ```bash
 curl -fsSL https://aimx.email/install.sh | sh -s -- --port-check-only

--- a/book/setup.md
+++ b/book/setup.md
@@ -37,10 +37,10 @@ sudo aimx portcheck
 If you haven't installed AIMX yet, the same check is available pre-install:
 
 ```bash
-curl -fsSL https://aimx.email/prtcheck.sh | sudo sh
+curl -fsSL https://aimx.email/portcheck.sh | sudo sh
 ```
 
-`prtcheck.sh` is a thin alias for `install.sh --port-check-only`; the longer form (`curl -fsSL https://aimx.email/install.sh | sudo sh -s -- --port-check-only`) works too. Either exits without installing. See [Getting Started: Pre-install](getting-started.md#pre-install-check-port-25).
+`portcheck.sh` is a thin alias for `install.sh --port-check-only`; the longer form (`curl -fsSL https://aimx.email/install.sh | sudo sh -s -- --port-check-only`) works too. Either exits without installing. See [Getting Started: Pre-install](getting-started.md#pre-install-check-port-25).
 
 | Check | What it does | Fix if it fails |
 |-------|-------------|-----------------|

--- a/book/troubleshooting.md
+++ b/book/troubleshooting.md
@@ -300,10 +300,10 @@ If portcheck fails with EHLO probe after setup, the issue is likely in the `aimx
 Before installing AIMX, you can run the same connectivity probe pre-install (no install side effects):
 
 ```bash
-curl -fsSL https://aimx.email/prtcheck.sh | sudo sh
+curl -fsSL https://aimx.email/portcheck.sh | sudo sh
 ```
 
-`prtcheck.sh` is a thin alias for `install.sh --port-check-only`; both URLs run the same checks. See [Getting Started: Pre-install check](getting-started.md#pre-install-check-port-25).
+`portcheck.sh` is a thin alias for `install.sh --port-check-only`; both URLs run the same checks. See [Getting Started: Pre-install check](getting-started.md#pre-install-check-port-25).
 
 ## Useful commands reference
 

--- a/portcheck.sh
+++ b/portcheck.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
-# aimx prtcheck — POSIX sh alias for `install.sh --port-check-only`.
+# aimx portcheck — POSIX sh alias for `install.sh --port-check-only`.
 #
 # Usage:
-#   curl -fsSL https://aimx.email/prtcheck.sh | sh
-#   curl -fsSL https://aimx.email/prtcheck.sh | sh -s -- --verify-host https://check.example.com
+#   curl -fsSL https://aimx.email/portcheck.sh | sh
+#   curl -fsSL https://aimx.email/portcheck.sh | sh -s -- --verify-host https://check.example.com
 #
 # Re-fetches install.sh from the same origin and execs it with
 # `--port-check-only` forced on. Any extra args are forwarded so
@@ -18,13 +18,13 @@ URL="${AIMX_INSTALL_URL:-https://aimx.email/install.sh}"
 case "${URL}" in
     https://*) : ;;
     *)
-        printf 'prtcheck: refusing non-HTTPS install URL: %s\n' "${URL}" >&2
+        printf 'portcheck: refusing non-HTTPS install URL: %s\n' "${URL}" >&2
         exit 1
         ;;
 esac
 
-_td="$(mktemp -d 2>/dev/null || mktemp -d -t aimx-prtcheck)"
-[ -d "${_td}" ] || { printf 'prtcheck: mktemp failed\n' >&2; exit 1; }
+_td="$(mktemp -d 2>/dev/null || mktemp -d -t aimx-portcheck)"
+[ -d "${_td}" ] || { printf 'portcheck: mktemp failed\n' >&2; exit 1; }
 trap 'rm -rf "${_td}"' EXIT INT TERM
 
 if command -v curl >/dev/null 2>&1; then
@@ -32,7 +32,7 @@ if command -v curl >/dev/null 2>&1; then
 elif command -v wget >/dev/null 2>&1; then
     wget --https-only -q -O "${_td}/install.sh" "${URL}"
 else
-    printf 'prtcheck: need curl or wget on PATH\n' >&2
+    printf 'portcheck: need curl or wget on PATH\n' >&2
     exit 1
 fi
 

--- a/website/Makefile
+++ b/website/Makefile
@@ -1,7 +1,7 @@
-DIST     := dist
-PIGEON   := ../etc/aimx-pigeon.svg
-INSTALL  := ../install.sh
-PRTCHECK := ../prtcheck.sh
+DIST      := dist
+PIGEON    := ../etc/aimx-pigeon.svg
+INSTALL   := ../install.sh
+PORTCHECK := ../portcheck.sh
 
 .PHONY: build serve clean
 
@@ -18,7 +18,7 @@ build:
 	cp $(INSTALL) $(DIST)/install.sh
 	# Shorter alias for `install.sh --port-check-only` — same trust
 	# anchor, fetches install.sh from the same origin and execs it.
-	cp $(PRTCHECK) $(DIST)/prtcheck.sh
+	cp $(PORTCHECK) $(DIST)/portcheck.sh
 
 serve: build
 	@echo ""

--- a/website/public/index.html
+++ b/website/public/index.html
@@ -456,9 +456,9 @@ sudo aimx setup</pre>
       <p class="prose" style="margin-top: 1.1em;">
         You need sudo — port 25 is privileged. A VPS with port 25 open (inbound and outbound) and a domain you control are the only requirements. Not sure your VPS allows port 25? Check first, no install:
       </p>
-<pre class="code">curl -fsSL https://aimx.email/prtcheck.sh | sh</pre>
+<pre class="code">curl -fsSL https://aimx.email/portcheck.sh | sh</pre>
       <p class="prose" style="margin-top: 1.1em;">
-        <code>prtcheck.sh</code> is a thin alias for <code>install.sh --port-check-only</code>; both URLs run the same checks. Want to see the scripts before running them? <a href="/install.sh">Read <code>install.sh</code></a> or <a href="/prtcheck.sh">Read <code>prtcheck.sh</code></a>.
+        <code>portcheck.sh</code> is a thin alias for <code>install.sh --port-check-only</code>; both URLs run the same checks. Want to see the scripts before running them? <a href="/install.sh">Read <code>install.sh</code></a> or <a href="/portcheck.sh">Read <code>portcheck.sh</code></a>.
       </p>
     </section>
 


### PR DESCRIPTION
## Summary

Renames the `install.sh --port-check-only` alias from the typo'd `prtcheck.sh` (shipped in #186) to `portcheck.sh`. Same script, same trust anchor, same forwarding behavior — only the filename and the surfaced URL change.

```sh
curl -fsSL https://aimx.email/portcheck.sh | sh
```

## Requirements

- [x] `prtcheck.sh` → `portcheck.sh` (file rename via `git mv`)
- [x] Script-internal references updated (header comment, error message prefixes, `mktemp -t` template)
- [x] `website/Makefile` `PRTCHECK` var → `PORTCHECK`, source path, and `dist/` filename
- [x] `.github/workflows/site.yml` path filter, `dist/portcheck.sh` existence check, `sh -n` invocation, shebang assertion
- [x] `website/public/index.html` Quick start URL + "read the script" link
- [x] `book/getting-started.md`, `book/setup.md`, `book/troubleshooting.md` URLs and prose mentions

## Out of scope

- No behavioral changes to the script itself.
- The old `prtcheck.sh` URL on `aimx.email` will 404 once this merges and GitHub Pages redeploys. That's the intended outcome — a 404 is better than silently serving a typo'd asset.

## Test plan

- [x] `sh -n portcheck.sh` (POSIX syntax)
- [x] `cd website && make build` produces `dist/portcheck.sh`; `sh -n dist/portcheck.sh` passes; `head -1 dist/portcheck.sh` is `#!/bin/sh`
- [x] `grep -rn prtcheck` across the tree returns no matches (no stragglers)

After merge: site CI deploys `aimx.email/portcheck.sh`; the typo'd URL returns 404.