### PR TITLE
install.sh: prompt to re-run setup when AIMX is already installed + capitalize brand prose

### DIFF
--- a/book/installation.md
+++ b/book/installation.md
@@ -35,7 +35,7 @@ The shell script is thin: it acquires `sudo` up front, downloads the binary, and
 6. Extracts into a temp directory cleaned up on every exit path.
 7. Installs the binary as `install -m 0755 /usr/local/bin/aimx` (override with `--to` / `AIMX_PREFIX`).
 8. On a fresh box, backs up any pre-existing `/etc/aimx/config.toml` to `config.toml.bak-YYYYMMDD-HHMMSS`, then `exec`s `sudo aimx setup </dev/tty`. DKIM keys and STARTTLS certs are preserved across re-runs.
-9. If an older `aimx` is already installed, the upgrade path runs instead: stop the service, swap the binary atomically, restart. No wizard re-run. If the running version matches the target, it exits without touching anything (pass `--force` to reinstall).
+9. If an older `aimx` is already installed, the upgrade path runs instead: stop the service, swap the binary atomically, restart. No wizard re-run. If the running version matches the target, the script asks `AIMX is already installed. Re-run setup to (re)configure it? [y/N]` — answer `y` to skip the download and re-enter `aimx setup` (handy if you aborted the wizard partway through), or `N` / Enter / no usable TTY (CI, scripted callers) to exit `0` without touching anything. `--force` skips the prompt and reinstalls the binary.
 
 In CI / non-TTY contexts, set `AIMX_NONINTERACTIVE=1` and supply defaults — see [Setup](setup.md).
 

