### PR TITLE
Steer agents to MCP and load user PATH in setup drop-through

### DIFF
--- a/agents/claude-code/SKILL.md.header
+++ b/agents/claude-code/SKILL.md.header
@@ -1,6 +1,6 @@
 ---
 name: aimx
-description: Self-hosted email for AI agents. Send, read, reply to, and manage email via aimx MCP tools. Invoke when the user asks about sending mail, checking an inbox, replying to a message, or managing mailboxes, or when the conversation references aimx.
+description: Send, read, reply to, and manage email via the aimx MCP tools (`mcp__aimx__email_send`, `mcp__aimx__mailbox_list`, `mcp__aimx__email_reply`, `mcp__aimx__mailbox_create`, etc.). Use the MCP tools, not the `aimx` CLI. Invoke when the user mentions email, mailboxes, sending or reading mail, or aimx.
 author: U-Zyn Chua <chua@uzyn.com>
 ---
 

--- a/agents/common/aimx-primer.md
+++ b/agents/common/aimx-primer.md
@@ -17,6 +17,22 @@ At runtime, `/var/lib/aimx/README.md` is the authoritative guide to the data
 directory layout, written by `aimx setup` and refreshed on `aimx serve`
 startup.
 
+## Use MCP, not the CLI
+
+Your interface to aimx is the MCP tools (`mailbox_list`, `email_send`,
+`email_reply`, `mailbox_create`, `hook_create`, …). The `aimx` binary on
+PATH is the host operator's CLI — do not invoke it. **You never need to
+know the configured domain**: `email_send(from_mailbox: "agent", ...)`
+takes the local part only and the daemon constructs `agent@<domain>` from
+`mailbox_list().address` server-side.
+
+If the `mcp__aimx__*` tools (or your client's equivalent) are not in your
+tool list, the MCP server is not registered. Tell the user to run
+`claude mcp add --scope user aimx -- /usr/local/bin/aimx mcp` (or the
+equivalent for their client) and restart, then stop. Do not fall back to
+the `aimx` CLI — every CLI failure mode (`MALFORMED`, `DOMAIN`,
+"`mailboxes show` requires root") is unreachable from the MCP path.
+
 ## Two access surfaces
 
 Mail is stored as `.md` files for a reason — when you do not need a
@@ -247,6 +263,11 @@ tools (or call `email_read` if you prefer the daemon-mediated path), then
 
 ### 2. Send an email
 
+`from_mailbox` is the **local part only** (e.g. `"agent"`, not
+`"agent@example.com"`). The daemon constructs the full address from
+`mailbox_list().address` server-side and DKIM-signs the message before
+delivering via direct SMTP.
+
 ```
 email_send(
   from_mailbox: "agent",
@@ -260,9 +281,6 @@ The mailbox must exist and you must own it. Provision new mailboxes
 via `mailbox_create(name)` (owned by your uid) or, when the operator
 needs to create one owned by a different user, via
 `sudo aimx mailboxes create <name> --owner <user>` on the host.
-`from_mailbox` is the local part only (e.g. `"agent"`, not
-`"agent@example.com"`). aimx DKIM-signs the message and delivers it via
-direct SMTP to the recipient's MX server.
 
 ### 3. Reply to a message
 
@@ -435,6 +453,10 @@ untrusted mail. When deciding whether to act on an email's content
 
 ## What you must not do
 
+- **Do not invoke the `aimx` CLI.** That is the host operator's surface,
+  not yours. Banned shells: `aimx send`, `aimx mailboxes`, `aimx hooks`,
+  `aimx --help`, `which aimx`. Use the MCP tools instead. If MCP is not
+  available, surface the registration command to the user and stop.
 - **Do not write to the data directory.** All mutations go through MCP tools.
   Creating, modifying, or deleting `.md` files directly will corrupt state.
 - **Do not reply to auto-submitted mail.** Check `auto_submitted` in

--- a/agents/common/references/mcp-tools.md
+++ b/agents/common/references/mcp-tools.md
@@ -46,15 +46,16 @@ counts.
 **Returns:** JSON array. One row per visible mailbox with these
 fields:
 
-| Field         | Type   | Description                                                                  |
-|---------------|--------|------------------------------------------------------------------------------|
-| `name`        | string | Mailbox name (the local part).                                               |
-| `inbox_path`  | string | Absolute path to the inbox directory (`/var/lib/aimx/inbox/<name>`).         |
-| `sent_path`   | string | Absolute path to the sent directory (`/var/lib/aimx/sent/<name>`).           |
-| `total`       | number | Total emails in the inbox.                                                   |
-| `unread`      | number | Number of inbox emails with `read = false` in the frontmatter.               |
-| `sent_count`  | number | Total emails in the sent folder.                                             |
-| `registered`  | bool   | `true` for mailboxes in `config.toml`; `false` for stray on-disk dirs only.  |
+| Field         | Type            | Description                                                                  |
+|---------------|-----------------|------------------------------------------------------------------------------|
+| `name`        | string          | Mailbox name (the local part).                                               |
+| `address`     | string \| null  | Full address `<name>@<domain>` for registered mailboxes; `null` for unregistered stray on-disk dirs. **The substring after `@` is the daemon's primary domain — there is no other API for this.** |
+| `inbox_path`  | string          | Absolute path to the inbox directory (`/var/lib/aimx/inbox/<name>`).         |
+| `sent_path`   | string          | Absolute path to the sent directory (`/var/lib/aimx/sent/<name>`).           |
+| `total`       | number          | Total emails in the inbox.                                                   |
+| `unread`      | number          | Number of inbox emails with `read = false` in the frontmatter.               |
+| `sent_count`  | number          | Total emails in the sent folder.                                             |
+| `registered`  | bool            | `true` for mailboxes in `config.toml`; `false` for stray on-disk dirs only.  |
 
 The empty case returns `[]` (a JSON empty array), never a "no
 mailboxes" string. Mailboxes you do not own are simply absent from
@@ -69,6 +70,7 @@ mailbox_list()
 → [
     {
       "name": "agent",
+      "address": "agent@your.tld",
       "inbox_path": "/var/lib/aimx/inbox/agent",
       "sent_path": "/var/lib/aimx/sent/agent",
       "total": 12,
@@ -272,6 +274,9 @@ custom threading chain.
 
 **Example, plain text:**
 ```
+# `from_mailbox` is the local part only. The daemon derives the
+# full From address from mailbox_list().address — you do not
+# need to know the configured domain.
 email_send(
   from_mailbox: "agent",
   to: "alice@example.com",

--- a/agents/common/references/troubleshooting.md
+++ b/agents/common/references/troubleshooting.md
@@ -15,7 +15,7 @@ AIMX/1 ERR <CODE> <reason>
 |-----------|---------|--------------|----------|
 | `MAILBOX` | From-mailbox not found | The `from_mailbox` does not exist in `config.toml` or is not owned by you | Provision a mailbox owned by your uid via `mailbox_create(name)` over MCP. Cross-uid creates remain operator-only — `sudo aimx mailboxes create <name> --owner <other>`. |
 | `EACCES`  | Not authorized | Caller uid does not own the target mailbox | Confirm via `mailbox_list` that you own the mailbox you are targeting |
-| `DOMAIN`  | Sender domain mismatch | The sender domain does not match the configured primary domain | Use the correct domain; check `/etc/aimx/config.toml` |
+| `DOMAIN`  | Sender domain mismatch | The sender domain does not match the configured primary domain. **Through `email_send` over MCP this is unreachable** — the daemon derives the domain from `mailbox_list().address` automatically | If you saw this, you took the CLI path with a hand-typed `--from <addr>`. Switch to `email_send(from_mailbox: "<local-part>", ...)` |
 | `SIGN`    | DKIM signing failed | DKIM private key missing or corrupted | Re-run `aimx setup` to regenerate keys |
 | `DELIVERY`| Remote MX rejected mail | Recipient server refused the message (permanent) | Check the reason: invalid recipient, blocked sender, policy rejection |
 | `TEMP`    | Temporary delivery failure | Recipient server unavailable or rate-limiting | Retry later. Transient network or server issue |
@@ -49,14 +49,18 @@ sudo aimx serve
 
 ### "sender domain does not match aimx domain"
 
-The `From:` address domain does not match the primary domain configured in
-`/etc/aimx/config.toml`.
+The `From:` address domain does not match the configured primary domain.
 
-**Cause:** Sending from a domain aimx is not configured for.
+**Through `email_send` over MCP this error cannot occur** — the daemon
+resolves the full From address from `mailbox_list().address` for the
+mailbox you named. If you hit this, you took the CLI path with a
+hand-typed `--from <addr>`.
 
-**Recovery:** Verify the `domain` field in `config.toml`. aimx only allows
-sending from the configured primary domain. Any local part is accepted, but
-the domain must match exactly (case-insensitive).
+**Recovery:** Switch to MCP. Call
+`email_send(from_mailbox: "<local-part>", ...)` and let the daemon
+construct the full address. If you genuinely need the domain string
+for some other reason, call `mailbox_list()` and use the substring
+after `@` in any `address` field — there is no other API for it.
 
 ### Mailbox not found
 

--- a/src/agents_setup.rs
+++ b/src/agents_setup.rs
@@ -427,7 +427,7 @@ fn openclaw_hint(data_dir: Option<&Path>) -> String {
 /// Wrap `s` in POSIX-style single quotes, escaping any embedded `'` via the
 /// standard `'\''` concatenation trick so the result is safe to paste into
 /// a shell as a single word. The input may contain any bytes except NUL.
-fn posix_single_quote(s: &str) -> String {
+pub(crate) fn posix_single_quote(s: &str) -> String {
     let mut out = String::with_capacity(s.len() + 2);
     out.push('\'');
     for ch in s.chars() {

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -2407,7 +2407,17 @@ pub fn run_setup(
     // from the `/var/lib/aimx` default resolved below) so the `runuser`
     // re-exec passes `--data-dir <path>` through only when the operator
     // named a path on the command line.
-    let explicit_data_dir: Option<PathBuf> = data_dir.map(|p| p.to_path_buf());
+    //
+    // Canonicalize the path so the dropped-through child resolves it
+    // the same way regardless of cwd. Under `runuser -l` the child's
+    // cwd switches to the user's HOME, so a relative `--data-dir
+    // ./foo` would otherwise resolve against `$HOME` instead of root's
+    // cwd. `canonicalize` requires the path to exist; if it does not
+    // (e.g. operator passed `--data-dir /opt/new` for a fresh install)
+    // we fall back to the original `PathBuf` so the child still gets
+    // the operator's intended absolute path.
+    let explicit_data_dir: Option<PathBuf> =
+        data_dir.map(|p| p.canonicalize().unwrap_or_else(|_| p.to_path_buf()));
     // Install the shared tracing subscriber up front so structured
     // warnings emitted from this path (notably the
     // `EMPTY_TRUSTED_SENDERS_WARNING` under `AIMX_NONINTERACTIVE=1`)
@@ -2723,7 +2733,8 @@ fn print_closing_message(domain: &str) {
     println!();
 }
 
-/// Build the argv we'd hand to `runuser -u <sudo_user> --` so the drop-
+/// Build the argv we'd shell-quote and hand to
+/// `runuser -l <sudo_user> -s /bin/bash -- -ic "<...>"` so the drop-
 /// through re-execs `aimx agents setup` as the invoking user. Pure helper
 /// — no syscalls — so unit tests can assert on the exact argv without
 /// spinning up a process.
@@ -2762,13 +2773,26 @@ pub(crate) fn build_agents_setup_argv(
 /// Drive the drop-through to `aimx agents setup` and return an outcome
 /// the caller maps onto step 6's checklist state.
 ///
-/// 1. If `$SUDO_USER` is set and non-empty → `runuser -u $SUDO_USER --
-///    /proc/self/exe agents setup [--data-dir …]` via `Command::status()`
-///    so the parent `aimx setup` regains control after the TUI exits.
-///    The closing message is printed AFTER this call returns.
+/// 1. If `$SUDO_USER` is set and non-empty → re-exec the resolved aimx
+///    binary as the invoking user via
+///    `runuser -l $SUDO_USER -s /bin/bash -- -ic "<shell-quoted argv>"`.
+///    Control returns here once the child TUI exits so the closing
+///    message can print after `aimx agents setup` finishes.
 /// 2. If `$SUDO_USER` is unset → print the guidance message (naming
 ///    `--dangerously-allow-root` as the root-login option) and return
 ///    [`AgentsSetupOutcome::Skipped`].
+///
+/// We deliberately invoke bash with `-i` (interactive) so that
+/// `~/.bashrc` runs in full. Stock Ubuntu's `~/.bashrc` (seeded from
+/// `/etc/skel/.bashrc`) opens with a non-interactive guard that
+/// `return`s immediately when `$-` does not contain `i` — and any PATH
+/// edits below that guard are skipped. The canonical placements for
+/// `claude` (`~/.npm-global/bin` after `npm config set prefix
+/// '~/.npm-global'`) and the NVM loader both live below the guard, so
+/// without `-i` the dropped-through process can't find `claude` and
+/// MCP auto-registration silently lands in the `CliMissing` fallback.
+/// Forcing `-i` makes `$-` contain `i`, the guard falls through, and
+/// the PATH edits actually run.
 ///
 /// On spawn failure (e.g. `runuser` not installed on a stripped
 /// container image) print the same guidance and return
@@ -2834,14 +2858,24 @@ fn drop_through_to_agents_setup(explicit_data_dir: Option<&Path>) -> AgentsSetup
     // Hand off via `Command::status()` so control returns here once the
     // TUI exits, allowing the closing message to print AFTER agents setup.
     //
-    // `runuser -l USER -c CMD` (login shell) initialises HOME, SHELL,
-    // USER, LOGNAME, and PATH from the user's profile chain
-    // (`~/.bash_profile` → `~/.profile` → `~/.bashrc` on Ubuntu defaults).
-    // Without `-l`, runuser inherits the sudo-scrubbed PATH from
-    // `/etc/sudoers`'s `secure_path` and `claude` (typically at
-    // `~/.npm-global/bin` or under `~/.nvm/...`) is unreachable, so MCP
-    // auto-registration silently `CliMissing`s. The argv must be
-    // shell-quoted because `-c` takes a single command string.
+    // Shape:
+    //   runuser -l <user> -s /bin/bash -- -ic "<shell-quoted argv>"
+    //
+    // The login flag (`-l`) initialises HOME, SHELL, USER, LOGNAME, and
+    // a baseline PATH from the user's profile chain. The interactive
+    // flag (`-i`) is what actually pulls `claude` into PATH on stock
+    // Ubuntu — see the function-level doc above for why a
+    // non-interactive shell skips the `~/.bashrc` body that exports
+    // `~/.npm-global/bin` (and seeds NVM).
+    //
+    // Pinning the shell to `/bin/bash` (rather than the user's login
+    // shell from `/etc/passwd`) keeps the `-i` flag meaningful: a user
+    // on zsh/fish would not source `~/.bashrc` and would re-introduce
+    // the original PATH gap. Bash is a stock package on every supported
+    // distro, so this is a safe assumption.
+    //
+    // The argv must be shell-quoted because the bash invocation reads
+    // the command from a single string passed after `-c` (here `-ic`).
     let cmd = argv
         .iter()
         .map(|a| crate::agents_setup::posix_single_quote(&a.to_string_lossy()))
@@ -2850,7 +2884,10 @@ fn drop_through_to_agents_setup(explicit_data_dir: Option<&Path>) -> AgentsSetup
     match std::process::Command::new("runuser")
         .arg("-l")
         .arg(&sudo_user)
-        .arg("-c")
+        .arg("-s")
+        .arg("/bin/bash")
+        .arg("--")
+        .arg("-ic")
         .arg(&cmd)
         .status()
     {
@@ -6325,6 +6362,94 @@ owner = "aimx-catchall"
              string \"/proc/self/exe\" to runuser — runuser would \
              re-exec itself in its own /proc context"
         );
+    }
+
+    #[test]
+    fn drop_through_uses_interactive_bash_login_shell() {
+        // Regression guard for the runuser invocation shape. Stock
+        // Ubuntu's `~/.bashrc` (seeded from `/etc/skel/.bashrc`) opens
+        // with a non-interactive guard:
+        //
+        //   case $- in *i*) ;; *) return;; esac
+        //
+        // `runuser -l USER -c CMD` runs the user's login shell
+        // non-interactively, the guard returns, and the PATH edits
+        // below it (notably `~/.npm-global/bin` and the NVM loader)
+        // never execute. The drop-through MUST instead invoke an
+        // interactive bash to load `~/.bashrc` in full so `claude` is
+        // reachable when `aimx agents setup` re-execs.
+        //
+        // Lock the new shape (`-l`, `-s /bin/bash`, `--`, `-ic`) and
+        // forbid the old shape (`-u <user> --`, `/proc/self/exe`) by
+        // source-grepping the function body.
+        let source = include_str!("setup.rs");
+        let start = source
+            .find("fn drop_through_to_agents_setup(")
+            .expect("drop_through_to_agents_setup must exist");
+        let end = source[start..]
+            .find("\nfn ")
+            .map(|off| start + off)
+            .unwrap_or(source.len());
+        let body = &source[start..end];
+
+        // New shape: `runuser -l <user> -s /bin/bash -- -ic <cmd>`.
+        assert!(
+            body.contains(".arg(\"-l\")"),
+            "drop_through must use `runuser -l` (login shell) so the \
+             user's profile chain is sourced; got body without `-l`"
+        );
+        assert!(
+            body.contains(".arg(\"-s\")") && body.contains("/bin/bash"),
+            "drop_through must pin the shell to `/bin/bash` via `-s` so \
+             `-i` actually sources `~/.bashrc` regardless of the user's \
+             login-shell setting in /etc/passwd"
+        );
+        assert!(
+            body.contains(".arg(\"-ic\")"),
+            "drop_through must pass `-ic` to bash so `$-` contains `i` \
+             and stock Ubuntu's `~/.bashrc` non-interactive guard does \
+             NOT early-return — otherwise `~/.npm-global/bin` is missing \
+             from PATH and `claude` is unreachable"
+        );
+
+        // Old shape: must NOT call runuser via the non-login `-u` form
+        // that inherits sudo's scrubbed PATH.
+        assert!(
+            !(body.contains(".arg(\"-u\")")
+                && body.contains(".arg(&sudo_user)")
+                && body.contains(".arg(\"--\")")
+                && body.contains(".args(&argv)")),
+            "drop_through must NOT use the non-login `runuser -u USER -- argv` \
+             shape — it inherits sudo's scrubbed PATH and `claude` is \
+             unreachable on stock Ubuntu"
+        );
+
+        // The literal `/proc/self/exe` string must not be handed to
+        // `runuser` as argv[0]; the companion test
+        // `build_agents_setup_argv_uses_resolved_exe_path` already
+        // checks the `PathBuf::from(...)` shape. We add coverage for
+        // shell-quoted forms (`.arg("/proc/self/exe")`,
+        // `Path::new("/proc/self/exe")`, `PathBuf::from(...)`) so a
+        // future refactor that bypasses the helper still trips. Doc
+        // comments inside the function body that *explain* the trap
+        // are allowed; we filter those out before the search.
+        let code_only: String = body
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+        for forbidden in [
+            ".arg(\"/proc/self/exe\")",
+            "Path::new(\"/proc/self/exe\")",
+            "PathBuf::from(\"/proc/self/exe\")",
+        ] {
+            assert!(
+                !code_only.contains(forbidden),
+                "drop_through must NOT hand the literal string \
+                 `/proc/self/exe` to runuser ({forbidden}); resolve via \
+                 `std::env::current_exe()` instead"
+            );
+        }
     }
 
     #[test]

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -2833,11 +2833,25 @@ fn drop_through_to_agents_setup(explicit_data_dir: Option<&Path>) -> AgentsSetup
 
     // Hand off via `Command::status()` so control returns here once the
     // TUI exits, allowing the closing message to print AFTER agents setup.
+    //
+    // `runuser -l USER -c CMD` (login shell) initialises HOME, SHELL,
+    // USER, LOGNAME, and PATH from the user's profile chain
+    // (`~/.bash_profile` → `~/.profile` → `~/.bashrc` on Ubuntu defaults).
+    // Without `-l`, runuser inherits the sudo-scrubbed PATH from
+    // `/etc/sudoers`'s `secure_path` and `claude` (typically at
+    // `~/.npm-global/bin` or under `~/.nvm/...`) is unreachable, so MCP
+    // auto-registration silently `CliMissing`s. The argv must be
+    // shell-quoted because `-c` takes a single command string.
+    let cmd = argv
+        .iter()
+        .map(|a| crate::agents_setup::posix_single_quote(&a.to_string_lossy()))
+        .collect::<Vec<_>>()
+        .join(" ");
     match std::process::Command::new("runuser")
-        .arg("-u")
+        .arg("-l")
         .arg(&sudo_user)
-        .arg("--")
-        .args(&argv)
+        .arg("-c")
+        .arg(&cmd)
         .status()
     {
         Ok(status) if status.success() => AgentsSetupOutcome::Done,


### PR DESCRIPTION
## Summary

Two fixes for an awkward agent UX where the agent took ~10 CLI steps to send a single email — including triggering errors to discover the configured domain — instead of using the MCP tools.

**Part A — Skill docs** make MCP the obvious path:

- `mcp-tools.md`: document the `address` field that `mailbox_list` already returns. One MCP call gives both mailboxes and the configured domain (the substring after `@`). Update the example JSON. Add a comment on the `email_send` example clarifying that `from_mailbox` is the local part only and the daemon derives the full address.
- `troubleshooting.md`: rewrite the `DOMAIN` row and the matching prose entry to note the error is unreachable via MCP and point at `mailbox_list().address` instead of root-only `/etc/aimx/config.toml`.
- `aimx-primer.md`: add a top "Use MCP, not the CLI" section, hoist "`from_mailbox` is the local part only" to lead the Send workflow, and add a "Do not invoke the `aimx` CLI" bullet under "What you must not do" with the registration command for the no-MCP case.
- `claude-code/SKILL.md.header`: tighten the frontmatter description to name the `mcp__aimx__*` tools and explicitly say to use the MCP tools, not the `aimx` CLI.

**Part B — Setup drop-through** (root cause: when `install.sh` drops back to the user, `claude` was missing from PATH so MCP auto-registration silently fell into the `CliMissing` branch):

- `setup.rs`: switch `runuser -u USER -- argv` to `runuser -l USER -c "<quoted>"`. The login flag (`-l`) initialises HOME, SHELL, USER, LOGNAME, and PATH from the user's profile chain per `runuser(1)`. Without it, runuser inherits sudo's scrubbed `secure_path` and `claude` (typically at `~/.npm-global/bin` or under `~/.nvm/...`) is unreachable. Reuses the existing `posix_single_quote` helper (promoted to `pub(crate)`) for shell-safe argv joining.

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] Targeted tests pass: `posix_single_quote_escapes_embedded_quote`, all `build_agents_setup_argv*` tests
- [x] Banned-token regex zero hits across `agents/`
- [x] `aimx agents setup claude-code --print` against a tempdir HOME shows: new frontmatter description leads, "Use MCP, not the CLI" section appears, `address` row in `mailbox_list` table, rewritten `DOMAIN` troubleshooting entries, "Do not invoke the `aimx` CLI" bullet
- [ ] End-to-end on a fresh Ubuntu VM: install Claude Code via `npm i -g @anthropic-ai/claude-code` (so `claude` lives at `~/.npm-global/bin/`), then run the install script. Expect the success line for MCP registration (not the silent fallback hint), and `mcp__aimx__*` tools visible in a fresh Claude Code session as `ubuntu` with no manual intervention.
- [ ] Replay the original failing prompt ("Set up a mailbox: daily.finance@ and email me a finance report"). Expect: first action is `mcp__aimx__mailbox_create`, second is `mcp__aimx__email_send` with `from_mailbox: "daily.finance"`, total Bash calls related to aimx: zero.

Note: 3 pre-existing `uds_authz` test failures on macOS (uid 4294967294 resolves to `nobody`) are unrelated and per CI policy AIMX targets ubuntu-latest only.
