### PR TITLE
Group `aimx --help` subcommands by audience

### DIFF
--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -38,10 +38,14 @@ fi
 
 HELP_OUT="$("${HELP_CMD[@]}" 2>/dev/null)"
 
+# Verb listings are indented with two spaces and begin with a
+# lowercase letter. This matches both the legacy clap `Commands:`
+# block and the hand-rolled `after_help` groupings ("Operations (as
+# current user):", "Server administration:") used by `src/cli.rs` to
+# split subcommands by audience.
 VERBS="$(
     printf '%s\n' "${HELP_OUT}" \
-        | awk '/^Commands:/ {flag=1; next} /^[A-Za-z]/ && flag {flag=0} flag' \
-        | awk '{print $1}' \
+        | awk '/^  [a-z][a-z0-9-]*[ \t]+[A-Z]/ {print $1}' \
         | grep -E '^[a-z][a-z0-9-]*$' \
         | sort -u
 )"
@@ -66,6 +70,10 @@ ALLOWED_NON_VERBS=(
     # `#[command(... alias = "...")]` attributes.
     hook
     mailbox
+    # Subcommands marked `#[command(hide = true)]` in `src/cli.rs`.
+    # These do not appear in `aimx --help` but remain valid CLI
+    # entry points and are documented in `book/`.
+    ingest
     # Words that appear after `aimx ` inside quoted-output examples
     # rather than as subcommand invocations (e.g. the success banner
     # `aimx is running for <domain>.` and the upgrade banner

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -3,14 +3,39 @@ use clap::{Parser, Subcommand};
 #[allow(unused_imports)]
 pub use crate::version::{build_date, git_hash, release_tag, target_triple, version_string};
 
+/// Hand-rolled subcommand listing, grouped by audience (per-user vs
+/// server-wide). Clap 4 does not support `help_heading` on subcommand
+/// variants, so the parent's `help_template` omits `{subcommands}` and
+/// injects this string via `{after-help}` instead. Keep the entries in
+/// sync with the `Command` enum below.
+const SUBCOMMAND_HELP: &str = "Operations (as current user):
+  send         Send an email
+  mailboxes    Manage mailboxes
+  hooks        Manage hooks
+  agents       Manage AI agent MCP wiring
+  mcp          Start the stdio MCP server (for AI agents)
+
+Server administration:
+  setup        Run the interactive setup wizard
+  serve        Start the SMTP daemon
+  doctor       Show server health, DNS, and recent logs
+  logs         Tail the aimx service log
+  dkim-keygen  Generate a DKIM keypair
+  portcheck    Check port 25 connectivity (inbound, outbound)
+  uninstall    Uninstall the aimx service (config and data retained)
+  upgrade      Fetch the latest release and swap the installed binary
+
+  help         Print help for a subcommand";
+
 #[derive(Parser)]
 #[command(
     name = "aimx",
-    about = "SMTP for AI agents. No middleman.",
-    long_about = "aimx (AI Mail Exchange). Self-hosted email for AI agents.\n\n\
-                   One command to give your AI agents their own email addresses.\n\
-                   Incoming mail is parsed to Markdown. Outbound mail is DKIM-signed.\n\
-                   MCP is built in. Hooks trigger agent actions on incoming mail.",
+    about = "The internet's oldest protocol, rebuilt for AI agents.",
+    after_help = SUBCOMMAND_HELP,
+    help_template = "{about}\n\n\
+                     {usage-heading} {usage}\
+                     {after-help}\n\n\
+                     Options:\n{options}\n",
     // We render `--version` ourselves so the output is exactly the
     // banner produced by `version_string()`. Clap's built-in version flag
     // would prepend the binary name, yielding `aimx aimx <tag> ...`.
@@ -20,6 +45,16 @@ pub struct Cli {
     /// Data directory override (default: /var/lib/aimx)
     #[arg(long, env = "AIMX_DATA_DIR", global = true)]
     pub data_dir: Option<std::path::PathBuf>,
+
+    // Declared so `--help` renders `-V, --version` alongside the other
+    // options. The flag is intercepted by `handle_version_flag` in
+    // `main.rs` before `Cli::parse()` runs, so this field is never read at
+    // runtime; clap's auto-version is disabled (see `disable_version_flag`
+    // above) so this hand-rolled flag is the only one in the parser.
+    /// Print version
+    #[arg(short = 'V', long = "version", action = clap::ArgAction::SetTrue)]
+    #[allow(dead_code)]
+    pub version: bool,
 
     #[command(subcommand)]
     pub command: Command,
@@ -84,12 +119,13 @@ mod tests {
 #[derive(Subcommand)]
 pub enum Command {
     /// Ingest an email from stdin (called by aimx serve or via stdin)
+    #[command(hide = true)]
     Ingest {
         /// Recipient address (e.g. user@domain.com)
         rcpt: String,
     },
 
-    /// Compose and send an email
+    /// Send an email
     Send(SendArgs),
 
     /// Manage mailboxes
@@ -100,10 +136,10 @@ pub enum Command {
     #[command(subcommand, alias = "hook")]
     Hooks(HookCommand),
 
-    /// Start MCP server in stdio mode
+    /// Start the stdio MCP server (for AI agents)
     Mcp,
 
-    /// Run interactive setup wizard
+    /// Run the interactive setup wizard
     Setup {
         /// Domain to configure (e.g. agent.example.com). Hidden from
         /// --help: the wizard prompts for the domain interactively, but
@@ -117,17 +153,17 @@ pub enum Command {
         verify_host: Option<String>,
     },
 
-    /// Uninstall the aimx daemon service (config and data are retained)
+    /// Uninstall the aimx service (config and data retained)
     Uninstall {
         /// Skip the confirmation prompt
         #[arg(short = 'y', long)]
         yes: bool,
     },
 
-    /// Show server health, mailbox counts, configuration, DNS verification, and recent logs
+    /// Show server health, DNS, and recent logs
     Doctor,
 
-    /// Tail or follow the aimx service log
+    /// Tail the aimx service log
     Logs {
         /// Number of lines to show (default: 50)
         #[arg(long)]
@@ -138,7 +174,7 @@ pub enum Command {
         follow: bool,
     },
 
-    /// Start the embedded SMTP listener daemon
+    /// Start the SMTP daemon
     Serve {
         /// Bind address (default: 0.0.0.0:25)
         #[arg(long, default_value = "0.0.0.0:25")]
@@ -153,18 +189,18 @@ pub enum Command {
         tls_key: Option<String>,
     },
 
-    /// Check port 25 connectivity (outbound, inbound)
+    /// Check port 25 connectivity (inbound, outbound)
     Portcheck {
         /// Override the verify service host (e.g. https://verify.example.com)
         #[arg(long)]
         verify_host: Option<String>,
     },
 
-    /// Manage AI agent MCP wiring (setup / remove / list)
+    /// Manage AI agent MCP wiring
     #[command(subcommand)]
     Agents(AgentsCommand),
 
-    /// Generate DKIM keypair for email signing
+    /// Generate a DKIM keypair
     DkimKeygen {
         /// DKIM selector name
         #[arg(long, default_value = "aimx")]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -170,7 +170,8 @@ fn help_shows_subcommands() {
         .arg("--help")
         .assert()
         .success()
-        .stdout(predicate::str::contains("ingest"))
+        .stdout(predicate::str::contains("Operations (as current user)"))
+        .stdout(predicate::str::contains("Server administration"))
         .stdout(predicate::str::contains("send"))
         .stdout(predicate::str::contains("mailboxes"))
         .stdout(predicate::str::contains("mcp"))
@@ -178,7 +179,10 @@ fn help_shows_subcommands() {
         .stdout(predicate::str::contains("doctor"))
         .stdout(predicate::str::contains("serve"))
         .stdout(predicate::str::contains("portcheck"))
-        .stdout(predicate::str::contains("dkim-keygen"));
+        .stdout(predicate::str::contains("dkim-keygen"))
+        // `ingest` is wired (called by `aimx serve` over stdin) but hidden
+        // from top-level --help so the user-facing command list stays clean.
+        .stdout(predicate::str::contains("ingest").not());
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Splits the flat 14-command list in `aimx --help` into two groups so newcomers can orient themselves at a glance:

- **Operations (as current user):** `send`, `mailboxes`, `hooks`, `agents`, `mcp` — the per-user verbs that the daemon resolves via `SO_PEERCRED`.
- **Server administration:** `setup`, `serve`, `doctor`, `logs`, `dkim-keygen`, `portcheck`, `uninstall`, `upgrade` — the operator-class verbs (most root-gated, `serve` effectively root because it binds `:25`).

Also retitles the tagline to "The internet's oldest protocol, rebuilt for AI agents.", hides the internal-only `ingest` subcommand from top-level `--help`, and tightens every command's one-line description.

### Before / after

Before:
```
Usage: aimx [OPTIONS] <COMMAND>

Commands:
  ingest       Ingest an email from stdin (called by aimx serve or via stdin)
  send         Compose and send an email
  mailboxes    Manage mailboxes
  hooks        Manage hooks
  mcp          Start MCP server in stdio mode
  setup        Run interactive setup wizard
  uninstall    Uninstall the aimx daemon service (config and data are retained)
  doctor       Show server health, mailbox counts, configuration, DNS verification, and recent logs
  logs         Tail or follow the aimx service log
  serve        Start the embedded SMTP listener daemon
  portcheck    Check port 25 connectivity (outbound, inbound)
  agents       Manage AI agent MCP wiring (setup / remove / list)
  dkim-keygen  Generate DKIM keypair for email signing
  help         Print this message or the help of the given subcommand(s)
```

After:
```
The internet's oldest protocol, rebuilt for AI agents.

Usage: aimx [OPTIONS] <COMMAND>

Operations (as current user):
  send         Send an email
  mailboxes    Manage mailboxes
  hooks        Manage hooks
  agents       Manage AI agent MCP wiring
  mcp          Start the stdio MCP server (for AI agents)

Server administration:
  setup        Run the interactive setup wizard
  serve        Start the SMTP daemon
  doctor       Show server health, DNS, and recent logs
  logs         Tail the aimx service log
  dkim-keygen  Generate a DKIM keypair
  portcheck    Check port 25 connectivity (inbound, outbound)
  uninstall    Uninstall the aimx service (config and data retained)
  upgrade      Fetch the latest release and swap the installed binary

  help         Print help for a subcommand

Options:
      --data-dir <DATA_DIR>  Data directory override (default: /var/lib/aimx) [env: AIMX_DATA_DIR=]
  -V, --version              Print version
  -h, --help                 Print help
```

## Implementation notes

- Clap 4.6 doesn't accept `help_heading` on `Subcommand` variants — only on `Arg`. The parent's `help_template` therefore omits `{subcommands}` and injects a hand-rolled grouped list via `{after-help}`. The list lives in a `SUBCOMMAND_HELP` `&str` constant with a maintainer comment to keep it in sync with the `Command` enum (the only real cost of this approach).
- Dropped `long_about` so `-h` and `--help` render identically; the multi-paragraph description it carried lives in `book/` and the README.
- Added a `Cli::version: bool` field purely so clap renders `-V, --version` in the Options block. The existing `handle_version_flag` interceptor in `main.rs` still fires before `Cli::parse()` runs, so the flag is intercepted exactly as before; the field is `#[allow(dead_code)]` and never read.
- `ingest` is now `#[command(hide = true)]`. The subcommand still parses and runs (it's invoked by `aimx serve` over stdin in production), it just no longer clutters top-level help.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo test` — 1175 passing, 0 failing across all suites (8/8 help-related integration tests pass)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt -- --check` — clean
- [x] Manual: `aimx --help` and `aimx -h` both render the new grouped layout
- [x] Manual: `aimx ingest <rcpt>` still parses and runs (verified hidden, not removed)
- [x] Manual: `aimx --version` still prints the custom banner via `handle_version_flag`
- [x] `aimx <subcommand> --help` unchanged (each subcommand keeps its own auto-rendered help)

🤖 Generated with [Claude Code](https://claude.com/claude-code)