--- a/book/release-notes.md
+++ b/book/release-notes.md
@@ -91,6 +91,14 @@ When the tags differ, restart the service (`systemctl restart aimx`, or `rc-serv
 - A new `pgrep`-based detector warns (never signals) when a manually-launched `aimx serve` is running outside systemd / OpenRC.
 - A single post-start `systemctl is-active` check confirms the daemon came up, with a `journalctl -u aimx -n 20` hint on failure.
 
+### `install.sh` recovery prompt when the binary is already at the target version
+
+Re-running `curl -fsSL https://aimx.email/install.sh | sh` on a host whose `aimx` binary already matches the target tag used to hard-exit with `aimx 0.0.7 is already installed (pass --force to re-install)`. That stranded operators who had aborted partway through `aimx setup` (e.g. to grab a different domain) and now wanted to redo configuration — they had to know about `--force`, which implies a binary swap they don't need.
+
+The script now prompts `AIMX is already installed. Re-run setup to (re)configure it? [y/N]` on that branch. Answer `y` to skip the download/extract/install step entirely (binary is already correct) and fall through to `backup_existing_config` + `exec aimx setup`, the same handoff fresh installs use. Answer `N` (default) or run with no usable TTY (CI, fully-scripted callers, `AIMX_DRY_RUN=1`) and the script keeps the existing exit-0 semantics. `--force` continues to bypass the prompt and reinstall the binary.
+
+Operator-facing prose strings in `install.sh` were also capitalized to **AIMX** to match the wizard. Lowercase `aimx` is preserved for command literals (`aimx setup`), service unit references (`aimx.service`), paths (`/etc/aimx/...`), and the GitHub repo identifier (`uzyn/aimx`).
+
 ### `aimx upgrade` confirms the restart
 
 After `wait_for_service_ready` returns true, `aimx upgrade` prints one extra line:

--- a/install.sh
+++ b/install.sh
@@ -252,13 +252,17 @@ resolve_sudo_prefix() {
 # 1 on no / no usable TTY. Default is no (Enter = no), so non-interactive
 # callers (CI, fully-scripted) keep today's exit-0 semantics.
 #
-# Same TTY logic as ensure_sudo and the post-install handoff: prefer
-# the script's own stdin if it's already a terminal; fall back to
-# /dev/tty when it's a pipe (curl | sh); otherwise no prompt.
+# _prompt_read prints the prompt only when a TTY is available for the
+# answer. Same TTY logic as ensure_sudo and the post-install handoff:
+# prefer the script's own stdin if it's already a terminal; fall back
+# to /dev/tty when it's a pipe (curl | sh); otherwise no prompt at all
+# (so `curl | sh </dev/null` stays quiet — no stray question in CI logs).
 _prompt_read() {
     if [ -t 0 ]; then
+        printf '%s' "$1" >&2
         read -r _ans
     elif [ -e /dev/tty ] && [ -r /dev/tty ]; then
+        printf '%s' "$1" >&2
         read -r _ans </dev/tty
     else
         return 1
@@ -267,8 +271,7 @@ _prompt_read() {
 
 prompt_reinstall() {
     _ans=""
-    printf '%s' 'AIMX is already installed. Re-run setup to (re)configure it? [y/N] ' >&2
-    _prompt_read || return 1
+    _prompt_read 'AIMX is already installed. Re-run setup to (re)configure it? [y/N] ' || return 1
     case "${_ans}" in
         y | Y | yes | YES | Yes) return 0 ;;
         *) return 1 ;;
@@ -1256,10 +1259,13 @@ main() {
                     if [ "${FORCE}" -eq 1 ]; then
                         say "re-installing ${TAG} (--force)"
                         _is_upgrade=1
-                    elif prompt_reinstall; then
+                    elif [ "${DRY_RUN}" != "1" ] && prompt_reinstall; then
                         # Binary is already correct; skip the swap and
                         # jump straight to the wizard. backup_existing_config
                         # below covers any partial config from an aborted run.
+                        # Dry-run never prompts — auditing the script must
+                        # stay non-interactive, matching pre-PR behavior on
+                        # the equal-version branch.
                         _skip_swap=1
                         _is_upgrade=0
                     else

--- a/install.sh
+++ b/install.sh
@@ -114,7 +114,7 @@ ui_success() {
 print_install_banner() {
     printf '\n' >&2
     printf '%s\n' "$(_ui_paint '1;35' 'AIMX installer')" >&2
-    printf '%s\n' "$(_ui_paint 2 '  downloading and installing aimx...')" >&2
+    printf '%s\n' "$(_ui_paint 2 '  downloading and installing AIMX...')" >&2
     printf '\n' >&2
 }
 
@@ -122,7 +122,7 @@ print_install_banner() {
 # is set, so it is visually obvious nothing is installing.
 print_port_check_banner() {
     printf '\n' >&2
-    printf '%s\n' "$(_ui_paint '1;35' 'aimx port 25 connectivity check')" >&2
+    printf '%s\n' "$(_ui_paint '1;35' 'AIMX port 25 connectivity check')" >&2
     printf '%s\n' "$(_ui_paint 2 '  no install will be performed')" >&2
     printf '\n' >&2
 }
@@ -167,7 +167,7 @@ download() {
 
 help() {
     cat <<'EOF'
-aimx install script
+AIMX install script
 
 USAGE:
     install.sh [FLAGS]
@@ -245,6 +245,34 @@ resolve_sudo_prefix() {
     else
         SUDO=""
     fi
+}
+
+# prompt_reinstall — ask the operator whether to re-run `aimx setup`
+# when the binary is already at the target version. Returns 0 on yes,
+# 1 on no / no usable TTY. Default is no (Enter = no), so non-interactive
+# callers (CI, fully-scripted) keep today's exit-0 semantics.
+#
+# Same TTY logic as ensure_sudo and the post-install handoff: prefer
+# the script's own stdin if it's already a terminal; fall back to
+# /dev/tty when it's a pipe (curl | sh); otherwise no prompt.
+_prompt_read() {
+    if [ -t 0 ]; then
+        read -r _ans
+    elif [ -e /dev/tty ] && [ -r /dev/tty ]; then
+        read -r _ans </dev/tty
+    else
+        return 1
+    fi
+}
+
+prompt_reinstall() {
+    _ans=""
+    printf '%s' 'AIMX is already installed. Re-run setup to (re)configure it? [y/N] ' >&2
+    _prompt_read || return 1
+    case "${_ans}" in
+        y | Y | yes | YES | Yes) return 0 ;;
+        *) return 1 ;;
+    esac
 }
 
 ensure_sudo() {
@@ -331,7 +359,7 @@ detect_os() {
     case "${_os}" in
         Linux) printf 'linux' ;;
         *)
-            err "aimx is Linux-only; detected ${_os}. See ${UNSUPPORTED_DOC}"
+            err "AIMX is Linux-only; detected ${_os}. See ${UNSUPPORTED_DOC}"
             ;;
     esac
 }
@@ -888,7 +916,7 @@ port_check_inbound() {
         # /probe can't tell aimx apart from Postfix/Sendmail/Exim, so a
         # green [ok] here is only meaningful if the holder is aimx.
         # Mirrors `aimx portcheck`'s Port25Status::OtherProcess handling.
-        ui_warn "port 25 is held by another process; verify it's aimx before running setup"
+        ui_warn "port 25 is held by another process; verify it's AIMX before running setup"
     else
         # Free or unknown: spawn a temp Python listener if available.
         if ! port_check_have_python3; then
@@ -1225,12 +1253,19 @@ main() {
             _cmp="$(compare_tags "${_installed_tag}" "${TAG}")"
             case "${_cmp}" in
                 equal)
-                    if [ "${FORCE}" -ne 1 ]; then
-                        say "aimx ${_installed_tag} is already installed (pass --force to re-install)"
+                    if [ "${FORCE}" -eq 1 ]; then
+                        say "re-installing ${TAG} (--force)"
+                        _is_upgrade=1
+                    elif prompt_reinstall; then
+                        # Binary is already correct; skip the swap and
+                        # jump straight to the wizard. backup_existing_config
+                        # below covers any partial config from an aborted run.
+                        _skip_swap=1
+                        _is_upgrade=0
+                    else
+                        say "AIMX ${_installed_tag} is already installed (pass --force to re-install)"
                         exit 0
                     fi
-                    say "re-installing ${TAG} (--force)"
-                    _is_upgrade=1
                     ;;
                 newer)
                     err "installed ${_installed_tag} is newer than target ${TAG}; run 'aimx upgrade --version ${TAG} --force' to downgrade explicitly"
@@ -1265,15 +1300,19 @@ main() {
         fi
     fi
 
-    # Download + extract.
-    _tarball="${_td}/${_asset}"
-    say "downloading ${_asset}"
-    download "${_url}" "${_tarball}"
-    verbose "extracting ${_tarball}"
-    (cd "${_td}" && tar -xzf "${_asset}") || err "tar extract failed"
-    _staged="${_td}/aimx-${_version}-${_artifact_target}/aimx"
-    if [ ! -x "${_staged}" ]; then
-        err "extracted tarball missing executable aimx at expected path"
+    # Download + extract. Skipped on the equal-version re-run path
+    # (operator answered "y" to prompt_reinstall) — the binary on disk
+    # already matches the target tag, so we have nothing to download.
+    if [ "${_skip_swap:-0}" -ne 1 ]; then
+        _tarball="${_td}/${_asset}"
+        say "downloading ${_asset}"
+        download "${_url}" "${_tarball}"
+        verbose "extracting ${_tarball}"
+        (cd "${_td}" && tar -xzf "${_asset}") || err "tar extract failed"
+        _staged="${_td}/aimx-${_version}-${_artifact_target}/aimx"
+        if [ ! -x "${_staged}" ]; then
+            err "extracted tarball missing executable aimx at expected path"
+        fi
     fi
 
     if [ "${_is_upgrade}" -eq 1 ]; then
@@ -1324,18 +1363,24 @@ main() {
         fi
 
         if [ -n "${_installed_tag}" ]; then
-            ui_success "aimx upgraded from ${_installed_tag} to ${TAG}"
+            ui_success "AIMX upgraded from ${_installed_tag} to ${TAG}"
         else
-            ui_success "aimx installed at ${TAG}"
+            ui_success "AIMX installed at ${TAG}"
         fi
-        say "upgrade complete. Run 'aimx doctor' for health."
+        say "Upgrade complete. Run 'aimx doctor' for health."
         exit 0
     fi
 
-    # Fresh install path.
-    ${SUDO} install -m 0755 "${_staged}" "${_install_path}" \
-        || err "install failed writing ${_install_path}"
-    ui_success "aimx ${TAG} installed to ${_install_path}"
+    # Fresh install path. On the equal-version re-run path we skip the
+    # binary swap entirely (already at target tag) and fall through to
+    # backup_existing_config + `exec aimx setup` below.
+    if [ "${_skip_swap:-0}" -ne 1 ]; then
+        ${SUDO} install -m 0755 "${_staged}" "${_install_path}" \
+            || err "install failed writing ${_install_path}"
+        ui_success "AIMX ${TAG} installed to ${_install_path}"
+    else
+        ui_info "Re-running AIMX setup (binary unchanged)"
+    fi
 
     # Hand off to the binary. `aimx setup` owns the welcome banner, the
     # six-step checklist, the agents setup drop-through, and the closing

--- a/install.sh
+++ b/install.sh
@@ -298,6 +298,7 @@ ensure_sudo() {
             if [ -t 0 ]; then
                 sudo -v || _sudo_rc=$?
             elif [ -e /dev/tty ] && [ -r /dev/tty ]; then
+                # shellcheck disable=SC2024 # /dev/tty feeds sudo's password prompt under curl|sh, not a privileged file through sudo
                 (sudo -v </dev/tty) || _sudo_rc=$?
             else
                 sudo -v || _sudo_rc=$?
@@ -781,6 +782,7 @@ port_check_ensure_inbound_privilege() {
         if [ -t 0 ]; then
             sudo -v || _sudo_rc=$?
         elif [ -e /dev/tty ] && [ -r /dev/tty ]; then
+            # shellcheck disable=SC2024 # /dev/tty feeds sudo's password prompt under curl|sh, not a privileged file through sudo
             (sudo -v </dev/tty) || _sudo_rc=$?
         else
             sudo -v || _sudo_rc=$?

--- a/tests/install_sh.sh
+++ b/tests/install_sh.sh
@@ -8,6 +8,14 @@
 # real filesystem or network. Sourcing install.sh under INSTALL_SH_TEST=1
 # skips the auto-invocation of `main` at the bottom of the script.
 
+# This file deliberately uses single-quoted strings for printf literals
+# (containing backticks and ${...} for human-facing display) and grep
+# patterns (containing escaped \${...} that must stay literal). Expanding
+# any of them would corrupt either the test output or the regex match,
+# so SC2016 is suppressed file-wide rather than per-line on each of the
+# ~20 sites where the idiom appears.
+# shellcheck disable=SC2016
+
 set -eu
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
@@ -207,16 +215,35 @@ else
 fi
 
 # (c) The redirected `exec ${SUDO} aimx setup </dev/tty` form must appear
-#     exactly once and its preceding line must be an `elif [ -e /dev/tty`
-#     guard (i.e., reached only when [ -t 0 ] was already false).
+#     exactly once and the nearest preceding code line must be an
+#     `elif [ -e /dev/tty` guard (i.e., reached only when [ -t 0 ] was
+#     already false). We walk back over comments and blank lines so
+#     intervening shellcheck directives or clarifying comments don't
+#     break the structural assertion.
+_nearest_code_line() {
+    # Print the nearest preceding non-comment, non-blank line of $1's
+    # parent file, where $1 is a 1-based line number. Returns empty
+    # string when no such line exists within 10 lines above.
+    _bound=$(($1 - 10))
+    [ "${_bound}" -lt 1 ] && _bound=1
+    _i=$(($1 - 1))
+    while [ "${_i}" -ge "${_bound}" ]; do
+        _t="$(sed -n "${_i}p" "$2")"
+        case "${_t}" in
+            ''|[[:space:]]*'#'*|'#'*) _i=$((_i - 1)); continue ;;
+            *) printf '%s' "${_t}"; return 0 ;;
+        esac
+    done
+    return 1
+}
+
 _redirected_line="$(grep -n 'exec \${SUDO} aimx setup </dev/tty' "${INSTALL_SH}" || true)"
 _redirected_count="$(printf '%s\n' "${_redirected_line}" | grep -c . || true)"
 if [ "${_redirected_count:-0}" -eq 1 ]; then
     PASS=$((PASS + 1))
     printf '  ok  redirected handoff appears exactly once\n'
     _ln="$(printf '%s' "${_redirected_line}" | cut -d: -f1)"
-    _prev_ln=$((_ln - 1))
-    _prev_text="$(sed -n "${_prev_ln}p" "${INSTALL_SH}")"
+    _prev_text="$(_nearest_code_line "${_ln}" "${INSTALL_SH}" || true)"
     case "${_prev_text}" in
         *"elif [ -e /dev/tty ]"*)
             PASS=$((PASS + 1))
@@ -225,7 +252,7 @@ if [ "${_redirected_count:-0}" -eq 1 ]; then
         *)
             FAIL=$((FAIL + 1))
             FAILED_NAMES="${FAILED_NAMES} tty-stdin-redirect-gate"
-            printf '  FAIL redirected handoff not gated by elif [ -e /dev/tty ] (prev line: %s)\n' "${_prev_text}" >&2
+            printf '  FAIL redirected handoff not gated by elif [ -e /dev/tty ] (nearest code: %s)\n' "${_prev_text}" >&2
             ;;
     esac
 else
@@ -239,8 +266,7 @@ fi
 _sudov_line="$(grep -n 'sudo -v </dev/tty' "${INSTALL_SH}" || true)"
 if [ -n "${_sudov_line}" ]; then
     _ln="$(printf '%s' "${_sudov_line}" | head -n1 | cut -d: -f1)"
-    _prev_ln=$((_ln - 1))
-    _prev_text="$(sed -n "${_prev_ln}p" "${INSTALL_SH}")"
+    _prev_text="$(_nearest_code_line "${_ln}" "${INSTALL_SH}" || true)"
     case "${_prev_text}" in
         *"elif [ -e /dev/tty ]"*)
             PASS=$((PASS + 1))
@@ -249,7 +275,7 @@ if [ -n "${_sudov_line}" ]; then
         *)
             FAIL=$((FAIL + 1))
             FAILED_NAMES="${FAILED_NAMES} sudo-v-redirect-gate"
-            printf '  FAIL sudo -v </dev/tty not gated by elif [ -e /dev/tty ] (prev line: %s)\n' "${_prev_text}" >&2
+            printf '  FAIL sudo -v </dev/tty not gated by elif [ -e /dev/tty ] (nearest code: %s)\n' "${_prev_text}" >&2
             ;;
     esac
 else
@@ -354,6 +380,7 @@ else
     printf '  FAIL original config.toml still present\n' >&2
 fi
 # Some config.toml.bak-* must exist.
+# shellcheck disable=SC2010 # tmpdir filenames are test-controlled (config.toml.bak-<utc>-<pid>)
 _bak="$(ls "${_tmp}/etc/aimx/" 2>/dev/null | grep '^config.toml.bak-' || true)"
 assert_contains "backup file created" "${_bak}" "config.toml.bak-"
 
@@ -1134,6 +1161,7 @@ _out="$(
 assert_zero "backup_existing_config succeeds with empty SUDO (root, no sudo)" "${_rc}"
 assert_contains "SUDO is empty on root" "${_out}" "SUDO=[]"
 # The backup file should exist even though sudo was never called.
+# shellcheck disable=SC2010 # tmpdir filenames are test-controlled (config.toml.bak-<utc>-<pid>)
 _bak="$(ls "${_tmp}/etc/aimx/" 2>/dev/null | grep '^config.toml.bak-' || true)"
 assert_contains "backup created via empty SUDO" "${_bak}" "config.toml.bak-"
 

--- a/tests/install_sh.sh
+++ b/tests/install_sh.sh
@@ -1183,6 +1183,32 @@ assert_not_contains "shell does not print step 6 title" "${_out}" "Set up MCP fo
 assert_not_contains "dry-run does not switch to port-check banner" "${_out}" "AIMX port 25 connectivity check"
 assert_not_contains "dry-run does not show outbound check line" "${_out}" "Outbound port 25"
 
+# Dry-run + equal-version + no-force must stay non-interactive: the
+# prompt_reinstall recovery prompt is for live re-runs only. Auditing
+# the script with AIMX_DRY_RUN=1 must never block on operator input,
+# matching pre-PR behavior on this branch.
+cat > "${_tmp}/bin/aimx" <<'AIMXEOF'
+#!/bin/sh
+# Fake aimx that only knows how to satisfy parse_installed_tag.
+case "$1" in
+    --version) echo "aimx 0.1.0 (deadbeef) x86_64-unknown-linux-gnu built 2026-01-01" ;;
+    *) exit 0 ;;
+esac
+AIMXEOF
+chmod +x "${_tmp}/bin/aimx"
+
+_out="$(
+    AIMX_DRY_RUN=1 \
+    AIMX_PREFIX="${_tmp}/bin" \
+    PATH="${_tmp}/bin:${PATH}" \
+    NO_COLOR=1 \
+    sh "${INSTALL_SH}" --target x86_64-unknown-linux-gnu --tag 0.1.0 2>&1
+)"
+assert_contains "dry-run+equal-version reports already-installed" "${_out}" "AIMX 0.1.0 is already installed"
+assert_not_contains "dry-run+equal-version does not invoke prompt_reinstall" "${_out}" "Re-run setup to (re)configure"
+
+rm -f "${_tmp}/bin/aimx"
+
 # ---------------------------------------------------------------------------
 # 9. prompt_reinstall — equal-version re-run flow
 # ---------------------------------------------------------------------------
