### PR TITLE
[Sprint 4] HOOK-LIST verb + MCP tool rewrites — close MCP EACCES bug class

### DIFF
--- a/src/hook_handler.rs
+++ b/src/hook_handler.rs
@@ -241,12 +241,17 @@ pub async fn handle_hook_delete(
         }
     };
 
-    if let Err(reject) =
+    if let Err(_reject) =
         enforce_mailbox_owner_or_root("HOOK-DELETE", caller, mailbox_name, &mailbox_cfg)
     {
+        // NFR2 opacity: a non-owner caller must not be able to
+        // distinguish "hook exists on a mailbox you don't own" from
+        // "hook doesn't exist anywhere." Both surface as ENOENT with
+        // the same canonical reason. The full reject is still logged
+        // (above) for operator forensics; only the wire shape collapses.
         return AckResponse::Err {
-            code: reject.code,
-            reason: reject.reason,
+            code: ErrCode::Enoent,
+            reason: format!("hook '{}' not found", req.name),
         };
     }
 
@@ -817,9 +822,19 @@ mod tests {
         let del = HookDeleteRequest {
             name: "greet".into(),
         };
+        // NFR2 opacity: a non-owner caller must not be able to
+        // distinguish "hook exists on a mailbox you don't own" from
+        // "hook doesn't exist anywhere." Both surface as ENOENT.
         match handle_hook_delete(&state_ctx, &mb_ctx, &del, &attacker).await {
-            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Eaccess),
-            other => panic!("expected EACCES, got {other:?}"),
+            AckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Enoent);
+                assert!(reason.contains("not found"), "{reason}");
+                assert!(
+                    !reason.contains("not authorized"),
+                    "wire reason must not leak authz state: {reason}"
+                );
+            }
+            other => panic!("expected ENOENT, got {other:?}"),
         }
         assert_eq!(
             mb_ctx.config_handle.load().mailboxes["alice"].hooks.len(),

--- a/src/hook_list_handler.rs
+++ b/src/hook_list_handler.rs
@@ -1,0 +1,306 @@
+//! Daemon-side handler for the `HOOK-LIST` verb of the `AIMX/1` UDS
+//! protocol.
+//!
+//! Mirrors `mailbox_list_handler` line-for-line: the daemon resolves
+//! the caller via `SO_PEERCRED`, walks the in-memory `Arc<Config>`, and
+//! returns a JSON array of the hooks visible to the caller. Root sees
+//! every hook on every mailbox; non-root sees only hooks on mailboxes
+//! it owns.
+//!
+//! The MCP `hook_list` tool used to read `/etc/aimx/config.toml`
+//! directly from a non-root process and would always fail on the
+//! `0640 root:root` permission. After this rework the MCP tool is a
+//! thin UDS client and the daemon answers from its `Arc<Config>`
+//! snapshot — no disk I/O, no caller-supplied filtering.
+//!
+//! No locks are taken; reads of `Arc<Config>` are wait-free. A
+//! concurrent `HOOK-CREATE` / `HOOK-DELETE` may swap the snapshot in
+//! between two `HOOK-LIST` calls, but each individual call observes a
+//! consistent snapshot.
+
+use serde::{Deserialize, Serialize};
+
+use crate::config::Config;
+use crate::hook::{HookEvent, effective_hook_name};
+use crate::mailbox;
+use crate::send_protocol::{ErrCode, JsonAckResponse};
+use crate::state_handler::StateContext;
+use crate::uds_authz::Caller;
+
+/// One row of the JSON array returned by `HOOK-LIST`. Schema is fixed
+/// by the user-mailbox PRD R34. `event` is the typed `HookEvent` enum
+/// (snake_case on the wire) so client and server share a single source
+/// of truth and a stale wire string cannot drift past the codec.
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+pub struct HookListRow {
+    /// Effective hook name — matches the CLI's `aimx hooks list`
+    /// output (explicit `name` if set, derived 12-char hex otherwise).
+    pub name: String,
+    /// Mailbox the hook is attached to.
+    pub mailbox: String,
+    /// Triggering event (`on_receive` / `after_send`).
+    pub event: HookEvent,
+    /// Argv form, not joined — agents can render a shell-safe display
+    /// without losing token boundaries.
+    pub cmd: Vec<String>,
+    /// Whether the hook fires on inbound emails the trust gate marks
+    /// untrusted. `false` for `after_send` hooks (no trust gate).
+    pub fire_on_untrusted: bool,
+    /// Hard subprocess timeout, seconds. Mirrors the config field.
+    pub timeout_secs: u32,
+}
+
+/// Build the JSON ack response for an `AIMX/1 HOOK-LIST` request.
+pub async fn handle_hook_list(state_ctx: &StateContext, caller: &Caller) -> JsonAckResponse {
+    let config = state_ctx.config_handle.load();
+    let rows = collect_rows(&config, caller.uid);
+    let body = match serde_json::to_vec(&rows) {
+        Ok(b) => b,
+        Err(e) => {
+            return JsonAckResponse::Err {
+                code: ErrCode::Io,
+                reason: format!("failed to serialize hook list: {e}"),
+            };
+        }
+    };
+    JsonAckResponse::Ok { body }
+}
+
+/// Pure helper: walk every mailbox in `config`, keep only those visible
+/// to `caller_uid`, and emit a `HookListRow` per attached hook. Sorted
+/// stably by `(mailbox, event, name)` so agents get deterministic
+/// output across calls.
+fn collect_rows(config: &Config, caller_uid: u32) -> Vec<HookListRow> {
+    let mut rows: Vec<HookListRow> = Vec::new();
+    for (mailbox_name, mb) in &config.mailboxes {
+        if !is_visible_to(config, mailbox_name, caller_uid) {
+            continue;
+        }
+        for hook in &mb.hooks {
+            rows.push(HookListRow {
+                name: effective_hook_name(hook),
+                mailbox: mailbox_name.clone(),
+                event: hook.event,
+                cmd: hook.cmd.clone(),
+                fire_on_untrusted: hook.fire_on_untrusted,
+                timeout_secs: hook.timeout_secs,
+            });
+        }
+    }
+    rows.sort_by(|a, b| {
+        a.mailbox
+            .cmp(&b.mailbox)
+            .then_with(|| a.event.as_str().cmp(b.event.as_str()))
+            .then_with(|| a.name.cmp(&b.name))
+    });
+    rows
+}
+
+/// Visibility rule: root sees every mailbox; a non-root caller sees a
+/// mailbox only when its configured `owner` resolves to the caller's
+/// uid. Stray on-disk directories without a config entry have no hooks
+/// (hooks live only in `[mailboxes.<name>].hooks`), so this filter is
+/// strictly tighter than the `MAILBOX-LIST` filter.
+fn is_visible_to(config: &Config, name: &str, caller_uid: u32) -> bool {
+    if caller_uid == 0 {
+        return true;
+    }
+    mailbox::caller_owns(config, name, caller_uid)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Config, ConfigHandle, MailboxConfig};
+    use crate::hook::Hook;
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    fn fake_resolver(name: &str) -> Option<crate::user_resolver::ResolvedUser> {
+        match name {
+            "alice" => Some(crate::user_resolver::ResolvedUser {
+                name: "alice".to_string(),
+                uid: 4242,
+                gid: 4242,
+            }),
+            "bob" => Some(crate::user_resolver::ResolvedUser {
+                name: "bob".to_string(),
+                uid: 5050,
+                gid: 5050,
+            }),
+            "root" => Some(crate::user_resolver::ResolvedUser {
+                name: "root".to_string(),
+                uid: 0,
+                gid: 0,
+            }),
+            _ => None,
+        }
+    }
+
+    fn install_resolver() -> crate::user_resolver::test_resolver::ResolverOverride {
+        crate::user_resolver::set_test_resolver(fake_resolver)
+    }
+
+    fn hook_for(event: HookEvent, cmd: Vec<&str>, name: Option<&str>) -> Hook {
+        Hook {
+            name: name.map(|s| s.to_string()),
+            event,
+            r#type: "cmd".to_string(),
+            cmd: cmd.into_iter().map(|s| s.to_string()).collect(),
+            fire_on_untrusted: false,
+            timeout_secs: 60,
+        }
+    }
+
+    fn config_with_hooks(data_dir: &std::path::Path) -> Config {
+        let mut mailboxes = HashMap::new();
+        mailboxes.insert(
+            "alice".to_string(),
+            MailboxConfig {
+                address: "alice@example.com".to_string(),
+                owner: "alice".to_string(),
+                hooks: vec![
+                    hook_for(HookEvent::OnReceive, vec!["/bin/true"], Some("a-recv")),
+                    hook_for(HookEvent::AfterSend, vec!["/bin/echo", "sent"], None),
+                ],
+                trust: None,
+                trusted_senders: None,
+                allow_root_catchall: false,
+            },
+        );
+        mailboxes.insert(
+            "bob".to_string(),
+            MailboxConfig {
+                address: "bob@example.com".to_string(),
+                owner: "bob".to_string(),
+                hooks: vec![hook_for(
+                    HookEvent::OnReceive,
+                    vec!["/bin/true"],
+                    Some("b-recv"),
+                )],
+                trust: None,
+                trusted_senders: None,
+                allow_root_catchall: false,
+            },
+        );
+        Config {
+            domain: "example.com".to_string(),
+            data_dir: data_dir.to_path_buf(),
+            dkim_selector: "aimx".to_string(),
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            mailboxes,
+            verify_host: None,
+            enable_ipv6: false,
+            upgrade: None,
+        }
+    }
+
+    /// Root sees every hook on every mailbox.
+    #[tokio::test]
+    async fn root_sees_every_hook() {
+        let tmp = TempDir::new().unwrap();
+        let _r = install_resolver();
+        let config = config_with_hooks(tmp.path());
+        let handle = ConfigHandle::new(config);
+        let state_ctx = StateContext::new(tmp.path().to_path_buf(), handle);
+
+        let resp = handle_hook_list(&state_ctx, &Caller::internal_root()).await;
+        let body = match resp {
+            JsonAckResponse::Ok { body } => body,
+            other => panic!("expected Ok, got {other:?}"),
+        };
+        let rows: Vec<HookListRow> = serde_json::from_slice(&body).unwrap();
+        let mailboxes: Vec<&str> = rows.iter().map(|r| r.mailbox.as_str()).collect();
+        assert_eq!(mailboxes, vec!["alice", "alice", "bob"]);
+    }
+
+    /// A non-root caller whose uid matches `alice`'s owner sees only
+    /// alice's hooks; bob's are filtered out.
+    #[tokio::test]
+    async fn non_root_owner_sees_only_owned_hooks() {
+        let tmp = TempDir::new().unwrap();
+        let _r = install_resolver();
+        let config = config_with_hooks(tmp.path());
+        let handle = ConfigHandle::new(config);
+        let state_ctx = StateContext::new(tmp.path().to_path_buf(), handle);
+
+        let caller = Caller::new(4242, 4242, None);
+        let resp = handle_hook_list(&state_ctx, &caller).await;
+        let body = match resp {
+            JsonAckResponse::Ok { body } => body,
+            other => panic!("expected Ok, got {other:?}"),
+        };
+        let rows: Vec<HookListRow> = serde_json::from_slice(&body).unwrap();
+        let mailboxes: Vec<&str> = rows.iter().map(|r| r.mailbox.as_str()).collect();
+        assert_eq!(mailboxes, vec!["alice", "alice"]);
+        // Sorted by (mailbox, event, name) — after_send comes before
+        // on_receive lexicographically.
+        assert_eq!(rows[0].event, HookEvent::AfterSend);
+        assert_eq!(rows[1].event, HookEvent::OnReceive);
+    }
+
+    /// A stranger uid sees an empty array — never `null` and never a
+    /// human-readable "no hooks" string.
+    #[tokio::test]
+    async fn stranger_sees_empty_array() {
+        let tmp = TempDir::new().unwrap();
+        let _r = install_resolver();
+        let config = config_with_hooks(tmp.path());
+        let handle = ConfigHandle::new(config);
+        let state_ctx = StateContext::new(tmp.path().to_path_buf(), handle);
+
+        let stranger = Caller::new(99999, 99999, None);
+        let resp = handle_hook_list(&state_ctx, &stranger).await;
+        let body = match resp {
+            JsonAckResponse::Ok { body } => body,
+            other => panic!("expected Ok, got {other:?}"),
+        };
+        assert_eq!(body, b"[]");
+    }
+
+    /// Hooks on mailboxes the caller doesn't own are filtered out even
+    /// when other mailboxes the caller does own carry hooks of the
+    /// same name. The visibility filter runs per-mailbox.
+    #[tokio::test]
+    async fn hooks_on_unowned_mailboxes_are_filtered() {
+        let tmp = TempDir::new().unwrap();
+        let _r = install_resolver();
+        let config = config_with_hooks(tmp.path());
+        let handle = ConfigHandle::new(config);
+        let state_ctx = StateContext::new(tmp.path().to_path_buf(), handle);
+
+        // Bob (uid 5050) should only see bob's mailbox's hooks.
+        let caller = Caller::new(5050, 5050, None);
+        let resp = handle_hook_list(&state_ctx, &caller).await;
+        let body = match resp {
+            JsonAckResponse::Ok { body } => body,
+            other => panic!("expected Ok, got {other:?}"),
+        };
+        let rows: Vec<HookListRow> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].mailbox, "bob");
+        assert_eq!(rows[0].name, "b-recv");
+    }
+
+    /// `HookListRow` round-trips through serde: a row encoded by the
+    /// daemon decodes identically client-side. Pins the schema so a
+    /// future field rename can't silently desync the wire shape.
+    #[test]
+    fn hook_list_row_serde_round_trip() {
+        let row = HookListRow {
+            name: "recv-1".to_string(),
+            mailbox: "alice".to_string(),
+            event: HookEvent::OnReceive,
+            cmd: vec!["/bin/echo".to_string(), "hi".to_string()],
+            fire_on_untrusted: true,
+            timeout_secs: 120,
+        };
+        let json = serde_json::to_string(&row).unwrap();
+        // event must serialize as snake_case so the wire matches the
+        // CLI's existing rendering.
+        assert!(json.contains("\"event\":\"on_receive\""), "{json}");
+        let decoded: HookListRow = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, row);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,11 +84,12 @@ fn dispatch(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         }
         // Portcheck does not read config for storage, only `verify_host`.
         Command::Portcheck { verify_host } => portcheck::run(verify_host.as_deref()),
