### PR TITLE
Add configurable default outbound signature

### DIFF
--- a/book/configuration.md
+++ b/book/configuration.md
@@ -55,6 +55,7 @@ Hook commands receive additional `AIMX_*` env vars carrying the triggering email
 | `trusted_senders` | array | `[]` | Default allowlist of glob patterns applied to every mailbox. Per-mailbox `trusted_senders` replaces this list (no merging). |
 | `verify_host` | string | `https://check.aimx.email` | Base URL of the verifier service used by `aimx portcheck` and `aimx setup`. Can be overridden per-invocation with the `--verify-host` flag. |
 | `enable_ipv6` | bool | `false` | Advanced. Opt into IPv6 outbound delivery. See [IPv6 delivery](#ipv6-delivery-advanced). |
+| `signature` | string | *(built-in)* | Outbound signature appended to every email's body. Omit to use the built-in default `Sent from AIMX.\nhttps://aimx.email`. Set to a custom string to override. Set to `""` to disable the signature entirely. See [Outbound signature](#outbound-signature). |
 
 `aimx setup` asks for a list of trusted sender addresses interactively on
 the first run (comma-separated, accepts plain addresses and globs like
@@ -148,6 +149,30 @@ Unknown fields on a hook table are rejected at config load. The legacy fields `s
 
 Each mailbox directory is chowned to `<owner>:<owner>` mode `0700` at create time and stays that way through every subsequent write (ingest, send, mark-read). Files inside are written by the daemon as `root:root 0644` — root bypasses dir perms regardless, while the mailbox owner reads via uid match. Other users cannot traverse the directory.
 
+## Outbound signature
+
+Every outbound email gets a signature appended to the body before DKIM signing. By default this is:
+
+```
+Sent from AIMX.
+https://aimx.email
+```
+
+Override via the top-level `signature` key in `config.toml`:
+
+```toml
+# Use the built-in default (omit the key entirely):
+# signature = "Sent from AIMX.\nhttps://aimx.email"
+
+# Custom signature:
+signature = "Best regards,\nThe team"
+
+# Disable the signature entirely:
+signature = ""
+```
+
+The signature is injected into the first `text/plain` body region: for plain messages it is appended after the body; for messages with attachments it lands inside the text part, before the first attachment boundary. Operators can edit `signature` and the new value applies to the next send (no daemon restart required) — `aimx serve` reads the live `Config` snapshot for each request.
+
 ## IPv6 delivery (advanced)
 
 By default, `aimx serve` delivers outbound email over IPv4 only (submitted to it by `aimx send` via `/run/aimx/aimx.sock`). This matches the SPF record that `aimx setup` generates (which lists only the server's IPv4 address) and is the right choice for most users.
@@ -207,6 +232,9 @@ dkim_selector = "aimx"
 
 # Opt into IPv6 outbound delivery (advanced, default: false)
 # enable_ipv6 = true
+
+# Outbound signature (omit for built-in default; "" disables; any other string overrides)
+# signature = "Best regards,\nThe team"
 
 # ----------------------------
 # Default trust policy (applies to every mailbox unless overridden)

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,12 @@ const DEFAULT_DATA_DIR: &str = "/var/lib/aimx";
 const DEFAULT_CONFIG_DIR: &str = "/etc/aimx";
 const CONFIG_DIR_ENV: &str = "AIMX_CONFIG_DIR";
 
+/// Default outbound signature appended to every email when
+/// [`Config::signature`] is `None`. Operators override by setting
+/// `signature = "..."` in `config.toml`; an empty string disables the
+/// signature entirely.
+pub const DEFAULT_SIGNATURE: &str = "Sent from AIMX.\nhttps://aimx.email";
+
 /// Resolve the configuration directory.
 ///
 /// Precedence:
@@ -145,11 +151,28 @@ pub struct Config {
     #[serde(default)]
     pub enable_ipv6: bool,
 
+    /// Outbound signature appended to the body of every email sent
+    /// through this daemon. `None` (field omitted) uses
+    /// [`DEFAULT_SIGNATURE`]. `Some("")` disables the signature
+    /// entirely. `Some(s)` replaces the default with `s`. Resolved
+    /// via [`Config::effective_signature`].
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signature: Option<String>,
+
     /// Optional `[upgrade]` section. Overrides the release-manifest URL used
     /// by `aimx upgrade`. The `AIMX_RELEASE_MANIFEST_URL` env
     /// var takes precedence over this value when both are set.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub upgrade: Option<UpgradeConfig>,
+}
+
+impl Config {
+    /// Resolve the effective outbound signature. `None` falls back to
+    /// [`DEFAULT_SIGNATURE`]; `Some(s)` is returned as-is (an empty
+    /// string disables the signature).
+    pub fn effective_signature(&self) -> &str {
+        self.signature.as_deref().unwrap_or(DEFAULT_SIGNATURE)
+    }
 }
 
 /// Operator-overridable knobs for `aimx upgrade`. Today only the manifest URL

--- a/src/hook.rs
+++ b/src/hook.rs
@@ -677,6 +677,7 @@ mod tests {
             mailboxes: HashMap::new(),
             verify_host: None,
             enable_ipv6: false,
+            signature: None,
             upgrade: None,
         }
     }

--- a/src/hook_handler.rs
+++ b/src/hook_handler.rs
@@ -432,6 +432,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            signature: None,
             upgrade: None,
         }
     }

--- a/src/hook_list_handler.rs
+++ b/src/hook_list_handler.rs
@@ -192,6 +192,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            signature: None,
             upgrade: None,
         }
     }

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -996,6 +996,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            signature: None,
             upgrade: None,
         }
     }
@@ -2579,6 +2580,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            signature: None,
             upgrade: None,
         };
 

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -1073,6 +1073,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            signature: None,
             upgrade: None,
         }
     }

--- a/src/mailbox_handler.rs
+++ b/src/mailbox_handler.rs
@@ -646,6 +646,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            signature: None,
             upgrade: None,
         }
     }

--- a/src/mailbox_list_handler.rs
+++ b/src/mailbox_list_handler.rs
@@ -249,6 +249,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            signature: None,
             upgrade: None,
         }
     }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1786,6 +1786,7 @@ mod auth_tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            signature: None,
             upgrade: None,
         }
     }

--- a/src/send_handler.rs
+++ b/src/send_handler.rs
@@ -241,7 +241,7 @@ where
     // `AIMX/1 OK <message-id>` still needs something to echo. Using the
     // configured primary domain matches the DKIM `d=` tag and avoids
     // leaking a recipient-side hostname.
-    let (message_id, body_bytes) = match headers.get("Message-ID") {
+    let (message_id, body_with_id) = match headers.get("Message-ID") {
         Some(v) => (v.clone(), req.body.clone()),
         None => {
             let synthetic = format!("<{}@{}>", Uuid::new_v4(), primary_domain);
@@ -249,6 +249,8 @@ where
             (synthetic, injected)
         }
     };
+
+    let body_bytes = append_signature(&body_with_id, config.effective_signature());
 
     let signed = match signer(
         &body_bytes,
@@ -416,6 +418,107 @@ fn resolve_concrete_mailbox(
     }
 
     None
+}
+
+/// Append `signature` to the first text body region of an RFC 5322 message.
+///
+/// Returns the body unchanged when `signature` is empty (operator-disabled
+/// signature). Otherwise inserts a blank-line separator followed by the
+/// signature into the message:
+///
+/// - Flat `text/plain` bodies (the no-attachment shape produced by
+///   [`crate::send::compose_message`]): signature is appended at the end of
+///   the body, before the trailing terminator slot.
+/// - `multipart/mixed` bodies: signature is injected at the end of the first
+///   part (which `compose_message` always emits as `text/plain`), just before
+///   the boundary line that opens the next part.
+///
+/// Line endings in `signature` are normalized to match the body's terminator
+/// (CRLF or LF). If the multipart structure can't be parsed, falls back to
+/// the flat append at end-of-body so DKIM signing still produces a
+/// deterministic result.
+fn append_signature(body: &[u8], signature: &str) -> Vec<u8> {
+    if signature.is_empty() {
+        return body.to_vec();
+    }
+
+    let crlf = body.windows(2).take(1024).any(|w| w == b"\r\n");
+    let term: &[u8] = if crlf { b"\r\n" } else { b"\n" };
+
+    let normalized_sig = normalize_signature_line_endings(signature, crlf);
+    let insert_at = find_first_part_terminator(body).unwrap_or(body.len());
+
+    let mut out = Vec::with_capacity(body.len() + normalized_sig.len() + 2 * term.len());
+    out.extend_from_slice(&body[..insert_at]);
+    out.extend_from_slice(term);
+    out.extend_from_slice(normalized_sig.as_bytes());
+    out.extend_from_slice(term);
+    out.extend_from_slice(&body[insert_at..]);
+    out
+}
+
+/// Locate the byte offset where a signature should be injected for a
+/// `multipart/...` body: the start of the second `--<boundary>` line, which
+/// terminates the first part. Returns `None` for non-multipart bodies and
+/// for malformed multipart bodies (caller falls back to end-of-body).
+fn find_first_part_terminator(body: &[u8]) -> Option<usize> {
+    let boundary = extract_multipart_boundary(body)?;
+    let marker = format!("--{boundary}");
+    let marker_bytes = marker.as_bytes();
+
+    let first = find_subslice(body, marker_bytes)?;
+    let after_first = first + marker_bytes.len();
+    let second_rel = find_subslice(&body[after_first..], marker_bytes)?;
+    Some(after_first + second_rel)
+}
+
+/// Extract the `boundary` parameter from the first `Content-Type:
+/// multipart/...` header in the message's header block. Returns `None` for
+/// flat (non-multipart) messages.
+fn extract_multipart_boundary(body: &[u8]) -> Option<String> {
+    let header_end = find_subslice(body, b"\r\n\r\n").or_else(|| find_subslice(body, b"\n\n"))?;
+    let header_text = std::str::from_utf8(&body[..header_end]).ok()?;
+
+    for line in header_text.lines() {
+        let lower = line.to_ascii_lowercase();
+        if !lower.starts_with("content-type:") || !lower.contains("multipart/") {
+            continue;
+        }
+        let pos = lower.find("boundary=")?;
+        let after = &line[pos + "boundary=".len()..];
+        if let Some(stripped) = after.strip_prefix('"') {
+            let end = stripped.find('"')?;
+            return Some(stripped[..end].to_string());
+        }
+        let end = after
+            .find(|c: char| c == ';' || c.is_whitespace())
+            .unwrap_or(after.len());
+        if end == 0 {
+            return None;
+        }
+        return Some(after[..end].to_string());
+    }
+    None
+}
+
+fn find_subslice(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() {
+        return Some(0);
+    }
+    if needle.len() > haystack.len() {
+        return None;
+    }
+    haystack.windows(needle.len()).position(|w| w == needle)
+}
+
+/// Convert any mix of CR / LF / CRLF in `signature` to the body's terminator.
+fn normalize_signature_line_endings(signature: &str, crlf: bool) -> String {
+    let lf_only = signature.replace("\r\n", "\n").replace('\r', "\n");
+    if crlf {
+        lf_only.replace('\n', "\r\n")
+    } else {
+        lf_only
+    }
 }
 
 /// Insert a `Message-ID:` header at the top of an RFC 5322 message body. The
@@ -756,6 +859,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            signature: None,
             upgrade: None,
         };
         let config_handle = ConfigHandle::new(config);
@@ -1352,6 +1456,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            signature: None,
             upgrade: None,
         };
         let ctx = SendContext {
@@ -1378,6 +1483,318 @@ mod tests {
             md.mode() & 0o777,
             0o600,
             "sent file must land 0o600 via post-persist chown"
+        );
+    }
+
+    // ------------------------------------------------------------------
+    // append_signature unit tests
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn append_signature_empty_is_noop() {
+        let body = b"From: a@example.com\r\nTo: b@x.com\r\n\r\nhello\r\n";
+        let out = append_signature(body, "");
+        assert_eq!(out, body);
+    }
+
+    #[test]
+    fn append_signature_text_plain_appends_after_body() {
+        let body = b"From: a@example.com\r\n\
+                     Content-Type: text/plain; charset=utf-8\r\n\
+                     \r\n\
+                     hello\r\n";
+        let out = append_signature(body, "Sig line 1\nSig line 2");
+        let text = std::str::from_utf8(&out).unwrap();
+        let sep = text.find("\r\n\r\n").expect("header separator missing");
+        let body_section = &text[sep + 4..];
+        assert!(
+            body_section.contains("hello\r\n\r\nSig line 1\r\nSig line 2"),
+            "body section was: {body_section:?}"
+        );
+        assert!(text.ends_with("\r\n"));
+    }
+
+    #[test]
+    fn append_signature_multipart_injects_into_text_part() {
+        let body = b"From: a@example.com\r\n\
+                     Content-Type: multipart/mixed; boundary=\"BND\"\r\n\
+                     \r\n\
+                     --BND\r\n\
+                     Content-Type: text/plain; charset=utf-8\r\n\
+                     \r\n\
+                     user body\r\n\
+                     --BND\r\n\
+                     Content-Type: application/pdf; name=\"x.pdf\"\r\n\
+                     \r\n\
+                     PDFDATA\r\n\
+                     --BND--\r\n";
+        let out = append_signature(body, "Trailer");
+        let text = std::str::from_utf8(&out).unwrap();
+        let sig_pos = text.find("Trailer").expect("signature missing");
+        let first_boundary = text.find("--BND\r\n").expect("first boundary missing");
+        let second_boundary = text[first_boundary + 7..]
+            .find("--BND\r\n")
+            .map(|p| first_boundary + 7 + p)
+            .expect("second boundary missing");
+        assert!(
+            sig_pos > first_boundary && sig_pos < second_boundary,
+            "signature must live inside the first text/plain part"
+        );
+        assert!(text.contains("user body\r\n\r\nTrailer\r\n--BND\r\n"));
+        assert!(text.contains("PDFDATA\r\n"));
+    }
+
+    #[test]
+    fn append_signature_preserves_lf_terminator() {
+        let body = b"From: a@example.com\nContent-Type: text/plain; charset=utf-8\n\nhello\n";
+        let out = append_signature(body, "sig\rline2");
+        let text = std::str::from_utf8(&out).unwrap();
+        assert!(!text.contains('\r'), "LF body must not gain CR bytes");
+        assert!(text.contains("hello\n\nsig\nline2\n"));
+    }
+
+    #[test]
+    fn append_signature_multibyte_signature() {
+        let body = b"From: a@example.com\r\nContent-Type: text/plain; charset=utf-8\r\n\r\nhi\r\n";
+        let out = append_signature(body, "Héllo — wörld");
+        let text = std::str::from_utf8(&out).expect("must remain valid UTF-8");
+        assert!(text.contains("Héllo — wörld"));
+    }
+
+    #[test]
+    fn append_signature_falls_back_when_multipart_malformed() {
+        let body = b"From: a@example.com\r\n\
+                     Content-Type: multipart/mixed; boundary=\"BND\"\r\n\
+                     \r\n\
+                     no boundaries follow at all\r\n";
+        let out = append_signature(body, "sig");
+        let text = std::str::from_utf8(&out).unwrap();
+        assert!(text.ends_with("sig\r\n"));
+    }
+
+    #[test]
+    fn extract_multipart_boundary_quoted() {
+        let body = b"Content-Type: multipart/mixed; boundary=\"abc-123\"\r\n\r\nbody";
+        assert_eq!(
+            extract_multipart_boundary(body),
+            Some("abc-123".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_multipart_boundary_unquoted() {
+        let body = b"Content-Type: multipart/mixed; boundary=abc-123\r\n\r\nbody";
+        assert_eq!(
+            extract_multipart_boundary(body),
+            Some("abc-123".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_multipart_boundary_unquoted_with_trailing_param() {
+        let body = b"Content-Type: multipart/mixed; boundary=abc-123; charset=utf-8\r\n\r\nbody";
+        assert_eq!(
+            extract_multipart_boundary(body),
+            Some("abc-123".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_multipart_boundary_returns_none_for_flat() {
+        let body = b"Content-Type: text/plain; charset=utf-8\r\n\r\nbody";
+        assert_eq!(extract_multipart_boundary(body), None);
+    }
+
+    #[test]
+    fn extract_multipart_boundary_case_insensitive() {
+        let body = b"CONTENT-TYPE: Multipart/Mixed; BOUNDARY=\"X\"\r\n\r\nbody";
+        assert_eq!(extract_multipart_boundary(body), Some("X".to_string()));
+    }
+
+    // ------------------------------------------------------------------
+    // Daemon-level signature tests (end-to-end through handle_send)
+    // ------------------------------------------------------------------
+
+    fn ctx_with_signature(
+        transport: Arc<dyn MailTransport + Send + Sync>,
+        data_dir: std::path::PathBuf,
+        signature: Option<String>,
+    ) -> SendContext {
+        let tmp = tempfile::TempDir::new().unwrap();
+        dkim::generate_keypair(tmp.path(), false).unwrap();
+        let key = dkim::load_private_key(tmp.path()).unwrap();
+        let mut mailboxes = std::collections::HashMap::new();
+        mailboxes.insert(
+            "alice".to_string(),
+            crate::config::MailboxConfig {
+                address: "alice@example.com".to_string(),
+                owner: "root".to_string(),
+                hooks: vec![],
+                trust: None,
+                trusted_senders: None,
+                allow_root_catchall: false,
+            },
+        );
+        let config = crate::config::Config {
+            domain: "example.com".to_string(),
+            data_dir: data_dir.clone(),
+            dkim_selector: "aimx".to_string(),
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            mailboxes,
+            verify_host: None,
+            enable_ipv6: false,
+            signature,
+            upgrade: None,
+        };
+        SendContext {
+            dkim_key: Arc::new(key),
+            dkim_selector: "aimx".to_string(),
+            config_handle: ConfigHandle::new(config),
+            transport,
+            data_dir,
+        }
+    }
+
+    fn read_sent_body(data_dir: &std::path::Path) -> String {
+        let sent_dir = data_dir.join("sent").join("alice");
+        let entries: Vec<_> = std::fs::read_dir(&sent_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .collect();
+        assert_eq!(entries.len(), 1);
+        std::fs::read_to_string(entries[0].path()).unwrap()
+    }
+
+    #[tokio::test]
+    async fn default_signature_appended_when_config_omits_it() {
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Ok,
+        });
+        let ctx = ctx_with_signature(mock.clone(), data_dir.path().to_path_buf(), None);
+        let req = SendRequest {
+            body: body("alice@example.com"),
+        };
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
+        assert!(matches!(resp, SendResponse::Ok { .. }), "{resp:?}");
+
+        let captured = mock.captured.lock().unwrap();
+        let delivered = String::from_utf8_lossy(&captured[0]);
+        assert!(
+            delivered.contains("Sent from AIMX.") && delivered.contains("https://aimx.email"),
+            "default signature must be appended to delivered body: {delivered}"
+        );
+
+        let persisted = read_sent_body(data_dir.path());
+        assert!(persisted.contains("Sent from AIMX."));
+        assert!(persisted.contains("https://aimx.email"));
+    }
+
+    #[tokio::test]
+    async fn custom_signature_overrides_default() {
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Ok,
+        });
+        let ctx = ctx_with_signature(
+            mock.clone(),
+            data_dir.path().to_path_buf(),
+            Some("Best,\nBot".to_string()),
+        );
+        let req = SendRequest {
+            body: body("alice@example.com"),
+        };
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
+        assert!(matches!(resp, SendResponse::Ok { .. }), "{resp:?}");
+
+        let persisted = read_sent_body(data_dir.path());
+        assert!(persisted.contains("Best,\r\nBot"));
+        assert!(
+            !persisted.contains("Sent from AIMX."),
+            "default signature must not appear when custom is set"
+        );
+    }
+
+    #[tokio::test]
+    async fn empty_signature_disables_appending() {
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Ok,
+        });
+        let ctx = ctx_with_signature(
+            mock.clone(),
+            data_dir.path().to_path_buf(),
+            Some(String::new()),
+        );
+        let req = SendRequest {
+            body: body("alice@example.com"),
+        };
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
+        assert!(matches!(resp, SendResponse::Ok { .. }), "{resp:?}");
+
+        let captured = mock.captured.lock().unwrap();
+        let delivered = String::from_utf8_lossy(&captured[0]);
+        assert!(
+            !delivered.contains("Sent from AIMX."),
+            "empty signature must disable the default: {delivered}"
+        );
+        assert!(
+            !delivered.contains("https://aimx.email"),
+            "empty signature must disable the default: {delivered}"
+        );
+    }
+
+    #[tokio::test]
+    async fn signature_appended_in_multipart_text_part() {
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Ok,
+        });
+        let ctx = ctx_with_signature(
+            mock.clone(),
+            data_dir.path().to_path_buf(),
+            Some("MARK".to_string()),
+        );
+        let multipart_body = b"From: alice@example.com\r\n\
+            To: user@gmail.com\r\n\
+            Subject: with attach\r\n\
+            Date: Thu, 01 Jan 2025 12:00:00 +0000\r\n\
+            Message-ID: <m1@example.com>\r\n\
+            Content-Type: multipart/mixed; boundary=\"BND\"\r\n\
+            \r\n\
+            --BND\r\n\
+            Content-Type: text/plain; charset=utf-8\r\n\
+            \r\n\
+            see attached.\r\n\
+            --BND\r\n\
+            Content-Type: application/octet-stream; name=\"x.bin\"\r\n\
+            Content-Disposition: attachment; filename=\"x.bin\"\r\n\
+            Content-Transfer-Encoding: base64\r\n\
+            \r\n\
+            QUFB\r\n\
+            --BND--\r\n";
+        let req = SendRequest {
+            body: multipart_body.to_vec(),
+        };
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
+        assert!(matches!(resp, SendResponse::Ok { .. }), "{resp:?}");
+
+        let captured = mock.captured.lock().unwrap();
+        let delivered = String::from_utf8_lossy(&captured[0]);
+        let mark_pos = delivered.find("MARK").expect("signature missing");
+        let first_boundary = delivered.find("--BND\r\n").expect("missing");
+        let second_boundary = delivered[first_boundary + 7..]
+            .find("--BND\r\n")
+            .map(|p| first_boundary + 7 + p)
+            .expect("missing");
+        assert!(
+            mark_pos > first_boundary && mark_pos < second_boundary,
+            "signature must sit inside the first text/plain part, not after attachments"
         );
     }
 }

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1566,6 +1566,7 @@ mod tests {
                 mailboxes,
                 verify_host: None,
                 enable_ipv6: false,
+                signature: None,
                 upgrade: None,
             };
 
@@ -1876,6 +1877,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            signature: None,
             upgrade: None,
         }
     }