@@ -1190,28 +1216,24 @@ assert_not_contains "dry-run does not show outbound check line" "${_out}" "Outbo
 # When `install.sh` finds the binary already at the target tag and --force
 # was not passed, it asks the operator whether to re-run `aimx setup`.
 # The helper is structured around an overridable `_prompt_read` so tests
-# can stub the answer without faking /dev/tty.
+# can stub the answer without faking /dev/tty. The real `_prompt_read`
+# owns the prompt printf and gates it on TTY availability — that's why
+# stubbing `_prompt_read` here also bypasses the prompt printing.
 
 echo "# prompt_reinstall"
 
-_out="$(
-    INSTALL_SH_TEST=1 NO_COLOR=1 sh -c '
-        . "'"${INSTALL_SH}"'"
-        _prompt_read() { _ans="y"; }
-        if prompt_reinstall; then echo YES; else echo NO; fi
-    ' 2>&1
-)"
-assert_contains "prompt_reinstall returns 0 on y" "${_out}" "YES"
-assert_contains "prompt_reinstall prints the prompt to stderr" "${_out}" "AIMX is already installed"
-
-_out="$(
-    INSTALL_SH_TEST=1 NO_COLOR=1 sh -c '
-        . "'"${INSTALL_SH}"'"
-        _prompt_read() { _ans="Yes"; }
-        if prompt_reinstall; then echo YES; else echo NO; fi
-    ' 2>&1
-)"
-assert_contains "prompt_reinstall accepts Yes" "${_out}" "YES"
+# Cover every accept-list value (y, Y, yes, YES, Yes) so a future
+# contributor cannot quietly narrow the case match in prompt_reinstall.
+for _accept in y Y yes YES Yes; do
+    _out="$(
+        INSTALL_SH_TEST=1 NO_COLOR=1 sh -c '
+            . "'"${INSTALL_SH}"'"
+            _prompt_read() { _ans="'"${_accept}"'"; }
+            if prompt_reinstall; then echo YES; else echo NO; fi
+        ' 2>&1
+    )"
+    assert_contains "prompt_reinstall accepts ${_accept}" "${_out}" "YES"
+done
 
 _out="$(
     INSTALL_SH_TEST=1 NO_COLOR=1 sh -c '
