### PR TITLE
feat: dialoguer-backed line editing for trusted-senders setup prompt

### DIFF
--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1858,6 +1858,15 @@ fn read_yn_line(
 
 /// Interactively prompt for the `trusted_senders` allowlist.
 ///
+/// Production entry point. Reads the senders line via `dialoguer::Input`
+/// so the operator gets the standard line-editor key set (Left/Right
+/// arrows, Home/End, Ctrl-A/E, Ctrl-U/W, Backspace, Delete) — `read_line`
+/// alone runs in canonical mode and turns Left into a literal `^[[D`
+/// byte sequence, which then trips the sender validator. The Y/n
+/// confirmations that follow (empty-warning re-prompt and
+/// `prompt_confirm_list`) still go through the existing `BufRead`-based
+/// helpers — single-char input doesn't benefit from line editing.
+///
 /// Returns `(policy, senders)`:
 /// - Non-empty list → `("verified", senders)`; echoed back and confirmed
 ///   via `[Y/n]` before returning. Operator can decline to re-enter.
@@ -1867,7 +1876,69 @@ fn read_yn_line(
 ///
 /// Invalid entries re-prompt with `✗ invalid sender '<entry>': <reason>`;
 /// after [`MAX_TRUSTED_SENDERS_ATTEMPTS`] rejections the wizard aborts.
-pub fn prompt_trusted_senders(
+///
+/// Tests drive the validation / re-prompt / confirm / max-attempts
+/// branches via [`prompt_trusted_senders_with_reader`] (a `BufRead`-based
+/// twin) — dialoguer requires a real TTY and cannot be exercised from
+/// `cargo test`.
+pub fn prompt_trusted_senders() -> Result<(String, Vec<String>), Box<dyn std::error::Error>> {
+    println!();
+    let mut attempt = 0usize;
+    loop {
+        attempt += 1;
+        println!("{TRUSTED_SENDERS_PROMPT}");
+        let line: String = dialoguer::Input::with_theme(&PlainPromptTheme)
+            .with_prompt("> ")
+            .allow_empty(true)
+            .interact_text()?;
+        // The Y/n helpers still take a `BufRead`; lock stdin freshly
+        // for each call. Single-char input doesn't need line editing.
+        let stdin = io::stdin();
+        let mut yn_reader = stdin.lock();
+        match parse_trusted_senders_line(&line) {
+            Ok(senders) if senders.is_empty() => {
+                print_empty_trusted_senders_warning();
+                if read_yn_line(&mut yn_reader, "Leave hooks disabled?")? {
+                    return Ok(("none".to_string(), vec![]));
+                }
+                // Operator wants to re-enter senders — fall through to
+                // the next loop iteration. Reset the attempt counter
+                // so a "no, let me try again" doesn't burn the budget.
+                attempt = 0;
+                continue;
+            }
+            Ok(senders) => {
+                if prompt_confirm_list(&mut yn_reader, "Trusted senders", &senders)? {
+                    return Ok(("verified".to_string(), senders));
+                }
+                // No → re-prompt. Reset the attempt budget so the
+                // operator can iterate freely.
+                attempt = 0;
+                continue;
+            }
+            Err((entry, reason)) => {
+                println!("{} invalid sender '{entry}': {reason}", term::fail_mark());
+                if attempt == MAX_TRUSTED_SENDERS_ATTEMPTS {
+                    return Err(format!(
+                        "trusted-senders prompt aborted after {MAX_TRUSTED_SENDERS_ATTEMPTS} \
+                         attempts; last error: invalid sender '{entry}': {reason}"
+                    )
+                    .into());
+                }
+            }
+        }
+    }
+}
+
+/// Inner trusted-senders helper that reads from an injectable `BufRead`.
+/// Production callers go through [`prompt_trusted_senders`] (which uses
+/// `dialoguer::Input` for the senders line); tests drive the
+/// validation / re-prompt / max-attempts / empty-warning / confirm
+/// branches with scripted `Cursor<&[u8]>` input. Body is identical to
+/// the pre-dialoguer implementation. Test-only — production builds get
+/// the dialoguer-backed entry point.
+#[cfg(test)]
+pub(crate) fn prompt_trusted_senders_with_reader(
     reader: &mut dyn BufRead,
 ) -> Result<(String, Vec<String>), Box<dyn std::error::Error>> {
     println!();
@@ -1911,6 +1982,31 @@ pub fn prompt_trusted_senders(
                 }
             }
         }
+    }
+}
+
+/// Custom dialoguer theme that writes input prompts verbatim — no
+/// trailing colon, no decoration. Lets us reuse `dialoguer::Input`'s
+/// line-editor behavior while keeping the existing `> ` cursor visual.
+struct PlainPromptTheme;
+
+impl dialoguer::theme::Theme for PlainPromptTheme {
+    fn format_input_prompt(
+        &self,
+        f: &mut dyn std::fmt::Write,
+        prompt: &str,
+        _default: Option<&str>,
+    ) -> std::fmt::Result {
+        write!(f, "{prompt}")
+    }
+
+    fn format_input_prompt_selection(
+        &self,
+        f: &mut dyn std::fmt::Write,
+        prompt: &str,
+        sel: &str,
+    ) -> std::fmt::Result {
+        write!(f, "{prompt}{sel}")
     }
 }
 
