### PR TITLE
fix(install.sh): unblock listener spawn and self-escalate to sudo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -716,16 +716,82 @@ port_check_detect_occupancy() {
     printf 'unknown'
 }
 
+# File where port_check_listener_start writes the python child's stderr.
+# Set lazily on first use so non-port-check codepaths don't allocate it.
+_PORT_CHECK_LISTENER_STDERR=""
+
+# Privilege prefix the listener spawn / kill / kill-0 use. Set by
+# port_check_ensure_inbound_privilege:
+#   - already root (euid 0)              → ""    (run directly)
+#   - non-root + sudo + creds OK         → "sudo"
+#   - non-root + no sudo / creds refused → still "" (caller skips inbound)
+_PORT_CHECK_SUDO=""
+
+# Validate that the inbound check has the privilege it needs to bind :25.
+# Returns 0 when we can proceed (root, or sudo creds are cached/granted),
+# 1 when we cannot (non-root + no sudo, or sudo prompt failed). Mirrors
+# install.sh's `ensure_sudo` flow but never `exit`s — port-check failure
+# is a soft skip, not a fatal install error.
+port_check_ensure_inbound_privilege() {
+    _PORT_CHECK_SUDO=""
+    _euid="$(id -u 2>/dev/null || echo 0)"
+    if [ "${_euid}" -eq 0 ]; then
+        return 0
+    fi
+    if ! command -v sudo >/dev/null 2>&1; then
+        return 1
+    fi
+    if ! sudo -n true >/dev/null 2>&1; then
+        ui_info "Inbound check needs root to bind port 25; enter your password"
+        _sudo_rc=0
+        # Same TTY logic as ensure_sudo: only re-point stdin at /dev/tty
+        # when the script's stdin is NOT already a terminal. This matters
+        # for `curl ... | sh` where stdin is the curl pipe.
+        if [ -t 0 ]; then
+            sudo -v || _sudo_rc=$?
+        elif [ -e /dev/tty ] && [ -r /dev/tty ]; then
+            (sudo -v </dev/tty) || _sudo_rc=$?
+        else
+            sudo -v || _sudo_rc=$?
+        fi
+        if [ "${_sudo_rc}" -ne 0 ]; then
+            return 1
+        fi
+    fi
+    _PORT_CHECK_SUDO="sudo"
+    return 0
+}
+
 # Spawn a temp Python SMTP listener on :25. Echoes the PID on stdout so the
 # caller can kill it after /probe returns. Mirrors src/portcheck.rs:69-129.
+#
+# Two non-obvious things matter here:
+#
+#   1. Python's stdout MUST be redirected to /dev/null (not the default
+#      inherited stdout). When the function is called via `$(...)` the
+#      subshell's stdout is a capture pipe; the backgrounded python
+#      child inherits it and holds the write end open for its full
+#      ~30s lifetime, so the parent's read on `$()` blocks until python
+#      exits. The result before this redirect: kill -0 ALWAYS reported
+#      "dead" because $() didn't return until python had already exited.
+#
+#   2. Python's stderr is captured to a tmpfile so port_check_inbound can
+#      surface the actual bind error (e.g. "Address already in use") on
+#      failure instead of a generic "another binder won the race?".
 port_check_listener_start() {
-    python3 - <<'PYEOF' &
+    if [ -z "${_PORT_CHECK_LISTENER_STDERR}" ]; then
+        _PORT_CHECK_LISTENER_STDERR="$(mktemp -t aimx-portcheck-listener.XXXXXX 2>/dev/null \
+            || echo "/tmp/aimx-portcheck-listener.$$")"
+    fi
+    : > "${_PORT_CHECK_LISTENER_STDERR}" 2>/dev/null || true
+    ${_PORT_CHECK_SUDO} python3 - >/dev/null 2>"${_PORT_CHECK_LISTENER_STDERR}" <<'PYEOF' &
 import socket, sys, time
 s = socket.socket()
 s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 try:
     s.bind(('0.0.0.0', 25))
-except Exception:
+except Exception as e:
+    print("listener bind error:", e, file=sys.stderr)
     sys.exit(1)
 s.listen(8)
 deadline = time.time() + 30
@@ -763,11 +829,20 @@ PYEOF
     printf '%s' "$!"
 }
 