@@ -2036,6 +2038,7 @@ mod tests {
                 mailboxes,
                 verify_host: None,
                 enable_ipv6: false,
+                signature: None,
                 upgrade: None,
             };
             let handle_cfg = ConfigHandle::new(config);

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1502,6 +1502,7 @@ pub fn finalize_setup(
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            signature: None,
             upgrade: None,
         };
         install_config_file(&cfg, &config_path)?;
@@ -4435,6 +4436,7 @@ owner = "aimx-catchall"
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            signature: None,
             upgrade: None,
         };
 

--- a/src/smtp/tests.rs
+++ b/src/smtp/tests.rs
@@ -87,6 +87,7 @@ fn test_config(data_dir: &std::path::Path) -> Config {
         mailboxes,
         verify_host: None,
         enable_ipv6: false,
+        signature: None,
         upgrade: None,
     }
 }
@@ -848,6 +849,7 @@ async fn test_ingest_failure_returns_451() {
         mailboxes,
         verify_host: None,
         enable_ipv6: false,
+        signature: None,
         upgrade: None,
     };
     let (port, _shutdown) = start_server(config).await;
@@ -1310,6 +1312,7 @@ fn test_config_no_catchall(data_dir: &std::path::Path) -> Config {
         mailboxes,
         verify_host: None,
         enable_ipv6: false,
+        signature: None,
         upgrade: None,
     }
 }
