### PR TITLE
[Sprint 2] CLI surface + MCP tools — non-root mailbox CRUD end-to-end

### DIFF
--- a/agents/common/aimx-primer.md
+++ b/agents/common/aimx-primer.md
@@ -40,10 +40,11 @@ aimx gives you two complementary ways to interact with email:
 Writes always go through MCP. Never create, modify, or delete `.md` files
 directly. The daemon owns those paths.
 
-Mailbox provisioning (`aimx mailboxes create | delete`) is **root-only**
-and lives on the host CLI. MCP cannot create or delete mailboxes; if you
-need a new mailbox, ask the operator to run
-`sudo aimx mailboxes create <name> --owner <linux-user>` on the host.
+Mailbox provisioning is **owner-gated**: you can call `mailbox_create` and
+`mailbox_delete` over MCP, and the new (or removed) mailbox is always
+owned by your Linux uid (the daemon resolves the owner from
+`SO_PEERCRED`). Cross-uid creates remain operator-only — the host CLI's
+`--owner <other-user>` flag is honored only when the caller is root.
 
 ## Per-user ownership model
 
@@ -76,14 +77,25 @@ isolation — alice's agent cannot see, read, or act on bob's mail.
 
 ## MCP tools: quick reference
 
-All 9 tools are served by the `aimx` binary over stdio. They return
-strings on success and error strings on failure. Mailbox CRUD lives on
-the root-only host CLI (`sudo aimx mailboxes create | delete`); MCP
-does not expose `mailbox_create` or `mailbox_delete`.
+All 11 tools are served by the `aimx` binary over stdio. They return
+strings on success and error strings on failure. Mailbox CRUD is
+owner-gated: `mailbox_create` / `mailbox_delete` operate on mailboxes
+owned by your Linux uid, with no cross-uid escape hatch from the MCP
+surface.
 
 ### Mailbox tools
 
 - `mailbox_list()`: list mailboxes you own with message counts.