@@ -1239,6 +1261,12 @@ _out="$(
     ' 2>&1
 )"
 assert_contains "prompt_reinstall returns 1 when no TTY" "${_out}" "NO"
+# Regression guard: when _prompt_read signals no-TTY, the prompt question
+# itself must not have been printed. Pre-fix the printf lived in
+# prompt_reinstall and fired before the TTY check, leaving a stray
+# "AIMX is already installed..." question in `curl | sh </dev/null`
+# / CI logs even though the script exited 0 cleanly.
+assert_not_contains "prompt_reinstall stays quiet on no TTY" "${_out}" "Re-run setup to (re)configure"
 
 # ---------------------------------------------------------------------------
 # 10. AIMX branding sweep — no lowercase brand-as-noun in install.sh prose

--- a/tests/install_sh.sh
+++ b/tests/install_sh.sh
@@ -699,7 +699,7 @@ _out="$(
     sh "${INSTALL_SH}" --port-check-only --help 2>&1
 )" || _rc=$?
 assert_zero "--port-check-only --help exits 0" "${_rc}"
-assert_contains "--port-check-only --help prints help" "${_out}" "aimx install script"
+assert_contains "--port-check-only --help prints help" "${_out}" "AIMX install script"
 
 # `install.sh --help` mentions port-check-only.
 _rc=0