+# kill-0 + kill use ${_PORT_CHECK_SUDO} so the non-root caller can signal
+# the root-owned python child.
 port_check_listener_stop() {
     _pid="$1"
-    if [ -n "${_pid}" ] && kill -0 "${_pid}" 2>/dev/null; then
-        kill "${_pid}" 2>/dev/null || true
+    if [ -z "${_pid}" ]; then
+        return 0
+    fi
+    if ${_PORT_CHECK_SUDO} kill -0 "${_pid}" 2>/dev/null; then
+        ${_PORT_CHECK_SUDO} kill "${_pid}" 2>/dev/null || true
         wait "${_pid}" 2>/dev/null || true
+    fi
+    if [ -n "${_PORT_CHECK_LISTENER_STDERR}" ] \
+        && [ -f "${_PORT_CHECK_LISTENER_STDERR}" ]; then
+        rm -f "${_PORT_CHECK_LISTENER_STDERR}" 2>/dev/null || true
     fi
 }
 
@@ -797,10 +872,11 @@ port_check_inbound() {
     _PORT_CHECK_INBOUND_IP=""
     _PORT_CHECK_INBOUND_MSG=""
 
-    _euid="$(id -u 2>/dev/null || echo 0)"
-    if [ "${_euid}" -ne 0 ]; then
+    # Need root (or sudo) to bind :25. Tries sudo cred refresh when
+    # non-root + sudo is available; falls back to skip when not.
+    if ! port_check_ensure_inbound_privilege; then
         _PORT_CHECK_INBOUND_STATE="skip"
-        _PORT_CHECK_INBOUND_MSG="inbound check requires root (re-run with sudo)"
+        _PORT_CHECK_INBOUND_MSG="inbound check requires root and sudo is unavailable; re-run as root"
         return 0
     fi
 
@@ -824,13 +900,18 @@ port_check_inbound() {
         # Give the listener a moment to bind before /probe fires.
         sleep 1
         # Liveness probe: if the python child died (bind() failed —
-        # race / EACCES / port stolen), surface that as a distinct
-        # error rather than letting /probe report a generic
-        # "unreachable". Mirrors the synchronous bind+error in
-        # src/portcheck.rs:44-53.
-        if ! kill -0 "${_listener_pid}" 2>/dev/null; then
+        # race / EACCES / port stolen), surface the actual python
+        # stderr rather than a generic "unreachable". Mirrors the
+        # synchronous bind+error in src/portcheck.rs:44-53.
+        if ! ${_PORT_CHECK_SUDO} kill -0 "${_listener_pid}" 2>/dev/null; then
             _PORT_CHECK_INBOUND_STATE="fail"
-            _PORT_CHECK_INBOUND_MSG="failed to spawn temp listener on :25 (bind failed; another binder won the race?)"
+            _err=""
+            if [ -n "${_PORT_CHECK_LISTENER_STDERR}" ] \
+                && [ -s "${_PORT_CHECK_LISTENER_STDERR}" ]; then
+                _err=" ($(head -n 1 "${_PORT_CHECK_LISTENER_STDERR}" 2>/dev/null))"
+                rm -f "${_PORT_CHECK_LISTENER_STDERR}" 2>/dev/null || true
+            fi
+            _PORT_CHECK_INBOUND_MSG="failed to spawn temp listener on :25${_err}"
             _listener_pid=""
             return 0
         fi

--- a/tests/install_sh.sh
+++ b/tests/install_sh.sh
@@ -843,6 +843,166 @@ else
 fi
 
 # ---------------------------------------------------------------------------
+# 7f-bis. Listener spawn must NOT block on $() capture pipe
+# ---------------------------------------------------------------------------
+#
+# `$(port_check_listener_start)` invokes the function in a subshell whose
+# stdout is a capture pipe. The backgrounded python child inherits that
+# pipe; if python's stdout isn't redirected, python keeps the pipe write
+# end open for its full ~30s lifetime, the parent's read on $() blocks,
+# and the kill -0 liveness check ALWAYS reports "dead". The fix is to
+# redirect python's stdout to /dev/null in the listener-start helper.
+# This is purely a source-grep — runtime behavior was verified manually.
+
+echo "# listener stdout redirect"
+
+# Find port_check_listener_start body.
+_pl_start_body="$(awk '
+    $0 ~ /^port_check_listener_start\(\)/ {inside=1}
+    inside {print}
+    inside && /^}/ {inside=0; exit}
+' "${INSTALL_SH}")"
+
+case "${_pl_start_body}" in
+    *'python3 - >/dev/null 2>'*)
+        PASS=$((PASS + 1))
+        printf '  ok  listener python3 stdout redirected to /dev/null (avoids $() capture-pipe block)\n'
+        ;;
+    *)
+        FAIL=$((FAIL + 1))
+        FAILED_NAMES="${FAILED_NAMES} listener-stdout-redirect"
+        printf '  FAIL listener python3 spawn missing >/dev/null redirect; $() will block on capture pipe\n' >&2
+        ;;
+esac
+
+case "${_pl_start_body}" in
+    *'_PORT_CHECK_LISTENER_STDERR'*)
+        PASS=$((PASS + 1))
+        printf '  ok  listener python3 stderr captured for diagnostics\n'
+        ;;
+    *)
+        FAIL=$((FAIL + 1))
+        FAILED_NAMES="${FAILED_NAMES} listener-stderr-capture"
+        printf '  FAIL listener python3 spawn does not capture stderr; bind errors are silent\n' >&2
+        ;;
+esac
+
+# Bind error message in port_check_inbound must include the captured
+# stderr (head -n 1 of _PORT_CHECK_LISTENER_STDERR) so operators see
+# the actual cause (e.g. "Address already in use") instead of a
+# generic "another binder won the race?".
+_pi_body="$(awk '
+    $0 ~ /^port_check_inbound\(\)/ {inside=1}
+    inside {print}
+    inside && /^}/ {inside=0; exit}
+' "${INSTALL_SH}")"
+
+case "${_pi_body}" in
+    *'head -n 1 "${_PORT_CHECK_LISTENER_STDERR}"'*)
+        PASS=$((PASS + 1))
+        printf '  ok  bind-failed message surfaces python stderr\n'
+        ;;
+    *)
+        FAIL=$((FAIL + 1))
+        FAILED_NAMES="${FAILED_NAMES} bind-error-surfacing"
+        printf '  FAIL bind-failed message does not surface python stderr (operators see misleading "another binder won the race?")\n' >&2
+        ;;
+esac
+
+# Liveness check + cleanup kill must use ${_PORT_CHECK_SUDO} so a non-root
+# caller can signal a root-owned (sudo-spawned) python child.
+case "${_pi_body}" in
+    *'${_PORT_CHECK_SUDO} kill -0'*)
+        PASS=$((PASS + 1))
+        printf '  ok  kill -0 liveness check uses ${_PORT_CHECK_SUDO} prefix\n'
+        ;;
+    *)
+        FAIL=$((FAIL + 1))
+        FAILED_NAMES="${FAILED_NAMES} kill0-sudo-prefix"
+        printf '  FAIL kill -0 liveness check missing ${_PORT_CHECK_SUDO} prefix; non-root cannot signal root-owned listener\n' >&2
+        ;;
+esac
+
+# ---------------------------------------------------------------------------
+# 7f-ter. Inbound privilege escalation via sudo
+# ---------------------------------------------------------------------------
+#
+# Non-root operators running `curl ... | sh` should still be able to run
+# the inbound check when sudo is available. port_check_ensure_inbound_privilege
+# mirrors install.sh's `ensure_sudo` flow: tries `sudo -v`, re-points stdin
+# to /dev/tty when stdin is the curl pipe, and sets _PORT_CHECK_SUDO="sudo"
+# so the listener spawn / kill / kill-0 carry the prefix. Returns non-zero
+# (soft skip) when sudo is unavailable or refused — never `exit`s.
+
+echo "# inbound privilege helper"
+
+# The function exists.
+if grep -q '^port_check_ensure_inbound_privilege()' "${INSTALL_SH}"; then
+    PASS=$((PASS + 1))
+    printf '  ok  port_check_ensure_inbound_privilege defined\n'
+else
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES="${FAILED_NAMES} sudo-helper-missing"
+    printf '  FAIL port_check_ensure_inbound_privilege missing\n' >&2
+fi
+
+_pe_body="$(awk '
+    $0 ~ /^port_check_ensure_inbound_privilege\(\)/ {inside=1}
+    inside {print}
+    inside && /^}/ {inside=0; exit}
+' "${INSTALL_SH}")"
+
+case "${_pe_body}" in
+    *'sudo -v'*)
+        PASS=$((PASS + 1))
+        printf '  ok  inbound privilege helper uses `sudo -v` to validate creds\n'
+        ;;
+    *)
+        FAIL=$((FAIL + 1))
+        FAILED_NAMES="${FAILED_NAMES} sudo-helper-no-validate"
+        printf '  FAIL inbound privilege helper missing `sudo -v` cred validation\n' >&2
+        ;;
+esac
+
+case "${_pe_body}" in
+    *'/dev/tty'*)
+        PASS=$((PASS + 1))
+        printf '  ok  inbound privilege helper handles `curl | sh` (stdin-is-pipe)\n'
+        ;;
+    *)
+        FAIL=$((FAIL + 1))
+        FAILED_NAMES="${FAILED_NAMES} sudo-helper-no-tty"
+        printf '  FAIL inbound privilege helper missing /dev/tty fallback for curl-pipe scenarios\n' >&2
+        ;;
+esac
+
+# Helper must NEVER call exit — port-check failure is a soft skip.
+case "${_pe_body}" in
+    *'exit '*)
+        FAIL=$((FAIL + 1))
+        FAILED_NAMES="${FAILED_NAMES} sudo-helper-no-exit"
+        printf '  FAIL inbound privilege helper calls exit; should `return` so the outbound result is preserved\n' >&2
+        ;;
+    *)
+        PASS=$((PASS + 1))
+        printf '  ok  inbound privilege helper never calls exit (soft skip on failure)\n'
+        ;;
+esac
+
+# Inbound orchestrator must use the helper instead of the bare euid check.
+case "${_pi_body}" in
+    *'port_check_ensure_inbound_privilege'*)
+        PASS=$((PASS + 1))
+        printf '  ok  port_check_inbound delegates privilege check to the helper\n'
+        ;;
+    *)
+        FAIL=$((FAIL + 1))
+        FAILED_NAMES="${FAILED_NAMES} inbound-uses-helper"
+        printf '  FAIL port_check_inbound still hard-skips on euid != 0; should call port_check_ensure_inbound_privilege\n' >&2
+        ;;
+esac
+
+# ---------------------------------------------------------------------------
 # 7g. Occupancy warning (review #4)
 # ---------------------------------------------------------------------------
 #