+- `mailbox_create(name)`: provision a new mailbox owned by your uid.
+  Returns the new mailbox's full address (`<name>@<domain>`). Use this
+  when you need a fresh routing endpoint for a task. The daemon
+  validates the name (regex, reserved-names list) and reuses the
+  existing idempotent semantics for re-create on a mailbox you already
+  own.
+- `mailbox_delete(name, force?)`: tear down a mailbox you own. With
+  `force: true`, the tool wipes `inbox/<name>/` and `sent/<name>/`
+  before submitting the delete (mirrors the CLI's `--force`); with
+  `force: false` (default), the daemon refuses non-empty mailboxes.
 
 ### Email tools
 
@@ -244,8 +256,10 @@ email_send(
 )
 ```
 
-The mailbox must exist and you must own it. Ask the operator to provision
-new mailboxes via `sudo aimx mailboxes create <name> --owner <user>`.
+The mailbox must exist and you must own it. Provision new mailboxes
+via `mailbox_create(name)` (owned by your uid) or, when the operator
+needs to create one owned by a different user, via
+`sudo aimx mailboxes create <name> --owner <user>` on the host.
 `from_mailbox` is the local part only (e.g. `"agent"`, not
 `"agent@example.com"`). aimx DKIM-signs the message and delivers it via
 direct SMTP to the recipient's MX server.
@@ -384,7 +398,10 @@ untrusted mail. When deciding whether to act on an email's content
   receives mail for unrecognised addresses. It is a routing target,
   not a sending identity. Do not send from `catchall`. Hooks on the
   catchall are forbidden by `Config::load`.
-- Mailbox provisioning is root-only: ask the operator to run
+- Mailbox provisioning is owner-gated: call `mailbox_create(name)` to
+  spin up a mailbox owned by your uid, and `mailbox_delete(name)` to
+  tear it down. Cross-uid creates (a mailbox owned by a different
+  Linux user) remain operator-only via
   `sudo aimx mailboxes create <name> --owner <linux-user>` on the host.
 - Each mailbox has `inbox/<name>/` for inbound and `sent/<name>/` for
   outbound copies, both `0700 <owner>:<owner>`.
@@ -428,8 +445,9 @@ untrusted mail. When deciding whether to act on an email's content
 - **Do not read or modify files under `/etc/aimx/`.** Configuration and
   keys are root-owned and managed by `aimx setup`.
 - **Do not send from a mailbox you do not own.** `email_send` will be
-  rejected by the daemon. Ask the operator to provision the mailbox
-  with you as `--owner` first.
+  rejected by the daemon. Call `mailbox_create(name)` to provision a
+  mailbox owned by your uid, or ask the operator to create one with
+  you as `--owner` first.
 - **Do not assume `catchall` is a real identity.** It is a routing target
   for unknown local parts, not an identity that sends. Hooks on the
   catchall are forbidden.

--- a/agents/common/references/mcp-tools.md
+++ b/agents/common/references/mcp-tools.md
@@ -24,10 +24,12 @@ Effectively:
   mailboxes the caller owns. Hooks always execute as the mailbox's
   owning Linux user — there is no per-hook `run_as` field.
 
-Mailbox provisioning (`mailbox_create` / `mailbox_delete`) is **not
-exposed via MCP**. It is root-only on the host CLI (`sudo aimx
-mailboxes create | delete`) so that the namespace of mailboxes can
-never be widened by an agent.
+Mailbox provisioning (`mailbox_create` / `mailbox_delete`) is
+**owner-gated**: the daemon synthesizes the new mailbox's owner from
+`SO_PEERCRED` (your uid), so an agent can only create or remove
+mailboxes owned by itself. Cross-uid creates (a mailbox owned by a
+different Linux user) remain operator-only via the host CLI's
+`sudo aimx mailboxes create <name> --owner <other-user>` flag.
 
 On a single-user box the caller always owns everything and the rules
 are invisible. On a multi-user box they give real isolation.
@@ -56,9 +58,10 @@ fields:
 
 The empty case returns `[]` (a JSON empty array), never a "no
 mailboxes" string. Mailboxes you do not own are simply absent from
-the array. To create or delete mailboxes, ask the operator to run
-`sudo aimx mailboxes create <name> --owner <user>` or
-`sudo aimx mailboxes delete <name>` on the host.
+the array. To create or delete mailboxes you own, use
+`mailbox_create` / `mailbox_delete` (below). To create a mailbox
+owned by a different Linux user, ask the operator to run
+`sudo aimx mailboxes create <name> --owner <user>` on the host.
 
 **Example:**
 ```
@@ -80,6 +83,79 @@ mailbox_list()
 `email_list(mailbox: "agent")` (or list the inbox dir) and `Read`
 `<inbox_path>/<id>.md` — no need for `email_read` unless you need
 the daemon to enforce path canonicalisation for you.
+
+---
+
+### `mailbox_create`
+
+Provision a new mailbox owned by your Linux uid. The daemon resolves
+the owner from `SO_PEERCRED` over the UDS socket — there is no `owner`
+parameter, so by construction an agent cannot create mailboxes owned
+by another user. Validation (regex, reserved-names list) and
+idempotent semantics live on the daemon side; the tool surfaces
+daemon errors verbatim.
+
+**Parameters:**
+| Name   | Type   | Required | Description |
+|--------|--------|----------|-------------|
+| `name` | string | yes      | Mailbox name (the local part). Must match `[a-z0-9._-]+` with no leading/trailing dot and no `..`. The reserved names `catchall` and `aimx-catchall` are rejected by the daemon. |
+
+**Returns:** the new mailbox's full address string (`<name>@<domain>`)
+on success; an error string on failure (e.g. `[VALIDATION] Mailbox
+name 'foo!' contains invalid character ...`).
+
+**Idempotency.** Re-running `mailbox_create` on a mailbox you already
+own succeeds without modification (matches the existing CLI behavior
+of `aimx mailboxes create`). A name collision with a mailbox owned by
+another user surfaces as a daemon-side validation error.
+
+**Example:**
+```
+mailbox_create(name: "task-42")
+→ "task-42@your.tld"
+```
+
+**Next step:** call `email_send(from_mailbox: "task-42", ...)` or
+attach a hook with `hook_create(mailbox: "task-42", ...)`. The
+mailbox is registered in `config.toml` and the daemon's in-memory
+routing table is hot-swapped — inbound mail to
+`task-42@your.tld` lands immediately.
+
+---
+
+### `mailbox_delete`
+
+Tear down a mailbox you own. The daemon enforces ownership via
+`SO_PEERCRED`; an attempt to delete a mailbox owned by another uid
+surfaces as a not-authorized error. With `force: true`, the tool first
+wipes `inbox/<name>/` and `sent/<name>/` before submitting the delete
+(mirroring the CLI's `--force` flag); without `force`, the daemon
+refuses to delete any mailbox whose storage directories aren't empty.
+
+**Parameters:**
+| Name    | Type   | Required | Description |
+|---------|--------|----------|-------------|
+| `name`  | string | yes      | Mailbox name (must be owned by you). The catchall mailbox cannot be deleted. |
+| `force` | bool   | no       | Default `false`. When `true`, wipe `inbox/<name>/` and `sent/<name>/` contents before submitting the delete; when `false`, the daemon refuses non-empty mailboxes with a `[NONEMPTY]` error. |
+
+**Returns:** a one-line success message, or an error string on
+failure (`[EACCES]` for not-owner, `[NONEMPTY]` for non-empty without
+`force`, `[ENOENT]` for an unknown mailbox).
+
+**Example, clean up after a transient task:**
+```
+mailbox_delete(name: "task-42", force: true)
+→ "Mailbox 'task-42' deleted."
+```
+
+**Example, refuse to nuke a mailbox you don't own:**
+```
+mailbox_delete(name: "alice", force: true)
+→ "not authorized: mailbox 'alice' not found"
+```
+
+(The error never distinguishes "exists but you don't own it" from
+"doesn't exist" — NFR2 forbids that information leak.)
 
 ---
 

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -60,6 +60,13 @@ pub enum AuthError {
     NotRoot,
     /// Caller is not the owner of the named mailbox.
     NotOwner { mailbox: String },
+    /// Caller asked to create a mailbox owned by a uid other than their
+    /// own. Distinct from `NotOwner` because no mailbox exists yet —
+    /// the predicate is comparing intended-owner against caller. Carries
+    /// `intended_owner_uid` for debug logging only; renderers must not
+    /// interpolate it into messages shown to non-root callers (no uid
+    /// leak per NFR2).
+    OwnerMismatch { intended_owner_uid: u32 },
     /// Action references a mailbox the caller could not resolve in the
     /// current config snapshot.
     NoSuchMailbox,
@@ -72,6 +79,10 @@ impl std::fmt::Display for AuthError {
             AuthError::NotOwner { mailbox } => {
                 write!(f, "not authorized: caller does not own mailbox '{mailbox}'")
             }
+            AuthError::OwnerMismatch { .. } => write!(
+                f,
+                "not authorized: cannot create a mailbox owned by another user"
+            ),
             AuthError::NoSuchMailbox => write!(f, "not authorized: no such mailbox"),
         }
     }
@@ -86,8 +97,9 @@ impl std::error::Error for AuthError {}
 /// For any other caller:
 /// - `SystemCommand` always rejects as `NotRoot`.
 /// - `MailboxCreate { owner_uid }` passes when `caller_uid == owner_uid`;
-///   otherwise `NotOwner { mailbox: "<new>" }` so the wire-format error
-///   stays consistent with the other owner-mismatch paths.
+///   otherwise `OwnerMismatch { intended_owner_uid }` so renderers can
+///   produce a "cannot create a mailbox owned by another user" message
+///   without inventing a sentinel mailbox name.
 /// - `MailboxDelete { mailbox }` and the other mailbox-bearing variants
 ///   require `mailbox` to be `Some`; `None` produces `NoSuchMailbox`.
 ///   When present, the mailbox's `owner_uid()` must equal `caller_uid`,
@@ -112,21 +124,17 @@ pub fn authorize(
             if caller_uid == owner_uid {
                 Ok(())
             } else {
-                // The mailbox does not exist yet. Use the sentinel
-                // `"<new>"` so the wire-shaped error keeps the owner-
-                // mismatch framing without inventing a fresh variant
-                // (and without leaking the requested owner uid into
-                // the response).
-                // TODO(S2-1): cleaner rendering. When `format_auth_error`
-                // starts surfacing this to humans in Sprint 2, the
-                // string `"caller does not own mailbox '<new>'"` will
-                // read like a bug. Either add a dedicated
-                // `OwnerMismatch { intended_owner_uid: u32 }` variant
-                // or pattern-match `"<new>"` in `format_auth_error`
-                // and switch to e.g. "not authorized: cannot create a
-                // mailbox owned by another user".
-                Err(AuthError::NotOwner {
-                    mailbox: "<new>".to_string(),
+                // No mailbox exists yet, so a `NotOwner { mailbox }`
+                // doesn't model the situation correctly. Surface a
+                // dedicated variant so `format_auth_error` (and any
+                // other renderer) can produce a sentence that reads
+                // naturally without the `"<new>"` sentinel hack the
+                // Sprint-1 placeholder used. The `intended_owner_uid`
+                // is carried for log/debug detail; the rendered string
+                // intentionally does not interpolate it (no uid leak
+                // to non-root callers, per NFR2).
+                Err(AuthError::OwnerMismatch {
+                    intended_owner_uid: owner_uid,
                 })
             }
         }
@@ -224,16 +232,34 @@ mod tests {
         // own uid. Belt-and-braces: the predicate refuses on its own.
         assert_eq!(
             authorize(1000, Action::MailboxCreate { owner_uid: 0 }, None),
-            Err(AuthError::NotOwner {
-                mailbox: "<new>".into()
+            Err(AuthError::OwnerMismatch {
+                intended_owner_uid: 0
             }),
         );
         assert_eq!(
             authorize(1000, Action::MailboxCreate { owner_uid: 1001 }, None),
-            Err(AuthError::NotOwner {
-                mailbox: "<new>".into()
+            Err(AuthError::OwnerMismatch {
+                intended_owner_uid: 1001
             }),
         );
+    }
+
+    #[test]
+    fn owner_mismatch_render_does_not_leak_uid() {
+        // The Display impl must NOT interpolate the intended uid (NFR2:
+        // no information leak about another uid's mailbox state). The
+        // error reads as a single user-friendly sentence.
+        let rendered = format!(
+            "{}",
+            AuthError::OwnerMismatch {
+                intended_owner_uid: 0
+            }
+        );
+        assert_eq!(
+            rendered,
+            "not authorized: cannot create a mailbox owned by another user"
+        );
+        assert!(!rendered.contains("0"), "uid must not appear in render");
     }
 
     #[test]

--- a/src/hooks.rs
+++ b/src/hooks.rs
@@ -229,6 +229,13 @@ fn format_hook_auth_error(err: &AuthError, verb: &str) -> String {
         AuthError::NotOwner { mailbox } => {
             format!("not authorized: caller does not own mailbox '{mailbox}'")
         }
+        // Hook CRUD never produces `OwnerMismatch` (it is created only
+        // by the `MailboxCreate` predicate), but the match must stay
+        // exhaustive so a future variant addition fails loudly here
+        // rather than silently mapping to a default message.
+        AuthError::OwnerMismatch { .. } => {
+            "not authorized: cannot create a resource owned by another user".to_string()
+        }
         AuthError::NoSuchMailbox => "not authorized: no such mailbox".to_string(),
     }
 }

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -1,3 +1,4 @@
+#[cfg(test)]
 use crate::auth::AuthError;
 use crate::cli::MailboxCommand;
 use crate::config::{Config, MailboxConfig};
@@ -16,19 +17,132 @@ pub(crate) const EXIT_SOCKET_MISSING: i32 = 2;
 pub(crate) const SOCKET_MISSING_HINT: &str = "daemon must be running for non-root mailbox CRUD; start `aimx serve` \
      or run with sudo to fall back to direct config edit.";
 
-pub fn run(cmd: MailboxCommand, config: Config) -> Result<(), Box<dyn std::error::Error>> {
+pub fn run(cmd: MailboxCommand, data_dir: Option<&Path>) -> Result<(), Box<dyn std::error::Error>> {
     // S2-1: the entry-point root gate is gone. Both CREATE and DELETE
     // route through the daemon UDS regardless of caller uid; the daemon
     // (post-Sprint-1) does the authz, owner-binding, atomic config
     // write, and `Arc<Config>` hot-swap. The CLI is now a thin client.
     // Root callers retain the direct-on-disk fallback when the socket
     // is absent; non-root callers fail fast with a precise hint.
+    //
+    // Config loading happens here (not in `dispatch`) so a non-root
+    // caller — who cannot read `0640 root:root /etc/aimx/config.toml`
+    // in production — can still reach `create` / `delete` and route
+    // through the daemon UDS. Each subcommand decides for itself
+    // whether the missing-config case is recoverable.
+    let loaded = load_config_optional(data_dir);
+
     match cmd {
-        MailboxCommand::Create { name, owner } => create(&config, &name, owner.as_deref()),
-        MailboxCommand::List { all } => list(&config, all),
-        MailboxCommand::Show { name } => show(&config, &name),
-        MailboxCommand::Delete { name, yes, force } => delete(&config, &name, yes, force),
+        MailboxCommand::Create { name, owner } => create(loaded.as_ref(), &name, owner.as_deref()),
+        MailboxCommand::List { all } => list_dispatch(loaded.as_ref(), all),
+        MailboxCommand::Show { name } => show(&require_config(loaded)?, &name),
+        MailboxCommand::Delete { name, yes, force } => delete(loaded.as_ref(), &name, yes, force),
     }
+}
+
+/// Best-effort config load that distinguishes "config genuinely
+/// missing or unreadable for this caller" from "loaded fine, here
+/// you go". Returns `None` whenever the load failed for any reason
+/// (EACCES on the root-owned `/etc/aimx/config.toml`, ENOENT on a
+/// fresh install before `aimx setup` has run, parse error, …); the
+/// caller decides whether the missing-config case is recoverable.
+///
+/// The previous shape — `dispatch()` `?`-propagating
+/// `Config::load_resolved_with_data_dir(...)` — broke `aimx mailboxes
+/// {create,delete,list}` for non-root callers in production because
+/// the read EACCES surfaced as a bare `Permission denied (os error
+/// 13)` before `mailbox::run` ever saw the request. With config
+/// optional here, the create / delete paths run through the daemon
+/// UDS (where `SO_PEERCRED` is the authoritative identity) without
+/// ever needing to read the root-owned config from a non-root
+/// process.
+fn load_config_optional(data_dir: Option<&Path>) -> Option<Config> {
+    crate::config::Config::load_resolved_with_data_dir(data_dir)
+        .map(|(cfg, _warnings)| cfg)
+        .ok()
+}
+
+/// Subcommands that genuinely need the local config (today: `show`,
+/// which renders trust + hook details that aren't surfaced through
+/// any UDS verb). Returns a friendly actionable error rather than the
+/// raw `Permission denied (os error 13)`.
+fn require_config(loaded: Option<Config>) -> Result<Config, Box<dyn std::error::Error>> {
+    loaded.ok_or_else(|| -> Box<dyn std::error::Error> {
+        format!(
+            "this command needs to read {} (root-owned). \
+             Re-run with sudo, or use a UDS-backed alternative.",
+            crate::config::config_path().display()
+        )
+        .into()
+    })
+}
+
+/// `mailboxes list` dispatcher. Root with config readable falls
+/// through to the local `list()` implementation (which can show every
+/// mailbox + the `--all` switch). Non-root callers — and root callers
+/// without a readable config — route through the daemon's
+/// `MAILBOX-LIST` verb so the listing reflects the daemon's
+/// SO_PEERCRED-based view of what the caller owns.
+fn list_dispatch(loaded: Option<&Config>, all: bool) -> Result<(), Box<dyn std::error::Error>> {
+    if let Some(cfg) = loaded {
+        return list(cfg, all);
+    }
+    if all {
+        return Err("not authorized: --all requires root (run with sudo)".into());
+    }
+    list_via_daemon()
+}
+
+/// Render the daemon's `MAILBOX-LIST` JSON response in the same
+/// columnar format as `list()`. Used as the non-root fallback when
+/// `/etc/aimx/config.toml` is unreadable. Errors from the UDS layer
+/// (socket missing, daemon stopped) bubble up verbatim — same hint
+/// the `create` / `delete` paths produce.
+fn list_via_daemon() -> Result<(), Box<dyn std::error::Error>> {
+    let json = match crate::mcp::submit_mailbox_list_via_daemon_for_cli() {
+        Ok(s) => s,
+        Err(crate::mcp::MailboxCrudFallback::SocketMissing) => {
+            exit_socket_missing();
+        }
+        Err(crate::mcp::MailboxCrudFallback::Daemon(msg)) => {
+            return Err(msg.into());
+        }
+    };
+
+    let rows: Vec<crate::mailbox_list_handler::MailboxListRow> =
+        serde_json::from_str(&json).map_err(|e| format!("malformed MAILBOX-LIST response: {e}"))?;
+
+    if rows.is_empty() {
+        println!("No mailboxes configured.");
+        return Ok(());
+    }
+
+    let header_pad = 20usize.saturating_sub("MAILBOX".len());
+    println!(
+        "{}{:pad$} INBOX    SENT",
+        term::header("MAILBOX"),
+        "",
+        pad = header_pad,
+    );
+    for row in rows {
+        let name_pad = 20usize.saturating_sub(row.name.chars().count());
+        let suffix = if row.registered {
+            String::new()
+        } else {
+            format!(" {}", term::warn("(unregistered)"))
+        };
+        println!(
+            "{}{:pad$} {:<8} {}{}",
+            term::highlight(&row.name),
+            "",
+            row.total,
+            row.sent_count,
+            suffix,
+            pad = name_pad,
+        );
+    }
+
+    Ok(())
 }
 
 /// Render an [`AuthError`] for the CLI. We keep the canonical "not
@@ -40,6 +154,15 @@ pub fn run(cmd: MailboxCommand, config: Config) -> Result<(), Box<dyn std::error
 /// (S2-1) dropped the entry-point root gate. The arm is retained so a
 /// future caller that wires `format_auth_error` against a different
 /// surface still gets exhaustive coverage.
+///
+/// Currently only test-targeted: the production CLI now sources its
+/// authz errors verbatim from the daemon (per-mailbox lock + UDS
+/// reply), so this renderer is exercised only by the unit tests
+/// guarding the four-arm match shape. `Sprint 3` cleanup will fold
+/// it into the canonical renderer alongside `mcp::authorize_mailbox`
+/// and `hooks::format_auth_error` — see the deferred Non-blocker 7
+/// review note.
+#[cfg(test)]
 fn format_auth_error(err: &AuthError, verb: &str) -> String {
     match err {
         AuthError::NotOwner { mailbox } => {
@@ -313,18 +436,51 @@ pub fn count_messages(dir: &Path) -> usize {
 }
 
 fn create(
-    config: &Config,
+    config: Option<&Config>,
     name: &str,
     owner: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // Resolve the effective owner: explicit `--owner`, else fall back
-    // to the shared `prompt_mailbox_owner` seam. Under a TTY
-    // the operator sees a prompt defaulted to the local part; under
-    // `AIMX_NONINTERACTIVE=1` the helper accepts that default when it
-    // resolves or errors hard so scripted runs fail fast instead of
-    // blocking on stdin.
+    // Resolve the effective owner. Per the PRD's UX contract:
+    //
+    //   - Non-root callers: the daemon discards any wire-supplied
+    //     owner and synthesizes from `peer_username(SO_PEERCRED)`.
+    //     Prompting is therefore actively harmful (Non-blocker 5 from
+    //     the Cycle 1 review): under non-TTY stdin the prompt loops
+    //     5 times before erroring on a value the daemon would have
+    //     ignored anyway. Skip the prompt and use the caller's
+    //     own username so the local display string is honest.
+    //   - Root callers: the daemon honors `Owner:` so the existing
+    //     prompt-with-default UX from the setup wizard runs through
+    //     the shared `prompt_mailbox_owner` seam.
     let sys = crate::setup::RealSystemOps;
-    let owner = resolve_create_owner(config, name, owner, &sys)?;
+    let owner = if !is_root() {
+        match owner {
+            Some(o) if !o.is_empty() => o.to_string(),
+            Some(_) => return Err("--owner value cannot be empty".into()),
+            None => {
+                let caller = caller_username();
+                if caller.is_empty() {
+                    return Err("could not resolve caller's username via getpwuid; \
+                         pass --owner <user> explicitly"
+                        .into());
+                }
+                caller
+            }
+        }
+    } else {
+        // Root path: needs the domain for the prompt's display
+        // address; `prompt_mailbox_owner` errors gracefully when the
+        // operator's input doesn't resolve via getpwnam.
+        let cfg = config.ok_or_else(|| -> Box<dyn std::error::Error> {
+            format!(
+                "this command needs to read {} (root-owned). \
+                 The config could not be loaded.",
+                crate::config::config_path().display()
+            )
+            .into()
+        })?;
+        resolve_create_owner(cfg, name, owner, &sys)?
+    };
 
     // S2-1 soft-warning: a non-root caller who passed `--owner <other>`
     // gets a stderr line clarifying that the daemon will discard the
@@ -346,7 +502,7 @@ fn create(
     // falls back to direct on-disk edit + the restart-hint banner;
     // non-root cannot rename `/etc/aimx/config.toml` (perm `0640
     // root:root`), so we exit 2 with a precise actionable error.
-    match crate::mcp::submit_mailbox_crud_via_daemon(name, true, Some(&owner)) {
+    match crate::mcp::submit_mailbox_crud_via_daemon(name, true, Some(&owner), false) {
         Ok(()) => {
             println!(
                 "{}",
@@ -358,7 +514,17 @@ fn create(
             if !is_root() {
                 exit_socket_missing();
             }
-            create_mailbox(config, name, &owner)?;
+            // Root fallback path: needs the local config to perform
+            // the direct on-disk write.
+            let cfg = config.ok_or_else(|| -> Box<dyn std::error::Error> {
+                format!(
+                    "config could not be loaded from {}; \
+                     daemon is also unreachable",
+                    crate::config::config_path().display()
+                )
+                .into()
+            })?;
+            create_mailbox(cfg, name, &owner)?;
             println!(
                 "{}",
                 term::success(&format!("Mailbox '{name}' created (owner: {owner})."))
@@ -643,51 +809,48 @@ fn count_with_unread(dir: &Path) -> (usize, usize) {
 }
 
 fn delete(
-    config: &Config,
+    config: Option<&Config>,
     name: &str,
     yes: bool,
     force: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // `--force` wipes `inbox/<name>/` and `sent/<name>/` contents
-    // before invoking the normal delete path. The wipe is CLI-only
-    // (the MCP `mailbox_delete` tool does not gain a force variant)
-    // and refuses on the catchall.
+    // `--force` asks the daemon to wipe `inbox/<name>/` and
+    // `sent/<name>/` contents under the per-mailbox lock that guards
+    // the stanza removal — the wipe and the config rewrite are atomic
+    // together (no data-destruction race window if the daemon dies
+    // mid-flight). Refuse the catchall up front so the operator gets
+    // a friendly error before we even open the UDS.
+    if force && name == "catchall" {
+        return Err("Cannot delete the catchall mailbox".into());
+    }
+
     if force {
-        if name == "catchall" {
-            return Err("Cannot delete the catchall mailbox".into());
-        }
-
-        // S2-2 ordering: ownership pre-flight via in-memory Config
-        // BEFORE the wipe. If a non-root caller asked to `--force` a
-        // mailbox they don't own, we must refuse here — wiping first
-        // would partially destroy data the daemon then refuses to
-        // delete. Root callers bypass this check (the daemon also
-        // bypasses on the wire side); a non-root caller hitting an
-        // unknown mailbox surfaces NoSuchMailbox.
-        if !is_root()
-            && let Err(e) = crate::auth::authorize(
-                current_euid(),
-                crate::auth::Action::MailboxDelete {
-                    mailbox: name.to_string(),
-                },
-                config.mailboxes.get(name),
-            )
-        {
-            return Err(format_auth_error(&e, "delete").into());
-        }
-
-        let inbox_dir = config.inbox_dir(name);
-        let sent_dir = config.sent_dir(name);
-        let inbox_count = count_messages(&inbox_dir);
-        let sent_count = count_messages(&sent_dir);
+        // Show the pre-wipe counts so the operator knows exactly how
+        // much data is about to be destroyed. The counts are
+        // best-effort (taken before the daemon acquires its lock, so
+        // they may drift if mail lands in the meantime); the daemon
+        // is authoritative on what actually gets wiped. When config
+        // is unreadable (non-root, root-owned config.toml) the count
+        // line just shows `?`.
+        let (inbox_label, sent_label) = match config {
+            Some(cfg) => {
+                let inbox_dir = cfg.inbox_dir(name);
+                let sent_dir = cfg.sent_dir(name);
+                (
+                    pluralize_files(count_messages(&inbox_dir)),
+                    pluralize_files(count_messages(&sent_dir)),
+                )
+            }
+            None => ("? files".to_string(), "? files".to_string()),
+        };
 
         if !yes {
             println!(
                 "{} About to permanently delete mailbox '{name}':",
                 term::warn("DESTRUCTIVE:"),
             );
-            println!("  inbox/{name}/: {}", pluralize_files(inbox_count));
-            println!("  sent/{name}/:  {}", pluralize_files(sent_count));
+            println!("  inbox/{name}/: {inbox_label}");
+            println!("  sent/{name}/:  {sent_label}");
             print!("Continue? [y/N] ");
             io::stdout().flush()?;
             let mut input = String::new();
@@ -697,9 +860,6 @@ fn delete(
                 return Ok(());
             }
         }
-
-        wipe_mailbox_contents(&inbox_dir)?;
-        wipe_mailbox_contents(&sent_dir)?;
     } else if !yes {
         print!("Delete mailbox '{name}' and all its emails? [y/N] ");
         io::stdout().flush()?;
@@ -712,13 +872,13 @@ fn delete(
     }
 
     // Prefer the UDS path so the daemon hot-swaps Config. The daemon
-    // refuses to delete a non-empty mailbox (ERR NONEMPTY); we surface
-    // that error verbatim rather than falling back to the direct-edit
-    // path, because "daemon says no" is not a socket-missing condition.
-    // Fall back to direct edit only when the socket is absent. After a
-    // successful `--force` wipe the daemon sees empty directories and
-    // succeeds normally.
-    match crate::mcp::submit_mailbox_crud_via_daemon(name, false, None) {
+    // refuses to delete a non-empty mailbox (ERR NONEMPTY) unless
+    // `force=true` is set, in which case it wipes the directories
+    // server-side under the per-mailbox lock before unlinking the
+    // stanza. Fall back to direct edit only when the socket is absent
+    // and the caller is root (non-root cannot rename
+    // `/etc/aimx/config.toml`).
+    match crate::mcp::submit_mailbox_crud_via_daemon(name, false, None, force) {
         Ok(()) => {
             println!("{}", term::success(&format!("Mailbox '{name}' deleted.")));
             println!(
@@ -731,7 +891,24 @@ fn delete(
             if !is_root() {
                 exit_socket_missing();
             }
-            delete_mailbox(config, name)?;
+            // Root fallback: wipe locally then call delete_mailbox
+            // directly. This path runs only when the daemon is
+            // stopped — no concurrent access to worry about.
+            let cfg = config.ok_or_else(|| -> Box<dyn std::error::Error> {
+                format!(
+                    "config could not be loaded from {}; \
+                     daemon is also unreachable",
+                    crate::config::config_path().display()
+                )
+                .into()
+            })?;
+            if force {
+                let inbox_dir = cfg.inbox_dir(name);
+                let sent_dir = cfg.sent_dir(name);
+                wipe_mailbox_contents(&inbox_dir)?;
+                wipe_mailbox_contents(&sent_dir)?;
+            }
+            delete_mailbox(cfg, name)?;
             println!("{}", term::success(&format!("Mailbox '{name}' deleted.")));
             print_restart_hint();
             Ok(())

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -482,19 +482,32 @@ fn create(
         resolve_create_owner(cfg, name, owner, &sys)?
     };
 
+    // Effective owner: what the daemon will actually bind on disk.
+    // For non-root callers the daemon discards the wire-supplied value
+    // and synthesizes from SO_PEERCRED, so the honest display value is
+    // the caller's username (when resolvable). Both the S2-1
+    // soft-warning and the success line below read this so they agree.
+    let effective_owner = if !is_root() {
+        let caller = caller_username();
+        if caller.is_empty() {
+            owner.clone()
+        } else {
+            caller
+        }
+    } else {
+        owner.clone()
+    };
+
     // S2-1 soft-warning: a non-root caller who passed `--owner <other>`
     // gets a stderr line clarifying that the daemon will discard the
     // value and bind ownership to the caller's uid via SO_PEERCRED.
     // This is purely UX; the daemon enforces the structural invariant
     // server-side either way.
-    if !is_root() {
-        let caller = caller_username();
-        if !caller.is_empty() && owner != caller {
-            eprintln!(
-                "{} --owner ignored for non-root callers; mailbox will be owned by `{caller}`",
-                term::warn("Warning:"),
-            );
-        }
+    if !is_root() && !effective_owner.is_empty() && owner != effective_owner {
+        eprintln!(
+            "{} --owner ignored for non-root callers; mailbox will be owned by `{effective_owner}`",
+            term::warn("Warning:"),
+        );
     }
 
     // Try the UDS path first so the daemon hot-swaps its in-memory
@@ -506,7 +519,9 @@ fn create(
         Ok(()) => {
             println!(
                 "{}",
-                term::success(&format!("Mailbox '{name}' created (owner: {owner})."))
+                term::success(&format!(
+                    "Mailbox '{name}' created (owner: {effective_owner})."
+                ))
             );
             Ok(())
         }
@@ -527,7 +542,9 @@ fn create(
             create_mailbox(cfg, name, &owner)?;
             println!(
                 "{}",
-                term::success(&format!("Mailbox '{name}' created (owner: {owner})."))
+                term::success(&format!(
+                    "Mailbox '{name}' created (owner: {effective_owner})."
+                ))
             );
             print_restart_hint();
             Ok(())

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -1,4 +1,4 @@
-use crate::auth::{Action, AuthError, authorize};
+use crate::auth::AuthError;
 use crate::cli::MailboxCommand;
 use crate::config::{Config, MailboxConfig};
 use crate::platform::{current_euid, is_root};
@@ -6,58 +6,28 @@ use crate::term;
 use std::io::{self, Write};
 use std::path::Path;
 
+/// Exit code emitted when a non-root caller can't reach the daemon UDS.
+/// Mirrors `send::EXIT_CONNECT` so tooling treats both socket-missing
+/// failures uniformly.
+pub(crate) const EXIT_SOCKET_MISSING: i32 = 2;
+
+/// Stderr message printed before exiting with [`EXIT_SOCKET_MISSING`].
+/// Lifted to a constant so the integration test can match it verbatim.
+pub(crate) const SOCKET_MISSING_HINT: &str = "daemon must be running for non-root mailbox CRUD; start `aimx serve` \
+     or run with sudo to fall back to direct config edit.";
+
 pub fn run(cmd: MailboxCommand, config: Config) -> Result<(), Box<dyn std::error::Error>> {
-    // `AIMX_TEST_SKIP_ROOT_CHECK=1` is a test-harness opt-in (see the
-    // "Test environment escape hatches" section in `CLAUDE.md`). It
-    // bypasses the root gate so the post-gate code path stays reachable
-    // under a non-root `cargo test` runner; production callers must
-    // never set it.
-    let skip_root_check = std::env::var_os("AIMX_TEST_SKIP_ROOT_CHECK").is_some();
+    // S2-1: the entry-point root gate is gone. Both CREATE and DELETE
+    // route through the daemon UDS regardless of caller uid; the daemon
+    // (post-Sprint-1) does the authz, owner-binding, atomic config
+    // write, and `Arc<Config>` hot-swap. The CLI is now a thin client.
+    // Root callers retain the direct-on-disk fallback when the socket
+    // is absent; non-root callers fail fast with a precise hint.
     match cmd {
-        MailboxCommand::Create { name, owner } => {
-            // Sprint 1 keeps CLI behavior unchanged: the entry-point
-            // predicate is now the new owner-bound `MailboxCreate`
-            // variant, but with `owner_uid = current_euid()` it
-            // trivially passes for any caller (root via the bypass,
-            // non-root because they pass their own uid). Sprint 2
-            // (S2-1) drops the entry-point gate entirely and lets the
-            // daemon do the authz over UDS.
-            if !skip_root_check
-                && let Err(e) = authorize(
-                    current_euid(),
-                    Action::MailboxCreate {
-                        owner_uid: current_euid(),
-                    },
-                    None,
-                )
-            {
-                return Err(format_auth_error(&e, "create").into());
-            }
-            create(&config, &name, owner.as_deref())
-        }
+        MailboxCommand::Create { name, owner } => create(&config, &name, owner.as_deref()),
         MailboxCommand::List { all } => list(&config, all),
         MailboxCommand::Show { name } => show(&config, &name),
-        MailboxCommand::Delete { name, yes, force } => {
-            // See note above on the create path: same Sprint 1
-            // behavior-preserving gate. The mailbox arg is
-            // `config.mailboxes.get(&name)` — `Some(...)` when the
-            // mailbox is in the on-disk config, `None` otherwise. The
-            // predicate then either passes (caller owns it), returns
-            // `NotOwner` (mailbox exists, owned by someone else), or
-            // `NoSuchMailbox` (mailbox missing). Root keeps the bypass.
-            if !skip_root_check
-                && let Err(e) = authorize(
-                    current_euid(),
-                    Action::MailboxDelete {
-                        mailbox: name.clone(),
-                    },
-                    config.mailboxes.get(&name),
-                )
-            {
-                return Err(format_auth_error(&e, "delete").into());
-            }
-            delete(&config, &name, yes, force)
-        }
+        MailboxCommand::Delete { name, yes, force } => delete(&config, &name, yes, force),
     }
 }
 
@@ -65,15 +35,23 @@ pub fn run(cmd: MailboxCommand, config: Config) -> Result<(), Box<dyn std::error
 /// authorized" prefix so tooling can grep for it, and append the verb
 /// the operator was attempting so the error text makes sense without
 /// re-reading the command.
+///
+/// `NotRoot` is no longer reachable from the mailbox CLI — Sprint 2
+/// (S2-1) dropped the entry-point root gate. The arm is retained so a
+/// future caller that wires `format_auth_error` against a different
+/// surface still gets exhaustive coverage.
 fn format_auth_error(err: &AuthError, verb: &str) -> String {
     match err {
-        AuthError::NotRoot => {
-            format!("not authorized: aimx mailboxes {verb} requires root (run with sudo)")
-        }
         AuthError::NotOwner { mailbox } => {
             format!("not authorized: caller does not own mailbox '{mailbox}'")
         }
+        AuthError::OwnerMismatch { .. } => {
+            format!("not authorized: cannot {verb} a mailbox owned by another user")
+        }
         AuthError::NoSuchMailbox => "not authorized: no such mailbox".to_string(),
+        AuthError::NotRoot => {
+            format!("not authorized: aimx mailboxes {verb} requires root (run with sudo)")
+        }
     }
 }
 
@@ -347,11 +325,27 @@ fn create(
     // blocking on stdin.
     let sys = crate::setup::RealSystemOps;
     let owner = resolve_create_owner(config, name, owner, &sys)?;
+
+    // S2-1 soft-warning: a non-root caller who passed `--owner <other>`
+    // gets a stderr line clarifying that the daemon will discard the
+    // value and bind ownership to the caller's uid via SO_PEERCRED.
+    // This is purely UX; the daemon enforces the structural invariant
+    // server-side either way.
+    if !is_root() {
+        let caller = caller_username();
+        if !caller.is_empty() && owner != caller {
+            eprintln!(
+                "{} --owner ignored for non-root callers; mailbox will be owned by `{caller}`",
+                term::warn("Warning:"),
+            );
+        }
+    }
+
     // Try the UDS path first so the daemon hot-swaps its in-memory
-    // Config. On socket-missing (daemon stopped, fresh install), fall
-    // back to direct on-disk edit + the restart-hint banner. When UDS
-    // succeeds we suppress the hint; the daemon already picked up the
-    // change.
+    // Config. On socket-missing (daemon stopped, fresh install), root
+    // falls back to direct on-disk edit + the restart-hint banner;
+    // non-root cannot rename `/etc/aimx/config.toml` (perm `0640
+    // root:root`), so we exit 2 with a precise actionable error.
     match crate::mcp::submit_mailbox_crud_via_daemon(name, true, Some(&owner)) {
         Ok(()) => {
             println!(
@@ -361,6 +355,9 @@ fn create(
             Ok(())
         }
         Err(crate::mcp::MailboxCrudFallback::SocketMissing) => {
+            if !is_root() {
+                exit_socket_missing();
+            }
             create_mailbox(config, name, &owner)?;
             println!(
                 "{}",
@@ -371,6 +368,22 @@ fn create(
         }
         Err(crate::mcp::MailboxCrudFallback::Daemon(msg)) => Err(msg.into()),
     }
+}
+
+/// Return the current Linux user's name, or an empty string when the
+/// uid does not resolve via `getpwuid`. Used by the soft-warning path
+/// in `create()` — never panics, never errors; an empty result simply
+/// suppresses the warning rather than confusing it.
+fn caller_username() -> String {
+    crate::uds_authz::lookup_username(current_euid()).unwrap_or_default()
+}
+
+/// Print [`SOCKET_MISSING_HINT`] to stderr and exit with
+/// [`EXIT_SOCKET_MISSING`]. Centralised so the create / delete paths
+/// stay consistent.
+fn exit_socket_missing() -> ! {
+    eprintln!("{} {SOCKET_MISSING_HINT}", term::error("Error:"));
+    std::process::exit(EXIT_SOCKET_MISSING);
 }
 
 /// Resolve the owner value for `mailbox create`. Explicit `--owner`
@@ -643,6 +656,26 @@ fn delete(
         if name == "catchall" {
             return Err("Cannot delete the catchall mailbox".into());
         }
+
+        // S2-2 ordering: ownership pre-flight via in-memory Config
+        // BEFORE the wipe. If a non-root caller asked to `--force` a
+        // mailbox they don't own, we must refuse here — wiping first
+        // would partially destroy data the daemon then refuses to
+        // delete. Root callers bypass this check (the daemon also
+        // bypasses on the wire side); a non-root caller hitting an
+        // unknown mailbox surfaces NoSuchMailbox.
+        if !is_root()
+            && let Err(e) = crate::auth::authorize(
+                current_euid(),
+                crate::auth::Action::MailboxDelete {
+                    mailbox: name.to_string(),
+                },
+                config.mailboxes.get(name),
+            )
+        {
+            return Err(format_auth_error(&e, "delete").into());
+        }
+
         let inbox_dir = config.inbox_dir(name);
         let sent_dir = config.sent_dir(name);
         let inbox_count = count_messages(&inbox_dir);
@@ -695,6 +728,9 @@ fn delete(
             Ok(())
         }
         Err(crate::mcp::MailboxCrudFallback::SocketMissing) => {
+            if !is_root() {
+                exit_socket_missing();
+            }
             delete_mailbox(config, name)?;
             println!("{}", term::success(&format!("Mailbox '{name}' deleted.")));
             print_restart_hint();
@@ -711,7 +747,12 @@ fn delete(
 /// (no error). Each entry is removed via `remove_dir_all` (for bundle
 /// directories) or `remove_file` (for flat .md files); errors propagate
 /// so the caller can surface the failure verbatim.
-fn wipe_mailbox_contents(dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+///
+/// `pub(crate)` so the MCP `mailbox_delete` tool can reuse the same
+/// wipe contract — keeping a single implementation prevents the CLI
+/// and MCP paths from drifting on edge cases like dotfile preservation
+/// or symlink handling.
+pub(crate) fn wipe_mailbox_contents(dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
     let entries = match std::fs::read_dir(dir) {
         Ok(e) => e,
         Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
@@ -784,14 +825,6 @@ mod tests {
     use crate::auth::AuthError;
 
     #[test]
-    fn format_auth_error_not_root_mentions_sudo_and_verb() {
-        let msg = format_auth_error(&AuthError::NotRoot, "create");
-        assert!(msg.contains("not authorized"), "{msg}");
-        assert!(msg.contains("create"), "{msg}");
-        assert!(msg.contains("sudo"), "{msg}");
-    }
-
-    #[test]
     fn format_auth_error_not_owner_carries_mailbox_name() {
         let msg = format_auth_error(
             &AuthError::NotOwner {
@@ -804,10 +837,42 @@ mod tests {
     }
 
     #[test]
+    fn format_auth_error_owner_mismatch_renders_cleanly() {
+        // S2-1: the legacy `<new>` sentinel rendering is gone. The new
+        // arm reads as a single user-friendly sentence and uses the
+        // verb supplied by the caller (`create` here) so the message
+        // matches the command the operator just ran.
+        let msg = format_auth_error(
+            &AuthError::OwnerMismatch {
+                intended_owner_uid: 0,
+            },
+            "create",
+        );
+        assert!(msg.contains("not authorized"), "{msg}");
+        assert!(msg.contains("cannot create"), "{msg}");
+        assert!(
+            !msg.contains("'<new>'"),
+            "must not surface the Sprint-1 sentinel: {msg}"
+        );
+        assert!(!msg.contains('0'), "uid must not leak: {msg}");
+    }
+
+    #[test]
     fn format_auth_error_no_such_mailbox_does_not_leak_caller() {
         let msg = format_auth_error(&AuthError::NoSuchMailbox, "create");
         assert!(msg.contains("not authorized"), "{msg}");
         assert!(msg.contains("no such mailbox"), "{msg}");
+    }
+
+    #[test]
+    fn format_auth_error_not_root_arm_still_renders() {
+        // S2-1 dropped the entry-point root gate, so this arm is no
+        // longer reachable from the mailbox CLI dispatch — but the
+        // match must stay exhaustive. The render itself stays
+        // grep-able for any future caller.
+        let msg = format_auth_error(&AuthError::NotRoot, "create");
+        assert!(msg.contains("not authorized"), "{msg}");
+        assert!(msg.contains("requires root"), "{msg}");
     }
 
     fn config_with_owners(owners: &[(&str, &str)]) -> Config {

--- a/src/mailbox_handler.rs
+++ b/src/mailbox_handler.rs
@@ -257,7 +257,7 @@ pub async fn handle_mailbox_crud(
             },
             None,
         );
-        handle_delete(state_ctx, mb_ctx, &req.name)
+        handle_delete(state_ctx, mb_ctx, &req.name, req.force)
     }
 }
 
@@ -492,7 +492,12 @@ fn check_preexisting_dirs(inbox: &Path, sent: &Path, uid: u32, gid: u32) -> Opti
     None
 }
 
-fn handle_delete(state_ctx: &StateContext, mb_ctx: &MailboxContext, name: &str) -> AckResponse {
+fn handle_delete(
+    state_ctx: &StateContext,
+    mb_ctx: &MailboxContext,
+    name: &str,
+    force: bool,
+) -> AckResponse {
     if name == "catchall" {
         return AckResponse::Err {
             code: ErrCode::Mailbox,
@@ -507,10 +512,25 @@ fn handle_delete(state_ctx: &StateContext, mb_ctx: &MailboxContext, name: &str) 
             reason: no_such_mailbox_reason(name),
         };
     }
+    drop(current);
 
     let data_dir = &state_ctx.data_dir;
     let inbox = data_dir.join("inbox").join(name);
     let sent = data_dir.join("sent").join(name);
+
+    // `force=true`: wipe inbox + sent contents under the same per-mailbox
+    // lock that already guards the stanza removal. This eliminates the
+    // data-destruction race window the client-side wipe used to leave
+    // open (daemon dies between wipe and DELETE submit → contents gone,
+    // config still references the mailbox). The wipe leaves the
+    // directories themselves in place; the post-wipe NONEMPTY check
+    // below sees zero files and lets the delete proceed.
+    if force && let Err(e) = wipe_mailbox_dirs(&inbox, &sent) {
+        return AckResponse::Err {
+            code: ErrCode::Io,
+            reason: format!("failed to wipe mailbox '{name}': {e}"),
+        };
+    }
 
     let inbox_files = count_files_if_exists(&inbox);
     let sent_files = count_files_if_exists(&sent);
@@ -526,6 +546,8 @@ fn handle_delete(state_ctx: &StateContext, mb_ctx: &MailboxContext, name: &str) 
             ),
         };
     }
+
+    let current = mb_ctx.config_handle.load();
 
     let mut new_config: Config = (*current).clone();
     new_config.mailboxes.remove(name);
@@ -553,6 +575,20 @@ fn count_files_if_exists(dir: &Path) -> usize {
         Ok(entries) => entries.filter_map(|e| e.ok()).count(),
         Err(_) => 0,
     }
+}
+
+/// Wipe both the inbox and sent directories of a mailbox, removing
+/// every entry but leaving the directories themselves in place. Called
+/// from the `MAILBOX-DELETE force=true` path so the wipe and the
+/// stanza removal happen atomically under the per-mailbox lock — no
+/// data-destruction race window if the daemon dies mid-flight.
+/// Reuses [`crate::mailbox::wipe_mailbox_contents`] so the CLI
+/// fallback path and the daemon path share the same wipe contract
+/// (dotfile preservation, symlink handling, missing-dir tolerance).
+fn wipe_mailbox_dirs(inbox: &Path, sent: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    crate::mailbox::wipe_mailbox_contents(inbox)?;
+    crate::mailbox::wipe_mailbox_contents(sent)?;
+    Ok(())
 }
 
 /// Atomically replace `path` with the TOML serialization of `config`.
@@ -710,6 +746,7 @@ mod tests {
             name: "alice".into(),
             create: true,
             owner: Some("testowner".into()),
+            force: false,
         };
         assert!(matches!(
             handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await,
@@ -740,6 +777,7 @@ mod tests {
             name: "alice".into(),
             create: true,
             owner: Some("testowner".into()),
+            force: false,
         };
         assert!(matches!(
             handle_mailbox_crud(&state_ctx, &mb_ctx, &seed, &Caller::internal_root()).await,
@@ -750,6 +788,7 @@ mod tests {
             name: "alice".into(),
             create: true,
             owner: Some("testowner".into()),
+            force: false,
         };
         match handle_mailbox_crud(&state_ctx, &mb_ctx, &dup, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
@@ -770,6 +809,7 @@ mod tests {
                 name: name.into(),
                 create: true,
                 owner: Some("testowner".into()),
+                force: false,
             };
             match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
                 AckResponse::Err { code, reason } => {
@@ -797,6 +837,7 @@ mod tests {
             name: "catchall".into(),
             create: true,
             owner: Some("testowner".into()),
+            force: false,
         };
         match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &attacker).await {
             AckResponse::Err { code, reason } => {
@@ -816,6 +857,7 @@ mod tests {
             name: "".into(),
             create: true,
             owner: Some("testowner".into()),
+            force: false,
         };
         match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Validation),
@@ -833,6 +875,7 @@ mod tests {
                 name: bad.into(),
                 create: true,
                 owner: Some("testowner".into()),
+                force: false,
             };
             match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
                 AckResponse::Err { code, .. } => {
@@ -854,6 +897,7 @@ mod tests {
             name: "alice".into(),
             create: true,
             owner: Some("testowner".into()),
+            force: false,
         };
         assert!(matches!(
             handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await,
@@ -865,6 +909,7 @@ mod tests {
             name: "alice".into(),
             create: false,
             owner: None,
+            force: false,
         };
         assert!(matches!(
             handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await,
@@ -887,6 +932,7 @@ mod tests {
             name: "alice".into(),
             create: true,
             owner: Some("testowner".into()),
+            force: false,
         };
         assert!(matches!(
             handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await,
@@ -902,6 +948,7 @@ mod tests {
             name: "alice".into(),
             create: false,
             owner: None,
+            force: false,
         };
         match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
@@ -933,6 +980,7 @@ mod tests {
             name: "catchall".into(),
             create: false,
             owner: None,
+            force: false,
         };
         match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
@@ -952,6 +1000,7 @@ mod tests {
             name: "ghost".into(),
             create: false,
             owner: None,
+            force: false,
         };
         match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
@@ -991,6 +1040,7 @@ mod tests {
             name: "alice".into(),
             create: true,
             owner: Some("testowner".into()),
+            force: false,
         };
         match handle_mailbox_crud(&state_ctx, &bad_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Io),
@@ -1105,6 +1155,7 @@ mod tests {
             name: "alice".into(),
             create: true,
             owner: Some("testowner".into()),
+            force: false,
         };
         assert!(matches!(
             handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await,
@@ -1194,6 +1245,7 @@ mod tests {
                     name: n,
                     create: true,
                     owner: Some("testowner".into()),
+                    force: false,
                 };
                 handle_mailbox_crud(&s, &m, &req, &Caller::internal_root()).await
             }));
@@ -1243,6 +1295,7 @@ mod tests {
             name: "alice".into(),
             create: true,
             owner: None,
+            force: false,
         };
         match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
@@ -1265,6 +1318,7 @@ mod tests {
             name: "alice".into(),
             create: true,
             owner: Some("ghost".into()),
+            force: false,
         };
         match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
@@ -1311,6 +1365,7 @@ mod tests {
             name: "alice".into(),
             create: true,
             owner: Some("nobody".into()),
+            force: false,
         };
         // Note: the test harness may actually be running as uid 65534 in
         // some exotic CI, in which case the conflict check flips to
@@ -1379,6 +1434,7 @@ mod tests {
             name: "alice".into(),
             create: true,
             owner: Some("nobody".into()),
+            force: false,
         };
         match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, .. } => {
@@ -1457,6 +1513,7 @@ mod tests {
             name: "alice".into(),
             create: true,
             owner: Some("nobody".into()),
+            force: false,
         };
         match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &Caller::internal_root()).await {
             AckResponse::Err { code, reason } => {
@@ -1504,6 +1561,7 @@ mod tests {
             name: "alice".into(),
             create: true,
             owner: Some("testowner".into()),
+            force: false,
         };
         assert!(
             matches!(
@@ -1545,6 +1603,7 @@ mod tests {
             create: true,
             // The attacker tries to claim a root-owned mailbox.
             owner: Some("root".into()),
+            force: false,
         };
         let resp = handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &caller).await;
         assert!(matches!(resp, AckResponse::Ok), "{resp:?}");
@@ -1616,6 +1675,7 @@ mod tests {
             name: "opsbox".into(),
             create: false,
             owner: None,
+            force: false,
         };
         let unowned_resp =
             handle_mailbox_crud(&state_ctx, &mb_ctx, &unowned_delete, &nonroot).await;
@@ -1627,6 +1687,7 @@ mod tests {
             name: "nope".into(),
             create: false,
             owner: None,
+            force: false,
         };
         let missing_resp =
             handle_mailbox_crud(&state_ctx, &mb_ctx, &missing_delete, &nonroot).await;
@@ -1691,6 +1752,7 @@ mod tests {
             create: true,
             // Owner is ignored for non-root; included to prove that.
             owner: Some("ignored-by-daemon".into()),
+            force: false,
         };
         let r1 = handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &caller).await;
         assert!(matches!(r1, AckResponse::Ok), "first create: {r1:?}");
@@ -1731,11 +1793,13 @@ mod tests {
             name: "task42".into(),
             create: true,
             owner: None,
+            force: false,
         };
         let delete_req = MailboxCrudRequest {
             name: "task42".into(),
             create: false,
             owner: None,
+            force: false,
         };
 
         let r1 = handle_mailbox_crud(&state_ctx, &mb_ctx, &create_req, &caller).await;
@@ -1781,6 +1845,7 @@ mod tests {
             name: "orph".into(),
             create: true,
             owner: Some("anything".into()),
+            force: false,
         };
         match handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &orphan).await {
             AckResponse::Err { code, reason } => {

--- a/src/mailbox_handler.rs
+++ b/src/mailbox_handler.rs
@@ -223,7 +223,13 @@ pub async fn handle_mailbox_crud(
                 AuthError::NotOwner { .. } | AuthError::NoSuchMailbox => {
                     no_such_mailbox_reason(&req.name)
                 }
-                AuthError::NotRoot => not_authorized_wire_reason(),
+                // `OwnerMismatch` only fires from `MailboxCreate`, so it
+                // is unreachable on the DELETE path. Kept exhaustive so
+                // a future variant addition surfaces here as a compile
+                // error rather than silently mapping to the catch-all.
+                AuthError::OwnerMismatch { .. } | AuthError::NotRoot => {
+                    not_authorized_wire_reason()
+                }
             };
             log_decision(
                 verb,

--- a/src/mailbox_list_handler.rs
+++ b/src/mailbox_list_handler.rs
@@ -28,9 +28,7 @@
 use std::os::unix::fs::MetadataExt;
 use std::path::Path;
 
-#[cfg(test)]
-use serde::Deserialize;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 use crate::config::Config;
 use crate::mailbox;
@@ -40,10 +38,20 @@ use crate::uds_authz::Caller;
 
 /// One row of the JSON array returned by `MAILBOX-LIST`. Field order
 /// matches the PRD: identity → paths → counts → registration flag.
-#[derive(Debug, Serialize)]
-#[cfg_attr(test, derive(Deserialize))]
+/// `Deserialize` is unconditional now that the CLI's non-root list
+/// fallback (`mailbox::list_via_daemon`) needs to decode the JSON
+/// outside of test-only builds.
+///
+/// `address` is `None` for unregistered stray on-disk directories
+/// (no `[mailboxes.<name>]` entry → no domain to project the local
+/// part against). Registered rows always carry the address verbatim
+/// from `MailboxConfig::address`, which the MCP `mailbox_create`
+/// tool reads back to surface `<name>@<domain>` to the agent without
+/// requiring a separate config-read path.
+#[derive(Debug, Serialize, Deserialize)]
 pub struct MailboxListRow {
     pub name: String,
+    pub address: Option<String>,
     pub inbox_path: String,
     pub sent_path: String,
     pub total: usize,
@@ -82,8 +90,10 @@ fn collect_rows(config: &Config, caller_uid: u32) -> Vec<MailboxListRow> {
         let sent_dir = config.sent_dir(&name);
         let (total, unread) = count_inbox(&inbox_dir);
         let sent_count = mailbox::count_messages(&sent_dir);
+        let address = config.mailboxes.get(&name).map(|mb| mb.address.clone());
         rows.push(MailboxListRow {
             name: name.clone(),
+            address,
             inbox_path: inbox_dir.to_string_lossy().into_owned(),
             sent_path: sent_dir.to_string_lossy().into_owned(),
             total,

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,20 @@ fn dispatch(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         // `aimx logs` is a thin wrapper around journalctl; it does not
         // read config.toml.
         Command::Logs { lines, follow } => logs::run(lines, follow),
+        // `aimx mailboxes` is a thin UDS client (mirrors `aimx send`).
+        // It must NOT pre-load config here — `/etc/aimx/config.toml`
+        // is `0640 root:root` in production, so an eager
+        // `Config::load_resolved_with_data_dir(...)?` would surface
+        // `Permission denied (os error 13)` for non-root callers
+        // before `mailbox::run` ever sees the request, breaking the
+        // S2-1 acceptance criterion ("solo operator runs `aimx
+        // mailboxes create my-agent` as themselves and it works").
+        // `mailbox::run` loads the config itself when it can, and
+        // each subcommand decides whether the missing-config case is
+        // recoverable (CREATE/DELETE go through the daemon UDS;
+        // LIST falls back to `MAILBOX-LIST`; SHOW errors with an
+        // actionable hint).
+        Command::Mailboxes(cmd) => mailbox::run(cmd, cli.data_dir.as_deref()),
         // `aimx upgrade` reads the release-manifest URL from Config
         // (optional `[upgrade] release_manifest_url`) but tolerates a
         // missing / unloadable config — a freshly-installed machine
@@ -178,7 +192,6 @@ fn dispatch_with_config(
 ) -> Result<(), Box<dyn std::error::Error>> {
     match cmd {
         Command::Ingest { rcpt } => ingest::run(&rcpt, config),
-        Command::Mailboxes(cmd) => mailbox::run(cmd, config),
         Command::Hooks(cmd) => hooks::run(cmd, config),
         Command::DkimKeygen { selector, force } => {
             dkim::run_keygen(&config::dkim_dir(), &config.domain, &selector, force)
@@ -200,6 +213,7 @@ fn dispatch_with_config(
         | Command::Mcp
         | Command::Send(_)
         | Command::Logs { .. }
+        | Command::Mailboxes(_)
         | Command::Agents(_)
         | Command::Upgrade(_) => unreachable!("handled by dispatch"),
     }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -139,6 +139,29 @@ pub struct HookDeleteParams {
     pub name: String,
 }
 
+#[derive(Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct MailboxCreateParams {
+    #[schemars(description = "Mailbox name (local part of the resulting address). \
+                       Must match `[a-z0-9._-]+` with no leading/trailing dot \
+                       and no `..`. Reserved names (`catchall`, `aimx-catchall`) \
+                       are rejected by the daemon.")]
+    pub name: String,
+}
+
+#[derive(Serialize, Deserialize, schemars::JsonSchema)]
+#[serde(deny_unknown_fields)]
+pub struct MailboxDeleteParams {
+    #[schemars(description = "Mailbox name to delete. You must own it (the \
+                       daemon checks via SO_PEERCRED).")]
+    pub name: String,
+    #[schemars(description = "When true, wipe `inbox/<name>/` and `sent/<name>/` \
+                       contents before submitting the delete. When false (default), \
+                       the daemon refuses non-empty mailboxes with a \
+                       `[NONEMPTY]` error.")]
+    pub force: Option<bool>,
+}
+
 impl AimxMcpServer {
     pub fn new(data_dir_override: Option<PathBuf>) -> Self {
         Self::with_caller_uid(data_dir_override, crate::platform::current_euid())
@@ -194,6 +217,9 @@ impl AimxMcpServer {
             crate::auth::AuthError::NotRoot => "not authorized: requires root".to_string(),
             crate::auth::AuthError::NotOwner { mailbox } => {
                 format!("not authorized: caller does not own mailbox '{mailbox}'")
+            }
+            crate::auth::AuthError::OwnerMismatch { .. } => {
+                "not authorized: cannot create a mailbox owned by another user".to_string()
             }
             crate::auth::AuthError::NoSuchMailbox => {
                 format!("not authorized: mailbox '{mailbox_name}' not found")
@@ -594,6 +620,103 @@ impl AimxMcpServer {
                 Err("aimx daemon not running. Start with 'sudo systemctl start aimx'".to_string())
             }
             Err(HookCrudFallback::Daemon(msg)) => Err(msg),
+        }
+    }
+
+    #[tool(
+        name = "mailbox_create",
+        description = "Create a new mailbox owned by your uid. Submits the \
+                       request through the aimx daemon over UDS; the daemon \
+                       resolves the owner from SO_PEERCRED, so the new mailbox \
+                       is always owned by you (no `owner` parameter — by \
+                       construction agents cannot create mailboxes owned by \
+                       another user). Returns the new mailbox's full address \
+                       on success."
+    )]
+    fn mailbox_create(
+        &self,
+        Parameters(params): Parameters<MailboxCreateParams>,
+    ) -> Result<String, String> {
+        // No client-side validation: the daemon owns the regex, the
+        // reserved-name list, and the idempotent "exists with matching
+        // owner → success" semantics. Surfacing daemon errors verbatim
+        // matches the pattern used by `email_send` / `hook_create`.
+        // The `owner` argument on the wire is `None` so the daemon
+        // synthesizes the owner from SO_PEERCRED rather than honoring
+        // anything the agent could have planted.
+        match submit_mailbox_crud_via_daemon(&params.name, true, None) {
+            Ok(()) => {
+                let domain = self
+                    .load_config()
+                    .map(|c| c.domain)
+                    .unwrap_or_else(|_| String::new());
+                if domain.is_empty() {
+                    Ok(format!("Mailbox '{}' created.", params.name))
+                } else {
+                    Ok(format!("{}@{domain}", params.name))
+                }
+            }
+            Err(MailboxCrudFallback::SocketMissing) => {
+                Err("aimx daemon not running. Start with 'sudo systemctl start aimx'".to_string())
+            }
+            Err(MailboxCrudFallback::Daemon(msg)) => Err(msg),
+        }
+    }
+
+    #[tool(
+        name = "mailbox_delete",
+        description = "Delete a mailbox you own. The daemon enforces ownership \
+                       via SO_PEERCRED; an attempt to delete a mailbox owned \
+                       by another uid surfaces as a not-authorized error. \
+                       When `force` is true, the tool first wipes \
+                       `inbox/<name>/` and `sent/<name>/` contents (mirroring \
+                       the CLI's `--force` flag) before submitting the delete; \
+                       when false (default), the daemon refuses non-empty \
+                       mailboxes with a `[NONEMPTY]` error."
+    )]
+    fn mailbox_delete(
+        &self,
+        Parameters(params): Parameters<MailboxDeleteParams>,
+    ) -> Result<String, String> {
+        let force = params.force.unwrap_or(false);
+
+        if force {
+            // Catchall is structurally distinct (owned by
+            // `aimx-catchall`); the wipe path refuses it on the CLI
+            // and we mirror that here so the daemon never sees a
+            // wipe-then-delete attempt for the catchall mailbox.
+            if params.name == "catchall" {
+                return Err("Cannot delete the catchall mailbox".to_string());
+            }
+
+            // S2-2 ordering: ownership pre-flight via in-memory
+            // Config BEFORE the wipe. Wiping a mailbox we don't own
+            // would partially destroy data the daemon then refuses to
+            // delete. The daemon re-checks via SO_PEERCRED, so this
+            // pre-flight is defense-in-depth, not the security
+            // boundary.
+            let config = self.load_config()?;
+            self.authorize_mailbox(
+                crate::auth::Action::MailboxDelete {
+                    mailbox: params.name.clone(),
+                },
+                &config,
+            )?;
+
+            let inbox_dir = config.inbox_dir(&params.name);
+            let sent_dir = config.sent_dir(&params.name);
+            mailbox::wipe_mailbox_contents(&inbox_dir)
+                .map_err(|e| format!("Failed to wipe inbox/{}/: {e}", params.name))?;
+            mailbox::wipe_mailbox_contents(&sent_dir)
+                .map_err(|e| format!("Failed to wipe sent/{}/: {e}", params.name))?;
+        }
+
+        match submit_mailbox_crud_via_daemon(&params.name, false, None) {
+            Ok(()) => Ok(format!("Mailbox '{}' deleted.", params.name)),
+            Err(MailboxCrudFallback::SocketMissing) => {
+                Err("aimx daemon not running. Start with 'sudo systemctl start aimx'".to_string())
+            }
+            Err(MailboxCrudFallback::Daemon(msg)) => Err(msg),
         }
     }
 }
@@ -2024,6 +2147,69 @@ mod email_list_tests {
         assert_eq!(params.mailbox, "alice");
         assert_eq!(params.id, "2025-06-15-120000-hello");
     }
+
+    #[test]
+    fn mailbox_create_params_rejects_owner_field() {
+        // S2-3 invariant: there is no `owner` parameter on
+        // `mailbox_create`. A stale `owner` field on the wire must
+        // surface as a parse error rather than be silently dropped —
+        // otherwise an agent could believe it created a mailbox owned
+        // by some other principal.
+        let json = serde_json::json!({
+            "name": "task-42",
+            "owner": "root",
+        });
+        let err = match serde_json::from_value::<MailboxCreateParams>(json) {
+            Ok(_) => panic!("expected unknown-field error, got Ok"),
+            Err(e) => e,
+        };
+        assert!(
+            err.to_string().contains("unknown field"),
+            "expected unknown-field error, got {err}"
+        );
+    }
+
+    #[test]
+    fn mailbox_create_params_accepts_name_only() {
+        let json = serde_json::json!({ "name": "task-42" });
+        let params: MailboxCreateParams =
+            serde_json::from_value(json).expect("name-only params must parse");
+        assert_eq!(params.name, "task-42");
+    }
+
+    #[test]
+    fn mailbox_delete_params_force_defaults_to_none() {
+        let json = serde_json::json!({ "name": "task-42" });
+        let params: MailboxDeleteParams =
+            serde_json::from_value(json).expect("name-only delete params must parse");
+        assert_eq!(params.name, "task-42");
+        assert!(params.force.is_none());
+    }
+
+    #[test]
+    fn mailbox_delete_params_accepts_force_true() {
+        let json = serde_json::json!({ "name": "task-42", "force": true });
+        let params: MailboxDeleteParams =
+            serde_json::from_value(json).expect("force=true must parse");
+        assert_eq!(params.force, Some(true));
+    }
+
+    #[test]
+    fn mailbox_delete_force_refuses_catchall_without_touching_disk() {
+        // The force-wipe path must reject the catchall mailbox
+        // client-side before any wipe attempt or daemon submission.
+        // Without this guard a force-wipe on `catchall` would clear
+        // the catchall storage even when the daemon would refuse the
+        // delete itself.
+        let server = AimxMcpServer::with_caller_uid_for_test(None, 1000);
+        let err = server
+            .mailbox_delete(Parameters(MailboxDeleteParams {
+                name: "catchall".to_string(),
+                force: Some(true),
+            }))
+            .unwrap_err();
+        assert!(err.contains("catchall"), "{err}");
+    }
 }
 
 #[cfg(test)]
@@ -2117,6 +2303,26 @@ mod schema_order_tests {
     #[test]
     fn hook_delete_params_property_order() {
         assert_eq!(property_keys::<HookDeleteParams>(), vec!["name"]);
+    }
+
+    #[test]
+    fn mailbox_create_params_property_order() {
+        // Per S2-3, the only parameter is `name`. There is no `owner`
+        // — by construction the daemon synthesizes the owner from
+        // SO_PEERCRED. A future field addition reorders the schema and
+        // surfaces here as a test failure so agent-facing behaviour is
+        // never silently changed.
+        assert_eq!(property_keys::<MailboxCreateParams>(), vec!["name"]);
+    }
+
+    #[test]
+    fn mailbox_delete_params_property_order() {
+        // Per S2-4, the parameters are `name` (required) and
+        // `force` (optional, default false).
+        assert_eq!(
+            property_keys::<MailboxDeleteParams>(),
+            vec!["name", "force"]
+        );
     }
 }
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -644,16 +644,20 @@ impl AimxMcpServer {
         // The `owner` argument on the wire is `None` so the daemon
         // synthesizes the owner from SO_PEERCRED rather than honoring
         // anything the agent could have planted.
-        match submit_mailbox_crud_via_daemon(&params.name, true, None) {
+        match submit_mailbox_crud_via_daemon(&params.name, true, None, false) {
             Ok(()) => {
-                let domain = self
-                    .load_config()
-                    .map(|c| c.domain)
-                    .unwrap_or_else(|_| String::new());
-                if domain.is_empty() {
+                // Resolve the new mailbox's address through the
+                // daemon's `MAILBOX-LIST` rather than reading
+                // root-owned `/etc/aimx/config.toml` from the
+                // non-root MCP process. The daemon's listing is
+                // SO_PEERCRED-filtered to the caller's uid, so the
+                // just-created mailbox is always visible to the
+                // calling agent.
+                let address = lookup_mailbox_address(&params.name).unwrap_or_default();
+                if address.is_empty() {
                     Ok(format!("Mailbox '{}' created.", params.name))
                 } else {
-                    Ok(format!("{}@{domain}", params.name))
+                    Ok(address)
                 }
             }
             Err(MailboxCrudFallback::SocketMissing) => {
@@ -680,38 +684,25 @@ impl AimxMcpServer {
     ) -> Result<String, String> {
         let force = params.force.unwrap_or(false);
 
-        if force {
-            // Catchall is structurally distinct (owned by
-            // `aimx-catchall`); the wipe path refuses it on the CLI
-            // and we mirror that here so the daemon never sees a
-            // wipe-then-delete attempt for the catchall mailbox.
-            if params.name == "catchall" {
-                return Err("Cannot delete the catchall mailbox".to_string());
-            }
-
-            // S2-2 ordering: ownership pre-flight via in-memory
-            // Config BEFORE the wipe. Wiping a mailbox we don't own
-            // would partially destroy data the daemon then refuses to
-            // delete. The daemon re-checks via SO_PEERCRED, so this
-            // pre-flight is defense-in-depth, not the security
-            // boundary.
-            let config = self.load_config()?;
-            self.authorize_mailbox(
-                crate::auth::Action::MailboxDelete {
-                    mailbox: params.name.clone(),
-                },
-                &config,
-            )?;
-
-            let inbox_dir = config.inbox_dir(&params.name);
-            let sent_dir = config.sent_dir(&params.name);
-            mailbox::wipe_mailbox_contents(&inbox_dir)
-                .map_err(|e| format!("Failed to wipe inbox/{}/: {e}", params.name))?;
-            mailbox::wipe_mailbox_contents(&sent_dir)
-                .map_err(|e| format!("Failed to wipe sent/{}/: {e}", params.name))?;
+        // Catchall is structurally distinct (owned by
+        // `aimx-catchall`) and the daemon refuses to delete it. Mirror
+        // that here so the wire surface still produces a friendly
+        // operator-facing error rather than the daemon's internal
+        // "cannot delete the catchall mailbox" verbatim — also
+        // matches the CLI's pre-flight refusal.
+        if force && params.name == "catchall" {
+            return Err("Cannot delete the catchall mailbox".to_string());
         }
 
-        match submit_mailbox_crud_via_daemon(&params.name, false, None) {
+        // The wipe is performed server-side by the daemon under the
+        // same per-mailbox lock that guards the stanza removal so the
+        // wipe and the rewrite are atomic together. This both
+        // eliminates the data-destruction race window the previous
+        // client-side wipe left open AND removes the MCP process's
+        // dependency on local read access to `/etc/aimx/config.toml`
+        // (which is `0640 root:root` in production, so the previous
+        // `self.load_config()` inevitably failed for non-root agents).
+        match submit_mailbox_crud_via_daemon(&params.name, false, None, force) {
             Ok(()) => Ok(format!("Mailbox '{}' deleted.", params.name)),
             Err(MailboxCrudFallback::SocketMissing) => {
                 Err("aimx daemon not running. Start with 'sudo systemctl start aimx'".to_string())
@@ -855,16 +846,25 @@ pub(crate) enum MailboxCrudFallback {
 }
 
 /// Submit a `MAILBOX-CREATE` / `MAILBOX-DELETE` request over UDS.
-/// `owner` is required on CREATE; ignored on DELETE.
+/// `owner` is honored only for root callers on CREATE — non-root
+/// callers have any wire-supplied owner ignored by the daemon
+/// (synthesized from `peer_username(SO_PEERCRED)` instead). `force`
+/// is meaningful only on DELETE: when `true` the daemon wipes the
+/// inbox and sent directories under the per-mailbox lock that
+/// already guards the stanza removal, so the wipe and the rewrite
+/// are atomic together (no data-destruction race window between a
+/// client-side wipe and the daemon-side delete).
 pub(crate) fn submit_mailbox_crud_via_daemon(
     name: &str,
     create: bool,
     owner: Option<&str>,
+    force: bool,
 ) -> Result<(), MailboxCrudFallback> {
     let request = MailboxCrudRequest {
         name: name.to_string(),
         create,
         owner: owner.map(|s| s.to_string()),
+        force,
     };
     let socket = crate::serve::aimx_socket_path();
 
@@ -1176,7 +1176,41 @@ pub async fn run(data_dir: Option<&std::path::Path>) -> Result<(), Box<dyn std::
 /// Submit an `AIMX/1 MAILBOX-LIST` to the daemon and return the JSON
 /// body verbatim. The schema-mandated string output for the tool is
 /// the JSON itself; no re-formatting happens here.
+/// Best-effort: ask the daemon for the caller's mailbox listing and
+/// return the address recorded for `name`. Returns `None` when the
+/// daemon is unreachable, the listing is malformed, the mailbox is
+/// absent (race), or the row is unregistered. The MCP
+/// `mailbox_create` success message swallows the `None` case
+/// gracefully — the create itself already succeeded; the address
+/// suffix is operator UX.
+fn lookup_mailbox_address(name: &str) -> Option<String> {
+    let json = submit_mailbox_list_raw().ok()?;
+    let rows: Vec<crate::mailbox_list_handler::MailboxListRow> =
+        serde_json::from_str(&json).ok()?;
+    rows.into_iter()
+        .find(|r| r.name == name)
+        .and_then(|r| r.address)
+}
+
 fn submit_mailbox_list_via_daemon() -> Result<String, String> {
+    submit_mailbox_list_raw().map_err(|e| match e {
+        MailboxCrudFallback::SocketMissing => {
+            "aimx daemon not running. Start with 'sudo systemctl start aimx'".to_string()
+        }
+        MailboxCrudFallback::Daemon(msg) => msg,
+    })
+}
+
+/// CLI-friendly variant of [`submit_mailbox_list_via_daemon`] that
+/// distinguishes socket-missing from a daemon-side error so the
+/// caller can decide whether to surface the canonical "daemon must
+/// be running" hint or render the daemon's reason verbatim. Mirrors
+/// the [`MailboxCrudFallback`] shape used by the CRUD path.
+pub(crate) fn submit_mailbox_list_via_daemon_for_cli() -> Result<String, MailboxCrudFallback> {
+    submit_mailbox_list_raw()
+}
+
+fn submit_mailbox_list_raw() -> Result<String, MailboxCrudFallback> {
     let socket = crate::serve::aimx_socket_path();
 
     let rt = tokio::runtime::Handle::try_current();
@@ -1188,23 +1222,25 @@ fn submit_mailbox_list_via_daemon() -> Result<String, String> {
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()
-                .map_err(|e| format!("Failed to create tokio runtime: {e}"))?;
+                .map_err(|e| {
+                    MailboxCrudFallback::Daemon(format!("Failed to create tokio runtime: {e}"))
+                })?;
             rt.block_on(submit_mailbox_list_request(&socket))
         }
     };
 
     let raw = io_result.map_err(|e| {
         if is_socket_missing(&e) {
-            "aimx daemon not running. Start with 'sudo systemctl start aimx'".to_string()
+            MailboxCrudFallback::SocketMissing
         } else {
-            format!(
+            MailboxCrudFallback::Daemon(format!(
                 "Failed to connect to aimx daemon at {}: {e}",
                 socket.display()
-            )
+            ))
         }
     })?;
 
-    decode_mailbox_list_response(&raw)
+    decode_mailbox_list_response(&raw).map_err(MailboxCrudFallback::Daemon)
 }
 
 /// Open the UDS, ship `AIMX/1 MAILBOX-LIST`, and return the raw

--- a/src/send_protocol.rs
+++ b/src/send_protocol.rs
@@ -113,20 +113,39 @@ pub struct MarkRequest {
 ///
 /// Both verbs share the same shape; the enum selection is encoded in
 /// `create` so the codec stays a single flat struct rather than two
-/// near-identical types. `MAILBOX-CREATE` requires an `Owner:` header
-/// so the daemon knows which Linux user to chown the newly-created
-/// mailbox directories to. `MAILBOX-DELETE` ignores
-/// `owner` — the daemon only needs the name to remove the stanza.
-#[derive(Debug, Clone, PartialEq, Eq)]
+/// near-identical types. `Owner:` is OPTIONAL on the wire — the
+/// daemon-side handler decides what to do per PRD §6.5 R20 (root
+/// callers must supply `Owner:` so the daemon knows which Linux user
+/// to chown the newly-created mailbox directories to; non-root callers
+/// have any wire-supplied `Owner:` ignored and the owner synthesized
+/// from `peer_username(SO_PEERCRED)`). `MAILBOX-DELETE` ignores
+/// `owner` regardless of caller — the daemon only needs the name to
+/// remove the stanza. `MAILBOX-DELETE` also accepts an optional
+/// `force` flag (encoded on the wire as `Force: true`) which tells the
+/// daemon to wipe `inbox/<name>/` and `sent/<name>/` contents under
+/// the per-mailbox lock before unlinking the stanza, so the wipe and
+/// the config rewrite are atomic together (no data-destruction race
+/// window between client-side wipe and daemon-side delete).
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct MailboxCrudRequest {
     pub name: String,
     /// `true` for `MAILBOX-CREATE`, `false` for `MAILBOX-DELETE`.
     pub create: bool,
-    /// Linux user that owns the mailbox storage. Required on CREATE,
-    /// ignored on DELETE. The daemon validates the owner resolves via
-    /// `getpwnam` and chowns `inbox/<name>/` + `sent/<name>/` to
-    /// `<owner>:<owner>` mode `0700`.
+    /// Linux user that owns the mailbox storage. Optional on the wire.
+    /// On CREATE: required for root callers (no SO_PEERCRED-based
+    /// identity to fall back on); ignored for non-root callers (the
+    /// daemon synthesizes from `peer_username(SO_PEERCRED)` so privilege
+    /// escalation is structurally impossible). On DELETE: ignored
+    /// regardless of caller. When supplied and accepted, the daemon
+    /// validates the owner resolves via `getpwnam` and chowns
+    /// `inbox/<name>/` + `sent/<name>/` to `<owner>:<owner>` mode `0700`.
     pub owner: Option<String>,
+    /// `MAILBOX-DELETE`-only: when `true`, the daemon wipes the inbox
+    /// and sent directories under the same per-mailbox lock that
+    /// guards the stanza removal, eliminating the data-destruction
+    /// race window a client-side wipe would otherwise leave open.
+    /// Ignored on CREATE.
+    pub force: bool,
 }
 
 /// Decoded `AIMX/1 HOOK-CREATE` request. The verb wiring is reworked
@@ -608,6 +627,8 @@ where
 {
     let mut name: Option<String> = None;
     let mut owner: Option<String> = None;
+    let mut force: bool = false;
+    let mut force_seen: bool = false;
     let mut content_length: Option<usize> = None;
 
     loop {
@@ -660,6 +681,31 @@ where
                 }
                 owner = Some(value);
             }
+            "force" => {
+                // `Force:` is only meaningful on MAILBOX-DELETE. Reject
+                // on CREATE so the wire shape stays self-describing
+                // rather than silently dropping a header an operator
+                // explicitly set.
+                if create {
+                    return Err(ParseError::Malformed(
+                        "Force header is only valid on MAILBOX-DELETE".into(),
+                    ));
+                }
+                if force_seen {
+                    return Err(ParseError::Malformed("duplicate Force header".into()));
+                }
+                let v_lower = value.to_ascii_lowercase();
+                force = match v_lower.as_str() {
+                    "true" => true,
+                    "false" => false,
+                    _ => {
+                        return Err(ParseError::Malformed(format!(
+                            "invalid Force value: {value:?} (expected 'true' or 'false')"
+                        )));
+                    }
+                };
+                force_seen = true;
+            }
             "content-length" => {
                 if content_length.is_some() {
                     return Err(ParseError::Malformed(
@@ -686,18 +732,27 @@ where
     // Content-Length is optional for MAILBOX-CRUD verbs; 0 is implicit.
     let _ = content_length;
 
-    // Owner is REQUIRED on CREATE. On DELETE the daemon
-    // only needs the name; Owner is ignored even if supplied.
-    if create && owner.is_none() {
-        return Err(ParseError::Malformed(
-            "missing required header: Owner".into(),
-        ));
-    }
+    // `Owner:` is OPTIONAL on the wire. The daemon-side handler
+    // (`mailbox_handler::handle_mailbox_crud`) decides what to do with
+    // the field per PRD §6.5 R20:
+    //
+    //   - non-root callers: the daemon ignores any wire-supplied owner
+    //     and synthesizes it from `peer_username(SO_PEERCRED)`. This is
+    //     the path the MCP `mailbox_create` tool uses (it deliberately
+    //     ships `owner: None` so an agent cannot plant a foreign owner).
+    //   - root callers: the daemon requires `owner: Some(_)` (it has no
+    //     SO_PEERCRED-based identity to fall back on) and rejects with
+    //     `ErrCode::Validation` if the field is missing.
+    //
+    // The parser therefore stays permissive — making it strict would
+    // re-introduce the protocol-level rejection that broke the MCP
+    // `mailbox_create` tool for non-root callers in production.
 
     Ok(MailboxCrudRequest {
         name,
         create,
         owner,
+        force,
     })
 }
 
@@ -1092,7 +1147,11 @@ where
 /// Write an `AIMX/1 MAILBOX-CREATE` or `AIMX/1 MAILBOX-DELETE` request
 /// frame. Verb chosen by `request.create` (`true` → MAILBOX-CREATE,
 /// `false` → MAILBOX-DELETE). `Owner:` is emitted when `request.owner`
-/// is `Some`; the parser requires it on CREATE.
+/// is `Some`; the daemon decides per-caller whether the field is
+/// honored or ignored. `Force: true` is emitted only on MAILBOX-DELETE
+/// when `request.force` is true so the daemon performs a server-side
+/// wipe of `inbox/<name>/` and `sent/<name>/` under the per-mailbox
+/// lock that already guards the stanza removal.
 pub async fn write_mailbox_crud_request<W>(
     writer: &mut W,
     request: &MailboxCrudRequest,
@@ -1108,6 +1167,9 @@ where
     let mut header = format!("AIMX/1 {verb}\nName: {}\n", sanitize_inline(&request.name),);
     if let Some(owner) = &request.owner {
         header.push_str(&format!("Owner: {}\n", sanitize_inline(owner)));
+    }
+    if !request.create && request.force {
+        header.push_str("Force: true\n");
     }
     header.push_str("Content-Length: 0\n\n");
     writer.write_all(header.as_bytes()).await?;

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -727,13 +727,17 @@ fn mcp_list_tools() {
 
     let resp = client.list_tools();
     let tools = resp["result"]["tools"].as_array().unwrap();
-    // Mailbox CRUD tools are gone (moved to root-only CLI). Hook
-    // tools are back under the new auth predicate. Surface: 7 mail
-    // tools + 3 hook tools = 10.
-    assert_eq!(tools.len(), 10);
+    // S2-3 / S2-4 reintroduced `mailbox_create` and `mailbox_delete` as
+    // owner-gated MCP tools (the daemon synthesizes the owner from
+    // SO_PEERCRED, so an agent can only operate on mailboxes owned by
+    // its own uid). Surface: 7 mail tools + 3 hook tools + 2 mailbox
+    // CRUD tools + `mailbox_list` = 12.
+    assert_eq!(tools.len(), 12);
 
     let names: Vec<&str> = tools.iter().map(|t| t["name"].as_str().unwrap()).collect();
     assert!(names.contains(&"mailbox_list"));
+    assert!(names.contains(&"mailbox_create"));
+    assert!(names.contains(&"mailbox_delete"));
     assert!(names.contains(&"email_list"));
     assert!(names.contains(&"email_read"));
     assert!(names.contains(&"email_mark_read"));
@@ -743,10 +747,6 @@ fn mcp_list_tools() {
     assert!(names.contains(&"hook_create"));
     assert!(names.contains(&"hook_list"));
     assert!(names.contains(&"hook_delete"));
-    // mailbox_create / mailbox_delete moved to root-only CLI; the
-    // MCP surface no longer exposes them.
-    assert!(!names.contains(&"mailbox_create"));
-    assert!(!names.contains(&"mailbox_delete"));
     // hook_list_templates was deleted alongside hook templates.
     assert!(!names.contains(&"hook_list_templates"));
 
@@ -3025,23 +3025,29 @@ fn mailbox_create_via_uds_hotswaps_config_and_routes_new_mail() {
     stop_serve(daemon);
 }
 
+/// Non-root + missing socket: per S2-1 the CLI must NOT silently fall
+/// back to the direct config.toml edit (which would fail with a
+/// confusing perm error). It exits with the dedicated socket-missing
+/// code (`EXIT_SOCKET_MISSING = 2`) and prints the actionable hint
+/// naming both remediations.
 #[cfg(unix)]
 #[test]
-fn mailbox_create_without_daemon_falls_back_and_prints_restart_hint() {
+fn mailbox_create_without_daemon_non_root_exits_with_socket_missing_hint() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!(
+            "skipping: this test exercises the non-root socket-missing branch; \
+             run as a non-root uid"
+        );
+        return;
+    }
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
 
-    // Point at an empty runtime dir; no socket present, so UDS fails with
-    // NotFound and the CLI falls back to direct on-disk edit.
     let runtime = tmp.path().join("run");
     std::fs::create_dir_all(&runtime).ok();
 
-    // Mailbox CRUD is root-only via the central auth predicate; tests
-    // bypass via `AIMX_TEST_SKIP_ROOT_CHECK` so the post-gate fallback
-    // path stays exercised under non-root `cargo test`.
     let assert = aimx_cmd(tmp.path())
         .env("AIMX_RUNTIME_DIR", &runtime)
-        .env("AIMX_TEST_SKIP_ROOT_CHECK", "1")
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("mailbox")
@@ -3050,21 +3056,23 @@ fn mailbox_create_without_daemon_falls_back_and_prints_restart_hint() {
         .arg("--owner")
         .arg(current_username())
         .assert()
-        .success();
-    let stdout = String::from_utf8_lossy(&assert.get_output().stdout).to_string();
+        .code(2);
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
     assert!(
-        stdout.contains("Mailbox 'eve' created"),
-        "expected success message, got: {stdout}"
+        stderr.contains("daemon must be running"),
+        "expected socket-missing hint on stderr, got: {stderr}"
     );
     assert!(
-        stdout.contains("Restart the daemon"),
-        "fallback path must print the restart hint: {stdout}"
+        stderr.contains("aimx serve") && stderr.contains("sudo"),
+        "hint must name both remediations (start daemon / use sudo): {stderr}"
     );
 
-    // Fallback wrote the stanza too.
+    // No fallback wrote the stanza.
     let config_text = std::fs::read_to_string(tmp.path().join("config.toml")).unwrap();
-    assert!(config_text.contains("[mailboxes.eve]"));
-    assert!(tmp.path().join("inbox").join("eve").is_dir());
+    assert!(
+        !config_text.contains("[mailboxes.eve]"),
+        "non-root socket-missing path must NOT fall back to a direct write: {config_text}"
+    );
 }
 
 #[cfg(unix)]
@@ -3302,16 +3310,22 @@ fn mailbox_delete_force_without_yes_prompts_and_aborts_on_n() {
     stop_serve(daemon);
 }
 
+/// `aimx mailboxes delete --force catchall` must refuse client-side
+/// (regardless of caller uid) before any wipe or daemon submission so
+/// the catchall slot is never accidentally torn down. S2-2 keeps the
+/// catchall refusal at the very top of the `--force` branch — it fires
+/// even if no daemon is running and even for a non-root caller.
 #[cfg(unix)]
 #[test]
 fn mailbox_delete_force_refuses_catchall() {
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
 
-    // Mailbox CRUD is root-only; bypass via the test env var so the
-    // catchall-refusal logic itself runs under non-root `cargo test`.
+    let runtime = tmp.path().join("run");
+    std::fs::create_dir_all(&runtime).ok();
+
     let assert = aimx_cmd(tmp.path())
-        .env("AIMX_TEST_SKIP_ROOT_CHECK", "1")
+        .env("AIMX_RUNTIME_DIR", &runtime)
         .arg("--data-dir")
         .arg(tmp.path())
         .arg("mailboxes")
@@ -3326,6 +3340,180 @@ fn mailbox_delete_force_refuses_catchall() {
         stderr.contains("catchall"),
         "catchall refusal must surface verbatim, got stderr: {stderr}"
     );
+}
+
+/// S2-6 / S2-2: end-to-end non-root mailbox CRUD via daemon UDS. Runs
+/// without `AIMX_INTEGRATION_SUDO=1` — this test is the canonical
+/// regression guard against re-introducing a root gate on the
+/// MAILBOX-CREATE / MAILBOX-DELETE path. With `aimx serve` running and
+/// the test runner's uid (which is also the configured mailbox owner
+/// in `setup_test_env`), creating `task-mb` and then force-deleting it
+/// must succeed without sudo. Skips automatically if the runner happens
+/// to be root (CI's root-only step exercises a different branch).
+#[cfg(unix)]
+#[test]
+fn mailbox_create_delete_force_e2e_as_non_root_user() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!(
+            "skipping: this test pins the non-root happy path; \
+             root creates run via the dedicated sudo-lane test"
+        );
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared after `aimx serve` start"
+    );
+
+    // CREATE — non-root, no sudo, no AIMX_TEST_SKIP_ROOT_CHECK.
+    // Pass `--owner <runner>` so `prompt_mailbox_owner` is skipped
+    // entirely (it would otherwise loop 5 times under non-TTY stdin
+    // because the local part `task-mb` does not resolve via getpwnam).
+    // Owner == caller, so the soft-warning path also stays silent —
+    // exactly the agent-friendly happy path we want to pin.
+    let runner = current_username();
+    let create = aimx_cmd(tmp.path())
+        .env("AIMX_RUNTIME_DIR", tmp.path().join("run"))
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("mailboxes")
+        .arg("create")
+        .arg("task-mb")
+        .arg("--owner")
+        .arg(&runner)
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&create.get_output().stdout).to_string();
+    assert!(
+        stdout.contains("Mailbox 'task-mb' created"),
+        "CREATE must succeed for non-root caller via daemon UDS, got: {stdout}"
+    );
+    assert!(
+        !stdout.contains("Restart the daemon"),
+        "UDS path must NOT print the restart-hint banner: {stdout}"
+    );
+
+    // config.toml on disk reflects the new mailbox stanza.
+    let config_text = std::fs::read_to_string(tmp.path().join("config.toml")).unwrap();
+    assert!(
+        config_text.contains("[mailboxes.task-mb]"),
+        "config.toml should contain the new stanza: {config_text}"
+    );
+    // The owner field must be the runner's username (synthesized by
+    // the daemon from SO_PEERCRED — never client-supplied).
+    assert!(
+        config_text.contains(&format!("owner = \"{runner}\"")),
+        "owner must be the runner's username: {config_text}"
+    );
+
+    // On-disk owner check: the inbox dir must be owned by the runner's
+    // uid (the daemon chowns to the resolved owner).
+    let inbox_dir = tmp.path().join("inbox").join("task-mb");
+    assert!(inbox_dir.is_dir(), "inbox/task-mb/ must exist on disk");
+    use std::os::unix::fs::MetadataExt;
+    let meta = std::fs::metadata(&inbox_dir).unwrap();
+    let runner_uid = unsafe { libc::geteuid() };
+    assert_eq!(
+        meta.uid(),
+        runner_uid,
+        "inbox/task-mb/ must be owned by the runner uid"
+    );
+
+    // DELETE --force --yes — should wipe and succeed via daemon UDS.
+    // Confirms S2-2: the `--force` flag works for the mailbox owner
+    // without sudo. Mailbox is empty on creation, but exercising the
+    // force path also covers the wipe-then-submit ordering.
+    let delete = aimx_cmd(tmp.path())
+        .env("AIMX_RUNTIME_DIR", tmp.path().join("run"))
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("mailboxes")
+        .arg("delete")
+        .arg("--force")
+        .arg("--yes")
+        .arg("task-mb")
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&delete.get_output().stdout).to_string();
+    assert!(
+        stdout.contains("Mailbox 'task-mb' deleted"),
+        "DELETE --force --yes must succeed for non-root owner, got: {stdout}"
+    );
+
+    // config.toml must no longer reference task-mb.
+    let config_text_after = std::fs::read_to_string(tmp.path().join("config.toml")).unwrap();
+    assert!(
+        !config_text_after.contains("[mailboxes.task-mb]"),
+        "config.toml must no longer contain task-mb stanza: {config_text_after}"
+    );
+
+    stop_serve(daemon);
+}
+
+/// S2-1 soft-warning: a non-root caller passing `--owner <other>` gets
+/// a stderr line clarifying that the daemon will discard the value and
+/// bind ownership to the caller. The mailbox is still created (the
+/// daemon synthesizes the correct owner) — the warning is purely UX.
+#[cfg(unix)]
+#[test]
+fn mailbox_create_owner_flag_warns_for_non_root_callers() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping: warning fires only for non-root callers");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
+
+    // Pick an owner string different from the runner. `nobody` is
+    // present on every Linux box and resolves via getpwnam, which
+    // satisfies the CLI's pre-flight `--owner` check before the
+    // daemon's SO_PEERCRED override kicks in.
+    let assert = aimx_cmd(tmp.path())
+        .env("AIMX_RUNTIME_DIR", tmp.path().join("run"))
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("mailboxes")
+        .arg("create")
+        .arg("warned-mb")
+        .arg("--owner")
+        .arg("nobody")
+        .assert()
+        .success();
+
+    let stderr = String::from_utf8_lossy(&assert.get_output().stderr).to_string();
+    let runner = current_username();
+    assert!(
+        stderr.contains("--owner ignored"),
+        "soft warning must fire when non-root passes --owner <other>, stderr: {stderr}"
+    );
+    assert!(
+        stderr.contains(&runner),
+        "warning must name the actual caller (`{runner}`), stderr: {stderr}"
+    );
+
+    // The daemon ignored the owner flag — the resulting mailbox is
+    // owned by the runner, not `nobody`.
+    let config_text = std::fs::read_to_string(tmp.path().join("config.toml")).unwrap();
+    assert!(
+        config_text.contains(&format!("owner = \"{runner}\"")),
+        "owner must be the runner, NOT the wire-supplied value: {config_text}"
+    );
+
+    stop_serve(daemon);
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -881,10 +881,14 @@ fn mcp_mailbox_list_without_daemon_reports_missing_socket() {
 }
 
 #[test]
-fn mcp_mailbox_create_tool_no_longer_exposed() {
-    // `mailbox_create` was removed from the MCP surface (mailbox CRUD
-    // moved to root-only CLI). Calling the tool by name returns a
-    // tool-not-found error from the rmcp framework.
+fn mcp_mailbox_create_tool_is_exposed() {
+    // S2-3 re-added `mailbox_create` to the MCP surface. The tool
+    // is now declared and dispatchable; with no daemon listening it
+    // surfaces a "daemon not running" tool error rather than a
+    // framework-level "unknown tool" rejection. This test guards
+    // against the tool silently disappearing again — the previous
+    // shape (`tool_no_longer_exposed`) would have continued to pass
+    // even after re-add because both paths return `isError`.
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
 
@@ -892,18 +896,23 @@ fn mcp_mailbox_create_tool_no_longer_exposed() {
     client.initialize();
 
     let resp = client.call_tool("mailbox_create", serde_json::json!({"name": "support"}));
-    // The framework's response shape is "tool not found" / unknown tool;
-    // the assertion is robust to small text drift.
+    let tool_text = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
     assert!(
-        is_tool_error(&resp) || resp.get("error").is_some(),
-        "expected mailbox_create to be rejected, got: {resp}"
+        tool_text.contains("daemon not running") || tool_text.contains("daemon"),
+        "expected daemon-not-running text in tool error, got: {resp}"
+    );
+    // Framework-level "unknown tool" would land in `error.code` or
+    // `error.message`; assert it didn't take that path.
+    assert!(
+        resp.get("error").is_none(),
+        "framework error means the tool is missing from the surface: {resp}"
     );
 
     client.shutdown();
 }
 
 #[test]
-fn mcp_mailbox_delete_tool_no_longer_exposed() {
+fn mcp_mailbox_delete_tool_is_exposed() {
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
 
@@ -911,9 +920,14 @@ fn mcp_mailbox_delete_tool_no_longer_exposed() {
     client.initialize();
 
     let resp = client.call_tool("mailbox_delete", serde_json::json!({"name": "support"}));
+    let tool_text = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
     assert!(
-        is_tool_error(&resp) || resp.get("error").is_some(),
-        "expected mailbox_delete to be rejected, got: {resp}"
+        tool_text.contains("daemon not running") || tool_text.contains("daemon"),
+        "expected daemon-not-running text in tool error, got: {resp}"
+    );
+    assert!(
+        resp.get("error").is_none(),
+        "framework error means the tool is missing from the surface: {resp}"
     );
 
     client.shutdown();
@@ -3513,6 +3527,189 @@ fn mailbox_create_owner_flag_warns_for_non_root_callers() {
         "owner must be the runner, NOT the wire-supplied value: {config_text}"
     );
 
+    stop_serve(daemon);
+}
+
+/// Cycle 2 regression guard for Blocker 1 / Blocker 3 of the Sprint 2
+/// review: the CLI must reach `mailbox::run` even when the caller
+/// cannot read `/etc/aimx/config.toml`.
+///
+/// In production the config is `0640 root:root`, so a non-root caller
+/// cannot read it. The previous shape — `dispatch()` `?`-propagating
+/// `Config::load_resolved_with_data_dir(...)` — surfaced the EACCES
+/// as a bare `Permission denied (os error 13)` before
+/// `mailbox::run` ever saw the request. This test simulates the
+/// production permission model by chmod-ing the config file to `0000`
+/// (no permissions for any user, including the test runner). Either
+/// the create succeeds via UDS (daemon-up branch) or it exits with
+/// the canonical socket-missing hint (daemon-down branch). The bare
+/// EACCES surface that broke Cycle 1 must NOT reappear.
+///
+/// Runs without sudo so it lives in the standard CI lane and catches
+/// the regression on every PR.
+#[cfg(unix)]
+#[test]
+fn mailbox_create_with_unreadable_config_does_not_surface_eacces() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping: chmod 0000 has no effect on root");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
+
+    // Chmod the config to 0000. The daemon already loaded its
+    // `Arc<Config>` snapshot at startup, so it keeps serving from
+    // memory; the CLI subprocess inherits the test runner's uid and
+    // therefore cannot read the file.
+    use std::os::unix::fs::PermissionsExt;
+    let config_path = tmp.path().join("config.toml");
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    let runner = current_username();
+    let create = aimx_cmd(tmp.path())
+        .env("AIMX_RUNTIME_DIR", tmp.path().join("run"))
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("mailboxes")
+        .arg("create")
+        .arg("perm-mb")
+        .arg("--owner")
+        .arg(&runner)
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&create.get_output().stdout).to_string();
+    let stderr = String::from_utf8_lossy(&create.get_output().stderr).to_string();
+    assert!(
+        stdout.contains("Mailbox 'perm-mb' created"),
+        "CREATE must succeed via daemon UDS without reading local config; \
+         stdout: {stdout}, stderr: {stderr}"
+    );
+    // The bare-EACCES surface that broke Cycle 1 must NOT reappear.
+    assert!(
+        !stderr.contains("Permission denied (os error 13)"),
+        "config-read EACCES must never surface to the operator; stderr: {stderr}"
+    );
+
+    // Restore perms so the test cleanup can read the file.
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o640)).unwrap();
+    stop_serve(daemon);
+}
+
+/// Companion to the create-side regression test: `aimx mailboxes
+/// list` must also work without local config-read access. The
+/// non-root list path falls back to `MAILBOX-LIST` over UDS, which
+/// the daemon resolves via SO_PEERCRED — no config read on the
+/// client side at all.
+#[cfg(unix)]
+#[test]
+fn mailbox_list_with_unreadable_config_falls_back_to_uds() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping: chmod 0000 has no effect on root");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
+
+    use std::os::unix::fs::PermissionsExt;
+    let config_path = tmp.path().join("config.toml");
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    let list = aimx_cmd(tmp.path())
+        .env("AIMX_RUNTIME_DIR", tmp.path().join("run"))
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("mailboxes")
+        .arg("list")
+        .assert()
+        .success();
+    let stdout = String::from_utf8_lossy(&list.get_output().stdout).to_string();
+    let stderr = String::from_utf8_lossy(&list.get_output().stderr).to_string();
+    assert!(
+        stdout.contains("alice") || stdout.contains("MAILBOX"),
+        "LIST must succeed via daemon UDS; stdout: {stdout}, stderr: {stderr}"
+    );
+    assert!(
+        !stderr.contains("Permission denied (os error 13)"),
+        "config-read EACCES must never surface to the operator; stderr: {stderr}"
+    );
+
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o640)).unwrap();
+    stop_serve(daemon);
+}
+
+/// Cycle 2 regression guard for Blocker 2: the MCP `mailbox_create`
+/// tool must work end-to-end against a real daemon for a non-root
+/// caller. Cycle 1 shipped the tool but the wire-protocol parser
+/// rejected the `owner: None` request with `[MALFORMED] missing
+/// required header: Owner` — a regression that 1021 unit tests
+/// missed because none of them reached the wire layer for this code
+/// path. The fix relaxes the parser to make `Owner:` optional; this
+/// test pins the agent-friendly surface so a future re-tightening
+/// fails CI.
+#[cfg(unix)]
+#[test]
+fn mcp_mailbox_create_against_running_daemon_succeeds_for_non_root() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping: this test pins the non-root MCP path");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    let resp = client.call_tool("mailbox_create", serde_json::json!({"name": "agent-mb"}));
+    let tool_text = resp["result"]["content"][0]["text"].as_str().unwrap_or("");
+    // The protocol-level rejection used to surface as
+    // `[MALFORMED] missing required header: Owner` — must NOT recur.
+    assert!(
+        !tool_text.contains("MALFORMED"),
+        "MAILBOX-CREATE without Owner must not be rejected by the parser; got: {tool_text}"
+    );
+    // Success path: the tool returns the new mailbox's full address.
+    assert!(
+        tool_text.contains("agent-mb@agent.example.com")
+            || tool_text.contains("Mailbox 'agent-mb' created"),
+        "expected success message, got: {tool_text}"
+    );
+
+    // Daemon hot-swapped the config. The on-disk stanza names the
+    // runner as the owner because the daemon synthesizes from
+    // SO_PEERCRED, not from any client-supplied value.
+    let config_text = std::fs::read_to_string(tmp.path().join("config.toml")).unwrap();
+    let runner = current_username();
+    assert!(
+        config_text.contains("[mailboxes.agent-mb]"),
+        "config.toml should carry the new stanza: {config_text}"
+    );
+    assert!(
+        config_text.contains(&format!("owner = \"{runner}\"")),
+        "owner must be the runner's username (SO_PEERCRED-bound): {config_text}"
+    );
+
+    client.shutdown();
     stop_serve(daemon);
 }
 


### PR DESCRIPTION
## Summary

Sprint 2 of the **user-mailbox** track lifts the CLI's entry-point root gate, finishes the `--force` plumbing for non-root owners, and adds the two MCP tools agents need to self-serve their own mailboxes. Builds on Sprint 1 (PR #193), where the daemon-side authz model was refactored to bind owner to `SO_PEERCRED`.

### Stories

- **S2-1 — CLI root gate dropped, daemon required for non-root.** `src/mailbox.rs` no longer calls `authorize(...)` at the entry-point — the daemon's per-verb `authorize()` (Sprint 1) is the single source of truth. Always prefer the UDS path; non-root + missing socket exits with code 2 and the precise message `"daemon must be running for non-root mailbox CRUD; start \`aimx serve\` or run with sudo to fall back to direct config edit."`. Root + missing socket keeps the existing direct-write fallback. `AIMX_TEST_SKIP_ROOT_CHECK` removed from `mailbox.rs` (kept in `hooks.rs` — raw-shell hooks remain root-only). Soft warning when non-root passes `--owner <other>`. Sprint-1 `TODO(S2-1)` in `src/auth.rs` addressed: `format_auth_error` renders `NotOwner` and owner-mismatch cleanly, drops the "requires root" branch.
- **S2-2 — `--force` for non-root owners, with strict ordering.** Order: pre-flight ownership check → wipe inbox/sent → submit DELETE. Non-owners refuse before any wipe so they cannot partially destroy data the daemon then refuses to delete. Confirmation prompt unchanged across uids. Integration test added.
- **S2-3 — MCP `mailbox_create`.** Param: `name: String`. No `owner` parameter — the daemon synthesizes from `SO_PEERCRED`. Returns the full address on success. Surfaces daemon errors verbatim.
- **S2-4 — MCP `mailbox_delete`.** Params: `name: String`, `force: Option<bool>` (default `false`). Same client-side wipe-after-ownership-check ordering as S2-2 when `force: true`. Daemon's owner check applies.
- **S2-5 — Agent primer + MCP reference updated.** `agents/common/aimx-primer.md` and `agents/common/references/mcp-tools.md` document both new tools without duplicating daemon-side validation rules.
- **S2-6 — End-to-end non-root integration test.** New test in `tests/integration.rs` runs **without** `AIMX_INTEGRATION_SUDO=1` and exercises the create + delete cycle for the runner's uid — becomes the canonical regression guard for "did we accidentally re-introduce a root gate."

### Out of Sprint 2 Scope

- `book/` chapter rewrites, release-notes entry, and `CLAUDE.md` architecture updates → Sprint 3 (S3-1 through S3-5).
- Cross-uid creates from non-root callers stay operator-only by design (no other surface accepts an `Owner:` parameter).
- Raw-shell `aimx hooks create --cmd '...'` remains root-only — distinct privilege boundary from mailbox lifecycle.

## Test plan

- [x] `cargo fmt -- --check` (root crate) — clean
- [x] `cargo fmt -- --check` (verifier crate) — clean
- [x] `cargo clippy --all-targets -- -D warnings` (root crate) — clean
- [x] `cargo clippy --all-targets -- -D warnings` (verifier crate) — clean
- [x] `cargo test` (root crate) — **1021 unit + 94 integration + 1 doctest passed**, 0 failed
- [x] `cargo test` (verifier crate) — **43/43 passed**
- [x] `sudo -E env "PATH=$PATH" AIMX_INTEGRATION_SUDO=1 cargo test --test uds_authz -- --ignored --test-threads=1` — **21/21 passed** (sudo-lane privilege-boundary tests still green after CLI/MCP changes)