@@ -1400,6 +1403,7 @@ fn test_config_two_mailboxes(data_dir: &std::path::Path) -> Config {
         mailboxes,
         verify_host: None,
         enable_ipv6: false,
+        signature: None,
         upgrade: None,
     }
 }

--- a/src/state_handler.rs
+++ b/src/state_handler.rs
@@ -362,6 +362,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            signature: None,
             upgrade: None,
         };
         StateContext::new(data_dir.to_path_buf(), ConfigHandle::new(config))
@@ -708,6 +709,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            signature: None,
             upgrade: None,
         };
         let sctx = StateContext::new(tmp.path().to_path_buf(), ConfigHandle::new(config));
@@ -800,6 +802,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            signature: None,
             upgrade: None,
         };
         let sctx = StateContext::new(tmp.path().to_path_buf(), ConfigHandle::new(config));
@@ -895,6 +898,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            signature: None,
             upgrade: None,
         };
         let sctx = StateContext::new(tmp.path().to_path_buf(), ConfigHandle::new(config));
@@ -972,6 +976,7 @@ mod tests {
             mailboxes,
             verify_host: None,
             enable_ipv6: false,
+            signature: None,
             upgrade: None,
         };
         let sctx = StateContext::new(tmp.path().to_path_buf(), ConfigHandle::new(config));

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2776,6 +2776,10 @@ fn send_uds_end_to_end_delivers_signed_message() {
         payload_str.contains("From: alice@agent.example.com"),
         "captured message must echo the original From header"
     );