@@ -2489,9 +2585,7 @@ pub fn run_setup(
         print_step_complete(4, &checklist);
         Some(defaults)
     } else {
-        let stdin = io::stdin();
-        let mut reader = stdin.lock();
-        let defaults = prompt_trusted_senders(&mut reader)?;
+        let defaults = prompt_trusted_senders()?;
         checklist.set(4, term::StepState::Done);
         print_step_complete(4, &checklist);
         Some(defaults)
@@ -4674,7 +4768,7 @@ owner = "aimx-catchall"
     fn prompt_trusted_senders_empty_input_returns_none_with_warning() {
         let input = b"\n";
         let mut reader = io::Cursor::new(input);
-        let (mode, senders) = prompt_trusted_senders(&mut reader).unwrap();
+        let (mode, senders) = prompt_trusted_senders_with_reader(&mut reader).unwrap();
         assert_eq!(mode, "none");
         assert!(senders.is_empty());
     }
@@ -4683,7 +4777,7 @@ owner = "aimx-catchall"
     fn prompt_trusted_senders_single_address() {
         let input = b"alice@example.com\n";
         let mut reader = io::Cursor::new(input);
-        let (mode, senders) = prompt_trusted_senders(&mut reader).unwrap();
+        let (mode, senders) = prompt_trusted_senders_with_reader(&mut reader).unwrap();
         assert_eq!(mode, "verified");
         assert_eq!(senders, vec!["alice@example.com".to_string()]);
     }
@@ -4692,7 +4786,7 @@ owner = "aimx-catchall"
     fn prompt_trusted_senders_comma_separated() {
         let input = b"alice@example.com, *@company.com\n";
         let mut reader = io::Cursor::new(input);
-        let (mode, senders) = prompt_trusted_senders(&mut reader).unwrap();
+        let (mode, senders) = prompt_trusted_senders_with_reader(&mut reader).unwrap();
         assert_eq!(mode, "verified");
         assert_eq!(
             senders,
@@ -4704,7 +4798,7 @@ owner = "aimx-catchall"
     fn prompt_trusted_senders_whitespace_separated() {
         let input = b"alice@example.com   *@company.com\n";
         let mut reader = io::Cursor::new(input);
-        let (mode, senders) = prompt_trusted_senders(&mut reader).unwrap();
+        let (mode, senders) = prompt_trusted_senders_with_reader(&mut reader).unwrap();
         assert_eq!(mode, "verified");
         assert_eq!(senders.len(), 2);
     }
@@ -4713,7 +4807,7 @@ owner = "aimx-catchall"
     fn prompt_trusted_senders_retries_invalid_then_accepts() {
         let input = b"not-an-address\nalice@example.com\n";
         let mut reader = io::Cursor::new(input);
-        let (mode, senders) = prompt_trusted_senders(&mut reader).unwrap();
+        let (mode, senders) = prompt_trusted_senders_with_reader(&mut reader).unwrap();
         assert_eq!(mode, "verified");
         assert_eq!(senders, vec!["alice@example.com".to_string()]);
     }
@@ -4724,7 +4818,9 @@ owner = "aimx-catchall"
         // the wizard aborts on attempt 5 per the error-budget contract.
         let input = b"bad1\nbad2\nbad3\nbad4\nbad5\nalice@example.com\n";
         let mut reader = io::Cursor::new(input);
-        let err = prompt_trusted_senders(&mut reader).unwrap_err().to_string();
+        let err = prompt_trusted_senders_with_reader(&mut reader)
+            .unwrap_err()
+            .to_string();
         assert!(
             err.contains(&MAX_TRUSTED_SENDERS_ATTEMPTS.to_string()),
             "error must name the attempt ceiling: {err}"
@@ -4733,6 +4829,18 @@ owner = "aimx-catchall"
             err.contains("bad5"),
             "error should name the last bad entry: {err}"
         );
+    }
+
+    #[test]
+    fn prompt_trusted_senders_no_arg_signature_compiles() {
+        // Compile-time check that the production no-arg entry point
+        // exists with the expected signature — we cannot drive
+        // `dialoguer::Input` from a unit test because `interact_text()`
+        // refuses to run without a real TTY. Coercion to a function
+        // pointer of the documented type is the cheapest assertion we
+        // can make without invoking the dialoguer reader.
+        let _: fn() -> Result<(String, Vec<String>), Box<dyn std::error::Error>> =
+            super::prompt_trusted_senders;
     }
 
     #[test]
@@ -5143,7 +5251,7 @@ owner = "aimx-catchall"
         // an empty line (= yes), wizard returns ("verified", senders).
         let input = b"alice@example.com, *@company.com\n\n";
         let mut reader = io::Cursor::new(input);
-        let (mode, senders) = prompt_trusted_senders(&mut reader).unwrap();
+        let (mode, senders) = prompt_trusted_senders_with_reader(&mut reader).unwrap();
         assert_eq!(mode, "verified");
         assert_eq!(
             senders,
@@ -5158,7 +5266,7 @@ owner = "aimx-catchall"
         // accepts (`\n`).
         let input = b"oldlist@example.com\nn\nnewlist@example.com\n\n";
         let mut reader = io::Cursor::new(input);
-        let (mode, senders) = prompt_trusted_senders(&mut reader).unwrap();
+        let (mode, senders) = prompt_trusted_senders_with_reader(&mut reader).unwrap();
         assert_eq!(mode, "verified");
         assert_eq!(senders, vec!["newlist@example.com".to_string()]);
     }
@@ -5169,7 +5277,7 @@ owner = "aimx-catchall"
         // confirm. `\n` (= yes default) returns ("none", []).
         let input = b"\n\n";
         let mut reader = io::Cursor::new(input);
-        let (mode, senders) = prompt_trusted_senders(&mut reader).unwrap();
+        let (mode, senders) = prompt_trusted_senders_with_reader(&mut reader).unwrap();
         assert_eq!(mode, "none");
         assert!(senders.is_empty());
     }
@@ -5180,7 +5288,7 @@ owner = "aimx-catchall"
         // wizard re-prompts → operator types real list → confirm.
         let input = b"\nn\nalice@example.com\n\n";
         let mut reader = io::Cursor::new(input);
-        let (mode, senders) = prompt_trusted_senders(&mut reader).unwrap();
+        let (mode, senders) = prompt_trusted_senders_with_reader(&mut reader).unwrap();
         assert_eq!(mode, "verified");
         assert_eq!(senders, vec!["alice@example.com".to_string()]);
     }

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1856,49 +1856,90 @@ fn read_yn_line(
     Ok(parse_yn(&buf))
 }
 