@@ -730,7 +730,7 @@ _out="$(
         print_port_check_banner
     ' 2>&1
 )"
-assert_contains "port-check banner shows connectivity title" "${_out}" "aimx port 25 connectivity check"
+assert_contains "port-check banner shows connectivity title" "${_out}" "AIMX port 25 connectivity check"
 assert_contains "port-check banner notes no install" "${_out}" "no install will be performed"
 
 # ---------------------------------------------------------------------------
@@ -1180,8 +1180,91 @@ assert_not_contains "shell does not print checklist" "${_out}" "Preflight checks
 assert_not_contains "shell does not print step 6 title" "${_out}" "Set up MCP for agent"
 
 # Dry-run must NOT run a port check (no port-check banner emitted).
-assert_not_contains "dry-run does not switch to port-check banner" "${_out}" "aimx port 25 connectivity check"
+assert_not_contains "dry-run does not switch to port-check banner" "${_out}" "AIMX port 25 connectivity check"
 assert_not_contains "dry-run does not show outbound check line" "${_out}" "Outbound port 25"
+
+# ---------------------------------------------------------------------------
+# 9. prompt_reinstall — equal-version re-run flow
+# ---------------------------------------------------------------------------
+#
+# When `install.sh` finds the binary already at the target tag and --force
+# was not passed, it asks the operator whether to re-run `aimx setup`.
+# The helper is structured around an overridable `_prompt_read` so tests
+# can stub the answer without faking /dev/tty.
+
+echo "# prompt_reinstall"
+
+_out="$(
+    INSTALL_SH_TEST=1 NO_COLOR=1 sh -c '
+        . "'"${INSTALL_SH}"'"
+        _prompt_read() { _ans="y"; }
+        if prompt_reinstall; then echo YES; else echo NO; fi
+    ' 2>&1
+)"
+assert_contains "prompt_reinstall returns 0 on y" "${_out}" "YES"
+assert_contains "prompt_reinstall prints the prompt to stderr" "${_out}" "AIMX is already installed"
+
+_out="$(
+    INSTALL_SH_TEST=1 NO_COLOR=1 sh -c '
+        . "'"${INSTALL_SH}"'"
+        _prompt_read() { _ans="Yes"; }
+        if prompt_reinstall; then echo YES; else echo NO; fi
+    ' 2>&1
+)"
+assert_contains "prompt_reinstall accepts Yes" "${_out}" "YES"
+
+_out="$(
+    INSTALL_SH_TEST=1 NO_COLOR=1 sh -c '
+        . "'"${INSTALL_SH}"'"
+        _prompt_read() { _ans="n"; }
+        if prompt_reinstall; then echo YES; else echo NO; fi
+    ' 2>&1
+)"
+assert_contains "prompt_reinstall returns 1 on n" "${_out}" "NO"
+
+_out="$(
+    INSTALL_SH_TEST=1 NO_COLOR=1 sh -c '
+        . "'"${INSTALL_SH}"'"
+        _prompt_read() { _ans=""; }
+        if prompt_reinstall; then echo YES; else echo NO; fi
+    ' 2>&1
+)"
+assert_contains "prompt_reinstall defaults to no on empty input" "${_out}" "NO"
+
+_out="$(
+    INSTALL_SH_TEST=1 NO_COLOR=1 sh -c '
+        . "'"${INSTALL_SH}"'"
+        _prompt_read() { return 1; }
+        if prompt_reinstall; then echo YES; else echo NO; fi
+    ' 2>&1
+)"
+assert_contains "prompt_reinstall returns 1 when no TTY" "${_out}" "NO"
+
+# ---------------------------------------------------------------------------
+# 10. AIMX branding sweep — no lowercase brand-as-noun in install.sh prose
+# ---------------------------------------------------------------------------
+#
+# Lowercase `aimx` is fine for command literals (`aimx setup`), service
+# unit names (`aimx.service`), paths (`/etc/aimx/...`), and the GitHub
+# repo identifier (`uzyn/aimx`). It is NOT fine when the brand is the
+# subject/object of an English sentence in operator-facing strings.
+# Catch the canonical regressions: "installing aimx", "aimx is", and
+# "aimx <ver> installed/upgraded".
+
+echo "# branding"
+
+_brand_hits="$(grep -nE '(installing|installed|upgraded) aimx\b' "${INSTALL_SH}" || true)"
+assert_eq "no 'installing/installed/upgraded aimx' in install.sh" "" "${_brand_hits}"
+
+_brand_hits="$(grep -nE '\baimx is\b' "${INSTALL_SH}" || true)"
+assert_eq "no 'aimx is' prose in install.sh" "" "${_brand_hits}"
+
+# `aimx <SEMVER>` prose ("aimx 0.0.7 is already installed"). Allow path
+# fragments like `aimx-0.0.7-...` (the hyphen separates them) and shell
+# redirects like `aimx 2>/dev/null` (the `>` does). The regex requires
+# the digit-dot-digit shape that real version tokens always have.
+_brand_hits="$(grep -nE 'aimx [0-9]+\.[0-9]' "${INSTALL_SH}" || true)"
+assert_eq "no 'aimx <semver>' prose in install.sh" "" "${_brand_hits}"
 
 # ---------------------------------------------------------------------------
 # Report