### PR DESCRIPTION
## Summary

Two bugs surfaced by hands-on testing of `portcheck.sh` (the alias merged in #186 + renamed in #187) on a real VPS:

1. **The temp listener spawn always reported `bind failed; another binder won the race?`**, even with port 25 free.

   Root cause: `_listener_pid="$(port_check_listener_start)"`. The `$()` subshell's stdout is a capture pipe; the backgrounded `python3` child inherits that pipe and holds the write end open for its full ~30s lifetime. The parent's read on `$()` therefore blocks until python exits, so by the time the outer `sleep 1 && kill -0` runs, python has just exited and is reported as dead — the misleading "bind failed" message fires on every successful spawn.

   **Fix:** redirect python's stdout to `/dev/null` inside the function, BEFORE the `&`. python no longer holds the capture pipe, `$()` returns immediately, `kill -0` correctly reports the live PID. Verified on a non-privileged port: `$()` returns in ~6ms instead of ~3000ms. Also redirect python's stderr to a tmpfile so `port_check_inbound` can surface the actual bind error (e.g. `[Errno 98] Address already in use`) when bind genuinely fails.

2. **`sudo curl ... | sh` did not escalate the script** — only `curl` ran under sudo, the piped `sh` ran as the operator's user. Inbound check therefore reported `[skip] inbound check requires root` even when the operator clearly meant to elevate.

   **Fix:** new `port_check_ensure_inbound_privilege` mirrors `install.sh`'s `ensure_sudo` flow. When non-root + sudo is on PATH, runs `sudo -v` to refresh creds (re-pointing stdin at `/dev/tty` when stdin is a pipe, so `curl ... | sh` still gets a password prompt). On success, sets `_PORT_CHECK_SUDO="sudo"` and the listener spawn / `kill -0` / `kill` / `wait` all carry that prefix. On failure (no sudo, refused creds), inbound soft-skips with a clearer message — never `exit`s, so the outbound result is preserved.

After this lands, the user-reported flow works end-to-end:

```
$ curl -fsSL https://aimx.email/portcheck.sh | sh
[info] Inbound check needs root to bind port 25; enter your password
[sudo] password for ubuntu:

aimx port 25 connectivity check
  no install will be performed

  Outbound port 25 ... [ok]
  Inbound port 25 .... [ok]   detected ip: 1.2.3.4
```

## Requirements

- [x] Listener spawn no longer blocks on `$()` capture pipe (stdout → `/dev/null`)
- [x] Listener stderr captured for diagnostics; bind-failure message includes python's actual error
- [x] `port_check_ensure_inbound_privilege` validates sudo creds, handles `curl | sh` via `/dev/tty` fallback, never `exit`s
- [x] Listener spawn / `kill -0` / `kill` / `wait` carry `${_PORT_CHECK_SUDO}` prefix so non-root caller can signal root-owned listener
- [x] Inbound orchestrator delegates the privilege check to the helper (no more bare `euid != 0` skip)
- [x] Existing exit-code contract preserved (0 pass-or-skip, 1 fail, 2 missing tool); soft-skip on sudo refusal keeps outbound result intact
- [x] Tests: 9 new source-grep + structural assertions; 93/95 pass (the 2 fails are the pre-existing shellcheck SC2024 baseline)

## Out of scope

- No change to `portcheck.sh` itself — it just execs `install.sh --port-check-only`, so all fixes land in `install.sh`.
- No change to the Rust `aimx portcheck` subcommand — those code paths run as root from the start and don't need either fix.
- No new IPv6 / dual-stack handling.

## Test plan

- [x] `sh -n install.sh` (POSIX syntax)
- [x] `sh tests/install_sh.sh` — 93/95 (baseline SC2024 only)
- [x] `sh install.sh --port-check-only --help` exits 0
- [x] `sh install.sh --help | grep -E "port-check|verify-host"` shows the documented flags
- [x] Local non-privileged simulation: `$()` returns in ~6ms post-fix vs ~3000ms pre-fix
- [x] Local bind-failure simulation: stderr is captured and surfaced as `(listener bind error: [Errno 98] Address already in use)`
- Manual smoke after merge:
  - `curl -fsSL https://aimx.email/portcheck.sh | sh` (non-root, sudo available) → prompts for password, both checks `[ok]`
  - `curl -fsSL https://aimx.email/portcheck.sh | sh` (non-root, no sudo) → outbound `[ok]`, inbound `[skip]` with clearer message, exit 0
  - `curl -fsSL https://aimx.email/portcheck.sh | sudo sh` (already root) → both `[ok]`