-/// Interactively prompt for the `trusted_senders` allowlist.
-///
-/// Production entry point. Reads the senders line via `dialoguer::Input`
-/// so the operator gets the standard line-editor key set (Left/Right
-/// arrows, Home/End, Ctrl-A/E, Ctrl-U/W, Backspace, Delete) — `read_line`
-/// alone runs in canonical mode and turns Left into a literal `^[[D`
-/// byte sequence, which then trips the sender validator. The Y/n
-/// confirmations that follow (empty-warning re-prompt and
-/// `prompt_confirm_list`) still go through the existing `BufRead`-based
-/// helpers — single-char input doesn't benefit from line editing.
-///
-/// Returns `(policy, senders)`:
-/// - Non-empty list → `("verified", senders)`; echoed back and confirmed
-///   via `[Y/n]` before returning. Operator can decline to re-enter.
-/// - Empty input  → `("none", vec![])`; a loud warning block is printed
-///   and the operator must explicitly confirm leaving hooks disabled
-///   (declining re-prompts for senders).
-///
-/// Invalid entries re-prompt with `✗ invalid sender '<entry>': <reason>`;
-/// after [`MAX_TRUSTED_SENDERS_ATTEMPTS`] rejections the wizard aborts.
-///
-/// Tests drive the validation / re-prompt / confirm / max-attempts
-/// branches via [`prompt_trusted_senders_with_reader`] (a `BufRead`-based
-/// twin) — dialoguer requires a real TTY and cannot be exercised from
-/// `cargo test`.
-pub fn prompt_trusted_senders() -> Result<(String, Vec<String>), Box<dyn std::error::Error>> {
+/// I/O seam for [`prompt_trusted_senders_inner`]: abstracts how the
+/// senders line is read (dialoguer in production vs. canonical
+/// `read_line` in tests) and exposes a `BufRead` for the follow-on Y/n
+/// confirmations. Production holds a long-lived `StdinLock` for the
+/// Y/n reader (dialoguer reads from its own term, so the lock doesn't
+/// conflict); tests use a single `Cursor<&[u8]>` for both.
+trait TrustedSendersIo {
+    /// Read one senders line (the equivalent of pressing Enter at the
+    /// `> ` cursor). Returned string may include a trailing newline —
+    /// `parse_trusted_senders_line` handles trimming.
+    fn read_senders_line(&mut self) -> Result<String, Box<dyn std::error::Error>>;
+
+    /// Re-borrow the Y/n reader for the helpers that follow
+    /// (`read_yn_line`, `prompt_confirm_list`). Returning a fresh
+    /// `&mut dyn BufRead` per call keeps the borrow scoped per-helper
+    /// invocation.
+    fn yn_reader(&mut self) -> &mut dyn BufRead;
+}
+
+/// Production `TrustedSendersIo`: dialoguer for the senders line,
+/// `StdinLock` for the Y/n confirmations.
+struct DialoguerTrustedSendersIo<'a> {
+    yn_lock: io::StdinLock<'a>,
+}
+
+impl TrustedSendersIo for DialoguerTrustedSendersIo<'_> {
+    fn read_senders_line(&mut self) -> Result<String, Box<dyn std::error::Error>> {
+        let line: String = dialoguer::Input::with_theme(&PlainPromptTheme)
+            .with_prompt("> ")
+            .allow_empty(true)
+            .interact_text()?;
+        Ok(line)
+    }
+
+    fn yn_reader(&mut self) -> &mut dyn BufRead {
+        &mut self.yn_lock
+    }
+}
+
+/// Test-only `TrustedSendersIo`: scripted `BufRead` drives both the
+/// senders line and the Y/n confirmations. The senders read mimics the
+/// pre-dialoguer canonical-mode behavior (`> ` cursor + `read_line`),
+/// so the existing branch tests exercise the same outer loop body that
+/// ships in release.
+#[cfg(test)]
+struct ReaderTrustedSendersIo<'a> {
+    reader: &'a mut dyn BufRead,
+}
+
+#[cfg(test)]
+impl TrustedSendersIo for ReaderTrustedSendersIo<'_> {
+    fn read_senders_line(&mut self) -> Result<String, Box<dyn std::error::Error>> {
+        print!("> ");
+        io::stdout().flush()?;
+        let mut line = String::new();
+        self.reader.read_line(&mut line)?;
+        Ok(line)
+    }
+
+    fn yn_reader(&mut self) -> &mut dyn BufRead {
+        self.reader
+    }
+}
+
+/// Shared outer state machine for the trusted-senders prompt. Both
+/// [`prompt_trusted_senders`] (dialoguer) and
+/// [`prompt_trusted_senders_with_reader`] (scripted `BufRead`) call
+/// through here so the validation / re-prompt / empty-warning /
+/// confirm / max-attempts contract has exactly one definition. The
+/// only thing the entry points differ on is *how* the senders line is
+/// read — captured by the [`TrustedSendersIo`] trait.
+fn prompt_trusted_senders_inner(
+    io: &mut dyn TrustedSendersIo,
+) -> Result<(String, Vec<String>), Box<dyn std::error::Error>> {
     println!();
     let mut attempt = 0usize;
     loop {
         attempt += 1;
         println!("{TRUSTED_SENDERS_PROMPT}");
-        let line: String = dialoguer::Input::with_theme(&PlainPromptTheme)
-            .with_prompt("> ")
-            .allow_empty(true)
-            .interact_text()?;
-        // The Y/n helpers still take a `BufRead`; lock stdin freshly
-        // for each call. Single-char input doesn't need line editing.
-        let stdin = io::stdin();
-        let mut yn_reader = stdin.lock();
+        let line = io.read_senders_line()?;
         match parse_trusted_senders_line(&line) {
             Ok(senders) if senders.is_empty() => {
                 print_empty_trusted_senders_warning();
-                if read_yn_line(&mut yn_reader, "Leave hooks disabled?")? {
+                if read_yn_line(io.yn_reader(), "Leave hooks disabled?")? {
                     return Ok(("none".to_string(), vec![]));
                 }
                 // Operator wants to re-enter senders — fall through to
@@ -1908,7 +1949,7 @@ pub fn prompt_trusted_senders() -> Result<(String, Vec<String>), Box<dyn std::er
                 continue;
             }
             Ok(senders) => {
-                if prompt_confirm_list(&mut yn_reader, "Trusted senders", &senders)? {
+                if prompt_confirm_list(io.yn_reader(), "Trusted senders", &senders)? {
                     return Ok(("verified".to_string(), senders));
                 }
                 // No → re-prompt. Reset the attempt budget so the
@@ -1930,59 +1971,51 @@ pub fn prompt_trusted_senders() -> Result<(String, Vec<String>), Box<dyn std::er
     }
 }
 
+/// Interactively prompt for the `trusted_senders` allowlist.
+///
+/// Production entry point. Reads the senders line via `dialoguer::Input`
+/// so the operator gets the standard line-editor key set (Left/Right
+/// arrows, Home/End, Ctrl-A/E, Ctrl-U/W, Backspace, Delete) — `read_line`
+/// alone runs in canonical mode and turns Left into a literal `^[[D`
+/// byte sequence, which then trips the sender validator. The Y/n
+/// confirmations that follow (empty-warning re-prompt and
+/// `prompt_confirm_list`) still go through the existing `BufRead`-based
+/// helpers — single-char input doesn't benefit from line editing.
+///
+/// Returns `(policy, senders)`:
+/// - Non-empty list → `("verified", senders)`; echoed back and confirmed
+///   via `[Y/n]` before returning. Operator can decline to re-enter.
+/// - Empty input  → `("none", vec![])`; a loud warning block is printed
+///   and the operator must explicitly confirm leaving hooks disabled
+///   (declining re-prompts for senders).
+///
+/// Invalid entries re-prompt with `✗ invalid sender '<entry>': <reason>`;
+/// after [`MAX_TRUSTED_SENDERS_ATTEMPTS`] rejections the wizard aborts.
+///
+/// Mirrors the [`prompt_mailbox_owner`] two-entry-point pattern: this
+/// thin wrapper builds the dialoguer/stdin I/O seam and delegates the
+/// shared loop to [`prompt_trusted_senders_inner`]. Tests reach the
+/// same body via [`prompt_trusted_senders_with_reader`].
+pub fn prompt_trusted_senders() -> Result<(String, Vec<String>), Box<dyn std::error::Error>> {
+    let stdin = io::stdin();
+    let yn_lock = stdin.lock();
+    let mut io_seam = DialoguerTrustedSendersIo { yn_lock };
+    prompt_trusted_senders_inner(&mut io_seam)
+}
+
 /// Inner trusted-senders helper that reads from an injectable `BufRead`.
 /// Production callers go through [`prompt_trusted_senders`] (which uses
 /// `dialoguer::Input` for the senders line); tests drive the
 /// validation / re-prompt / max-attempts / empty-warning / confirm
-/// branches with scripted `Cursor<&[u8]>` input. Body is identical to
-/// the pre-dialoguer implementation. Test-only — production builds get
-/// the dialoguer-backed entry point.
+/// branches with scripted `Cursor<&[u8]>` input. Both entry points
+/// share [`prompt_trusted_senders_inner`], so this seam tests the
+/// same loop body that ships in release.
 #[cfg(test)]
 pub(crate) fn prompt_trusted_senders_with_reader(
     reader: &mut dyn BufRead,
 ) -> Result<(String, Vec<String>), Box<dyn std::error::Error>> {
-    println!();
-    let mut attempt = 0usize;
-    loop {
-        attempt += 1;
-        println!("{TRUSTED_SENDERS_PROMPT}");
-        print!("> ");
-        io::stdout().flush()?;
-        let mut line = String::new();
-        reader.read_line(&mut line)?;
-        match parse_trusted_senders_line(&line) {
-            Ok(senders) if senders.is_empty() => {
-                print_empty_trusted_senders_warning();
-                if read_yn_line(reader, "Leave hooks disabled?")? {
-                    return Ok(("none".to_string(), vec![]));
-                }
-                // Operator wants to re-enter senders — fall through to
-                // the next loop iteration. Reset the attempt counter
-                // so a "no, let me try again" doesn't burn the budget.
-                attempt = 0;
-                continue;
-            }
-            Ok(senders) => {
-                if prompt_confirm_list(reader, "Trusted senders", &senders)? {
-                    return Ok(("verified".to_string(), senders));
-                }
-                // No → re-prompt. Reset the attempt budget so the
-                // operator can iterate freely.
-                attempt = 0;
-                continue;
-            }
-            Err((entry, reason)) => {
-                println!("{} invalid sender '{entry}': {reason}", term::fail_mark());
-                if attempt == MAX_TRUSTED_SENDERS_ATTEMPTS {
-                    return Err(format!(
-                        "trusted-senders prompt aborted after {MAX_TRUSTED_SENDERS_ATTEMPTS} \
-                         attempts; last error: invalid sender '{entry}': {reason}"
-                    )
-                    .into());
-                }
-            }
-        }
-    }
+    let mut io_seam = ReaderTrustedSendersIo { reader };
+    prompt_trusted_senders_inner(&mut io_seam)
 }
 
 /// Custom dialoguer theme that writes input prompts verbatim — no
@@ -2011,7 +2044,9 @@ impl dialoguer::theme::Theme for PlainPromptTheme {
 }
 
 /// Print the loud warning block for an empty trusted-senders list.
-/// Extracted so [`prompt_trusted_senders`] and the non-interactive
+/// Extracted so [`prompt_trusted_senders_inner`] (the shared loop body
+/// reached by both [`prompt_trusted_senders`] and
+/// [`prompt_trusted_senders_with_reader`]) and the non-interactive
 /// branch in [`run_setup`] can share the exact wording.
 fn print_empty_trusted_senders_warning() {
     println!();
@@ -4831,17 +4866,13 @@ owner = "aimx-catchall"
         );
     }
 
-    #[test]
-    fn prompt_trusted_senders_no_arg_signature_compiles() {
-        // Compile-time check that the production no-arg entry point
-        // exists with the expected signature — we cannot drive
-        // `dialoguer::Input` from a unit test because `interact_text()`
-        // refuses to run without a real TTY. Coercion to a function
-        // pointer of the documented type is the cheapest assertion we
-        // can make without invoking the dialoguer reader.
-        let _: fn() -> Result<(String, Vec<String>), Box<dyn std::error::Error>> =
-            super::prompt_trusted_senders;
-    }
+    // Note: a separate `prompt_trusted_senders` signature-check test
+    // used to live here. After the refactor that pushed the outer
+    // state machine into the shared `prompt_trusted_senders_inner`,
+    // every existing `_with_reader` test transitively exercises the
+    // same loop body that ships in release — the symbol-existence
+    // assertion was redundant and tripped `clippy::type_complexity`
+    // on the fn-pointer coercion.
 
     #[test]
     fn empty_trusted_senders_warning_text_is_stable() {


### PR DESCRIPTION
## Summary

The Step 4 trusted-senders prompt in `aimx setup` reads stdin in canonical mode via `BufRead::read_line`. Backspace works (kernel line discipline) but arrow keys do not — pressing Left appends raw `^[[D` bytes to the input buffer, which then fail the sender validator with a confusing error. Switch only this prompt to `dialoguer::Input` (already a project dependency) so operators get the standard line-editor key set: Left/Right arrows, Home/End, Ctrl-A/E, Ctrl-U/W, Delete, plus the backspace they already had.

Mirrors the established `prompt_mailbox_owner` ↔ `prompt_mailbox_owner_with_reader` two-entry-point pattern: a no-arg production function and a `_with_reader` test seam, both delegating to a single shared body so tests exercise the same loop that ships in release.

## Requirements

- [x] Production trusted-senders prompt accepts the standard line-editor key set: Left/Right arrows, Home/End, Ctrl-A, Ctrl-E, Ctrl-U, Ctrl-W, Backspace, Delete (whatever `dialoguer::Input` provides out of the box).
- [x] Visual format is preserved exactly: the existing 3-line `TRUSTED_SENDERS_PROMPT` block prints first, then the `> ` cursor line where the operator types. A custom `PlainPromptTheme` overrides `format_input_prompt` / `format_input_prompt_selection` so dialoguer adds no `prompt:` decoration.
- [x] All existing `prompt_trusted_senders_*` unit tests in `src/setup.rs` continue to pass — they're testing the validation, re-prompt, max-attempts, empty-warning, and confirmation branches, all of which live in shared logic, now reached via `prompt_trusted_senders_with_reader`.
- [x] Validation, re-prompt loop, max-attempts cap, empty-input warning, and `prompt_confirm_list` Y/n confirmation behavior are all unchanged.
- [x] Non-interactive (`AIMX_NONINTERACTIVE=1`) path is untouched — it doesn't call this prompt anyway.
- [x] No new top-level dependencies. `dialoguer = { version = "0.12", default-features = false }` already in `Cargo.toml`; default-features-disabled build exports `Input` and `theme::Theme`, so no feature flag changes were needed.
- [x] `cargo clippy --all-targets -- -D warnings` and `cargo fmt -- --check` pass (the `--all-targets` flag is what CI runs — see `.github/workflows/ci.yml`).

## Out of scope

- `prompt_domain` and `prompt_mailbox_owner`: short single-token prompts where mid-line editing is rarely needed. Today's behavior preserved.
- `prompt_confirm`, `prompt_confirm_list`, `read_yn_line`: `[Y/n]` prompts. Single-char input, no editing benefit. Today's behavior preserved.
- Any `is_terminal()` / TTY-fallback branching in production. Real callers always have a TTY (`install.sh` redirects `</dev/tty`, `AIMX_NONINTERACTIVE=1` skips this path). The two-entry-point pattern IS the seam — production assumes TTY, tests use `_with_reader`.
- Up/Down history recall across prompts or runs.
- Any change to the trust-policy data model, validation rules, or `config.toml` schema.
- Any change to Step 1–3 or Step 5+ of the setup wizard.

## Technical approach

`src/setup.rs`:

1. Single shared loop body in `prompt_trusted_senders_inner(io: &mut dyn TrustedSendersIo)` owns the outer state machine: parse → empty-warning re-prompt → confirm → max-attempts. There is exactly one definition of the contract; both entry points call through it, so the test seam exercises the same code that ships in release.
2. A small private trait `TrustedSendersIo` captures the only seam — *how* the senders line is read — with two impls:
   - `DialoguerTrustedSendersIo` (production): `dialoguer::Input::with_theme(&PlainPromptTheme).with_prompt("> ").allow_empty(true).interact_text()` for the senders line, plus a long-lived `StdinLock` for the Y/n confirmations. (Dialoguer reads from its own `Term::stderr()`, not stdin, so the lock doesn't conflict.)
   - `ReaderTrustedSendersIo` (`#[cfg(test)]`): scripted `BufRead` drives both reads, mimicking the pre-dialoguer canonical-mode behavior (`> ` cursor + `read_line`).
3. `pub fn prompt_trusted_senders()` is the no-arg production entry point — it builds the dialoguer I/O seam and delegates. `pub(crate) fn prompt_trusted_senders_with_reader(reader: &mut dyn BufRead)` is the `#[cfg(test)]` test entry point — it builds the reader seam and delegates. Both bodies are ~3 lines; all logic lives in `_inner`.
4. `PlainPromptTheme` overrides `format_input_prompt` and `format_input_prompt_selection` to write the prompt verbatim (no `:` suffix, no decoration). Default `SimpleTheme` would render `> :` because dialoguer's default `format_input_prompt` appends a colon — the override is the simplest correct shape.
5. The single production call site in `run_setup` is updated to `let defaults = prompt_trusted_senders()?;` and the now-unused local `let mut reader = stdin().lock();` for the trust step is dropped.

## Test plan

**Automated:**

- `cargo test` — full suite green: 988 + 92 + 1 = 1,081 active tests, 0 failures. The 12 existing branch tests now drive `prompt_trusted_senders_with_reader`, which delegates to the shared `prompt_trusted_senders_inner` body.
- `cargo clippy --all-targets -- -D warnings` — clean for both crates (`aimx` and `aimx-verifier`). This is the exact invocation in `.github/workflows/ci.yml:35` and `:157`; the bare `cargo clippy` form silently skips the test target.
- `cargo fmt -- --check` — clean.

**Manual (must be replayed in a real TTY by the maintainer):**

1. `cargo build --release && sudo ./target/release/aimx setup` on a throwaway domain.
2. At the trusted-senders prompt, type `chua@uzyn.com, second@gmail.com`.
3. Press **Left arrow** several times — cursor must move left through the typed text (no `^[[D` artifacts).
4. Press **Home** — cursor jumps to the start.
5. Press **End** — cursor jumps to the end.
6. Press **Ctrl-W** — deletes the previous word.
7. Press **Backspace** repeatedly — deletes characters one at a time.
8. Type a replacement, press **Enter** — input parses cleanly, the `[Y/n]` confirmation lists the senders correctly.
9. Re-run setup; at the prompt, leave it blank and press Enter — the empty-trusted-senders warning + Y/n re-prompt still works.
10. Re-run setup; type `not-an-email` — the existing validation error still triggers and re-prompts.

## Notes

- Verified against `dialoguer 0.12.0` source: `Input` and `theme::Theme` are exported with `default-features = false`. The default `Theme::format_input_prompt` writes `"{prompt}: "`, so `SimpleTheme` alone would render `> :` — using a one-method `PlainPromptTheme` (overriding both `format_input_prompt` and `format_input_prompt_selection`) was the cleanest way to get a zero-decoration `> ` cursor.
- The `_with_reader` helper and `ReaderTrustedSendersIo` are `#[cfg(test)]` so a release build does not warn (or fail clippy with `-D warnings`) on dead code.
- Dialoguer renders to `Term::stderr()`; the previous `print!("> ")` went to stdout. The plan accepted this stream change because the prompt itself is interactive UX, not parseable output, and is only rendered when there is a TTY.
- This PR deliberately does not add a TTY-fallback branch. If a future bug shows up where someone pipes stdin into a real interactive setup invocation (no install.sh, no `AIMX_NONINTERACTIVE`), an `is_terminal()` guard can be added then. Today there is no such caller.