-        // MCP server reloads config on each tool call; pass the override through.
+        // MCP tools route through the daemon UDS; no config or data-dir
+        // override is read in-process.
         Command::Mcp => {
             let rt = tokio::runtime::Runtime::new()
                 .map_err(|e| format!("Failed to create runtime: {e}"))?;
-            rt.block_on(mcp::run(cli.data_dir.as_deref()))
+            rt.block_on(mcp::run())
         }
         // `aimx agents <command>`: the canonical plural-noun-with-verb
         // shape. Setup / Remove / List dispatch to their dedicated

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod doctor;
 mod frontmatter;
 mod hook;
 mod hook_handler;
+mod hook_list_handler;
 mod hooks;
 mod ingest;
 mod logging;

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1,7 +1,7 @@
 use crate::cli::SendArgs;
+#[cfg(test)]
 use crate::config::Config;
 use crate::frontmatter::InboundFrontmatter;
-use crate::mailbox;
 use crate::send;
 use crate::send_protocol::{
     self, ErrCode, HookCreateRequest, HookDeleteRequest, MailboxLifecycleRequest, MarkRequest,
@@ -17,14 +17,18 @@ use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
 pub struct AimxMcpServer {
-    /// CLI `--data-dir` / `AIMX_DATA_DIR` override. When `Some`, it
-    /// supersedes `config.data_dir` for all storage operations; when
-    /// `None`, the value from `/etc/aimx/config.toml` is used.
+    /// CLI `--data-dir` / `AIMX_DATA_DIR` override. Read by the
+    /// test-only `load_config` helper; production tools route through
+    /// the daemon UDS and never read `config.toml` directly.
+    #[allow(dead_code)]
     data_dir_override: Option<PathBuf>,
     /// Effective uid of the process running `aimx mcp`. Captured at
-    /// `new()` and passed into `auth::authorize` for every tool call.
-    /// Agents inherit the operator's uid via the launching shell, so
-    /// this is the agent's authorization principal.
+    /// `new()` and read by the test-only `authorize_mailbox` helper.
+    /// Production tools delegate authorization to the daemon (which
+    /// resolves the caller via SO_PEERCRED and runs the central
+    /// `authorize()` predicate) so this field is never read in shipped
+    /// builds.
+    #[allow(dead_code)]
     caller_uid: u32,
     #[allow(dead_code)]
     tool_router: ToolRouter<Self>,
@@ -183,16 +187,15 @@ impl AimxMcpServer {
         }
     }
 
-    fn load_config(&self) -> Result<Config, String> {
-        Config::load_resolved_with_data_dir(self.data_dir_override.as_deref())
-            .map(|(cfg, _warnings)| cfg)
-            .map_err(|e| format!("Failed to load config: {e}"))
-    }
-
     /// Return the auth predicate's verdict for `action` against the
     /// named mailbox. Mirrors the daemon-side helper so the auth gate
     /// runs the same way through CLI, daemon UDS, and MCP. The MCP
     /// surface returns errors as `String` per `rmcp` conventions.
+    /// Now test-only: production tools delegate authz to the daemon
+    /// over UDS (the daemon owns the central `authorize()` predicate
+    /// and re-runs it on every wire request, so the MCP-side
+    /// pre-flight is redundant).
+    #[cfg(test)]
     fn authorize_mailbox(
         &self,
         action: crate::auth::Action,
@@ -271,24 +274,17 @@ impl AimxMcpServer {
         &self,
         Parameters(params): Parameters<EmailListParams>,
     ) -> Result<String, String> {
-        let config = self.load_config()?;
-
-        if !config.mailboxes.contains_key(&params.mailbox) {
-            return Err(format!("Mailbox '{}' does not exist.", params.mailbox));
-        }
-
-        // Point operations on mailboxes the caller doesn't own return
-        // the canonical "not authorized" error. This is distinct from
-        // `mailbox_list`, which silently filters — point ops surface
-        // an explicit failure so the agent doesn't loop on an empty
-        // list it cannot interpret.
-        self.authorize_mailbox(
-            crate::auth::Action::MailboxRead(params.mailbox.clone()),
-            &config,
-        )?;
+        // The daemon's `MAILBOX-LIST` is filtered to the caller's uid
+        // via SO_PEERCRED, so a missing row collapses "no such mailbox"
+        // and "you don't own that mailbox" into the same opaque error
+        // (NFR2 opacity contract). This avoids the previous
+        // `self.load_config()` path which fails with EACCES on a
+        // production-perm `0640 root:root` config from a non-root MCP
+        // process.
+        let row = lookup_mailbox_row(&params.mailbox)?;
 
         let folder = resolve_folder(params.folder.as_deref())?;
-        let mailbox_dir = folder_dir(&config, &params.mailbox, folder);
+        let mailbox_dir = folder_path_from_row(&row, folder);
 
         let limit = clamp_limit(params.limit);
         let offset = params.offset.unwrap_or(0) as usize;
@@ -301,23 +297,15 @@ impl AimxMcpServer {
         &self,
         Parameters(params): Parameters<EmailReadParams>,
     ) -> Result<String, String> {
-        let config = self.load_config()?;
         validate_email_id(&params.id)?;
-
-        if !config.mailboxes.contains_key(&params.mailbox) {
-            return Err(format!("Mailbox '{}' does not exist.", params.mailbox));
-        }
-        self.authorize_mailbox(
-            crate::auth::Action::MailboxRead(params.mailbox.clone()),
-            &config,
-        )?;
+        let row = lookup_mailbox_row(&params.mailbox)?;
 
         let folder = resolve_folder(params.folder.as_deref())?;
-        let mailbox_dir = folder_dir(&config, &params.mailbox, folder);
-        // Read paths audit — `email_read` goes through
-        // the strict resolver so a planted symlink or escape path
-        // cannot exfiltrate another mailbox's mail via `email_read`,
-        // not just via the MARK verbs.
+        let mailbox_dir = folder_path_from_row(&row, folder);
+        // Read paths audit — `email_read` goes through the strict
+        // resolver so a planted symlink or escape path cannot
+        // exfiltrate another mailbox's mail via `email_read`, not just
+        // via the MARK verbs.
         let filepath = resolve_email_path_strict(&mailbox_dir, &params.id).ok_or_else(|| {
             format!(
                 "Email '{}' not found in mailbox '{}'.",
@@ -338,15 +326,11 @@ impl AimxMcpServer {
         Parameters(params): Parameters<EmailMarkParams>,
     ) -> Result<String, String> {
         validate_email_id(&params.id)?;
-        let config = self.load_config()?;
-        self.authorize_mailbox(
-            crate::auth::Action::MarkReadWrite(params.mailbox.clone()),
-            &config,
-        )?;
-        // Route through the daemon; mailbox files are root-owned and
-        // the MCP process runs as the invoking user. The daemon
-        // re-checks via SO_PEERCRED, so MCP's pre-flight authz is
-        // defense in depth, not the security boundary.
+        // The daemon's MARK handler re-runs SO_PEERCRED-based authz;
+        // the MCP-side row lookup is the friendly pre-flight that
+        // surfaces "mailbox not found / not yours" as the opaque
+        // shared error rather than the daemon's wire reason.
+        let _row = lookup_mailbox_row(&params.mailbox)?;
         submit_mark_via_daemon(&params.mailbox, &params.id, true)?;
         Ok(format!("Email '{}' marked as read.", params.id))
     }
@@ -361,11 +345,7 @@ impl AimxMcpServer {
         Parameters(params): Parameters<EmailMarkParams>,
     ) -> Result<String, String> {
         validate_email_id(&params.id)?;
-        let config = self.load_config()?;
-        self.authorize_mailbox(
-            crate::auth::Action::MarkReadWrite(params.mailbox.clone()),
-            &config,
-        )?;
+        let _row = lookup_mailbox_row(&params.mailbox)?;
         submit_mark_via_daemon(&params.mailbox, &params.id, false)?;
         Ok(format!("Email '{}' marked as unread.", params.id))
     }
@@ -378,17 +358,17 @@ impl AimxMcpServer {
         &self,
         Parameters(params): Parameters<EmailSendParams>,
     ) -> Result<String, String> {
-        let config = self.load_config()?;
-
-        if !config.mailboxes.contains_key(&params.from_mailbox) {
-            return Err(format!("Mailbox '{}' does not exist.", params.from_mailbox));
-        }
-        self.authorize_mailbox(
-            crate::auth::Action::MailboxSendAs(params.from_mailbox.clone()),
-            &config,
-        )?;
-
-        let from_address = &config.mailboxes[&params.from_mailbox].address;
+        // The daemon's MAILBOX-LIST row carries the registered address
+        // verbatim. We derive the from-address (and only secondarily
+        // the domain) from it without reading root-owned
+        // `/etc/aimx/config.toml`. The daemon-side SEND handler
+        // re-runs SO_PEERCRED authz; the MCP pre-flight is operator
+        // UX, not the security boundary.
+        let row = lookup_mailbox_row(&params.from_mailbox)?;
+        let from_address = row
+            .address
+            .as_deref()
+            .ok_or_else(|| format!("Mailbox '{}' is not registered.", params.from_mailbox))?;
         if from_address.starts_with('*') {
             return Err(format!(
                 "Cannot send from '{}': catchall mailbox has no valid sender address. Use a named mailbox.",
@@ -409,24 +389,14 @@ impl AimxMcpServer {
         &self,
         Parameters(params): Parameters<EmailReplyParams>,
     ) -> Result<String, String> {
-        let config = self.load_config()?;
         validate_email_id(&params.id)?;
+        let row = lookup_mailbox_row(&params.mailbox)?;
 
-        if !config.mailboxes.contains_key(&params.mailbox) {
-            return Err(format!("Mailbox '{}' does not exist.", params.mailbox));
-        }
-        // `email_reply` reads the parent and submits a new outbound
-        // message — both surfaces are scoped to caller-owned mailboxes.
-        self.authorize_mailbox(
-            crate::auth::Action::MailboxSendAs(params.mailbox.clone()),
-            &config,
-        )?;
-
-        let mailbox_dir = config.inbox_dir(&params.mailbox);
-        // `email_reply` reads the parent message to
-        // inherit threading headers; route through the strict resolver
-        // so a symlink cannot leak another mailbox's message into a
-        // reply composition.
+        let mailbox_dir = folder_path_from_row(&row, Folder::Inbox);
+        // `email_reply` reads the parent message to inherit threading
+        // headers; route through the strict resolver so a symlink
+        // cannot leak another mailbox's message into a reply
+        // composition.
         let filepath = resolve_email_path_strict(&mailbox_dir, &params.id).ok_or_else(|| {
             format!(
                 "Email '{}' not found in mailbox '{}'.",
@@ -440,7 +410,10 @@ impl AimxMcpServer {
         let meta = parse_frontmatter(&content)
             .ok_or_else(|| "Failed to parse email frontmatter.".to_string())?;
 
-        let from_address = &config.mailboxes[&params.mailbox].address;
+        let from_address = row
+            .address
+            .as_deref()
+            .ok_or_else(|| format!("Mailbox '{}' is not registered.", params.mailbox))?;
         if from_address.starts_with('*') {
             return Err(format!(
                 "Cannot reply from '{}': catchall mailbox has no valid sender address. Use a named mailbox.",
@@ -465,7 +438,7 @@ impl AimxMcpServer {
         };
 
         let args = SendArgs {
-            from: from_address.clone(),
+            from: from_address.to_string(),
             to: reply_to_email.to_string(),
             subject,
             body: params.body,
@@ -489,17 +462,14 @@ impl AimxMcpServer {
         &self,
         Parameters(params): Parameters<HookCreateParams>,
     ) -> Result<String, String> {
-        let config = self.load_config()?;
-        if !config.mailboxes.contains_key(&params.mailbox) {
-            return Err(format!("Mailbox '{}' does not exist.", params.mailbox));
-        }
-        // Authorize against the central predicate before any wire I/O so
-        // a non-owner sees the canonical "not authorized" error rather
-        // than the daemon's opaque rejection text.
-        self.authorize_mailbox(
-            crate::auth::Action::HookCrud(params.mailbox.clone()),
-            &config,
-        )?;
+        // Pre-flight: verify the mailbox is visible to the caller via
+        // the daemon's MAILBOX-LIST. The listing is SO_PEERCRED-
+        // filtered so a missing row collapses "no such mailbox" and
+        // "exists but you don't own it" into one opaque error (NFR2).
+        // The daemon's HOOK-CREATE handler runs the central
+        // `authorize()` predicate again — this pre-flight only exists
+        // for a friendly error vs. relying on the daemon's wire shape.
+        let _row = lookup_mailbox_row(&params.mailbox)?;
 
         if params.cmd.is_empty() {
             return Err("cmd must not be empty".to_string());
@@ -538,58 +508,29 @@ impl AimxMcpServer {
                        every hook on every mailbox you own."
     )]
     fn hook_list(&self, Parameters(params): Parameters<HookListParams>) -> Result<String, String> {
-        let config = self.load_config()?;
+        // Route through the daemon's HOOK-LIST so the non-root MCP
+        // process never reads root-owned `/etc/aimx/config.toml`. The
+        // daemon's listing is SO_PEERCRED-filtered to the caller's uid
+        // (root sees every hook on every mailbox; non-root sees only
+        // hooks on mailboxes it owns), matching the previous behavior
+        // exactly.
+        let json = submit_hook_list_via_daemon()?;
 
-        if let Some(name) = &params.mailbox {
-            if !config.mailboxes.contains_key(name) {
-                return Err(format!("Mailbox '{name}' does not exist."));
-            }
-            self.authorize_mailbox(crate::auth::Action::HookCrud(name.clone()), &config)?;
-        }
-
-        let mut rows: Vec<serde_json::Value> = Vec::new();
-        for (mailbox_name, mb) in &config.mailboxes {
-            // Filter by --mailbox, or by caller ownership for non-root.
-            if let Some(f) = &params.mailbox
-                && f != mailbox_name
-            {
-                continue;
-            }
-            if self.caller_uid != 0 && !mailbox::caller_owns(&config, mailbox_name, self.caller_uid)
-            {
-                continue;
-            }
-            for hook in &mb.hooks {
-                rows.push(serde_json::json!({
-                    "name": crate::hook::effective_hook_name(hook),
-                    "mailbox": mailbox_name,
-                    "event": hook.event.as_str(),
-                    "cmd": hook.cmd,
-                    "fire_on_untrusted": hook.fire_on_untrusted,
-                    "timeout_secs": hook.timeout_secs,
-                }));
-            }
-        }
-        rows.sort_by(|a, b| {
-            a["mailbox"]
-                .as_str()
-                .unwrap_or("")
-                .cmp(b["mailbox"].as_str().unwrap_or(""))
-                .then_with(|| {
-                    a["event"]
-                        .as_str()
-                        .unwrap_or("")
-                        .cmp(b["event"].as_str().unwrap_or(""))
-                })
-                .then_with(|| {
-                    a["name"]
-                        .as_str()
-                        .unwrap_or("")
-                        .cmp(b["name"].as_str().unwrap_or(""))
-                })
-        });
-
-        serde_json::to_string(&rows).map_err(|e| format!("Failed to serialize: {e}"))
+        // The optional `mailbox` filter narrows the daemon's response
+        // to a single mailbox; the daemon-side filter already removed
+        // unowned mailboxes, so this is a pure post-filter for UX.
+        // When `mailbox` references a mailbox the caller doesn't own
+        // (or that doesn't exist), `lookup_mailbox_row` surfaces the
+        // canonical opaque error rather than silently returning `[]`.
+        let Some(name) = params.mailbox.as_deref() else {
+            return Ok(json);
+        };
+        let _row = lookup_mailbox_row(name)?;
+        let rows: Vec<crate::hook_list_handler::HookListRow> =
+            serde_json::from_str(&json).map_err(|e| format!("Failed to parse hook list: {e}"))?;
+        let filtered: Vec<crate::hook_list_handler::HookListRow> =
+            rows.into_iter().filter(|r| r.mailbox == name).collect();
+        serde_json::to_string(&filtered).map_err(|e| format!("Failed to serialize: {e}"))
     }
 
     #[tool(
@@ -601,36 +542,15 @@ impl AimxMcpServer {
         &self,
         Parameters(params): Parameters<HookDeleteParams>,
     ) -> Result<String, String> {
-        // Resolve the hook to its mailbox so the auth predicate runs
-        // against the right principal. Hidden mailboxes (owned by other
-        // users) surface as "hook not found" — we deliberately do not
-        // distinguish "exists but you don't own it" from "doesn't exist"
-        // to avoid leaking ownership of foreign mailboxes. The UDS wire
-        // already returns canonical opaque text on auth failures; this
-        // collapse keeps the MCP surface from leaking more than the wire.
-        let config = self.load_config()?;
-        let mailbox_name = config
-            .mailboxes
-            .iter()
-            .find_map(|(mb_name, mb)| {
-                mb.hooks
-                    .iter()
-                    .find(|h| crate::hook::effective_hook_name(h) == params.name)
-                    .map(|_| mb_name.clone())
-            })
-            .ok_or_else(|| format!("Hook '{}' not found", params.name))?;
-
-        // If authorization fails (caller is not the mailbox's owner and
-        // is not root), surface as `not found` rather than leaking the
-        // foreign mailbox's name through a "caller does not own
-        // mailbox 'X'" error.
-        if self
-            .authorize_mailbox(crate::auth::Action::HookCrud(mailbox_name.clone()), &config)
-            .is_err()
-        {
-            return Err(format!("Hook '{}' not found", params.name));
-        }
-
+        // Thin pass-through to HOOK-DELETE. The daemon's handler
+        // resolves the hook by effective name, runs the central
+        // `authorize()` predicate, and returns the canonical opaque
+        // not-found error for both unowned and nonexistent hooks
+        // (NFR2 opacity contract). The previous MCP-side pre-flight
+        // duplicated that work AND introduced the EACCES bug class on
+        // production-perm `0640 root:root` configs by reading
+        // `/etc/aimx/config.toml` from a non-root MCP process. Trust
+        // the daemon.
         match submit_hook_delete_via_daemon(&params.name) {
             Ok(()) => Ok(format!("Hook '{}' deleted.", params.name)),
             Err(HookCrudFallback::SocketMissing) => {
@@ -1209,6 +1129,26 @@ fn lookup_mailbox_address(name: &str) -> Option<String> {
         .and_then(|r| r.address)
 }
 
+/// Fetch the daemon's `MAILBOX-LIST` and return the row matching
+/// `name`. Used by every email tool to resolve `inbox_path` /
+/// `sent_path` / `address` without the non-root MCP process needing
+/// read access to root-owned `/etc/aimx/config.toml`.
+///
+/// Returns the daemon's verbatim error string on a wire-level failure
+/// (socket missing, malformed response, daemon-side ERR), and a
+/// canonical "not found" error when the listing comes back clean but
+/// no row matches — the listing is already SO_PEERCRED-filtered to
+/// the caller's uid, so a missing row is opaque between "doesn't
+/// exist" and "exists but you don't own it" (NFR2 opacity).
+fn lookup_mailbox_row(name: &str) -> Result<crate::mailbox_list_handler::MailboxListRow, String> {
+    let json = submit_mailbox_list_via_daemon()?;
+    let rows: Vec<crate::mailbox_list_handler::MailboxListRow> =
+        serde_json::from_str(&json).map_err(|e| format!("Failed to parse mailbox list: {e}"))?;
+    rows.into_iter()
+        .find(|r| r.name == name)
+        .ok_or_else(|| format!("Mailbox '{name}' does not exist."))
+}
+
 fn submit_mailbox_list_via_daemon() -> Result<String, String> {
     submit_mailbox_list_raw().map_err(|e| match e {
         MailboxLifecycleFallback::SocketMissing => {
@@ -1216,6 +1156,72 @@ fn submit_mailbox_list_via_daemon() -> Result<String, String> {
         }
         MailboxLifecycleFallback::Daemon(msg) => msg,
     })
+}
+
+/// Submit an `AIMX/1 HOOK-LIST` and return the JSON body verbatim.
+/// Mirrors [`submit_mailbox_list_via_daemon`] line-for-line so the
+/// non-root MCP process answers `hook_list` without reading
+/// root-owned `/etc/aimx/config.toml`.
+fn submit_hook_list_via_daemon() -> Result<String, String> {
+    submit_hook_list_raw().map_err(|e| match e {
+        MailboxLifecycleFallback::SocketMissing => {
+            "aimx daemon not running. Start with 'sudo systemctl start aimx'".to_string()
+        }
+        MailboxLifecycleFallback::Daemon(msg) => msg,
+    })
+}
+
+fn submit_hook_list_raw() -> Result<String, MailboxLifecycleFallback> {
+    let socket = crate::serve::aimx_socket_path();
+
+    let rt = tokio::runtime::Handle::try_current();
+    let io_result: Result<Vec<u8>, std::io::Error> = match rt {
+        Ok(handle) => {
+            tokio::task::block_in_place(|| handle.block_on(submit_hook_list_request(&socket)))
+        }
+        Err(_) => {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| {
+                    MailboxLifecycleFallback::Daemon(format!("Failed to create tokio runtime: {e}"))
+                })?;
+            rt.block_on(submit_hook_list_request(&socket))
+        }
+    };
+
+    let raw = io_result.map_err(|e| {
+        if is_socket_missing(&e) {
+            MailboxLifecycleFallback::SocketMissing
+        } else {
+            MailboxLifecycleFallback::Daemon(format!(
+                "Failed to connect to aimx daemon at {}: {e}",
+                socket.display()
+            ))
+        }
+    })?;
+
+    decode_mailbox_list_response(&raw).map_err(MailboxLifecycleFallback::Daemon)
+}
+
+/// Open the UDS, ship `AIMX/1 HOOK-LIST`, and return the raw daemon
+/// response bytes. Decoding shares the `MAILBOX-LIST` decoder because
+/// the wire shape (status line + Content-Length + JSON body) is
+/// identical — only the schema of the JSON differs.
+async fn submit_hook_list_request(
+    socket_path: &std::path::Path,
+) -> Result<Vec<u8>, std::io::Error> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let stream = tokio::net::UnixStream::connect(socket_path).await?;
+    let (mut reader, mut writer) = stream.into_split();
+
+    send_protocol::write_hook_list_request(&mut writer).await?;
+    writer.shutdown().await.ok();
+
+    let mut buf = Vec::with_capacity(1024);
+    reader.read_to_end(&mut buf).await?;
+    Ok(buf)
 }
 
 /// CLI-friendly variant of [`submit_mailbox_list_via_daemon`] that
@@ -1644,10 +1650,25 @@ pub fn resolve_folder(raw: Option<&str>) -> Result<Folder, String> {
     }
 }
 
+#[cfg(test)]
 fn folder_dir(config: &Config, mailbox: &str, folder: Folder) -> PathBuf {
     match folder {
         Folder::Inbox => config.inbox_dir(mailbox),
         Folder::Sent => config.sent_dir(mailbox),
+    }
+}
+
+/// Pick the folder-specific path a `MAILBOX-LIST` row carries. The
+/// daemon already populates `inbox_path` / `sent_path` per row, so MCP
+/// tools rendering email pages no longer need to read root-owned
+/// `/etc/aimx/config.toml` to compute the path themselves.
+fn folder_path_from_row(
+    row: &crate::mailbox_list_handler::MailboxListRow,
+    folder: Folder,
+) -> PathBuf {
+    match folder {
+        Folder::Inbox => PathBuf::from(&row.inbox_path),
+        Folder::Sent => PathBuf::from(&row.sent_path),
     }
 }
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -17,11 +17,6 @@ use std::path::PathBuf;
 
 #[derive(Debug, Clone)]
 pub struct AimxMcpServer {
-    /// CLI `--data-dir` / `AIMX_DATA_DIR` override. Read by the
-    /// test-only `load_config` helper; production tools route through
-    /// the daemon UDS and never read `config.toml` directly.
-    #[allow(dead_code)]
-    data_dir_override: Option<PathBuf>,
     /// Effective uid of the process running `aimx mcp`. Captured at
     /// `new()` and read by the test-only `authorize_mailbox` helper.
     /// Production tools delegate authorization to the daemon (which
@@ -167,21 +162,20 @@ pub struct MailboxDeleteParams {
 }
 
 impl AimxMcpServer {
-    pub fn new(data_dir_override: Option<PathBuf>) -> Self {
-        Self::with_caller_uid(data_dir_override, crate::platform::current_euid())
+    pub fn new() -> Self {
+        Self::with_caller_uid(crate::platform::current_euid())
     }
 
     /// Test-only constructor that lets the caller pin the authorization
     /// principal. Production code calls `new()`, which derives the uid
     /// from `geteuid()` at startup.
     #[cfg(test)]
-    pub fn with_caller_uid_for_test(data_dir_override: Option<PathBuf>, caller_uid: u32) -> Self {
-        Self::with_caller_uid(data_dir_override, caller_uid)
+    pub fn with_caller_uid_for_test(caller_uid: u32) -> Self {
+        Self::with_caller_uid(caller_uid)
     }
 
-    fn with_caller_uid(data_dir_override: Option<PathBuf>, caller_uid: u32) -> Self {
+    fn with_caller_uid(caller_uid: u32) -> Self {
         Self {
-            data_dir_override,
             caller_uid,
             tool_router: Self::tool_router(),
         }
@@ -1097,8 +1091,8 @@ impl ServerHandler for AimxMcpServer {
     }
 }
 
-pub async fn run(data_dir: Option<&std::path::Path>) -> Result<(), Box<dyn std::error::Error>> {
-    let server = AimxMcpServer::new(data_dir.map(|p| p.to_path_buf()));
+pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    let server = AimxMcpServer::new();
     let transport = rmcp::transport::io::stdio();
 
     let service = server
@@ -1800,7 +1794,7 @@ mod auth_tests {
     fn root_caller_passes_authorize_mailbox_for_any_action() {
         let tmp = TempDir::new().unwrap();
         let config = build_config(tmp.path(), &[("alice", "root")]);
-        let server = AimxMcpServer::with_caller_uid_for_test(None, 0);
+        let server = AimxMcpServer::with_caller_uid_for_test(0);
 
         assert!(
             server
@@ -1826,7 +1820,7 @@ mod auth_tests {
         // Pick a uid that's almost certainly not 0 and not root —
         // exact value is irrelevant since the orphan-owner branch
         // collapses to NoSuchMailbox before the uid match runs.
-        let server = AimxMcpServer::with_caller_uid_for_test(None, 1000);
+        let server = AimxMcpServer::with_caller_uid_for_test(1000);
 
         let err = server
             .authorize_mailbox(Action::MailboxRead("alice".into()), &config)
@@ -1844,7 +1838,7 @@ mod auth_tests {
         // Caller uid 1000 vs mailbox owner uid 0 → NotOwner.
         let tmp = TempDir::new().unwrap();
         let config = build_config(tmp.path(), &[("admin", "root")]);
-        let server = AimxMcpServer::with_caller_uid_for_test(None, 1000);
+        let server = AimxMcpServer::with_caller_uid_for_test(1000);
 
         let err = server
             .authorize_mailbox(Action::MailboxRead("admin".into()), &config)
@@ -1857,7 +1851,7 @@ mod auth_tests {
     fn missing_mailbox_returns_not_authorized_not_found_for_non_root() {
         let tmp = TempDir::new().unwrap();
         let config = build_config(tmp.path(), &[]);
-        let server = AimxMcpServer::with_caller_uid_for_test(None, 1000);
+        let server = AimxMcpServer::with_caller_uid_for_test(1000);
 
         let err = server
             .authorize_mailbox(Action::MailboxRead("missing".into()), &config)
@@ -2275,7 +2269,7 @@ mod email_list_tests {
         // Without this guard a force-wipe on `catchall` would clear
         // the catchall storage even when the daemon would refuse the
         // delete itself.
-        let server = AimxMcpServer::with_caller_uid_for_test(None, 1000);
+        let server = AimxMcpServer::with_caller_uid_for_test(1000);
         let err = server
             .mailbox_delete(Parameters(MailboxDeleteParams {
                 name: "catchall".to_string(),

--- a/src/send_protocol.rs
+++ b/src/send_protocol.rs
@@ -48,6 +48,10 @@
 //!   Content-Length: 0\n
 //!   \n
 //!
+//! Client → Server (HOOK-LIST):
+//!   AIMX/1 HOOK-LIST\n
+//!   \n
+//!
 //! Server → Client:
 //!   AIMX/1 OK [<message-id>]\n
 //! or
@@ -168,6 +172,13 @@ pub struct HookDeleteRequest {
     pub name: String,
 }
 
+// `AIMX/1 HOOK-LIST` carries no payload; the daemon resolves the
+// caller via `SO_PEERCRED` and returns the hooks visible to the
+// caller's uid (root sees every hook on every mailbox; non-root sees
+// only hooks on mailboxes it owns). The verb mirrors `MAILBOX-LIST`
+// line-for-line so the codec stays uniform — see `Request::HookList`
+// below and `parse_hook_list_headers` for the codec entry points.
+
 /// JSON payload of an `AIMX/1 VERSION` response. Mirrors the four
 /// `crate::version` build-metadata helpers so a client can render the
 /// same `aimx <tag> (<sha>) <target> built <date>` banner without
@@ -193,6 +204,11 @@ pub enum Request {
     MailboxList,
     HookCreate(HookCreateRequest),
     HookDelete(HookDeleteRequest),
+    /// `AIMX/1 HOOK-LIST` carries no payload. The daemon resolves the
+    /// caller via `SO_PEERCRED` and returns a JSON array of the hooks
+    /// visible to the caller; non-root callers see only hooks on
+    /// mailboxes they own. Mirrors `MAILBOX-LIST` line-for-line.
+    HookList,
     /// `AIMX/1 VERSION` carries no payload. Returns the daemon's build
     /// metadata so operators can detect drift between an upgraded
     /// binary on disk and a still-running pre-upgrade daemon. Open to
@@ -421,6 +437,9 @@ where
         "HOOK-DELETE" => parse_hook_delete_headers(reader)
             .await
             .map(Request::HookDelete),
+        "HOOK-LIST" => parse_hook_list_headers(reader)
+            .await
+            .map(|()| Request::HookList),
         "VERSION" => parse_version_headers(reader)
             .await
             .map(|()| Request::Version),
@@ -447,9 +466,9 @@ where
         Request::MailboxLifecycle(_) | Request::MailboxList => Err(ParseError::Malformed(
             "expected SEND verb, got MAILBOX-*".to_string(),
         )),
-        Request::HookCreate(_) | Request::HookDelete(_) => Err(ParseError::Malformed(
-            "expected SEND verb, got HOOK-*".to_string(),
-        )),
+        Request::HookCreate(_) | Request::HookDelete(_) | Request::HookList => Err(
+            ParseError::Malformed("expected SEND verb, got HOOK-*".to_string()),
+        ),
         Request::Version => Err(ParseError::Malformed(
             "expected SEND verb, got VERSION".to_string(),
         )),
@@ -772,6 +791,26 @@ where
     if !line.is_empty() {
         return Err(ParseError::Malformed(format!(
             "MAILBOX-LIST takes no headers, got {line:?}"
+        )));
+    }
+    Ok(())
+}
+
+/// Parse the empty body of an `AIMX/1 HOOK-LIST` request. Mirrors
+/// `parse_mailbox_list_headers` line-for-line: the verb carries no
+/// headers, and silently ignoring one would let a future caller smuggle
+/// a forged owner header past the `SO_PEERCRED` filter.
+async fn parse_hook_list_headers<R>(reader: &mut R) -> Result<(), ParseError>
+where
+    R: AsyncRead + Unpin,
+{
+    let line = read_line(reader)
+        .await?
+        .ok_or_else(|| ParseError::Malformed("unexpected EOF in headers".into()))?;
+    let line = line.trim_end_matches('\r');
+    if !line.is_empty() {
+        return Err(ParseError::Malformed(format!(
+            "HOOK-LIST takes no headers, got {line:?}"
         )));
     }
     Ok(())
@@ -1188,6 +1227,18 @@ where
     Ok(())
 }
 
+/// Write an `AIMX/1 HOOK-LIST` request frame. Bare verb line plus a
+/// single blank separator — no headers, no body. Mirrors
+/// [`write_mailbox_list_request`] line-for-line.
+pub async fn write_hook_list_request<W>(writer: &mut W) -> Result<(), std::io::Error>
+where
+    W: AsyncWrite + Unpin,
+{
+    writer.write_all(b"AIMX/1 HOOK-LIST\n\n").await?;
+    writer.flush().await?;
+    Ok(())
+}
+
 /// Write an `AIMX/1 VERSION` request frame. Bare verb line plus a single
 /// blank separator — no headers, no body. Used by the doctor's daemon
 /// version probe.
@@ -1431,6 +1482,47 @@ mod mailbox_list_codec_tests {
             Err(ParseError::Malformed(reason)) => {
                 assert!(reason.contains("Folder"), "{reason}");
             }
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    /// Round-trip a `HOOK-LIST` frame: writer emits the bare verb +
+    /// blank separator, parser decodes it as `Request::HookList`.
+    #[tokio::test]
+    async fn round_trip_hook_list_request() {
+        let mut buf: Vec<u8> = Vec::new();
+        write_hook_list_request(&mut buf).await.unwrap();
+        assert_eq!(buf, b"AIMX/1 HOOK-LIST\n\n");
+
+        let mut reader = std::io::Cursor::new(buf);
+        let req = parse_request(&mut reader).await.unwrap();
+        assert_eq!(req, Request::HookList);
+    }
+
+    /// Any header on a `HOOK-LIST` frame is rejected. The verb resolves
+    /// the caller via `SO_PEERCRED`; client-supplied owner / mailbox
+    /// hints would defeat that and must be a hard parse error.
+    #[tokio::test]
+    async fn hook_list_rejects_owner_header() {
+        let frame = b"AIMX/1 HOOK-LIST\nOwner: alice\n\n";
+        let mut reader = std::io::Cursor::new(frame.to_vec());
+        match parse_request(&mut reader).await {
+            Err(ParseError::Malformed(reason)) => {
+                assert!(reason.contains("HOOK-LIST"), "{reason}");
+            }
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    /// `Content-Length:` headers are also rejected — `HOOK-LIST` has
+    /// no body, and silently ignoring the header would invite a future
+    /// caller to send one and have it skipped.
+    #[tokio::test]
+    async fn hook_list_rejects_content_length_header() {
+        let frame = b"AIMX/1 HOOK-LIST\nContent-Length: 0\n\n";
+        let mut reader = std::io::Cursor::new(frame.to_vec());
+        match parse_request(&mut reader).await {
+            Err(ParseError::Malformed(_)) => {}
             other => panic!("expected Malformed, got {other:?}"),
         }
     }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -881,6 +881,10 @@ async fn handle_uds_connection_with_timeout(
                 ),
                 false,
             ),
+            Ok(Ok(Request::HookList)) => (
+                Reply::Json(crate::hook_list_handler::handle_hook_list(&state_ctx, &caller).await),
+                false,
+            ),
             Ok(Ok(Request::Version)) => (
                 Reply::Version(crate::version_handler::current_version_response()),
                 false,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -962,6 +962,18 @@ fn mcp_email_list_and_read() {
         true,
     );
 
+    // The MCP `email_*` tools route through the daemon's `MAILBOX-LIST`
+    // for path resolution so the non-root MCP process never reads
+    // root-owned `/etc/aimx/config.toml`. Tests must spawn a daemon
+    // even for read-only tools.
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
+
     let mut client = McpClient::spawn(tmp.path());
     client.initialize();
 
@@ -994,6 +1006,7 @@ fn mcp_email_list_and_read() {
     assert!(text.contains("Body of 2025-06-01-001"));
 
     client.shutdown();
+    stop_serve(daemon);
 }
 
 #[test]
@@ -1010,6 +1023,14 @@ fn mcp_email_list_pagination() {
         create_email_file(&alice_dir, &id, "s@example.com", "S", false);
     }
 
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
+
     let mut client = McpClient::spawn(tmp.path());
     client.initialize();
 
@@ -1025,12 +1046,21 @@ fn mcp_email_list_pagination() {
     assert_eq!(rows[1]["id"], "2025-06-03-001");
 
     client.shutdown();
+    stop_serve(daemon);
 }
 
 #[test]
 fn mcp_email_list_empty_mailbox_returns_empty_json_array() {
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
+
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
 
     let mut client = McpClient::spawn(tmp.path());
     client.initialize();
@@ -1040,12 +1070,21 @@ fn mcp_email_list_empty_mailbox_returns_empty_json_array() {
     assert_eq!(text, "[]");
 
     client.shutdown();
+    stop_serve(daemon);
 }
 
 #[test]
 fn mcp_email_read_nonexistent_error() {
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
+
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
 
     let mut client = McpClient::spawn(tmp.path());
     client.initialize();
@@ -1059,12 +1098,21 @@ fn mcp_email_read_nonexistent_error() {
     assert!(text.contains("not found"), "Got: {text}");
 
     client.shutdown();
+    stop_serve(daemon);
 }
 
 #[test]
 fn mcp_email_list_nonexistent_mailbox_error() {
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
+
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
 
     let mut client = McpClient::spawn(tmp.path());
     client.initialize();
@@ -1075,6 +1123,7 @@ fn mcp_email_list_nonexistent_mailbox_error() {
     assert!(text.contains("does not exist"), "Got: {text}");
 
     client.shutdown();
+    stop_serve(daemon);
 }
 
 #[cfg(unix)]
@@ -1222,6 +1271,14 @@ fn mcp_email_send_missing_mailbox_error() {
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
 
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
+
     let mut client = McpClient::spawn(tmp.path());
     client.initialize();
 
@@ -1239,12 +1296,21 @@ fn mcp_email_send_missing_mailbox_error() {
     assert!(text.contains("does not exist"), "Got: {text}");
 
     client.shutdown();
+    stop_serve(daemon);
 }
 
 #[test]
 fn mcp_email_reply_nonexistent_email_error() {
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
+
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
 
     let mut client = McpClient::spawn(tmp.path());
     client.initialize();
@@ -1262,6 +1328,7 @@ fn mcp_email_reply_nonexistent_email_error() {
     assert!(text.contains("not found"), "Got: {text}");
 
     client.shutdown();
+    stop_serve(daemon);
 }
 
 #[test]
@@ -3651,6 +3718,426 @@ fn mailbox_list_with_unreadable_config_falls_back_to_uds() {
     stop_serve(daemon);
 }
 
+// ---------------------------------------------------------------------------
+// Per-tool production-perm regression tests for the 9 MCP tools that
+// previously fell through `self.load_config()` and broke on a real
+// install (`/etc/aimx/config.toml` is `0640 root:root`; the non-root
+// MCP process would always fail with `Permission denied (os error
+// 13)`). Every tool now routes through the daemon's `MAILBOX-LIST` /
+// `HOOK-LIST` verbs, and `AimxMcpServer::load_config` was deleted from
+// `src/mcp.rs` so production code cannot accidentally reintroduce the
+// bug class.
+//
+// Each test follows the same shape: spawn the daemon (which loaded
+// `Arc<Config>` at startup so it keeps serving from memory), `chmod
+// 0000` on the on-disk config so any client-side direct read would
+// fail with EACCES, then invoke the tool and assert (a) it works and
+// (b) no EACCES surfaces from a config-load path.
+// ---------------------------------------------------------------------------
+
+/// Regression test: `email_list` must not surface EACCES on a config
+/// with `0000` perms — the tool now derives `inbox_path` / `sent_path`
+/// from the daemon's `MAILBOX-LIST` row, never reads `config.toml`.
+#[cfg(unix)]
+#[test]
+fn mcp_email_list_with_unreadable_config_does_not_surface_eacces() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping: chmod 0000 has no effect on root");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
+
+    use std::os::unix::fs::PermissionsExt;
+    let config_path = tmp.path().join("config.toml");
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    let resp = client.call_tool("email_list", serde_json::json!({"mailbox": "alice"}));
+    let text = get_tool_text(&resp);
+    assert!(
+        !text.contains("Permission denied"),
+        "email_list must not surface EACCES on `0000` config; got: {text}"
+    );
+    // Empty mailbox returns the literal `[]` string.
+    assert_eq!(text, "[]", "{text}");
+
+    client.shutdown();
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o640)).unwrap();
+    stop_serve(daemon);
+}
+
+/// Regression test: `email_read` against `0000` config — same shape.
+#[cfg(unix)]
+#[test]
+fn mcp_email_read_with_unreadable_config_does_not_surface_eacces() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping: chmod 0000 has no effect on root");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let alice_dir = inbox(tmp.path(), "alice");
+    create_email_file(&alice_dir, "2025-06-01-001", "s@example.com", "Hi", false);
+
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
+
+    use std::os::unix::fs::PermissionsExt;
+    let config_path = tmp.path().join("config.toml");
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    let resp = client.call_tool(
+        "email_read",
+        serde_json::json!({"mailbox": "alice", "id": "2025-06-01-001"}),
+    );
+    let text = get_tool_text(&resp);
+    assert!(
+        !text.contains("Permission denied"),
+        "email_read must not surface EACCES; got: {text}"
+    );
+    assert!(
+        text.contains("Body of 2025-06-01-001"),
+        "email_read must return body; got: {text}"
+    );
+
+    client.shutdown();
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o640)).unwrap();
+    stop_serve(daemon);
+}
+
+/// Regression test: `email_mark_read` against `0000` config.
+#[cfg(unix)]
+#[test]
+fn mcp_email_mark_read_with_unreadable_config_does_not_surface_eacces() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping: chmod 0000 has no effect on root");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let alice_dir = inbox(tmp.path(), "alice");
+    create_email_file(&alice_dir, "2025-06-01-001", "s@example.com", "Hi", false);
+
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
+
+    use std::os::unix::fs::PermissionsExt;
+    let config_path = tmp.path().join("config.toml");
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    let resp = client.call_tool(
+        "email_mark_read",
+        serde_json::json!({"mailbox": "alice", "id": "2025-06-01-001"}),
+    );
+    let text = get_tool_text(&resp);
+    assert!(
+        !text.contains("Permission denied"),
+        "email_mark_read must not surface EACCES; got: {text}"
+    );
+
+    client.shutdown();
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o640)).unwrap();
+    stop_serve(daemon);
+}
+
+/// Regression test: `email_mark_unread` against `0000` config.
+#[cfg(unix)]
+#[test]
+fn mcp_email_mark_unread_with_unreadable_config_does_not_surface_eacces() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping: chmod 0000 has no effect on root");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let alice_dir = inbox(tmp.path(), "alice");
+    create_email_file(&alice_dir, "2025-06-01-001", "s@example.com", "Hi", true);
+
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
+
+    use std::os::unix::fs::PermissionsExt;
+    let config_path = tmp.path().join("config.toml");
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    let resp = client.call_tool(
+        "email_mark_unread",
+        serde_json::json!({"mailbox": "alice", "id": "2025-06-01-001"}),
+    );
+    let text = get_tool_text(&resp);
+    assert!(
+        !text.contains("Permission denied"),
+        "email_mark_unread must not surface EACCES; got: {text}"
+    );
+
+    client.shutdown();
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o640)).unwrap();
+    stop_serve(daemon);
+}
+
+/// Regression test: `email_send` against `0000` config — the tool now
+/// derives the from-address from the daemon's `MAILBOX-LIST` row, no
+/// `config.toml` read.
+#[cfg(unix)]
+#[test]
+fn mcp_email_send_with_unreadable_config_does_not_surface_eacces() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping: chmod 0000 has no effect on root");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
+
+    use std::os::unix::fs::PermissionsExt;
+    let config_path = tmp.path().join("config.toml");
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    // Send to a nonexistent recipient — we don't care whether the SMTP
+    // delivery itself succeeds, only that a config-EACCES does not
+    // surface from the MCP tool entry point.
+    let resp = client.call_tool(
+        "email_send",
+        serde_json::json!({
+            "from_mailbox": "alice",
+            "to": "nobody@invalid.example.invalid",
+            "subject": "perm test",
+            "body": "x"
+        }),
+    );
+    let text = get_tool_text(&resp);
+    assert!(
+        !text.contains("Permission denied"),
+        "email_send must not surface EACCES; got: {text}"
+    );
+
+    client.shutdown();
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o640)).unwrap();
+    stop_serve(daemon);
+}
+
+/// Regression test: `email_reply` against `0000` config.
+#[cfg(unix)]
+#[test]
+fn mcp_email_reply_with_unreadable_config_does_not_surface_eacces() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping: chmod 0000 has no effect on root");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let alice_dir = inbox(tmp.path(), "alice");
+    create_email_file(&alice_dir, "2025-06-01-001", "s@example.com", "Hi", false);
+
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
+
+    use std::os::unix::fs::PermissionsExt;
+    let config_path = tmp.path().join("config.toml");
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    let resp = client.call_tool(
+        "email_reply",
+        serde_json::json!({
+            "mailbox": "alice",
+            "id": "2025-06-01-001",
+            "body": "reply body"
+        }),
+    );
+    let text = get_tool_text(&resp);
+    assert!(
+        !text.contains("Permission denied"),
+        "email_reply must not surface EACCES; got: {text}"
+    );
+
+    client.shutdown();
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o640)).unwrap();
+    stop_serve(daemon);
+}
+
+/// Regression test: `hook_create` against `0000` config — the tool now
+/// pre-flights via `MAILBOX-LIST` over UDS, no `config.toml` read.
+#[cfg(unix)]
+#[test]
+fn mcp_hook_create_with_unreadable_config_does_not_surface_eacces() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping: chmod 0000 has no effect on root");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
+
+    use std::os::unix::fs::PermissionsExt;
+    let config_path = tmp.path().join("config.toml");
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    let resp = client.call_tool(
+        "hook_create",
+        serde_json::json!({
+            "mailbox": "alice",
+            "event": "on_receive",
+            "cmd": ["/bin/true"]
+        }),
+    );
+    let text = get_tool_text(&resp);
+    assert!(
+        !text.contains("Permission denied"),
+        "hook_create must not surface EACCES; got: {text}"
+    );
+
+    client.shutdown();
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o640)).unwrap();
+    stop_serve(daemon);
+}
+
+/// Regression test: `hook_list` against `0000` config — routes through
+/// the new `HOOK-LIST` UDS verb, no `config.toml` read.
+#[cfg(unix)]
+#[test]
+fn mcp_hook_list_with_unreadable_config_does_not_surface_eacces() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping: chmod 0000 has no effect on root");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
+
+    use std::os::unix::fs::PermissionsExt;
+    let config_path = tmp.path().join("config.toml");
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    let resp = client.call_tool("hook_list", serde_json::json!({}));
+    let text = get_tool_text(&resp);
+    assert!(
+        !text.contains("Permission denied"),
+        "hook_list must not surface EACCES; got: {text}"
+    );
+    assert_eq!(text, "[]", "{text}");
+
+    client.shutdown();
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o640)).unwrap();
+    stop_serve(daemon);
+}
+
+/// Regression test: `hook_delete` against `0000` config — the tool is
+/// a thin pass-through to `HOOK-DELETE`, no `config.toml` read.
+#[cfg(unix)]
+#[test]
+fn mcp_hook_delete_with_unreadable_config_does_not_surface_eacces() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping: chmod 0000 has no effect on root");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
+
+    use std::os::unix::fs::PermissionsExt;
+    let config_path = tmp.path().join("config.toml");
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o000)).unwrap();
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    let resp = client.call_tool("hook_delete", serde_json::json!({"name": "no_such_hook"}));
+    let text = get_tool_text(&resp);
+    assert!(
+        !text.contains("Permission denied"),
+        "hook_delete must not surface EACCES; got: {text}"
+    );
+    // The daemon-side handler will canonically return ENOENT for a
+    // hook name it doesn't know.
+    assert!(
+        text.contains("not found") || text.contains("ENOENT"),
+        "hook_delete error should be opaque not-found: {text}"
+    );
+
+    client.shutdown();
+    std::fs::set_permissions(&config_path, std::fs::Permissions::from_mode(0o640)).unwrap();
+    stop_serve(daemon);
+}
+
 /// Cycle 2 regression guard for Blocker 2: the MCP `mailbox_create`
 /// tool must work end-to-end against a real daemon for a non-root
 /// caller. Cycle 1 shipped the tool but the wire-protocol parser
@@ -4842,6 +5329,14 @@ fn mcp_hook_create_unowned_mailbox_returns_not_authorized() {
     std::fs::write(tmp.path().join("config.toml"), &config).unwrap();
     install_cached_dkim_keys(tmp.path());
 
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
+
     let mut client = McpClient::spawn(tmp.path());
     client.initialize();
 
@@ -4855,22 +5350,36 @@ fn mcp_hook_create_unowned_mailbox_returns_not_authorized() {
     );
     assert!(is_tool_error(&resp), "{resp}");
     let text = get_tool_text(&resp);
+    // NFR2 opacity: a hook_create on a mailbox the caller doesn't own
+    // surfaces as the same opaque "does not exist" error a missing
+    // mailbox would, because the daemon's MAILBOX-LIST is filtered
+    // by SO_PEERCRED. The MCP-side pre-flight cannot distinguish
+    // "doesn't exist" from "exists but unowned" client-side.
     assert!(
-        text.contains("not authorized"),
-        "expected not-authorized error, got: {text}"
+        text.contains("does not exist"),
+        "expected opaque does-not-exist error, got: {text}"
     );
 
     client.shutdown();
+    stop_serve(daemon);
 }
 
 /// `hook_delete` against a hook that does not exist returns the
-/// canonical "not found" error without ever reaching the daemon. The
-/// test deliberately uses the standard fixture (no daemon spawned) to
-/// pin behavior under the new MCP shape.
+/// canonical "not found" error from the daemon's HOOK-DELETE handler.
+/// The MCP tool is now a thin pass-through (no client-side
+/// `load_config` pre-flight), so the daemon must be running.
 #[test]
 fn mcp_hook_delete_unknown_hook_returns_not_found() {
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
+
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
 
     let mut client = McpClient::spawn(tmp.path());
     client.initialize();
@@ -4878,9 +5387,13 @@ fn mcp_hook_delete_unknown_hook_returns_not_found() {
     let resp = client.call_tool("hook_delete", serde_json::json!({"name": "no_such_hook"}));
     assert!(is_tool_error(&resp), "{resp}");
     let text = get_tool_text(&resp);
-    assert!(text.contains("not found"), "{text}");
+    assert!(
+        text.contains("not found") || text.contains("ENOENT"),
+        "{text}"
+    );
 
     client.shutdown();
+    stop_serve(daemon);
 }
 
 /// `hook_delete` against a hook that lives on a mailbox the caller
@@ -4926,13 +5439,24 @@ fn mcp_hook_delete_unowned_hook_returns_not_found_not_unauthorized() {
     std::fs::write(tmp.path().join("config.toml"), &config).unwrap();
     install_cached_dkim_keys(tmp.path());
 
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
+
     let mut client = McpClient::spawn(tmp.path());
     client.initialize();
 
     let resp = client.call_tool("hook_delete", serde_json::json!({"name": "hidden_hook"}));
     assert!(is_tool_error(&resp), "{resp}");
     let text = get_tool_text(&resp);
-    assert!(text.contains("not found"), "expected `not found`: {text}");
+    assert!(
+        text.contains("not found") || text.contains("ENOENT"),
+        "expected `not found` (or ENOENT): {text}"
+    );
     // Crucially, the foreign mailbox name must not appear in the error
     // shown to a non-owner caller.
     assert!(
@@ -4945,14 +5469,24 @@ fn mcp_hook_delete_unowned_hook_returns_not_found_not_unauthorized() {
     );
 
     client.shutdown();
+    stop_serve(daemon);
 }
 
 /// `hook_list` with no hooks configured returns `[]`. Exercises the
-/// new MCP `hook_list` tool's empty-output shape end-to-end.
+/// new MCP `hook_list` tool's empty-output shape end-to-end through
+/// the new `HOOK-LIST` UDS verb.
 #[test]
 fn mcp_hook_list_empty_returns_empty_array() {
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
+
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
 
     let mut client = McpClient::spawn(tmp.path());
     client.initialize();
@@ -4962,6 +5496,7 @@ fn mcp_hook_list_empty_returns_empty_array() {
     assert_eq!(text, "[]", "{text}");
 
     client.shutdown();
+    stop_serve(daemon);
 }
 
 // ---------------------------------------------------------------------

--- a/tests/uds_authz.rs
+++ b/tests/uds_authz.rs
@@ -720,7 +720,14 @@ fn hook_delete_as_other_forbidden() {
         &fx.socket_path,
         raw_hook_delete_frame("alice_owned_hook").as_bytes(),
     );
-    assert_response_contains(&del, "EACCES");
+    // NFR2 opacity: a non-owner caller must not be able to distinguish
+    // "hook exists on a mailbox you don't own" from "hook doesn't exist
+    // anywhere." Both surface as ENOENT with the same canonical reason;
+    // the wire response must not leak that authz rejected the request.
+    assert_response_contains(&del, "ENOENT");
+    assert_response_contains(&del, "hook 'alice_owned_hook' not found");
+    assert_response_does_not_contain(&del, "not authorized");
+    assert_response_does_not_contain(&del, "EACCES");
     drop(fx);
 }
 


### PR DESCRIPTION
## Summary

- Add a new `HOOK-LIST` UDS verb (mirrors `MAILBOX-LIST` line-for-line) and rewrite the 9 email/hook MCP tools to drop `self.load_config()` so a non-root agent on a production-perm install (`/etc/aimx/config.toml` is `0640 root:root`) no longer fails with `EACCES` on tool entry.
- Structurally delete `AimxMcpServer::load_config` from non-test code; release builds compile with no `load_config` symbol in `src/mcp.rs`, so a future tool cannot reintroduce the bug class by accident.
- Tighten the daemon's `HOOK-DELETE` so the not-owner reject collapses to `ENOENT "hook 'X' not found"` (matches the existing opacity contract and the previous MCP-side collapse).

### Wire / daemon

- New `Request::HookList` in `src/send_protocol.rs` plus parser, writer, and codec round-trip tests.
- New `src/hook_list_handler.rs`: returns `Vec<HookListRow>` via `JsonAckResponse::Ok`, filtered to hooks on mailboxes the caller's uid owns; root sees every hook on every mailbox. Schema uses the existing `HookEvent` enum for `event` so client/server share one source of truth.
- Daemon dispatch in `src/serve.rs` wires `Request::HookList` to the new handler.
- `src/hook_handler.rs::handle_hook_delete` now collapses authz reject into `ENOENT` so non-owners cannot distinguish "exists on a mailbox you don't own" from "doesn't exist anywhere."

### MCP rewrites (`src/mcp.rs`)

- `email_list` / `email_read` / `email_mark_read` / `email_mark_unread`: resolve mailbox via the daemon's `MAILBOX-LIST`; use `row.inbox_path` / `row.sent_path` for filesystem ops.
- `email_send` / `email_reply`: derive the from-address from `row.address` verbatim; surface the canonical "not registered" error when `address` is `None`.
- `hook_create`: pre-flight via `MAILBOX-LIST` lookup (opaque on missing row); daemon's `HOOK-CREATE` handler still re-runs `authorize()`.
- `hook_list`: routes through the new `HOOK-LIST` verb; the optional `mailbox` filter is a UX-only post-filter.
- `hook_delete`: thin pass-through to `HOOK-DELETE`; the daemon resolves by name, runs authz, returns `ENOENT` for both unowned and nonexistent.
- `AimxMcpServer::load_config` deleted from non-test code; `data_dir_override` / `caller_uid` retained for the remaining test-only `authorize_mailbox` helper and gated `#[allow(dead_code)]`.

### Tests

- 9 new per-tool production-perm regression tests (`mcp_*_with_unreadable_config_does_not_surface_eacces`) — `chmod 0000` on the on-disk config, daemon serves from `Arc<Config>`, every tool succeeds without EACCES.
- 11 existing MCP integration tests now spawn `aimx serve` so the tools have a daemon to talk to (the old tests passed because `load_config` read the writable test config; that path no longer exists).
- Codec tests pin the `HOOK-LIST` round-trip and the parser's rejection of any header (forged owner / `Content-Length`).
- `HookListRow` round-trips through serde with `event` serializing as `snake_case`.
- Daemon-side `non_owner_cannot_delete_hook` test asserts the new opacity collapse.

## Test plan

- [x] `cargo test` green: 1034 unit + 106 integration on the default lane.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [x] `cargo fmt -- --check` clean.
- [x] `cargo build --release` succeeds; `grep -n 'fn load_config' src/mcp.rs` returns nothing.
- [x] `cargo test --test integration -- --ignored` passes (5 sudo-lane tests skip cleanly when `AIMX_INTEGRATION_SUDO` is unset).