### PR DESCRIPTION
## Summary
- When `curl -fsSL https://aimx.email/install.sh | sh` is re-run and the binary already matches the target tag, ask "AIMX is already installed. Re-run setup to (re)configure it? [y/N]" instead of hard-exiting. Lets an operator who aborted partway through `aimx setup` (e.g. to grab a different domain) resume without knowing about `--force`. Default is **No** so non-interactive callers (CI, scripted upgrades) keep today's exit-0 semantics; `--force` still bypasses the prompt. `AIMX_DRY_RUN=1` also bypasses the prompt — auditing the script stays non-interactive.
- On "yes" the script skips the download/extract/install entirely (binary is already correct) and falls through to `backup_existing_config` + `exec aimx setup` — the same handoff fresh installs already use.
- Capitalize the brand name **AIMX** in operator-facing prose. Lowercase `aimx` stays for command literals (`aimx setup`, `aimx doctor`), service unit references (`aimx.service`), paths (`/etc/aimx/...`), and the repo identifier (`uzyn/aimx`).
- Silence pre-existing shellcheck false positives in `install.sh` + `tests/install_sh.sh` (SC2024 on `(sudo -v </dev/tty)`, SC2016 on intentional single-quoted printf/grep literals, SC2010 on `ls | grep` over a test-controlled tmpdir) so the test suite reaches a clean 109/109.

