### PR TITLE
chore: user-mailbox track backlog cleanup (rename MailboxCrud* wire types, drop dead require_root, soften MCP verb)

### DIFF
--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -99,10 +99,10 @@ fn list_dispatch(loaded: Option<&Config>, all: bool) -> Result<(), Box<dyn std::
 fn list_via_daemon() -> Result<(), Box<dyn std::error::Error>> {
     let json = match crate::mcp::submit_mailbox_list_via_daemon_for_cli() {
         Ok(s) => s,
-        Err(crate::mcp::MailboxCrudFallback::SocketMissing) => {
+        Err(crate::mcp::MailboxLifecycleFallback::SocketMissing) => {
             exit_socket_missing();
         }
-        Err(crate::mcp::MailboxCrudFallback::Daemon(msg)) => {
+        Err(crate::mcp::MailboxLifecycleFallback::Daemon(msg)) => {
             return Err(msg.into());
         }
     };
@@ -490,7 +490,7 @@ fn create(
             );
             Ok(())
         }
-        Err(crate::mcp::MailboxCrudFallback::SocketMissing) => {
+        Err(crate::mcp::MailboxLifecycleFallback::SocketMissing) => {
             if !is_root() {
                 exit_socket_missing();
             }
@@ -514,7 +514,7 @@ fn create(
             print_restart_hint();
             Ok(())
         }
-        Err(crate::mcp::MailboxCrudFallback::Daemon(msg)) => Err(msg.into()),
+        Err(crate::mcp::MailboxLifecycleFallback::Daemon(msg)) => Err(msg.into()),
     }
 }
 
@@ -869,7 +869,7 @@ fn delete(
             );
             Ok(())
         }
-        Err(crate::mcp::MailboxCrudFallback::SocketMissing) => {
+        Err(crate::mcp::MailboxLifecycleFallback::SocketMissing) => {
             if !is_root() {
                 exit_socket_missing();
             }
@@ -895,7 +895,7 @@ fn delete(
             print_restart_hint();
             Ok(())
         }
-        Err(crate::mcp::MailboxCrudFallback::Daemon(msg)) => Err(msg.into()),
+        Err(crate::mcp::MailboxLifecycleFallback::Daemon(msg)) => Err(msg.into()),
     }
 }
 

--- a/src/mailbox_handler.rs
+++ b/src/mailbox_handler.rs
@@ -42,7 +42,7 @@ use std::sync::Mutex;
 use crate::auth::{Action, AuthError, authorize};
 use crate::config::{Config, ConfigHandle, MailboxConfig};
 use crate::ownership::chown_as_owner;
-use crate::send_protocol::{AckResponse, ErrCode, MailboxCrudRequest};
+use crate::send_protocol::{AckResponse, ErrCode, MailboxLifecycleRequest};
 use crate::state_handler::StateContext;
 use crate::uds_authz::{Caller, log_decision, peer_username};
 
@@ -83,7 +83,7 @@ impl MailboxContext {
 pub async fn handle_mailbox_crud(
     state_ctx: &StateContext,
     mb_ctx: &MailboxContext,
-    req: &MailboxCrudRequest,
+    req: &MailboxLifecycleRequest,
     caller: &Caller,
 ) -> AckResponse {
     if let Err(e) = crate::mailbox::validate_mailbox_name(&req.name) {
@@ -110,7 +110,7 @@ pub async fn handle_mailbox_crud(
     let resolved_owner: Option<String> = if req.create {
         if caller.is_root() {
             // Root path: the dispatcher already enforces that
-            // MailboxCrudRequest carries `owner: Some(...)` for
+            // MailboxLifecycleRequest carries `owner: Some(...)` for
             // CREATE; defense-in-depth check below.
             match req.owner.as_deref() {
                 Some(o) => Some(o.to_string()),
@@ -706,6 +706,10 @@ mod tests {
             // Resolve the current Linux user's actual name so this
             // resolver answers for whatever the daemon's
             // `peer_username` synthesized.
+            // Per-call `lookup_username` (a thin `getpwuid` wrapper) is
+            // intentional and cheap — do not memoize: tests rely on
+            // each invocation re-reading passwd so resolver overrides
+            // installed/torn down between calls stay isolated.
             let current_user = crate::uds_authz::lookup_username(uid);
             if name == "testowner" || name == "root" || current_user.as_deref() == Some(name) {
                 Some(crate::user_resolver::ResolvedUser {
@@ -742,7 +746,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let (state_ctx, mb_ctx) = contexts(&tmp);
 
-        let req = MailboxCrudRequest {
+        let req = MailboxLifecycleRequest {
             name: "alice".into(),
             create: true,
             owner: Some("testowner".into()),
@@ -773,7 +777,7 @@ mod tests {
         let (state_ctx, mb_ctx) = contexts(&tmp);
 
         // Seed a non-reserved mailbox first.
-        let seed = MailboxCrudRequest {
+        let seed = MailboxLifecycleRequest {
             name: "alice".into(),
             create: true,
             owner: Some("testowner".into()),
@@ -784,7 +788,7 @@ mod tests {
             AckResponse::Ok
         ));
 
-        let dup = MailboxCrudRequest {
+        let dup = MailboxLifecycleRequest {
             name: "alice".into(),
             create: true,
             owner: Some("testowner".into()),
@@ -805,7 +809,7 @@ mod tests {
         let (state_ctx, mb_ctx) = contexts(&tmp);
 
         for name in ["catchall", "aimx-catchall"] {
-            let req = MailboxCrudRequest {
+            let req = MailboxLifecycleRequest {
                 name: name.into(),
                 create: true,
                 owner: Some("testowner".into()),
@@ -833,7 +837,7 @@ mod tests {
         let (state_ctx, mb_ctx) = contexts(&tmp);
 
         let attacker = Caller::with_username(99999, 99999, "attacker");
-        let req = MailboxCrudRequest {
+        let req = MailboxLifecycleRequest {
             name: "catchall".into(),
             create: true,
             owner: Some("testowner".into()),
@@ -853,7 +857,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let (state_ctx, mb_ctx) = contexts(&tmp);
 
-        let req = MailboxCrudRequest {
+        let req = MailboxLifecycleRequest {
             name: "".into(),
             create: true,
             owner: Some("testowner".into()),
@@ -871,7 +875,7 @@ mod tests {
         let (state_ctx, mb_ctx) = contexts(&tmp);
 
         for bad in ["../etc", "foo/bar", "foo\\bar", "a\0b"] {
-            let req = MailboxCrudRequest {
+            let req = MailboxLifecycleRequest {
                 name: bad.into(),
                 create: true,
                 owner: Some("testowner".into()),
@@ -893,7 +897,7 @@ mod tests {
         let (state_ctx, mb_ctx) = contexts(&tmp);
 
         // Pre-create
-        let req = MailboxCrudRequest {
+        let req = MailboxLifecycleRequest {
             name: "alice".into(),
             create: true,
             owner: Some("testowner".into()),
@@ -905,7 +909,7 @@ mod tests {
         ));
 
         // Delete with empty dirs should succeed.
-        let req = MailboxCrudRequest {
+        let req = MailboxLifecycleRequest {
             name: "alice".into(),
             create: false,
             owner: None,
@@ -928,7 +932,7 @@ mod tests {
         let (state_ctx, mb_ctx) = contexts(&tmp);
 
         // Create
-        let req = MailboxCrudRequest {
+        let req = MailboxLifecycleRequest {
             name: "alice".into(),
             create: true,
             owner: Some("testowner".into()),
@@ -944,7 +948,7 @@ mod tests {
         std::fs::write(inbox.join("2025-06-01-001.md"), "content").unwrap();
 
         // Delete must be refused
-        let req = MailboxCrudRequest {
+        let req = MailboxLifecycleRequest {
             name: "alice".into(),
             create: false,
             owner: None,
@@ -976,7 +980,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let (state_ctx, mb_ctx) = contexts(&tmp);
 
-        let req = MailboxCrudRequest {
+        let req = MailboxLifecycleRequest {
             name: "catchall".into(),
             create: false,
             owner: None,
@@ -996,7 +1000,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let (state_ctx, mb_ctx) = contexts(&tmp);
 
-        let req = MailboxCrudRequest {
+        let req = MailboxLifecycleRequest {
             name: "ghost".into(),
             create: false,
             owner: None,
@@ -1036,7 +1040,7 @@ mod tests {
         std::fs::write(dir_path.join("blocker"), "x").unwrap();
         let bad_ctx = MailboxContext::new(dir_path.clone(), mb_ctx.config_handle.clone());
 
-        let req = MailboxCrudRequest {
+        let req = MailboxLifecycleRequest {
             name: "alice".into(),
             create: true,
             owner: Some("testowner".into()),
@@ -1151,7 +1155,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let (state_ctx, mb_ctx) = contexts(&tmp);
 
-        let req = MailboxCrudRequest {
+        let req = MailboxLifecycleRequest {
             name: "alice".into(),
             create: true,
             owner: Some("testowner".into()),
@@ -1241,7 +1245,7 @@ mod tests {
             let m = mb_ctx.clone();
             let n = name.clone();
             handles.push(tokio::spawn(async move {
-                let req = MailboxCrudRequest {
+                let req = MailboxLifecycleRequest {
                     name: n,
                     create: true,
                     owner: Some("testowner".into()),
@@ -1291,7 +1295,7 @@ mod tests {
         let _r = install_tester_resolver();
         let tmp = TempDir::new().unwrap();
         let (state_ctx, mb_ctx) = contexts(&tmp);
-        let req = MailboxCrudRequest {
+        let req = MailboxLifecycleRequest {
             name: "alice".into(),
             create: true,
             owner: None,
@@ -1314,7 +1318,7 @@ mod tests {
         let _r = install_tester_resolver();
         let tmp = TempDir::new().unwrap();
         let (state_ctx, mb_ctx) = contexts(&tmp);
-        let req = MailboxCrudRequest {
+        let req = MailboxLifecycleRequest {
             name: "alice".into(),
             create: true,
             owner: Some("ghost".into()),
@@ -1361,7 +1365,7 @@ mod tests {
         }
         let _r = crate::user_resolver::set_test_resolver(nobody);
 
-        let req = MailboxCrudRequest {
+        let req = MailboxLifecycleRequest {
             name: "alice".into(),
             create: true,
             owner: Some("nobody".into()),
@@ -1430,7 +1434,7 @@ mod tests {
         // touch it even if rollback *did* try to remove it.
         std::fs::write(inbox.join("do-not-delete"), b"operator data").unwrap();
 
-        let req = MailboxCrudRequest {
+        let req = MailboxLifecycleRequest {
             name: "alice".into(),
             create: true,
             owner: Some("nobody".into()),
@@ -1509,7 +1513,7 @@ mod tests {
         assert!(!inbox.exists());
         assert!(!sent.exists());
 
-        let req = MailboxCrudRequest {
+        let req = MailboxLifecycleRequest {
             name: "alice".into(),
             create: true,
             owner: Some("nobody".into()),
@@ -1557,7 +1561,7 @@ mod tests {
         std::fs::create_dir_all(&inbox).unwrap();
         std::fs::create_dir_all(&sent).unwrap();
 
-        let req = MailboxCrudRequest {
+        let req = MailboxLifecycleRequest {
             name: "alice".into(),
             create: true,
             owner: Some("testowner".into()),
@@ -1598,7 +1602,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let (state_ctx, mb_ctx) = contexts(&tmp);
 
-        let req = MailboxCrudRequest {
+        let req = MailboxLifecycleRequest {
             name: "x".into(),
             create: true,
             // The attacker tries to claim a root-owned mailbox.
@@ -1671,7 +1675,7 @@ mod tests {
 
         // Non-root tries to delete the root-owned mailbox: the wire
         // response must equal what they'd get for a non-existent name.
-        let unowned_delete = MailboxCrudRequest {
+        let unowned_delete = MailboxLifecycleRequest {
             name: "opsbox".into(),
             create: false,
             owner: None,
@@ -1683,7 +1687,7 @@ mod tests {
         // Same caller, mailbox that never existed: this is the
         // baseline "no such mailbox" string the unowned response must
         // match (modulo the mailbox name).
-        let missing_delete = MailboxCrudRequest {
+        let missing_delete = MailboxLifecycleRequest {
             name: "nope".into(),
             create: false,
             owner: None,
@@ -1747,7 +1751,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let (state_ctx, mb_ctx) = contexts(&tmp);
 
-        let req = MailboxCrudRequest {
+        let req = MailboxLifecycleRequest {
             name: "agent".into(),
             create: true,
             // Owner is ignored for non-root; included to prove that.
@@ -1789,13 +1793,13 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let (state_ctx, mb_ctx) = contexts(&tmp);
 
-        let create_req = MailboxCrudRequest {
+        let create_req = MailboxLifecycleRequest {
             name: "task42".into(),
             create: true,
             owner: None,
             force: false,
         };
-        let delete_req = MailboxCrudRequest {
+        let delete_req = MailboxLifecycleRequest {
             name: "task42".into(),
             create: false,
             owner: None,
@@ -1841,7 +1845,7 @@ mod tests {
         let (state_ctx, mb_ctx) = contexts(&tmp);
         let orphan = Caller::new(orphan_uid, orphan_uid, None);
 
-        let req = MailboxCrudRequest {
+        let req = MailboxLifecycleRequest {
             name: "orph".into(),
             create: true,
             owner: Some("anything".into()),

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -4,7 +4,7 @@ use crate::frontmatter::InboundFrontmatter;
 use crate::mailbox;
 use crate::send;
 use crate::send_protocol::{
-    self, ErrCode, HookCreateRequest, HookDeleteRequest, MailboxCrudRequest, MarkRequest,
+    self, ErrCode, HookCreateRequest, HookDeleteRequest, MailboxLifecycleRequest, MarkRequest,
     SendRequest,
 };
 
@@ -208,6 +208,14 @@ impl AimxMcpServer {
                 String::new()
             }
         };
+        // Derive the rendering verb from the action so a future change
+        // that produces `OwnerMismatch` from a non-create predicate
+        // doesn't render "cannot create a..." for, say, a delete.
+        let verb = match &action {
+            crate::auth::Action::MailboxCreate { .. } => Some("create"),
+            crate::auth::Action::MailboxDelete { .. } => Some("delete"),
+            _ => None,
+        };
         let mb = if mailbox_name.is_empty() {
             None
         } else {
@@ -217,10 +225,10 @@ impl AimxMcpServer {
             // Sprint 3 (S3-5): the MCP, CLI, and hooks surfaces all
             // share `auth::format_auth_error` so the four-arm match
             // can never drift between them. The MCP surface skips the
-            // `surface` / `verb` hints (the renderer falls back to the
-            // generic "requires root" line) but does pass the resolved
-            // mailbox name so `NoSuchMailbox` reads as
-            // "mailbox '<name>' not found" — the agent-friendly form.
+            // `surface` hint (the renderer falls back to the generic
+            // "requires root" line) but does pass the resolved mailbox
+            // name so `NoSuchMailbox` reads as "mailbox '<name>' not
+            // found" — the agent-friendly form.
             crate::auth::format_auth_error(
                 &e,
                 &crate::auth::AuthErrorContext {
@@ -229,7 +237,7 @@ impl AimxMcpServer {
                     } else {
                         Some(&mailbox_name)
                     },
-                    verb: Some("create"),
+                    verb,
                     ..Default::default()
                 },
             )
@@ -669,10 +677,10 @@ impl AimxMcpServer {
                     Ok(address)
                 }
             }
-            Err(MailboxCrudFallback::SocketMissing) => {
+            Err(MailboxLifecycleFallback::SocketMissing) => {
                 Err("aimx daemon not running. Start with 'sudo systemctl start aimx'".to_string())
             }
-            Err(MailboxCrudFallback::Daemon(msg)) => Err(msg),
+            Err(MailboxLifecycleFallback::Daemon(msg)) => Err(msg),
         }
     }
 
@@ -713,10 +721,10 @@ impl AimxMcpServer {
         // `self.load_config()` inevitably failed for non-root agents).
         match submit_mailbox_crud_via_daemon(&params.name, false, None, force) {
             Ok(()) => Ok(format!("Mailbox '{}' deleted.", params.name)),
-            Err(MailboxCrudFallback::SocketMissing) => {
+            Err(MailboxLifecycleFallback::SocketMissing) => {
                 Err("aimx daemon not running. Start with 'sudo systemctl start aimx'".to_string())
             }
-            Err(MailboxCrudFallback::Daemon(msg)) => Err(msg),
+            Err(MailboxLifecycleFallback::Daemon(msg)) => Err(msg),
         }
     }
 }
@@ -845,7 +853,7 @@ pub(crate) enum MarkOutcome {
 /// Tracks socket-missing distinctly from daemon-side errors so the MCP
 /// tool can decide whether to fall back to the direct on-disk edit or
 /// surface the daemon's reason verbatim.
-pub(crate) enum MailboxCrudFallback {
+pub(crate) enum MailboxLifecycleFallback {
     /// Socket not present / not connectable (daemon stopped, socket
     /// cleaned up, first-time setup). Callers fall back to direct edit.
     SocketMissing,
@@ -868,8 +876,8 @@ pub(crate) fn submit_mailbox_crud_via_daemon(
     create: bool,
     owner: Option<&str>,
     force: bool,
-) -> Result<(), MailboxCrudFallback> {
-    let request = MailboxCrudRequest {
+) -> Result<(), MailboxLifecycleFallback> {
+    let request = MailboxLifecycleRequest {
         name: name.to_string(),
         create,
         owner: owner.map(|s| s.to_string()),
@@ -887,7 +895,7 @@ pub(crate) fn submit_mailbox_crud_via_daemon(
                 .enable_all()
                 .build()
                 .map_err(|e| {
-                    MailboxCrudFallback::Daemon(format!("Failed to create tokio runtime: {e}"))
+                    MailboxLifecycleFallback::Daemon(format!("Failed to create tokio runtime: {e}"))
                 })?;
             rt.block_on(submit_mailbox_crud_request(&socket, &request))
         }
@@ -895,18 +903,18 @@ pub(crate) fn submit_mailbox_crud_via_daemon(
 
     match io_result {
         Ok(MarkOutcome::Ok) => Ok(()),
-        Ok(MarkOutcome::Err { code, reason }) => Err(MailboxCrudFallback::Daemon(format!(
+        Ok(MarkOutcome::Err { code, reason }) => Err(MailboxLifecycleFallback::Daemon(format!(
             "[{}] {reason}",
             code.as_str()
         ))),
-        Ok(MarkOutcome::Malformed(reason)) => Err(MailboxCrudFallback::Daemon(format!(
+        Ok(MarkOutcome::Malformed(reason)) => Err(MailboxLifecycleFallback::Daemon(format!(
             "Malformed response from aimx daemon: {reason}"
         ))),
         Err(e) => {
             if is_socket_missing(&e) {
-                Err(MailboxCrudFallback::SocketMissing)
+                Err(MailboxLifecycleFallback::SocketMissing)
             } else {
-                Err(MailboxCrudFallback::Daemon(format!(
+                Err(MailboxLifecycleFallback::Daemon(format!(
                     "Failed to connect to aimx daemon at {}: {e}",
                     socket.display()
                 )))
@@ -917,7 +925,7 @@ pub(crate) fn submit_mailbox_crud_via_daemon(
 
 async fn submit_mailbox_crud_request(
     socket_path: &std::path::Path,
-    request: &MailboxCrudRequest,
+    request: &MailboxLifecycleRequest,
 ) -> Result<MarkOutcome, std::io::Error> {
     use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
@@ -934,7 +942,7 @@ async fn submit_mailbox_crud_request(
 }
 
 /// Outcome of a `HOOK-CREATE` / `HOOK-DELETE` UDS submission. Mirrors
-/// [`MailboxCrudFallback`] so callers can decide whether to fall back to
+/// [`MailboxLifecycleFallback`] so callers can decide whether to fall back to
 /// a direct on-disk edit (only when the caller is root) or surface the
 /// daemon's reason verbatim.
 pub(crate) enum HookCrudFallback {
@@ -1203,10 +1211,10 @@ fn lookup_mailbox_address(name: &str) -> Option<String> {
 
 fn submit_mailbox_list_via_daemon() -> Result<String, String> {
     submit_mailbox_list_raw().map_err(|e| match e {
-        MailboxCrudFallback::SocketMissing => {
+        MailboxLifecycleFallback::SocketMissing => {
             "aimx daemon not running. Start with 'sudo systemctl start aimx'".to_string()
         }
-        MailboxCrudFallback::Daemon(msg) => msg,
+        MailboxLifecycleFallback::Daemon(msg) => msg,
     })
 }
 
@@ -1214,12 +1222,12 @@ fn submit_mailbox_list_via_daemon() -> Result<String, String> {
 /// distinguishes socket-missing from a daemon-side error so the
 /// caller can decide whether to surface the canonical "daemon must
 /// be running" hint or render the daemon's reason verbatim. Mirrors
-/// the [`MailboxCrudFallback`] shape used by the CRUD path.
-pub(crate) fn submit_mailbox_list_via_daemon_for_cli() -> Result<String, MailboxCrudFallback> {
+/// the [`MailboxLifecycleFallback`] shape used by the CRUD path.
+pub(crate) fn submit_mailbox_list_via_daemon_for_cli() -> Result<String, MailboxLifecycleFallback> {
     submit_mailbox_list_raw()
 }
 
-fn submit_mailbox_list_raw() -> Result<String, MailboxCrudFallback> {
+fn submit_mailbox_list_raw() -> Result<String, MailboxLifecycleFallback> {
     let socket = crate::serve::aimx_socket_path();
 
     let rt = tokio::runtime::Handle::try_current();
@@ -1232,7 +1240,7 @@ fn submit_mailbox_list_raw() -> Result<String, MailboxCrudFallback> {
                 .enable_all()
                 .build()
                 .map_err(|e| {
-                    MailboxCrudFallback::Daemon(format!("Failed to create tokio runtime: {e}"))
+                    MailboxLifecycleFallback::Daemon(format!("Failed to create tokio runtime: {e}"))
                 })?;
             rt.block_on(submit_mailbox_list_request(&socket))
         }
@@ -1240,16 +1248,16 @@ fn submit_mailbox_list_raw() -> Result<String, MailboxCrudFallback> {
 
     let raw = io_result.map_err(|e| {
         if is_socket_missing(&e) {
-            MailboxCrudFallback::SocketMissing
+            MailboxLifecycleFallback::SocketMissing
         } else {
-            MailboxCrudFallback::Daemon(format!(
+            MailboxLifecycleFallback::Daemon(format!(
                 "Failed to connect to aimx daemon at {}: {e}",
                 socket.display()
             ))
         }
     })?;
 
-    decode_mailbox_list_response(&raw).map_err(MailboxCrudFallback::Daemon)
+    decode_mailbox_list_response(&raw).map_err(MailboxLifecycleFallback::Daemon)
 }
 
 /// Open the UDS, ship `AIMX/1 MAILBOX-LIST`, and return the raw

--- a/src/send_protocol.rs
+++ b/src/send_protocol.rs
@@ -127,7 +127,7 @@ pub struct MarkRequest {
 /// the config rewrite are atomic together (no data-destruction race
 /// window between client-side wipe and daemon-side delete).
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
-pub struct MailboxCrudRequest {
+pub struct MailboxLifecycleRequest {
     pub name: String,
     /// `true` for `MAILBOX-CREATE`, `false` for `MAILBOX-DELETE`.
     pub create: bool,
@@ -186,7 +186,7 @@ pub struct VersionResponse {
 pub enum Request {
     Send(SendRequest),
     Mark(MarkRequest),
-    MailboxCrud(MailboxCrudRequest),
+    MailboxLifecycle(MailboxLifecycleRequest),
     /// `AIMX/1 MAILBOX-LIST` carries no payload. The daemon resolves
     /// the caller via `SO_PEERCRED` and returns the mailboxes the uid
     /// owns; root sees every mailbox.
@@ -408,10 +408,10 @@ where
         "MARK-UNREAD" => parse_mark_headers(reader, false).await.map(Request::Mark),
         "MAILBOX-CREATE" => parse_mailbox_crud_headers(reader, true)
             .await
-            .map(Request::MailboxCrud),
+            .map(Request::MailboxLifecycle),
         "MAILBOX-DELETE" => parse_mailbox_crud_headers(reader, false)
             .await
-            .map(Request::MailboxCrud),
+            .map(Request::MailboxLifecycle),
         "MAILBOX-LIST" => parse_mailbox_list_headers(reader)
             .await
             .map(|()| Request::MailboxList),
@@ -444,7 +444,7 @@ where
         Request::Mark(_) => Err(ParseError::Malformed(
             "expected SEND verb, got MARK-*".to_string(),
         )),
-        Request::MailboxCrud(_) | Request::MailboxList => Err(ParseError::Malformed(
+        Request::MailboxLifecycle(_) | Request::MailboxList => Err(ParseError::Malformed(
             "expected SEND verb, got MAILBOX-*".to_string(),
         )),
         Request::HookCreate(_) | Request::HookDelete(_) => Err(ParseError::Malformed(
@@ -621,7 +621,7 @@ where
 async fn parse_mailbox_crud_headers<R>(
     reader: &mut R,
     create: bool,
-) -> Result<MailboxCrudRequest, ParseError>
+) -> Result<MailboxLifecycleRequest, ParseError>
 where
     R: AsyncRead + Unpin,
 {
@@ -748,7 +748,7 @@ where
     // re-introduce the protocol-level rejection that broke the MCP
     // `mailbox_create` tool for non-root callers in production.
 
-    Ok(MailboxCrudRequest {
+    Ok(MailboxLifecycleRequest {
         name,
         create,
         owner,
@@ -1154,7 +1154,7 @@ where
 /// lock that already guards the stanza removal.
 pub async fn write_mailbox_crud_request<W>(
     writer: &mut W,
-    request: &MailboxCrudRequest,
+    request: &MailboxLifecycleRequest,
 ) -> Result<(), std::io::Error>
 where
     W: AsyncWrite + Unpin,

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -854,7 +854,7 @@ async fn handle_uds_connection_with_timeout(
                 Reply::Ack(crate::state_handler::handle_mark(&state_ctx, &req, &caller).await),
                 false,
             ),
-            Ok(Ok(Request::MailboxCrud(req))) => (
+            Ok(Ok(Request::MailboxLifecycle(req))) => (
                 Reply::Ack(
                     crate::mailbox_handler::handle_mailbox_crud(&state_ctx, &mb_ctx, &req, &caller)
                         .await,

--- a/src/uds_authz.rs
+++ b/src/uds_authz.rs
@@ -238,33 +238,6 @@ pub fn require_mailbox_owner_or_root(
     }
 }
 
-/// Require the caller to be root.
-///
-/// Sprint 1 of the user-mailbox track retired the `MAILBOX-CREATE` /
-/// `MAILBOX-DELETE` callers of this helper — the daemon now uses
-/// owner-bound `auth::Action` variants so non-root callers can manage
-/// their own mailboxes. The helper is kept available (with the
-/// existing test coverage) for future root-gated UDS verbs and the
-/// SystemCommand-style paths.
-#[allow(dead_code)]
-pub fn require_root(caller: &Caller) -> Result<AuthzDecision, AuthzReject> {
-    if caller.is_root() {
-        // Not a "bypass" — root is the required identity here, not an
-        // escalation past an ownership rule. Surface as Accept so the
-        // structured log says `decision = "accept"`.
-        Ok(AuthzDecision::Accept)
-    } else {
-        Err(AuthzReject {
-            code: ErrCode::Eaccess,
-            reason: format!(
-                "mailbox CRUD is root-only (caller uid {} / '{}')",
-                caller.uid,
-                caller.username_display()
-            ),
-        })
-    }
-}
-
 /// Decision value passed to [`log_decision`]. Typed so the compiler —
 /// rather than a string-match wildcard — catches new variants: if a
 /// future caller invents a fourth outcome, it has to add an arm here
@@ -375,41 +348,6 @@ pub fn enforce_mailbox_owner_or_root(
                 verb,
                 caller,
                 Some(mailbox_name),
-                LogDecision::Reject,
-                Some(&reject.reason),
-            );
-            Err(AuthzReject {
-                code: reject.code,
-                reason: WIRE_REASON_NOT_AUTHORIZED.to_string(),
-            })
-        }
-    }
-}
-
-/// Convenience for root-gated UDS verbs. Logs without a `mailbox`
-/// field. Same wire/log split as [`enforce_mailbox_owner_or_root`]:
-/// rich reason in the log, opaque `not authorized` on the wire.
-///
-/// Sprint 1 of the user-mailbox track stopped using this helper for
-/// `MAILBOX-CREATE` / `MAILBOX-DELETE` (the daemon now uses the
-/// owner-bound `auth::Action` variants). Kept available for future
-/// root-only UDS verbs.
-#[allow(dead_code)]
-pub fn enforce_root(
-    verb: &str,
-    caller: &Caller,
-    mailbox_hint: Option<&str>,
-) -> Result<(), AuthzReject> {
-    match require_root(caller) {
-        Ok(_) => {
-            log_decision(verb, caller, mailbox_hint, LogDecision::Accept, None);
-            Ok(())
-        }
-        Err(reject) => {
-            log_decision(
-                verb,
-                caller,
-                mailbox_hint,
                 LogDecision::Reject,
                 Some(&reject.reason),
             );
@@ -559,21 +497,6 @@ mod tests {
     }
 
     #[test]
-    fn require_root_rejects_non_root() {
-        let c = Caller::new(1002, 1002, None);
-        let _ = c.username_cache.set(Some("bob".to_string()));
-        let err = require_root(&c).unwrap_err();
-        assert_eq!(err.code, ErrCode::Eaccess);
-        assert!(err.reason.contains("bob"));
-    }
-
-    #[test]
-    fn require_root_accepts_root() {
-        let c = Caller::internal_root();
-        assert_eq!(require_root(&c).unwrap(), AuthzDecision::Accept);
-    }
-
-    #[test]
     #[tracing_test::traced_test]
     fn enforce_mailbox_owner_or_root_logs_accept() {
         let c = Caller::new(1001, 1001, None);
@@ -630,25 +553,5 @@ mod tests {
             "leaked owner: {}",
             err.reason
         );
-    }
-
-    #[test]
-    #[tracing_test::traced_test]
-    fn enforce_root_logs_reject() {
-        // Generic test of the `enforce_root` helper's logging shape.
-        // Sprint 3 (S3-6) intentionally uses a placeholder verb label
-        // here. The user-mailbox spot-check verifies no production
-        // mailbox-lifecycle verb is wired to this helper — every
-        // mailbox CRUD UDS verb is now owner-gated, never root-gated.
-        let c = Caller::new(1002, 1002, None);
-        let _ = c.username_cache.set(Some("bob".to_string()));
-        let err = enforce_root("DEMO-VERB", &c, Some("alice")).unwrap_err();
-        assert_eq!(err.code, ErrCode::Eaccess);
-        // Wire reason is opaque.
-        assert_eq!(err.reason, "not authorized");
-        assert!(logs_contain("decision=\"reject\""));
-        assert!(logs_contain("verb=\"DEMO-VERB\""));
-        // Log keeps the rich diagnostic naming the caller.
-        assert!(logs_contain("caller uid 1002"));
     }
 }


### PR DESCRIPTION
## Summary

Bundles the four open items in the **Non-blocking Review Backlog** of `docs/user-mailbox-sprint.md` (lines 332-335) into a single mechanical cleanup PR. The user-mailbox initiative shipped in three sprints (PRs #193, #194, #195); these are the deferred-but-tracked nits.

## Requirements

- [x] **R1** — Add a one-line comment in `install_tester_resolver_with_current_user` (`src/mailbox_handler.rs`) explaining that the per-call `lookup_username`/`getpwuid` is intentional and cheap — preempts a future "let me memoize this" PR that would break test isolation.
- [x] **R2** — Delete dead `require_root` / `enforce_root` from `src/uds_authz.rs` along with their three direct unit tests (`require_root_rejects_non_root`, `require_root_accepts_root`, `enforce_root_logs_reject`). Sprint 2 settled with no new root-only UDS verb adopting them. `Caller`, `peer_username`, and the rest of `uds_authz.rs` are untouched.
- [x] **R3** — Rename pre-existing wire-protocol type names off the `MailboxCrud` prefix:
  - `MailboxCrudRequest` -> `MailboxLifecycleRequest`
  - `Request::MailboxCrud(...)` -> `Request::MailboxLifecycle(...)`
  - `MailboxCrudFallback` -> `MailboxLifecycleFallback`

  Mechanical refactor, ~71 occurrences across 5 files (`src/send_protocol.rs`, `src/mailbox.rs`, `src/mailbox_handler.rs`, `src/mcp.rs`, `src/serve.rs`). Wire-protocol verb strings (`MAILBOX-CREATE`, `MAILBOX-DELETE`) and other on-the-wire identifiers are unchanged.
- [x] **R4** — Derive the `format_auth_error` rendering verb from the `auth::Action` variant in `mcp::authorize_mailbox` instead of hardcoding `verb: Some("create")`. `MailboxCreate { .. }` -> `Some("create")`, `MailboxDelete { .. }` -> `Some("delete")`, anything else -> `None` (renders as the generic "perform"). Keeps the rendering correct if a future predicate ever produces `OwnerMismatch` from a non-create action.
- [x] **R5** — Mark the four bullets in the Non-blocking Review Backlog Improvements subsection as `[x]` (with an inline note pointing at this PR). The `docs/` tree is gitignored in this repo, so the file is updated locally but does not appear in the PR diff.

## Out of scope

- Renaming any `Action::Mailbox*` authz variants — those landed correctly in Sprint 1.
- Standardising the user-visible wording across the three `format_auth_error` call sites — Sprint 3 deliberately preserved each surface's existing strings; changing wording is a separate UX decision, not a cleanup.
- Any other backlog items added later — only the four listed at lines 332-335 of `docs/user-mailbox-sprint.md` are in scope.

## Technical approach

- **R1**: single comment edit in the test scaffolding. No semantic change.
- **R2**: pre-flight `grep -rn "require_root\|enforce_root" src/ services/ | grep -v src/uds_authz.rs` returned nothing — confirmed zero production callers. Deleted both `pub fn` definitions and the three direct unit tests. Other tests in `uds_authz.rs::tests` that consume `Caller` / `AuthzDecision` are untouched.
- **R3**: per-file `Edit` with `replace_all: true` for each name, file by file. `cargo build` after each renamed-definition change caught any remaining call sites; the final post-rename `grep -rn "MailboxCrud" src/ services/` returned nothing.
- **R4**: five-line `let verb = match &action { ... }` block computed before the existing `authorize(...)` call (which moves `action`); the closure passes `verb` instead of `Some("create")`. Per the plan, no test scaffold added — the verb-derivation logic is one match arm and `mcp.rs` has no existing tests module that covers `authorize_mailbox` directly.

## Test plan

- [x] `cargo fmt -- --check` (root + verifier) — clean
- [x] `cargo clippy --all-targets -- -D warnings` (root + verifier) — clean
- [x] `cargo test` (root crate, default lane) — **1124 tests pass**, 0 failures (1026 unit + 97 integration + 1 uds_authz default; 8/5/21 ignored slots remain)
- [x] `cargo test` (verifier crate) — **43 pass**, 0 failures
- [x] `sudo -E env "PATH=$PATH" AIMX_INTEGRATION_SUDO=1 cargo test --test uds_authz -- --ignored --test-threads=1` — **21/21 pass** (the canonical privilege-boundary regression guard; the rename touches handler entry points so this matters)
- [x] **Strict spot-check:** `grep -rn "MailboxCrud" src/ services/` returns nothing — closes S3-6 strictly
- [x] **Production callers gone:** `grep -rn "require_root\|enforce_root" src/ services/` returns nothing