### PR TITLE
Add NanoClaw to aimx agents setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Human-friendly setup. LLM-friendly everything else.
 
 AIMX (AI Mail Exchange) is a self-hosted mail server for AI agents. One command gives your agents their own email addresses. No Gmail, no OAuth, no SaaS. Self-hosted means full sovereignty.
 
-Mail in as Markdown. Mail out DKIM-signed. MCP built in. Works with any MCP-capable agent: Claude Code, Codex CLI, OpenCode, Gemini CLI, Goose, OpenClaw, Hermes.
+Mail in as Markdown. Mail out DKIM-signed. MCP built in. Works with any MCP-capable agent: Claude Code, Codex CLI, OpenCode, Gemini CLI, Goose, OpenClaw, Hermes, NanoClaw.
 
 
 - **Single binary.** One binary, no other dependencies.
@@ -141,6 +141,7 @@ Install aimx into your agent with one command:
 | Goose | `aimx agents setup goose` | Run `goose run --recipe aimx`. |
 | OpenClaw | `aimx agents setup openclaw` | Run the printed `openclaw mcp set aimx '...'` command, then restart the gateway. |
 | Hermes | `aimx agents setup hermes` | Paste the printed YAML block under `mcp_servers:` in `~/.hermes/config.yaml`, then run `/reload-mcp` inside Hermes. |
+| NanoClaw | `aimx agents setup nanoclaw` | Auto-merged into `<fork>/.mcp.json` under `mcpServers.aimx`. Default fork path is `~/nanoclaw`; override with `$NANOCLAW_HOME`. Restart NanoClaw so the new server is loaded. |
 
 Run `aimx agents setup` (no args, launches the interactive picker) or `aimx agents list` to print the supported-agent registry. See [`book/agent-integration.md`](book/agent-integration.md) for per-agent activation steps and manual MCP wiring, and [`book/hook-recipes.md`](book/hook-recipes.md) for copy-paste hook recipes covering every supported agent plus Aider.
 