## Why
Re-running `install.sh` after aborting the wizard mid-flow is the natural "I got the wrong domain, let me start over" recovery path, but today it dead-ends on `aimx 0.0.7 is already installed (pass --force to re-install)` — a message that both implies a binary swap the operator doesn't need and isn't discoverable as a recovery handle. The existing `backup_existing_config` rename already protects partial config from clobbering, so the right fix is to ask and fall through.

The brand sweep was raised in the same conversation: the shell wrapper's prose had drifted from the wizard, which already uses `AIMX setup` / `Install AIMX` / `AIMX has been set up successfully` correctly.

## Docs

- `book/installation.md` — rewrote step 9 of the install-flow numbered list to describe the new prompt-on-equal-version behavior, default-no semantics, non-TTY exit-0 path, and `--force` bypass.
- `book/release-notes.md` — added an Unreleased entry under the existing `install.sh` block covering both the recovery prompt and the brand-prose capitalization sweep.

## Test plan
- [x] `sh tests/install_sh.sh` — 109/109 passing.
- [x] `shellcheck install.sh` and `shellcheck -s sh tests/install_sh.sh` both exit 0 with no warnings.
- [x] `sh -n install.sh && sh -n tests/install_sh.sh` — POSIX-clean.
- [x] Prompt assertions cover the full accept-list (y / Y / yes / YES / Yes) plus rejects (n / empty / no-TTY) via an overridable `_prompt_read` stub.
- [x] No-TTY regression assertion: with `_prompt_read` signalling no usable TTY, the prompt question itself does NOT appear in stderr.
- [x] Dry-run regression test: with a fake aimx binary at `${PREFIX}/aimx` reporting the target tag and `AIMX_DRY_RUN=1`, the recovery prompt is never invoked and the script exits 0 with the "AIMX X.Y.Z is already installed" line.
- [x] Branding regressions: `(installing|installed|upgraded) aimx\b`, `\baimx is\b`, and `aimx [0-9]+\.[0-9]` all return zero hits.
- [ ] Manual end-to-end on a real VPS (cannot reproduce in CI):
  - Fresh install → abort wizard at the domain prompt → re-run `install.sh` → confirm prompt appears, Enter exits 0, `y` skips the download and re-enters `aimx setup`.
  - Re-run with `--force` → bypasses the prompt and re-installs.
  - `curl ... | sh </dev/null` (no TTY) → exits 0 with the "already installed" line, no prompt printed.