+    assert!(
+        payload_str.contains("Sent from AIMX.") && payload_str.contains("https://aimx.email"),
+        "default signature must be appended to the delivered body when config omits it; got:\n{payload_str}"
+    );
 
     // Cryptographic DKIM body-hash verification using relaxed
     // canonicalization.


### PR DESCRIPTION
## Summary

- Every outbound email now carries a signature appended to the body before DKIM signing. Default is `Sent from AIMX.\nhttps://aimx.email`.
- Operators override via the new top-level `signature` key in `config.toml` — omit for the built-in default, set a string to customize, or set `""` to disable. Implemented as `Option<String>` to match existing `Option<T>` "default + override" precedents (`verify_host`, `upgrade`, per-mailbox `trust` / `trusted_senders`); rejected the alternative of a separate `disable_signature` boolean since the codebase has no such precedent and one field naturally encodes all three states.
- Injection happens daemon-side (`send_handler::append_signature`, called between `inject_message_id_header` and DKIM signing) so the same behavior applies uniformly to `aimx send`, `email_send`, and `email_reply`. Multipart messages get the signature inside the first `text/plain` part (before the next boundary); flat text messages get it appended to the body. Malformed multipart falls back to end-of-body append so DKIM signing stays deterministic.
- `Config` is hot-swappable via `ConfigHandle`, so editing `signature` takes effect on the next send without restarting `aimx serve`.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] `cargo test` — 1050 unit + 106 integration tests pass; 0 failures
- [x] New unit tests for `append_signature`, `extract_multipart_boundary`, and `find_first_part_terminator` (11 tests covering empty-signature noop, text/plain end-append, multipart text-part injection, LF terminator preservation, multibyte signatures, malformed-multipart fallback, quoted/unquoted/case-insensitive boundary parsing)
- [x] New daemon-level tests through `handle_send` (4 tests covering default-when-omitted, custom override, empty disables, and signature-lands-in-text-part for multipart)
- [x] Default-signature assertion added to the existing `send_uds_end_to_end_delivers_signed_message` integration test (real `aimx serve` + `aimx send` round-trip via the file-drop mail transport)
- [x] Manual verification path documented in `book/configuration.md` under the new "Outbound signature" section