@@ -183,7 +184,7 @@ cmd = ["/usr/bin/ntfy", "pub", "agent-mail", "$AIMX_SUBJECT from $AIMX_FROM"]
 fire_on_untrusted = true
 ```
 
-See [`book/hooks.md`](book/hooks.md) for the hook model and [`book/hook-recipes.md`](book/hook-recipes.md) for copy-paste recipes (Claude Code, Codex CLI, OpenCode, Gemini CLI, Goose, OpenClaw, Hermes, Aider).
+See [`book/hooks.md`](book/hooks.md) for the hook model and [`book/hook-recipes.md`](book/hook-recipes.md) for copy-paste recipes (Claude Code, Codex CLI, OpenCode, Gemini CLI, Goose, OpenClaw, Hermes, Aider). NanoClaw is a long-running daemon and uses a scheduled-job pull model rather than `on_receive` hooks — see [`book/agent-integration.md`](book/agent-integration.md#nanoclaw).
 
 
 ## Email format

--- a/agents/nanoclaw/README.md
+++ b/agents/nanoclaw/README.md
@@ -1,0 +1,110 @@
+# aimx skill for NanoClaw
+
+AIMX (AI Mail Exchange) skill source tree for NanoClaw. This directory
+wires aimx into [NanoClaw](https://nanoclaw.dev/), the lightweight
+container-isolated personal AI agent built on Anthropic's Claude Agent
+SDK. Contents are bundled into the `aimx` binary at compile time (via
+`include_dir!`) and installed by `aimx agents setup nanoclaw`.
+
+## What gets installed
+
+- `skills/aimx/SKILL.md`: an agent-facing skill dropped into
+  `<fork>/skills/aimx/SKILL.md`. Its body is the canonical aimx
+  primer (`agents/common/aimx-primer.md`). The installer assembles
+  the final `SKILL.md` from a YAML header plus that primer so there
+  is one source of truth.
+- `skills/aimx/references/`: detailed reference docs (MCP tool
+  signatures, frontmatter schema, hooks, workflows, troubleshooting)
+  copied from `agents/common/references/`.
+- `<fork>/.mcp.json` is updated in place to add an `mcpServers.aimx`
+  entry pointing at `/usr/local/bin/aimx mcp`. NanoClaw is the one
+  integration where aimx mutates the agent's primary config file —
+  see "Design choice" below for why.
+
+## Where is the fork?
+
+NanoClaw is a per-user fork of `qwibitai/nanoclaw`, not a globally
+installed CLI, so there is no `~/.nanoclaw/` directory on disk. The
+installer resolves the fork directory in this order:
+
+1. The `NANOCLAW_HOME` environment variable, if set.
+2. `~/nanoclaw` as the default (matches the README's `git clone …
+   nanoclaw && cd nanoclaw` workflow).
+
+If your fork lives elsewhere, export `NANOCLAW_HOME` before running
+the installer:
+
+```bash
+NANOCLAW_HOME=/opt/my-nanoclaw aimx agents setup nanoclaw
+```
+
+## Install
+
+```bash
+aimx agents setup nanoclaw
+```
+
+Default skill destination: `~/nanoclaw/skills/aimx/SKILL.md` (or
+`$NANOCLAW_HOME/skills/aimx/SKILL.md` when the env var is set).
+
+## Activation
+
+After the installer runs, restart NanoClaw so it loads the new
+`.mcp.json` entry and discovers the skill. NanoClaw will then be
+able to call the aimx mailbox/email tools.
+
+To trigger NanoClaw on inbound mail without writing a one-shot
+hook, add a NanoClaw scheduled job that polls
+`email_list(folder: "inbox", unread_only: true)` on a cadence that
+suits the workload (every minute for transactional mail, every
+fifteen for digest-style inboxes).
+
+## Overriding the data directory
+
+If aimx was set up with a non-default data directory, re-run the
+installer with `--data-dir`:
+
+```bash
+aimx --data-dir /custom/path agents setup nanoclaw
+```
+
+The `args` array in `<fork>/.mcp.json` will include
+`--data-dir /custom/path`.
+
+## Channel-trigger recipes
+
+NanoClaw does not currently ship a one-shot `run` / `exec` CLI
+suitable for `on_receive` hooks. For sub-second-latency reactions to
+inbound mail, wire a different agent (Claude Code, Codex, or Hermes)
+as the hook and let NanoClaw consume the resulting state via the
+aimx MCP server on its next scheduled-job tick. See the per-agent
+recipe in `book/agent-integration.md` for the worked example.
+
+## Schema reference
+
+NanoClaw's skill format is derived from the Claude Agent SDK
+convention: a directory bundle with a YAML-frontmattered `SKILL.md`
+plus optional siblings. The `metadata.nanoclaw.requires.bins`
+manifest declares the binary the skill expects on `PATH`.
+
+NanoClaw's MCP server configuration lives in `<fork>/.mcp.json`
+under the top-level `mcpServers` object with `command` + `args`
+(stdio transport).
+
+## Design choice: in-place `.mcp.json` merge
+
+NanoClaw is the one supported agent where aimx mutates the agent's
+own MCP config file on the user's behalf. Every other supported
+agent either has a first-class CLI for MCP registration (Claude
+Code, Codex, OpenClaw) or expects the user to paste a snippet
+(OpenCode, Gemini, Hermes, Goose).
+
+NanoClaw exposes neither: there is no `nanoclaw mcp add` command,
+and asking the user to hand-edit `<fork>/.mcp.json` (a JSON5-flavoured
+file the user already customises in their fork) is the worst option
+of the three. So `aimx agents setup nanoclaw` reads the existing
+`.mcp.json` (if any), merges an `aimx` entry under `mcpServers`,
+and writes the file back via temp-file + atomic rename. Other
+servers in the file are preserved untouched. `--print` prints the
+proposed JSON to stdout instead of writing; `--force` overwrites an
+existing `aimx` entry without prompting.

--- a/agents/nanoclaw/SKILL.md.header
+++ b/agents/nanoclaw/SKILL.md.header
@@ -1,0 +1,46 @@
+---
+name: aimx
+description: Self-hosted email for AI agents. Send, read, reply to, and manage email via aimx MCP tools. Invoke when the user asks about sending mail, checking an inbox, replying to a message, or managing mailboxes, or when the conversation references aimx.
+author: U-Zyn Chua <chua@uzyn.com>
+version: 1.0.0
+metadata: {"nanoclaw": {"requires": {"bins": ["aimx"]}}}
+---
+
+## Wiring yourself up as a mailbox hook (NanoClaw)
+
+Headless mailbox hooks (the `cmd: ["/usr/local/bin/...", ...]` recipe
+that other agents use under `hook_create(event="on_receive", ...)`) are
+not the right shape for NanoClaw. NanoClaw is a long-running Node.js
+process listening on messaging channels (WhatsApp, Slack, Telegram,
+…) inside a container; it does not expose a one-shot CLI that can be
+re-launched per inbound email. Spawning a fresh NanoClaw process from
+an aimx hook would skip its container isolation and its in-memory
+state.
+
+The integration is the **other direction** instead — NanoClaw pulls
+from aimx on its own schedule using the aimx MCP server:
+
+1. The aimx MCP server is registered in `<fork>/.mcp.json`. The
+   `aimx agents setup nanoclaw` installer adds this entry for you.
+2. Add a NanoClaw scheduled job (one of the agent's first-class
+   features) that runs every N minutes and:
+   - calls `email_list(folder: "inbox", unread_only: true)` via aimx
+     MCP for each mailbox the user owns,
+   - reads each unread message with `email_read`,
+   - acts on the message (reply, file, label, …) using the regular
+     aimx MCP write tools,
+   - marks the message read with `email_mark_read` so the next tick
+     ignores it.
+
+If you later need an immediate reaction (sub-second latency on inbound
+mail), wire a different agent that does support headless one-shot
+invocation (Claude Code's `claude -p`, Codex's `codex run`, Hermes's
+`hermes chat -q`) as the on_receive hook on the aimx side, and let
+NanoClaw consume the resulting state via MCP on its next tick.
+
+Note: the user the scheduled job runs as (the mailbox's owner) must
+have the aimx skill installed too — re-run `aimx agents setup
+nanoclaw` against the fork that user is running, or the scheduled job
+will start without the skill loaded and the agent won't know what to
+do with the email.
+

--- a/book/agent-integration.md
+++ b/book/agent-integration.md
@@ -103,8 +103,11 @@ aimx agents remove claude-code
 | Goose | `aimx agents setup goose` | `~/.config/goose/recipes/aimx.yaml` | Run `goose run --recipe aimx`. The recipe bundles its own MCP extension, so no separate config step. | Single YAML blob (primer as `prompt` block scalar). References inlined |
 | OpenClaw | `aimx agents setup openclaw` | `~/.openclaw/skills/aimx/` | Run the printed `openclaw mcp set aimx '...'` command, then restart the OpenClaw gateway. | Primer as skill + `references/` directory copied as siblings |
 | Hermes | `aimx agents setup hermes` | `~/.hermes/skills/aimx/` | Paste the printed YAML block under `mcp_servers:` in `~/.hermes/config.yaml`, then run `/reload-mcp` inside Hermes. | Primer as skill + `references/` directory copied as siblings |
+| NanoClaw | `aimx agents setup nanoclaw` | `<fork>/skills/aimx/` (default `~/nanoclaw/`, override via `$NANOCLAW_HOME`) | Auto-merged into `<fork>/.mcp.json` under `mcpServers.aimx`. Restart NanoClaw so the new server is loaded. | Primer as skill + `references/` directory copied as siblings |
 
-> **Progressive disclosure.** Every agent receives the same canonical aimx primer (`agents/common/aimx-primer.md`). Agents with multi-file skill directories (Claude Code, Codex CLI, OpenClaw, Hermes) also receive `agents/common/references/` as siblings so detailed material loads on demand without bloating the initial context. Single-file agents (OpenCode, Gemini CLI, Goose) receive the primer inline. The `references/` content remains available in the aimx source tree and at `/var/lib/aimx/README.md`.
+> **Progressive disclosure.** Every agent receives the same canonical aimx primer (`agents/common/aimx-primer.md`). Agents with multi-file skill directories (Claude Code, Codex CLI, OpenClaw, Hermes, NanoClaw) also receive `agents/common/references/` as siblings so detailed material loads on demand without bloating the initial context. Single-file agents (OpenCode, Gemini CLI, Goose) receive the primer inline. The `references/` content remains available in the aimx source tree and at `/var/lib/aimx/README.md`.
+
+> **`.mcp.json` auto-merge (NanoClaw only).** NanoClaw is the one supported agent where `aimx agents setup` writes to the agent's primary MCP config file. NanoClaw exposes no `mcp add` CLI and ships its MCP servers as JSON5 in the per-fork `.mcp.json`, so the installer reads that file (if present), merges an `mcpServers.aimx` entry preserving any other servers, and writes back via temp-file + atomic rename. `--print` shows the proposed JSON without touching disk; `--force` overwrites an existing `aimx` entry. Every other agent either has a registration CLI or expects the user to paste a snippet; aimx does not mutate their config files.
 
 ### Per-agent hook recipes
 
@@ -387,6 +390,76 @@ The printed YAML's `args` line will become
 `args: [--data-dir, /custom/path, mcp]`.
 
 See [`agents/hermes/README.md`](https://github.com/uzyn/aimx/tree/main/agents/hermes)
+for the schema reference.
+
+### NanoClaw
+
+[NanoClaw](https://nanoclaw.dev/) is a lightweight container-isolated
+personal AI agent built on Anthropic's Claude Agent SDK. It is forked
+per-user from `qwibitai/nanoclaw` and run from the clone, so there is
+no global `~/.nanoclaw/` directory; instead the integration target is
+the fork directory itself. The installer resolves the fork path from
+`$NANOCLAW_HOME`, defaulting to `~/nanoclaw` (the path the upstream
+README's `git clone … nanoclaw && cd nanoclaw` workflow leaves you
+in). Set the env var before running setup if your fork lives
+elsewhere.
+
+NanoClaw is the one supported agent where aimx mutates the agent's
+own MCP config file. NanoClaw exposes no `mcp add` CLI, and its MCP
+servers live in `<fork>/.mcp.json` (Claude-Agent-SDK project-scoped
+convention). Asking the user to hand-edit that JSON5 file is the
+worst of three options, so the installer reads it (if present),
+merges an `mcpServers.aimx` entry under `mcpServers`, and writes
+back via temp-file + atomic rename. Other servers in the file are
+preserved untouched.
+
+Install:
+
+```bash
+aimx agents setup nanoclaw
+```
+
+(or, with a non-default fork path):
+
+```bash
+NANOCLAW_HOME=/opt/my-nanoclaw aimx agents setup nanoclaw
+```
+
+The installer requires the fork directory to exist (no
+auto-`mkdir`) so it never creates a stub a follow-up `git clone`
+would fail on. After it succeeds, restart NanoClaw so it loads the
+new `.mcp.json` entry and discovers the skill.
+
+For a custom data directory:
+
+```bash
+aimx --data-dir /custom/path agents setup nanoclaw
+```
+
+The merged `.mcp.json` entry's `args` array will include
+`--data-dir /custom/path`.
+
+**Re-running.** The installer is idempotent on the skill files
+(re-running with `--force` overwrites them). On `.mcp.json`, an
+existing `mcpServers.aimx` entry is left in place unless `--force`
+is passed; the installer prints a clear "pass --force to overwrite"
+warning and exits cleanly so a stale entry never silently
+shadows what the user had before.
+
+**Channel triggers / hooks.** NanoClaw is a long-running Node.js
+daemon listening on messaging channels inside a container; it does
+not expose a one-shot CLI suitable for an aimx `on_receive` hook.
+The natural integration is the **other direction**: NanoClaw pulls
+unread mail from aimx via MCP on its own scheduled-job cadence,
+acts on each message (reply, file, label), then marks it read.
+Wire one of NanoClaw's first-class scheduled jobs to call
+`email_list(folder: "inbox", unread_only: true)` every N minutes.
+For sub-second-latency reactions to inbound mail, wire a different
+agent (Claude Code, Codex, or Hermes) as the on_receive hook on the
+aimx side and let NanoClaw consume the resulting state on its next
+tick.
+
+See [`agents/nanoclaw/README.md`](https://github.com/uzyn/aimx/tree/main/agents/nanoclaw)
 for the schema reference.
 
 ## Manual MCP wiring

--- a/src/agents_cleanup.rs
+++ b/src/agents_cleanup.rs
@@ -139,6 +139,9 @@ mod tests {
         fn xdg_config_home(&self) -> Option<PathBuf> {
             None
         }
+        fn nanoclaw_home(&self) -> Option<PathBuf> {
+            None
+        }
         fn is_root(&self) -> bool {
             self.is_root
         }

--- a/src/agents_remove.rs
+++ b/src/agents_remove.rs
@@ -180,6 +180,9 @@ pub fn removal_hint(spec: &AgentSpec) -> String {
         "hermes" => {
             "Remove the `aimx` block from `~/.hermes/config.yaml` under `mcp_servers:` to also unregister the MCP server.".to_string()
         }
+        "nanoclaw" => {
+            "Remove the `aimx` entry from `mcpServers` in `<fork>/.mcp.json` to also unregister the MCP server (set $NANOCLAW_HOME if your fork is not at ~/nanoclaw).".to_string()
+        }
         // Future-proof: never panic on a registry-name mismatch.
         other => format!("(No agent-specific cleanup hint registered for `{other}`.)"),
     }
@@ -242,6 +245,9 @@ mod tests {
             Some(self.home.clone())
         }
         fn xdg_config_home(&self) -> Option<PathBuf> {
+            None
+        }
+        fn nanoclaw_home(&self) -> Option<PathBuf> {
             None
         }
         fn is_root(&self) -> bool {

--- a/src/agents_setup.rs
+++ b/src/agents_setup.rs
@@ -45,7 +45,7 @@ pub struct AgentSpec {
 /// Static registry of supported agents.
 ///
 /// v1 roster: `claude-code`, `codex`, `opencode`, `gemini`, `goose`,
-/// `openclaw`, `hermes`. Source-tree layout asymmetry is by
+/// `openclaw`, `hermes`, `nanoclaw`. Source-tree layout asymmetry is by
 /// design; `assemble_plugin_files` walks each source tree relative to its
 /// root and handles all three shapes. Do not "normalize" the layout;
 /// the destination template determines the depth.
@@ -141,6 +141,24 @@ pub fn registry() -> &'static [AgentSpec] {
             agent_root_template: "$HOME/.hermes",
             display_name: "Hermes",
             activation_hint: hermes_hint,
+            progressive_disclosure: true,
+        },
+        AgentSpec {
+            name: "nanoclaw",
+            source_subdir: "nanoclaw",
+            // NanoClaw is forked per-user from qwibitai/nanoclaw and run
+            // from the clone, so there is no global $HOME config dir. The
+            // fork dir comes from $NANOCLAW_HOME (default $HOME/nanoclaw)
+            // and skills live at <fork>/skills/<name>/SKILL.md, mirroring
+            // the Claude Agent SDK convention NanoClaw is built on. MCP
+            // wiring lives in <fork>/.mcp.json (project-scoped MCP); the
+            // installer merges an entry there directly because NanoClaw
+            // exposes no `mcp add` CLI and hand-editing JSON5 is the
+            // worst option for users.
+            dest_template: "$NANOCLAW_HOME/skills/aimx",
+            agent_root_template: "$NANOCLAW_HOME",
+            display_name: "NanoClaw",
+            activation_hint: nanoclaw_hint,
             progressive_disclosure: true,
         },
     ]
@@ -325,6 +343,56 @@ fn hermes_hint(data_dir: Option<&Path>) -> String {
     )
 }
 
+fn nanoclaw_hint(data_dir: Option<&Path>) -> String {
+    // NanoClaw is the one supported agent where aimx mutates the agent's
+    // own MCP config file (`<fork>/.mcp.json`). Every other agent either
+    // has a first-class registration CLI (Claude Code, Codex, OpenClaw)
+    // or expects the user to paste a snippet (OpenCode, Gemini, Hermes,
+    // Goose). NanoClaw exposes neither — `nanoclaw mcp add` does not
+    // exist, and asking the user to hand-edit `.mcp.json` (a JSON5-ish
+    // file the user already customises in their fork) is the worst of
+    // the three options. So `install_to_writer` calls `patch_mcp_json`
+    // before this hint runs to merge an entry under `mcpServers.aimx`.
+    //
+    // The hint is the post-merge confirmation: it prints the JSON we
+    // wrote so the user can see exactly what landed, plus a one-line
+    // pointer to `<fork>/.mcp.json` and a reminder to restart NanoClaw.
+    // It also reuses serde_json so paths containing `"`/`\` escape
+    // safely — same defensive shape as the OpenCode / Gemini hints.
+    let args: Vec<String> = match data_dir {
+        Some(dd) => vec![
+            "--data-dir".to_string(),
+            dd.to_string_lossy().into_owned(),
+            "mcp".to_string(),
+        ],
+        None => vec!["mcp".to_string()],
+    };
+    let snippet = serde_json::json!({
+        "mcpServers": {
+            "aimx": {
+                "command": "/usr/local/bin/aimx",
+                "args": args,
+            }
+        }
+    });
+    let snippet_text = serde_json::to_string_pretty(&snippet)
+        .unwrap_or_else(|_| "<failed to render snippet>".to_string());
+    format!(
+        "Skill installed and aimx merged into <fork>/.mcp.json under \
+         mcpServers.aimx:\n\
+         \n\
+         {snippet_text}\n\
+         \n\
+         If the merge was skipped (fork directory missing or \
+         .mcp.json not writable), add the block above to the \
+         `mcpServers` object in <fork>/.mcp.json by hand. Set \
+         $NANOCLAW_HOME if your fork is not at ~/nanoclaw. Restart \
+         NanoClaw after the file is in place so the new server is \
+         loaded; then add a NanoClaw scheduled job that calls \
+         email_list via aimx MCP on the cadence you want."
+    )
+}
+
 fn openclaw_hint(data_dir: Option<&Path>) -> String {
     // OpenClaw exposes `openclaw mcp set <name> <json>`. The user can wire
     // MCP with one pasted command. Route the JSON through serde_json so
@@ -383,6 +451,14 @@ pub fn find_agent(name: &str) -> Option<&'static AgentSpec> {
 pub trait AgentEnv {
     fn home_dir(&self) -> Option<PathBuf>;
     fn xdg_config_home(&self) -> Option<PathBuf>;
+    /// Resolve `$NANOCLAW_HOME` for the NanoClaw integration. Returns
+    /// `None` when the variable is unset; `resolve_template_in_home`
+    /// then falls back to `<home>/nanoclaw`. Lives on the trait so
+    /// tests can pin the path to a tempdir without mutating the real
+    /// env.
+    fn nanoclaw_home(&self) -> Option<PathBuf> {
+        std::env::var_os("NANOCLAW_HOME").map(PathBuf::from)
+    }
     fn is_root(&self) -> bool;
     fn is_stdin_tty(&self) -> bool;
     fn read_line(&self) -> io::Result<String>;
@@ -465,6 +541,15 @@ impl<'a> AgentEnv for OverrideHomeEnv<'a> {
         None
     }
 
+    fn nanoclaw_home(&self) -> Option<PathBuf> {
+        // Forward to the inner env so an explicit `$NANOCLAW_HOME` still
+        // wins under `--dangerously-allow-root`. When unset, the default
+        // resolves under `home_dir()` (now `/root`), giving
+        // `/root/nanoclaw`, which mirrors how XDG defaults to
+        // `<home>/.config` in the same code path.
+        self.inner.nanoclaw_home()
+    }
+
     fn is_root(&self) -> bool {
         self.inner.is_root()
     }
@@ -537,7 +622,7 @@ pub struct InstallOptions<'a> {
 }
 
 /// Resolve a destination template against the environment. Substitutes
-/// `$HOME` and `$XDG_CONFIG_HOME`.
+/// `$HOME`, `$XDG_CONFIG_HOME`, and `$NANOCLAW_HOME`.
 pub fn resolve_dest(template: &str, env: &dyn AgentEnv) -> Result<PathBuf, String> {
     let home = env.home_dir().ok_or_else(|| {
         "HOME is not set; agents setup writes to the user's home directory".to_string()
@@ -546,19 +631,28 @@ pub fn resolve_dest(template: &str, env: &dyn AgentEnv) -> Result<PathBuf, Strin
         template,
         &home,
         env.xdg_config_home(),
+        env.nanoclaw_home(),
     ))
 }
 
-/// Substitute `$HOME` / `$XDG_CONFIG_HOME` in a template against an explicit
-/// home path. The `detect_install_state` probe uses this helper
-/// to resolve paths against a caller-chosen home — for
+/// Substitute `$HOME` / `$XDG_CONFIG_HOME` / `$NANOCLAW_HOME` in a template
+/// against an explicit home path. The `detect_install_state` probe uses this
+/// helper to resolve paths against a caller-chosen home — for
 /// `--dangerously-allow-root` that's `/root`, not the ambient env's HOME.
 /// When `xdg` is `None`, defaults to `<home>/.config` per the XDG Base
-/// Directory spec.
-pub fn resolve_template_in_home(template: &str, home: &Path, xdg: Option<PathBuf>) -> PathBuf {
+/// Directory spec. When `nanoclaw` is `None`, defaults to `<home>/nanoclaw`
+/// (matches the canonical `git clone … nanoclaw && cd nanoclaw` workflow).
+pub fn resolve_template_in_home(
+    template: &str,
+    home: &Path,
+    xdg: Option<PathBuf>,
+    nanoclaw: Option<PathBuf>,
+) -> PathBuf {
     let xdg_dir = xdg.unwrap_or_else(|| home.join(".config"));
+    let nanoclaw_dir = nanoclaw.unwrap_or_else(|| home.join("nanoclaw"));
     let substituted = template
         .replace("$XDG_CONFIG_HOME", &xdg_dir.to_string_lossy())
+        .replace("$NANOCLAW_HOME", &nanoclaw_dir.to_string_lossy())
         .replace("$HOME", &home.to_string_lossy());
     PathBuf::from(substituted)
 }
@@ -609,13 +703,19 @@ pub enum InstallState {
 ///
 /// `xdg` is threaded through so agents whose paths use `$XDG_CONFIG_HOME`
 /// (opencode, goose) resolve identically to how the installer would
-/// resolve them. `None` falls back to `<home>/.config`.
-pub fn detect_install_state(spec: &AgentSpec, home: &Path, xdg: Option<PathBuf>) -> InstallState {
-    let dest = resolve_template_in_home(spec.dest_template, home, xdg.clone());
+/// resolve them. `None` falls back to `<home>/.config`. `nanoclaw` does
+/// the same job for `$NANOCLAW_HOME` (defaulting to `<home>/nanoclaw`).
+pub fn detect_install_state(
+    spec: &AgentSpec,
+    home: &Path,
+    xdg: Option<PathBuf>,
+    nanoclaw: Option<PathBuf>,
+) -> InstallState {
+    let dest = resolve_template_in_home(spec.dest_template, home, xdg.clone(), nanoclaw.clone());
     if dest.exists() && dest_contains_aimx_entry(spec, &dest) {
         return InstallState::InstalledWired;
     }
-    let root = resolve_template_in_home(spec.agent_root_template, home, xdg);
+    let root = resolve_template_in_home(spec.agent_root_template, home, xdg, nanoclaw);
     if root.exists() {
         return InstallState::InstalledNotWired;
     }
@@ -898,6 +998,25 @@ fn install_to_writer(
         cleanup_legacy_claude_plugin(env, out)?;
     }
 
+    // NanoClaw is installed *into* a user-owned fork of qwibitai/nanoclaw,
+    // not into a system-style config dir. If we let `write_files` blindly
+    // create the missing parent we would happily create a `~/nanoclaw/`
+    // stub on a host that hasn't cloned NanoClaw yet — and a follow-up
+    // `git clone … nanoclaw` would fail because the directory exists.
+    // Fail fast with a message that names the override env var instead.
+    if spec.name == "nanoclaw" {
+        let fork_dir = resolve_dest(spec.agent_root_template, env)?;
+        if !fork_dir.exists() {
+            return Err(format!(
+                "NanoClaw fork directory {} does not exist. Clone NanoClaw first \
+                 (e.g. `git clone https://github.com/qwibitai/nanoclaw.git ~/nanoclaw`), \
+                 or set $NANOCLAW_HOME if your fork lives elsewhere, then re-run.",
+                fork_dir.display()
+            )
+            .into());
+        }
+    }
+
     let dest_root = resolve_dest(spec.dest_template, env)?;
     write_files(&dest_root, &files, opts.force, env)?;
 
@@ -907,6 +1026,11 @@ fn install_to_writer(
         term::success("Installed"),
         term::highlight(&dest_root.to_string_lossy())
     )?;
+
+    if spec.name == "nanoclaw" {
+        let fork_dir = resolve_dest(spec.agent_root_template, env)?;
+        merge_nanoclaw_mcp_json(&fork_dir, opts, out)?;
+    }
 
     if let Some(registration) = try_auto_register_mcp(spec, env, opts.data_dir) {
         match registration {
@@ -966,6 +1090,168 @@ fn try_auto_register_mcp(
         "codex" => Some(crate::agents_mcp::register_codex(env.mcp_cli(), data_dir)),
         _ => None,
     }
+}
+
+/// Outcome of `patch_nanoclaw_mcp_json`. Drives the printed status line
+/// in `merge_nanoclaw_mcp_json` so the user can tell what happened.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum McpJsonMergeOutcome {
+    /// `<fork>/.mcp.json` did not exist; created it with our entry.
+    Created,
+    /// `<fork>/.mcp.json` existed; merged our entry under `mcpServers.aimx`,
+    /// preserving any other servers untouched.
+    Merged,
+    /// `mcpServers.aimx` already existed and `force` was not set. The
+    /// caller should print the activation hint so the user can re-run
+    /// with `--force` once they confirm the override is intended.
+    Conflict,
+    /// Fork directory does not exist on disk. The user has not cloned
+    /// NanoClaw yet, or `$NANOCLAW_HOME` points somewhere stale. The
+    /// caller falls back to printing the activation hint as a snippet.
+    ForkMissing,
+}
+
+/// Merge an `mcpServers.aimx` entry into `<fork>/.mcp.json`. NanoClaw is
+/// the one supported agent where aimx mutates the agent's own MCP
+/// config file directly: there is no `nanoclaw mcp add` CLI, and
+/// hand-editing JSON5 is the worst path for users. See the design
+/// note at the top of `agents/nanoclaw/README.md` for why this is
+/// intentional rather than the start of a pattern.
+///
+/// The write is atomic (temp file in the same directory + rename) so
+/// concurrent reads of `.mcp.json` (e.g. by a running NanoClaw process
+/// reloading its config) never observe a half-written file. Any servers
+/// already configured under `mcpServers` are preserved verbatim;
+/// only the `aimx` key is touched.
+///
+/// `force=true` overwrites an existing `mcpServers.aimx` entry without
+/// prompting. `force=false` returns `Conflict` instead so the caller
+/// can surface a clear error rather than silently overwriting whatever
+/// the user had before.
+pub fn patch_nanoclaw_mcp_json(
+    fork_dir: &Path,
+    command_path: &str,
+    args: &[String],
+    force: bool,
+) -> Result<McpJsonMergeOutcome, Box<dyn std::error::Error>> {
+    if !fork_dir.exists() {
+        return Ok(McpJsonMergeOutcome::ForkMissing);
+    }
+    let mcp_path = fork_dir.join(".mcp.json");
+    let existed_before = mcp_path.exists();
+
+    let entry = serde_json::json!({
+        "command": command_path,
+        "args": args,
+    });
+
+    let mut root: serde_json::Value = if existed_before {
+        let bytes = std::fs::read(&mcp_path)?;
+        let text = std::str::from_utf8(&bytes)
+            .map_err(|e| format!("{}: not valid UTF-8: {}", mcp_path.display(), e))?;
+        if text.trim().is_empty() {
+            serde_json::json!({})
+        } else {
+            serde_json::from_str(text)
+                .map_err(|e| format!("{}: not valid JSON: {}", mcp_path.display(), e))?
+        }
+    } else {
+        serde_json::json!({})
+    };
+
+    let root_obj = root.as_object_mut().ok_or_else(|| {
+        format!(
+            "{}: top-level value is not a JSON object",
+            mcp_path.display()
+        )
+    })?;
+
+    let servers = root_obj
+        .entry("mcpServers".to_string())
+        .or_insert_with(|| serde_json::json!({}))
+        .as_object_mut()
+        .ok_or_else(|| format!("{}: mcpServers is not a JSON object", mcp_path.display()))?;
+
+    if servers.contains_key("aimx") && !force {
+        return Ok(McpJsonMergeOutcome::Conflict);
+    }
+    servers.insert("aimx".to_string(), entry);
+
+    let mut serialized = serde_json::to_string_pretty(&root)?;
+    serialized.push('\n');
+
+    // Write to a sibling temp file, then atomic-rename. Same FS as the
+    // target, so rename(2) is atomic. The `.aimx-tmp` suffix is unique
+    // enough to not collide with any user file the fork might carry.
+    let tmp_path = fork_dir.join(".mcp.json.aimx-tmp");
+    std::fs::write(&tmp_path, serialized.as_bytes())?;
+    set_file_mode(&tmp_path)?;
+    std::fs::rename(&tmp_path, &mcp_path)?;
+
+    Ok(if existed_before {
+        McpJsonMergeOutcome::Merged
+    } else {
+        McpJsonMergeOutcome::Created
+    })
+}
+
+/// Wrapper around `patch_nanoclaw_mcp_json` that picks the command/args
+/// from `InstallOptions::data_dir` and prints a status line. Skips the
+/// patch under `--print` (dry-run); the activation hint already shows
+/// the proposed JSON in that path.
+fn merge_nanoclaw_mcp_json(
+    fork_dir: &Path,
+    opts: &InstallOptions,
+    out: &mut dyn Write,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if opts.print {
+        return Ok(());
+    }
+    let args: Vec<String> = match opts.data_dir {
+        Some(dd) => vec![
+            "--data-dir".to_string(),
+            dd.to_string_lossy().into_owned(),
+            "mcp".to_string(),
+        ],
+        None => vec!["mcp".to_string()],
+    };
+    let mcp_path = fork_dir.join(".mcp.json");
+    match patch_nanoclaw_mcp_json(fork_dir, "/usr/local/bin/aimx", &args, opts.force)? {
+        McpJsonMergeOutcome::Created => {
+            writeln!(
+                out,
+                "{} created {} with mcpServers.aimx",
+                term::success_mark(),
+                term::highlight(&mcp_path.to_string_lossy()),
+            )?;
+        }
+        McpJsonMergeOutcome::Merged => {
+            writeln!(
+                out,
+                "{} merged mcpServers.aimx into {}",
+                term::success_mark(),
+                term::highlight(&mcp_path.to_string_lossy()),
+            )?;
+        }
+        McpJsonMergeOutcome::Conflict => {
+            writeln!(
+                out,
+                "{} mcpServers.aimx already exists in {}; pass --force to overwrite",
+                term::warn_mark(),
+                mcp_path.display(),
+            )?;
+        }
+        McpJsonMergeOutcome::ForkMissing => {
+            writeln!(
+                out,
+                "{} fork directory {} not found; skipping .mcp.json merge \
+                 (set $NANOCLAW_HOME or clone NanoClaw, then re-run)",
+                term::warn_mark(),
+                fork_dir.display(),
+            )?;
+        }
+    }
+    Ok(())
 }
 
 /// Remove `~/.claude/plugins/aimx/` if it exists. aimx <= 0.x installed
@@ -1345,6 +1631,7 @@ mod tests {
     struct MockEnv {
         home: PathBuf,
         xdg: Option<PathBuf>,
+        nanoclaw: Option<PathBuf>,
         root: bool,
         tty: bool,
         responses: RefCell<Vec<String>>,
@@ -1356,6 +1643,7 @@ mod tests {
             Self {
                 home,
                 xdg: None,
+                nanoclaw: None,
                 root: false,
                 tty: false,
                 responses: RefCell::new(Vec::new()),
@@ -1370,6 +1658,9 @@ mod tests {
         }
         fn xdg_config_home(&self) -> Option<PathBuf> {
             self.xdg.clone()
+        }
+        fn nanoclaw_home(&self) -> Option<PathBuf> {
+            self.nanoclaw.clone()
         }
         fn is_root(&self) -> bool {
             self.root
@@ -1446,7 +1737,7 @@ mod tests {
         // Pristine tempdir → every agent's root dir is missing.
         let tmp = TempDir::new().unwrap();
         for spec in registry() {
-            let state = detect_install_state(spec, tmp.path(), None);
+            let state = detect_install_state(spec, tmp.path(), None, None);
             assert_eq!(
                 state,
                 InstallState::NotInstalled,
@@ -1463,7 +1754,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         std::fs::create_dir_all(tmp.path().join(".claude")).unwrap();
         let spec = find_agent("claude-code").unwrap();
-        let state = detect_install_state(spec, tmp.path(), None);
+        let state = detect_install_state(spec, tmp.path(), None, None);
         assert_eq!(state, InstallState::InstalledNotWired);
     }
 
@@ -1477,12 +1768,12 @@ mod tests {
         std::fs::create_dir_all(&skill_dir).unwrap();
         let spec = find_agent("claude-code").unwrap();
         // Empty dir → NotWired (falls back to agent_root existence = InstalledNotWired).
-        let state_empty = detect_install_state(spec, tmp.path(), None);
+        let state_empty = detect_install_state(spec, tmp.path(), None, None);
         assert_eq!(state_empty, InstallState::InstalledNotWired);
 
         // Drop a SKILL.md mentioning "aimx" → Wired.
         std::fs::write(skill_dir.join("SKILL.md"), "---\nname: aimx\n---\nbody").unwrap();
-        let state_wired = detect_install_state(spec, tmp.path(), None);
+        let state_wired = detect_install_state(spec, tmp.path(), None, None);
         assert_eq!(state_wired, InstallState::InstalledWired);
     }
 
@@ -1499,7 +1790,7 @@ mod tests {
         std::fs::write(skill_dir.join("SKILL.md"), "---\nname: aimx\n---\nbody").unwrap();
 
         let spec = find_agent("claude-code").unwrap();
-        let state = detect_install_state(spec, tmp.path(), None);
+        let state = detect_install_state(spec, tmp.path(), None, None);
         assert_eq!(
             state,
             InstallState::InstalledWired,
@@ -1515,7 +1806,7 @@ mod tests {
         let skill_dir = tmp.path().join(".claude").join("skills").join("aimx");
         std::fs::create_dir_all(&skill_dir).unwrap();
         let spec = find_agent("claude-code").unwrap();
-        let state = detect_install_state(spec, tmp.path(), None);
+        let state = detect_install_state(spec, tmp.path(), None, None);
         // Empty dir is not Wired (agent_root exists → NotWired).
         assert_eq!(state, InstallState::InstalledNotWired);
     }
@@ -1529,7 +1820,7 @@ mod tests {
         std::fs::create_dir_all(&skill_dir).unwrap();
         std::fs::write(skill_dir.join("stale.txt"), "nothing to see").unwrap();
         let spec = find_agent("claude-code").unwrap();
-        let state = detect_install_state(spec, tmp.path(), None);
+        let state = detect_install_state(spec, tmp.path(), None, None);
         assert_eq!(state, InstallState::InstalledNotWired);
     }
 
@@ -1543,12 +1834,12 @@ mod tests {
         let xdg = tmp.path().join("custom-xdg");
         std::fs::create_dir_all(xdg.join("opencode")).unwrap();
         let spec = find_agent("opencode").unwrap();
-        let state_with_xdg = detect_install_state(spec, tmp.path(), Some(xdg.clone()));
+        let state_with_xdg = detect_install_state(spec, tmp.path(), Some(xdg.clone()), None);
         assert_eq!(state_with_xdg, InstallState::InstalledNotWired);
 
         // Without the override, `<home>/.config/opencode` is missing, so
         // the same spec reports NotInstalled.
-        let state_no_xdg = detect_install_state(spec, tmp.path(), None);
+        let state_no_xdg = detect_install_state(spec, tmp.path(), None, None);
         assert_eq!(state_no_xdg, InstallState::NotInstalled);
     }
 
@@ -1564,12 +1855,12 @@ mod tests {
         std::fs::create_dir_all(&recipes).unwrap();
         let spec = find_agent("goose").unwrap();
         // No aimx.yaml yet → NotWired.
-        let state_empty = detect_install_state(spec, tmp.path(), Some(xdg.clone()));
+        let state_empty = detect_install_state(spec, tmp.path(), Some(xdg.clone()), None);
         assert_eq!(state_empty, InstallState::InstalledNotWired);
 
         // Drop aimx.yaml → Wired.
         std::fs::write(recipes.join("aimx.yaml"), "# aimx recipe\n").unwrap();
-        let state_wired = detect_install_state(spec, tmp.path(), Some(xdg));
+        let state_wired = detect_install_state(spec, tmp.path(), Some(xdg), None);
         assert_eq!(state_wired, InstallState::InstalledWired);
     }
 
@@ -1607,7 +1898,7 @@ mod tests {
         let env = OverrideHomeEnv::new(&inner, root_home.clone());
         let home = env.home_dir().unwrap();
         let spec = find_agent("claude-code").unwrap();
-        let state = detect_install_state(spec, &home, env.xdg_config_home());
+        let state = detect_install_state(spec, &home, env.xdg_config_home(), env.nanoclaw_home());
         assert_eq!(state, InstallState::InstalledNotWired);
     }
 
@@ -2372,7 +2663,7 @@ mod tests {
     }
 
     #[test]
-    fn registry_lists_seven_agents_in_canonical_order() {
+    fn registry_lists_agents_in_canonical_order() {
         let names: Vec<&str> = registry().iter().map(|s| s.name).collect();
         assert_eq!(
             names,
@@ -2384,6 +2675,7 @@ mod tests {
                 "goose",
                 "openclaw",
                 "hermes",
+                "nanoclaw",
             ]
         );
     }
@@ -3858,6 +4150,401 @@ mod tests {
         assert!(
             printed.contains("claude mcp add"),
             "expected manual fallback hint after RegisterFailed: {printed}"
+        );
+    }
+
+    // --- NanoClaw integration tests ---------------------------------------
+
+    /// Build a `MockEnv` that points at a tempdir and pins NanoClaw's fork
+    /// to `<tmp>/nanoclaw` (created on disk so the install path doesn't
+    /// fail the fork-dir precheck). Returns the env plus the fork path
+    /// for the test to assert against.
+    fn nanoclaw_mock_env(tmp: &TempDir) -> (MockEnv, PathBuf) {
+        let fork = tmp.path().join("nanoclaw");
+        std::fs::create_dir_all(&fork).unwrap();
+        let mut env = MockEnv::new(tmp.path().to_path_buf());
+        env.nanoclaw = Some(fork.clone());
+        (env, fork)
+    }
+
+    #[test]
+    fn registry_contains_nanoclaw() {
+        let spec = find_agent("nanoclaw").expect("registry must include nanoclaw");
+        assert_eq!(spec.dest_template, "$NANOCLAW_HOME/skills/aimx");
+        assert_eq!(spec.agent_root_template, "$NANOCLAW_HOME");
+        assert!(spec.progressive_disclosure);
+    }
+
+    #[test]
+    fn install_nanoclaw_lays_out_expected_files() {
+        let tmp = TempDir::new().unwrap();
+        let (env, fork) = nanoclaw_mock_env(&tmp);
+
+        run_with_env(Some("nanoclaw".into()), false, false, false, None, &env).unwrap();
+
+        let dest = fork.join("skills/aimx");
+        assert!(dest.join("SKILL.md").exists());
+        assert!(!dest.join("SKILL.md.header").exists());
+        assert!(!dest.join("README.md").exists());
+
+        let skill = std::fs::read_to_string(dest.join("SKILL.md")).unwrap();
+        assert!(
+            skill.starts_with("---\n"),
+            "missing YAML frontmatter: {skill:.200}"
+        );
+        assert!(skill.contains("name: aimx"));
+        assert!(skill.contains("description:"));
+        assert!(skill.contains("nanoclaw"));
+        assert!(skill.contains("scheduled job"));
+        assert!(skill.contains("mailbox_list()"));
+    }
+
+    #[test]
+    fn nanoclaw_progressive_disclosure_installs_references() {
+        let tmp = TempDir::new().unwrap();
+        let (env, fork) = nanoclaw_mock_env(&tmp);
+
+        run_with_env(Some("nanoclaw".into()), false, false, false, None, &env).unwrap();
+
+        let dest = fork.join("skills/aimx");
+        assert!(dest.join("SKILL.md").exists());
+        assert!(dest.join("references/mcp-tools.md").exists());
+        assert!(dest.join("references/frontmatter.md").exists());
+        assert!(dest.join("references/workflows.md").exists());
+        assert!(dest.join("references/troubleshooting.md").exists());
+        assert!(dest.join("references/hooks.md").exists());
+    }
+
+    #[test]
+    fn nanoclaw_activation_hint_mentions_mcp_json_and_scheduled_job() {
+        let spec = find_agent("nanoclaw").unwrap();
+        let hint = (spec.activation_hint)(None);
+        assert!(hint.contains("<fork>/.mcp.json"));
+        assert!(hint.contains("mcpServers"));
+        assert!(hint.contains("\"aimx\""));
+        assert!(hint.contains("/usr/local/bin/aimx"));
+        assert!(hint.contains("scheduled job"));
+        assert!(hint.contains("$NANOCLAW_HOME"));
+        // Default install must not leak --data-dir into the snippet.
+        assert!(!hint.contains("--data-dir"));
+    }
+
+    #[test]
+    fn nanoclaw_activation_hint_with_custom_data_dir_rewrites_args() {
+        let spec = find_agent("nanoclaw").unwrap();
+        let hint = (spec.activation_hint)(Some(Path::new("/custom/aimx-data")));
+        // The path is routed through serde_json so it always renders as a
+        // proper JSON string, even for "safe" inputs.
+        assert!(hint.contains("\"--data-dir\""));
+        assert!(hint.contains("\"/custom/aimx-data\""));
+        assert!(hint.contains("\"mcp\""));
+    }
+
+    #[test]
+    fn nanoclaw_activation_hint_escapes_json_special_chars_in_data_dir() {
+        // A `--data-dir` containing `"` or `\` MUST be JSON-escaped, or
+        // the rendered snippet is invalid JSON when the user pastes it
+        // back. Mirrors the equivalent regression test for Hermes/YAML.
+        let spec = find_agent("nanoclaw").unwrap();
+        let hint = (spec.activation_hint)(Some(Path::new(r#"/opt/a"b\c"#)));
+        // Pull out the JSON snippet and parse it back to confirm it round-trips.
+        let snippet_start = hint.find('{').expect("hint must contain JSON");
+        let snippet_end = hint.rfind('}').expect("hint must contain closing brace");
+        let snippet = &hint[snippet_start..=snippet_end];
+        let parsed: serde_json::Value = serde_json::from_str(snippet)
+            .unwrap_or_else(|e| panic!("rendered snippet must be valid JSON: {e}\n{snippet}"));
+        let args = parsed
+            .pointer("/mcpServers/aimx/args")
+            .and_then(|v| v.as_array())
+            .expect("args array must be present");
+        // The original path must round-trip byte-for-byte through JSON.
+        assert_eq!(args[1].as_str().unwrap(), r#"/opt/a"b\c"#);
+    }
+
+    #[test]
+    fn assembled_nanoclaw_skill_is_header_plus_primer_byte_for_byte() {
+        let source = AGENTS_DIR.get_dir("nanoclaw").unwrap();
+        let files = assemble_plugin_files(source, None).unwrap();
+
+        let (_, skill_bytes) = files
+            .iter()
+            .find(|(rel, _)| rel.to_string_lossy() == "SKILL.md")
+            .expect("assembled SKILL.md should be present");
+
+        let header = AGENTS_DIR
+            .get_file("nanoclaw/SKILL.md.header")
+            .unwrap()
+            .contents();
+        let primer = AGENTS_DIR
+            .get_file("common/aimx-primer.md")
+            .unwrap()
+            .contents();
+
+        let mut expected = Vec::with_capacity(header.len() + primer.len());
+        expected.extend_from_slice(header);
+        expected.extend_from_slice(primer);
+
+        assert_eq!(skill_bytes, &expected);
+    }
+
+    #[test]
+    fn resolve_dest_substitutes_nanoclaw_home() {
+        let tmp = TempDir::new().unwrap();
+        let mut env = MockEnv::new(tmp.path().to_path_buf());
+        env.nanoclaw = Some(PathBuf::from("/opt/custom-nanoclaw"));
+        let spec = find_agent("nanoclaw").unwrap();
+        let dest = resolve_dest(spec.dest_template, &env).unwrap();
+        assert_eq!(
+            dest,
+            PathBuf::from("/opt/custom-nanoclaw/skills/aimx"),
+            "nanoclaw_home() override must replace $NANOCLAW_HOME in dest_template"
+        );
+    }
+
+    #[test]
+    fn resolve_dest_defaults_nanoclaw_home_to_home_nanoclaw() {
+        let tmp = TempDir::new().unwrap();
+        let env = MockEnv::new(tmp.path().to_path_buf()); // nanoclaw = None
+        let spec = find_agent("nanoclaw").unwrap();
+        let dest = resolve_dest(spec.dest_template, &env).unwrap();
+        assert_eq!(
+            dest,
+            tmp.path().join("nanoclaw").join("skills").join("aimx"),
+            "unset $NANOCLAW_HOME must fall back to <home>/nanoclaw"
+        );
+    }
+
+    #[test]
+    fn install_nanoclaw_errors_when_fork_dir_missing() {
+        // No fork dir on disk → install must fail fast with a message
+        // that names $NANOCLAW_HOME so the user can fix the misconfig.
+        let tmp = TempDir::new().unwrap();
+        // tmp.path() exists but `<tmp>/nanoclaw` (the default fork path)
+        // does not.
+        let env = MockEnv::new(tmp.path().to_path_buf());
+        let err = run_with_env(Some("nanoclaw".into()), false, false, false, None, &env)
+            .expect_err("install must fail when fork dir is missing");
+        let msg = err.to_string();
+        assert!(msg.contains("NanoClaw"), "{msg}");
+        assert!(msg.contains("$NANOCLAW_HOME"), "{msg}");
+        // No skill files should have been written.
+        assert!(!tmp.path().join("nanoclaw").exists());
+    }
+
+    // --- patch_nanoclaw_mcp_json -----------------------------------------
+
+    #[test]
+    fn patch_mcp_json_creates_when_absent() {
+        let tmp = TempDir::new().unwrap();
+        let fork = tmp.path().join("fork");
+        std::fs::create_dir_all(&fork).unwrap();
+
+        let outcome =
+            patch_nanoclaw_mcp_json(&fork, "/usr/local/bin/aimx", &["mcp".to_string()], false)
+                .unwrap();
+        assert_eq!(outcome, McpJsonMergeOutcome::Created);
+
+        let written = std::fs::read_to_string(fork.join(".mcp.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&written).unwrap();
+        assert_eq!(
+            parsed.pointer("/mcpServers/aimx/command").unwrap(),
+            "/usr/local/bin/aimx"
+        );
+        let args = parsed
+            .pointer("/mcpServers/aimx/args")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert_eq!(args.len(), 1);
+        assert_eq!(args[0].as_str().unwrap(), "mcp");
+    }
+
+    #[test]
+    fn patch_mcp_json_merges_into_existing_file() {
+        let tmp = TempDir::new().unwrap();
+        let fork = tmp.path().join("fork");
+        std::fs::create_dir_all(&fork).unwrap();
+        // Pre-existing .mcp.json with another server. The patcher must
+        // preserve `someone-else` untouched while adding `aimx`.
+        let initial = serde_json::json!({
+            "mcpServers": {
+                "someone-else": {
+                    "command": "/opt/other",
+                    "args": ["serve"],
+                }
+            },
+            "unrelated": "must-survive"
+        });
+        std::fs::write(
+            fork.join(".mcp.json"),
+            serde_json::to_string_pretty(&initial).unwrap(),
+        )
+        .unwrap();
+
+        let outcome =
+            patch_nanoclaw_mcp_json(&fork, "/usr/local/bin/aimx", &["mcp".to_string()], false)
+                .unwrap();
+        assert_eq!(outcome, McpJsonMergeOutcome::Merged);
+
+        let written = std::fs::read_to_string(fork.join(".mcp.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&written).unwrap();
+        assert_eq!(
+            parsed.pointer("/mcpServers/someone-else/command").unwrap(),
+            "/opt/other"
+        );
+        assert_eq!(
+            parsed.pointer("/mcpServers/aimx/command").unwrap(),
+            "/usr/local/bin/aimx"
+        );
+        assert_eq!(parsed.pointer("/unrelated").unwrap(), "must-survive");
+    }
+
+    #[test]
+    fn patch_mcp_json_conflict_without_force_keeps_existing_entry() {
+        let tmp = TempDir::new().unwrap();
+        let fork = tmp.path().join("fork");
+        std::fs::create_dir_all(&fork).unwrap();
+        let initial = serde_json::json!({
+            "mcpServers": {
+                "aimx": {
+                    "command": "/opt/old-aimx",
+                    "args": ["mcp"],
+                }
+            }
+        });
+        std::fs::write(
+            fork.join(".mcp.json"),
+            serde_json::to_string_pretty(&initial).unwrap(),
+        )
+        .unwrap();
+
+        let outcome =
+            patch_nanoclaw_mcp_json(&fork, "/usr/local/bin/aimx", &["mcp".to_string()], false)
+                .unwrap();
+        assert_eq!(outcome, McpJsonMergeOutcome::Conflict);
+
+        // File must be unchanged.
+        let written = std::fs::read_to_string(fork.join(".mcp.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&written).unwrap();
+        assert_eq!(
+            parsed.pointer("/mcpServers/aimx/command").unwrap(),
+            "/opt/old-aimx"
+        );
+    }
+
+    #[test]
+    fn patch_mcp_json_force_overwrites_existing_aimx_entry() {
+        let tmp = TempDir::new().unwrap();
+        let fork = tmp.path().join("fork");
+        std::fs::create_dir_all(&fork).unwrap();
+        let initial = serde_json::json!({
+            "mcpServers": {
+                "aimx": {
+                    "command": "/opt/old-aimx",
+                    "args": ["mcp"],
+                }
+            }
+        });
+        std::fs::write(
+            fork.join(".mcp.json"),
+            serde_json::to_string_pretty(&initial).unwrap(),
+        )
+        .unwrap();
+
+        let outcome = patch_nanoclaw_mcp_json(
+            &fork,
+            "/usr/local/bin/aimx",
+            &[
+                "--data-dir".to_string(),
+                "/x".to_string(),
+                "mcp".to_string(),
+            ],
+            true,
+        )
+        .unwrap();
+        assert_eq!(outcome, McpJsonMergeOutcome::Merged);
+
+        let written = std::fs::read_to_string(fork.join(".mcp.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&written).unwrap();
+        assert_eq!(
+            parsed.pointer("/mcpServers/aimx/command").unwrap(),
+            "/usr/local/bin/aimx"
+        );
+        let args = parsed
+            .pointer("/mcpServers/aimx/args")
+            .and_then(|v| v.as_array())
+            .unwrap();
+        assert_eq!(args.len(), 3);
+        assert_eq!(args[0].as_str().unwrap(), "--data-dir");
+        assert_eq!(args[1].as_str().unwrap(), "/x");
+        assert_eq!(args[2].as_str().unwrap(), "mcp");
+    }
+
+    #[test]
+    fn patch_mcp_json_fork_missing_returns_outcome() {
+        // No fork dir on disk → return the ForkMissing variant rather
+        // than erroring. The caller decides whether to surface it as a
+        // warning or a hard error.
+        let tmp = TempDir::new().unwrap();
+        let outcome = patch_nanoclaw_mcp_json(
+            &tmp.path().join("does-not-exist"),
+            "/usr/local/bin/aimx",
+            &["mcp".to_string()],
+            false,
+        )
+        .unwrap();
+        assert_eq!(outcome, McpJsonMergeOutcome::ForkMissing);
+    }
+
+    #[test]
+    fn install_nanoclaw_dry_run_does_not_touch_mcp_json() {
+        // `--print` must not write to disk. Run install with print=true
+        // and confirm no .mcp.json was created.
+        let tmp = TempDir::new().unwrap();
+        let (env, fork) = nanoclaw_mock_env(&tmp);
+        let mut buf: Vec<u8> = Vec::new();
+
+        run_with_env_to_writer(
+            Some("nanoclaw".into()),
+            false,
+            false,
+            true, // print
+            None,
+            &env,
+            &mut buf,
+        )
+        .unwrap();
+
+        assert!(
+            !fork.join(".mcp.json").exists(),
+            "--print must not create .mcp.json"
+        );
+        // The skill files must also not have been written under print mode.
+        assert!(
+            !fork.join("skills/aimx/SKILL.md").exists(),
+            "--print must not write skill files"
+        );
+
+        // The printed output must include the proposed JSON snippet so the
+        // user can preview it.
+        let printed = String::from_utf8(buf).unwrap();
+        assert!(printed.contains("=== activation ==="));
+        assert!(printed.contains("mcpServers"));
+        assert!(printed.contains("/usr/local/bin/aimx"));
+    }
+
+    #[test]
+    fn install_nanoclaw_writes_mcp_json_under_normal_install() {
+        // Sanity: a real (non-print) install merges the entry.
+        let tmp = TempDir::new().unwrap();
+        let (env, fork) = nanoclaw_mock_env(&tmp);
+
+        run_with_env(Some("nanoclaw".into()), false, false, false, None, &env).unwrap();
+
+        let written = std::fs::read_to_string(fork.join(".mcp.json")).unwrap();
+        let parsed: serde_json::Value = serde_json::from_str(&written).unwrap();
+        assert_eq!(
+            parsed.pointer("/mcpServers/aimx/command").unwrap(),
+            "/usr/local/bin/aimx"
         );
     }
 }

--- a/src/agents_tui.rs
+++ b/src/agents_tui.rs
@@ -65,11 +65,12 @@ pub(crate) fn build_rows(env: &dyn AgentEnv) -> Vec<Row> {
         .home_dir()
         .expect("agents setup TUI requires HOME to be resolved by the caller");
     let xdg = env.xdg_config_home();
+    let nanoclaw = env.nanoclaw_home();
     registry()
         .iter()
         .enumerate()
         .map(|(i, spec)| {
-            let state = detect_install_state(spec, &home, xdg.clone());
+            let state = detect_install_state(spec, &home, xdg.clone(), nanoclaw.clone());
             let selected = matches!(state, InstallState::InstalledNotWired);
             Row {
                 spec_index: i,
@@ -506,6 +507,9 @@ mod tests {
         }
         fn xdg_config_home(&self) -> Option<PathBuf> {
             self.xdg.clone()
+        }
+        fn nanoclaw_home(&self) -> Option<PathBuf> {
+            None
         }
         fn is_root(&self) -> bool {
             false

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -5823,6 +5823,24 @@ fn agents_setup_list_works() {
         .stdout(predicate::str::contains("claude-code"));
 }
 
+/// NanoClaw was added as the eighth supported agent. A separate assertion
+/// (rather than folding it into `agents_setup_list_works`) keeps the failure
+/// message specific if NanoClaw is ever accidentally dropped from
+/// `registry()`. Also confirms the `$NANOCLAW_HOME` template surfaces in
+/// the printed destination so users see the env var without reading the
+/// guide.
+#[test]
+fn agents_setup_list_includes_nanoclaw() {
+    Command::cargo_bin("aimx")
+        .unwrap()
+        .args(["agents", "setup", "--list"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("nanoclaw"))
+        .stdout(predicate::str::contains("NanoClaw"))
+        .stdout(predicate::str::contains("nanoclaw/skills/aimx"));
+}
+
 /// `aimx agents remove <unknown>` must surface an explicit "Unknown agent"
 /// error rather than a clap usage hint or a silent no-op.
 #[test]


### PR DESCRIPTION
## Summary

- Adds NanoClaw as the eighth `aimx agents setup` agent. NanoClaw is a Claude-Agent-SDK-based container-isolated personal AI agent forked per-user from `qwibitai/nanoclaw`, so the integration target is the fork directory (default `~/nanoclaw`, override via `$NANOCLAW_HOME`) instead of a global `$HOME` config dir.
- Auto-merges an `mcpServers.aimx` entry into `<fork>/.mcp.json` via temp-file + atomic rename, preserving any other servers. NanoClaw exposes no `mcp add` CLI and the file is JSON5-flavoured, so this is the one supported agent where aimx mutates the agent's primary config — `--print` is a dry-run, `--force` overwrites an existing `aimx` entry, and the trade-off is documented next to the helper and in `book/agent-integration.md`.
- Documents NanoClaw's scheduled-job pull model in the bundled `SKILL.md.header`. NanoClaw is a long-running daemon, so `on_receive` hook recipes don't fit; the recommendation is to add a NanoClaw scheduled job that polls `email_list` on a cadence, with a one-line escape hatch for operators who need sub-second latency (wire a different agent as the hook).
- Fork-dir existence precheck before `write_files` so a host without a NanoClaw clone can never end up with a stub `~/nanoclaw/` that a follow-up `git clone` would conflict with; error names `$NANOCLAW_HOME` so users can fix the misconfig.
- Removal flow updated symmetrically — `aimx agents remove nanoclaw` deletes the skill bundle and prints a hint pointing at `<fork>/.mcp.json`. The `.mcp.json` itself is preserved, matching the behaviour for every other agent.

## Test plan

- [x] `cargo build` (clean)
- [x] `cargo test --bin aimx` — 1052 unit tests pass (118 `agents_setup::tests::*`, 14 of them new for NanoClaw)
- [x] `cargo test --test integration agents_` — 4 integration tests pass, including the new `agents_setup_list_includes_nanoclaw`
- [x] `cargo clippy -- -D warnings` (clean)
- [x] `cargo fmt -- --check` (clean)
- [x] Verifier crate: `cd services/verifier && cargo clippy -- -D warnings` (clean)
- [x] Banned-tokens guard from `CLAUDE.local.md` returns zero hits
- [x] End-to-end smoke under `NANOCLAW_HOME=/tmp/fake-nanoclaw`: `--print` prints proposed JSON without writing; real install lays out `skills/aimx/{SKILL.md,references/*.md}` and creates `.mcp.json`; merge into a pre-seeded `.mcp.json` preserves a `someone-else` server and an unrelated top-level field; fork-missing case fails fast with a message naming `$NANOCLAW_HOME`; `aimx agents remove nanoclaw` deletes the skill dir and prints the cleanup hint