### PR TITLE
[Sprint 1] Markdown renderer + inlined stylesheet

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -26,6 +26,7 @@ dependencies = [
  "chrono",
  "clap",
  "colored",
+ "comrak",
  "console",
  "dialoguer",
  "flate2",
@@ -35,6 +36,7 @@ dependencies = [
  "include_dir",
  "lettre",
  "libc",
+ "lol_html",
  "mail-auth",
  "mail-parser",
  "mime_guess",
@@ -67,6 +69,12 @@ dependencies = [
  "uuid",
  "wait-timeout",
 ]
+
+[[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "android_system_properties"
@@ -278,6 +286,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
+name = "caseless"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b6fd507454086c8edfd769ca6ada439193cdb209c7681712ef6275cccbfe5d8"
+dependencies = [
+ "unicode-normalization",
+]
+
+[[package]]
 name = "cc"
 version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -388,6 +405,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "comrak"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aac0b255932a9cd52fbfd664b67957f9f2e095ae4711cb0e41b4e291edef94c2"
+dependencies = [
+ "caseless",
+ "entities",
+ "finl_unicode",
+ "jetscii",
+ "phf",
+ "phf_codegen",
+ "rustc-hash",
+ "smallvec",
+ "typed-arena",
 ]
 
 [[package]]
@@ -517,6 +551,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -591,6 +648,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+]
+
+[[package]]
 name = "dialoguer"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -648,6 +726,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
 name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -679,6 +772,12 @@ checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "entities"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
 
 [[package]]
 name = "enum-as-inner"
@@ -732,6 +831,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -755,6 +860,12 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foldhash"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
@@ -928,7 +1039,7 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
@@ -936,6 +1047,11 @@ name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashify"
@@ -1305,6 +1421,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
+name = "jetscii"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
+
+[[package]]
 name = "jobserver"
 version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +1539,25 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lol_html"
+version = "2.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00aad58f6ec3990e795943872f13651e7a5fa59dca2c8f31a74faf8a0e0fb652"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "cssparser",
+ "encoding_rs",
+ "foldhash 0.2.0",
+ "hashbrown 0.17.0",
+ "memchr",
+ "mime",
+ "precomputed-hash",
+ "selectors",
+ "thiserror",
+]
 
 [[package]]
 name = "mail-auth"
@@ -1741,6 +1882,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
+ "phf_macros",
  "phf_shared",
  "serde",
 ]
@@ -1763,6 +1905,19 @@ checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
  "phf_shared",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2169,6 +2324,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustc-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
+
+[[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2290,6 +2460,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
+name = "selectors"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cfaaa6035167f0e604e42723c7650d59ee269ef220d7bbe0565602c8a0173b9"
+dependencies = [
+ "bitflags",
+ "cssparser",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "rustc-hash",
+ "servo_arc",
+ "smallvec",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2383,6 +2572,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -2852,6 +3050,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typed-path"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -72,6 +72,19 @@ ureq = { version = "3", default-features = false, features = ["rustls-no-provide
 # no symlink handling. `tar` + `flate2` are the obvious minimal deps.
 tar = "0.4"
 flate2 = { version = "1", default-features = false, features = ["rust_backend"] }
+# Markdown → HTML renderer for the rich-text outbound path. Pinned to
+# an exact version because the determinism guarantee (recipient HTML
+# is recoverable by re-rendering the stored Markdown source) only
+# holds across builds when the renderer output is byte-stable.
+# Bumping requires regenerating the checked-in
+# `tests/fixtures/markdown/*.expected.html` fixtures and a release-
+# notes line. Default features (`cli`, `syntect`) are disabled so we
+# don't pull clap/xdg/syntect into the binary.
+comrak = { version = "=0.52.0", default-features = false }
+# Streaming HTML rewriter used by `inline_email_styles` to walk the
+# comrak output and add per-element `style="..."` attributes. Inlining
+# is required because Gmail / Outlook for Web strip `<style>` blocks.
+lol_html = "2"
 # `aimx upgrade` stages the extracted tarball in a tempdir before
 # atomically swapping the binary into place. Pulled into runtime deps
 # (not just dev-deps) so `run_upgrade` can call `tempfile::tempdir`

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,6 +21,14 @@ mod mailbox;
 mod mailbox_handler;
 mod mailbox_list_handler;
 mod mailbox_locks;
+// `markdown_render` lands the renderer used by the daemon's outbound
+// path. The daemon-side wire-up (`send_handler` calling
+// `render_markdown_to_email_html`) lands in a follow-up commit; until
+// then the public surface is consumed only by the module's own tests.
+// `#[allow(dead_code)]` here is scoped to keep `cargo clippy -D
+// warnings` clean without silencing genuinely-dead items elsewhere.
+#[allow(dead_code)]
+mod markdown_render;
 mod mcp;
 mod mx;
 mod ownership;

--- a/src/markdown_render.rs
+++ b/src/markdown_render.rs
@@ -67,6 +67,17 @@ fn comrak_options() -> &'static Options<'static> {
     })
 }
 
+/// Test-only counter incremented immediately before each `comrak` call.
+/// Lets the body-cap test prove comrak never runs on oversize input.
+/// Paired with `COMRAK_PROBE_LOCK` so the observing test can take an
+/// exclusive write-lock that blocks any concurrent renderer thread from
+/// touching the counter mid-measurement.
+#[cfg(test)]
+static COMRAK_INVOCATIONS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+#[cfg(test)]
+static COMRAK_PROBE_LOCK: std::sync::RwLock<()> = std::sync::RwLock::new(());
+
 /// Render a Markdown source to email-ready HTML with inlined per-element
 /// styles. Returns `BodyTooLarge` when the source exceeds the configured
 /// byte cap; comrak is **not** invoked in that case.
@@ -74,6 +85,10 @@ pub fn render_markdown_to_email_html(markdown: &str) -> Result<String, MarkdownR
     if markdown.len() > MAX_MARKDOWN_BODY_BYTES {
         return Err(MarkdownRenderError::BodyTooLarge);
     }
+    #[cfg(test)]
+    let _probe = COMRAK_PROBE_LOCK.read().expect("probe lock poisoned");
+    #[cfg(test)]
+    COMRAK_INVOCATIONS.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let raw_html = markdown_to_html(markdown, comrak_options());
     Ok(inline_email_styles(&raw_html))
 }
@@ -131,7 +146,6 @@ const STYLED_TAGS: &[(&str, &str)] = &[
 /// (the renderer's defaults are appended to the end so inline overrides
 /// keep precedence). Unsupported tags are left untouched.
 pub fn inline_email_styles(html: &str) -> String {
-    use lol_html::html_content::ContentType;
     use lol_html::{HtmlRewriter, Settings, element};
 
     let mut output: Vec<u8> = Vec::with_capacity(html.len() + 1024);
@@ -165,11 +179,20 @@ pub fn inline_email_styles(html: &str) -> String {
         // The rewriter only fails on internal-state issues we don't expect
         // for our well-formed comrak output; fall back to the un-rewritten
         // HTML so a render still produces a usable message.
-        let _ = ContentType::Html;
         return html.to_string();
     }
 
-    String::from_utf8(output).unwrap_or_else(|_| html.to_string())
+    String::from_utf8(output).unwrap_or_else(|_| {
+        // Unreachable today: input is comrak-produced HTML which is always
+        // valid UTF-8, and lol_html only emits the bytes the handlers
+        // produce (also UTF-8 here). Surface a future regression in debug
+        // builds; release builds degrade gracefully to un-styled HTML.
+        debug_assert!(
+            false,
+            "rewriter produced invalid UTF-8 — silent degrade to un-styled HTML",
+        );
+        html.to_string()
+    })
 }
 
 #[cfg(test)]
@@ -190,13 +213,12 @@ mod tests {
 
     #[test]
     fn raw_html_in_markdown_is_neutralised() {
-        // The PRD intent (FR-A2) is that raw HTML embedded in Markdown
-        // never reaches the recipient as an executable element. With
-        // `unsafe = false` plus the GFM tagfilter, comrak strips
-        // disallowed tags (`<script>`, `<iframe>`, …) entirely; for
-        // arbitrary raw HTML it emits the input as a stripped /
-        // escaped form. Both shapes satisfy the security invariant —
-        // assert that, not the exact rendering.
+        // Raw HTML embedded in Markdown must never reach the recipient
+        // as an executable element. With `unsafe = false` plus the GFM
+        // tagfilter, comrak strips disallowed tags (`<script>`,
+        // `<iframe>`, …) entirely; for arbitrary raw HTML it emits the
+        // input as a stripped / escaped form. Both shapes satisfy the
+        // security invariant — assert that, not the exact rendering.
         let out = render_markdown_to_email_html("<script>alert(1)</script>").unwrap();
         assert!(
             !out.contains("<script>"),
@@ -339,14 +361,44 @@ mod tests {
 
     #[test]
     fn oversize_body_does_not_invoke_comrak() {
-        // We can't observe comrak directly, but we can assert that the
-        // returned error is BodyTooLarge for a body that — if comrak ran
-        // — would otherwise produce some HTML output. A body of all `>`
-        // characters would yield blockquote nodes in comrak; here, the
-        // size cap fires first and we get no rendered HTML at all.
+        // The renderer increments `COMRAK_INVOCATIONS` immediately before
+        // each comrak call (test-only) under a shared read-lock on
+        // `COMRAK_PROBE_LOCK`. Taking the write-lock here blocks every
+        // other concurrent renderer thread from touching the counter for
+        // the duration of the measurement, so a stable snapshot proves
+        // the early-return ran before comrak — not just that the error
+        // type matches.
+        use std::sync::atomic::Ordering;
+        let _probe = COMRAK_PROBE_LOCK.write().expect("probe lock poisoned");
+
+        let before = COMRAK_INVOCATIONS.load(Ordering::Relaxed);
         let body = ">".repeat(MAX_MARKDOWN_BODY_BYTES + 1);
         let err = render_markdown_to_email_html(&body).expect_err("expected BodyTooLarge");
+        let after_oversize = COMRAK_INVOCATIONS.load(Ordering::Relaxed);
+
         assert!(matches!(err, MarkdownRenderError::BodyTooLarge));
+        assert_eq!(
+            before, after_oversize,
+            "comrak must not be invoked for an oversize body (before={before}, after={after_oversize})",
+        );
+
+        // Sanity check: an under-cap call DOES tick the counter under the
+        // same write-lock window, so the counter is wired correctly and
+        // the equality above is meaningful rather than vacuous. The
+        // renderer's own read-lock acquisition is reentrant-safe here
+        // because `RwLock::read` from the writer thread on a write-held
+        // lock would deadlock — so we drop the write-lock first, take
+        // the read-lock implicitly via the renderer call, and re-take
+        // the write-lock after to read the counter.
+        drop(_probe);
+        let pre_tick = COMRAK_INVOCATIONS.load(Ordering::Relaxed);
+        let _ = render_markdown_to_email_html("# tick\n").unwrap();
+        let _probe2 = COMRAK_PROBE_LOCK.write().expect("probe lock poisoned");
+        let post_tick = COMRAK_INVOCATIONS.load(Ordering::Relaxed);
+        assert!(
+            post_tick > pre_tick,
+            "under-cap render should tick the counter (pre_tick={pre_tick}, post_tick={post_tick})",
+        );
     }
 
     #[test]

--- a/src/markdown_render.rs
+++ b/src/markdown_render.rs
@@ -1,0 +1,470 @@
+//! Markdown → email-ready HTML renderer.
+//!
+//! Pure transform: a UTF-8 Markdown source becomes a self-contained HTML
+//! document with per-element inlined styles, suitable for use as the
+//! `text/html` part of a `multipart/alternative` outbound message. No I/O,
+//! no remote resources, no `<style>` block — Gmail and Outlook for Web
+//! strip those, so every style lives directly on the element it targets.
+//!
+//! The renderer config (CommonMark + GFM extensions) is built once per
+//! process via `OnceLock` so high-volume sends don't repeat option setup.
+//! Output is deterministic: the same input bytes produce byte-identical
+//! HTML across invocations of the same binary, which is what justifies
+//! storing only the Markdown source in `sent/<mailbox>/` (the recipient's
+//! HTML view is recoverable by re-running this function).
+
+use std::fmt;
+use std::sync::OnceLock;
+
+use comrak::{Options, markdown_to_html};
+
+/// Hard cap on the Markdown source byte length the renderer accepts.
+///
+/// 5 MiB Markdown renders to ~15-25 MiB on the wire after HTML expansion +
+/// base64 transfer-encoding overhead, which sits at the edge of mainstream
+/// receiver limits (Gmail 25 MB, Outlook.com / iCloud 20 MB). Anything
+/// larger belongs as an attachment, not as a body.
+pub const MAX_MARKDOWN_BODY_BYTES: usize = 5 * 1024 * 1024;
+
+/// Errors returned by the renderer entry point.
+#[derive(Debug)]
+pub enum MarkdownRenderError {
+    /// The Markdown source exceeded `MAX_MARKDOWN_BODY_BYTES`.
+    BodyTooLarge,
+}
+
+impl fmt::Display for MarkdownRenderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            MarkdownRenderError::BodyTooLarge => f.write_str(
+                "markdown body exceeds 5MB; use --html-body for pre-rendered large documents or --attachment for sending the document as a file",
+            ),
+        }
+    }
+}
+
+impl std::error::Error for MarkdownRenderError {}
+
+fn comrak_options() -> &'static Options<'static> {
+    static OPTS: OnceLock<Options<'static>> = OnceLock::new();
+    OPTS.get_or_init(|| {
+        let mut opts = Options::default();
+        // GFM extensions per the PRD.
+        opts.extension.table = true;
+        opts.extension.strikethrough = true;
+        opts.extension.autolink = true;
+        opts.extension.tasklist = true;
+        opts.extension.footnotes = true;
+        opts.extension.tagfilter = true;
+        // In-document anchors. Empty prefix keeps generated IDs stable
+        // across versions and matches the un-prefixed shape rich-text
+        // mail clients expect.
+        opts.extension.header_id_prefix = Some(String::new());
+        // Raw HTML embedded in Markdown is escaped, never rendered.
+        // Operators wanting raw HTML pass through use --html-body.
+        opts.render.r#unsafe = false;
+        opts
+    })
+}
+
+/// Render a Markdown source to email-ready HTML with inlined per-element
+/// styles. Returns `BodyTooLarge` when the source exceeds the configured
+/// byte cap; comrak is **not** invoked in that case.
+pub fn render_markdown_to_email_html(markdown: &str) -> Result<String, MarkdownRenderError> {
+    if markdown.len() > MAX_MARKDOWN_BODY_BYTES {
+        return Err(MarkdownRenderError::BodyTooLarge);
+    }
+    let raw_html = markdown_to_html(markdown, comrak_options());
+    Ok(inline_email_styles(&raw_html))
+}
+
+// ---------------------------------------------------------------------------
+// Inlined stylesheet
+// ---------------------------------------------------------------------------
+
+// Per-element styles, baked in as `&'static str` constants. Values are the
+// minimum needed for tasteful rendering across Gmail / Outlook / Apple
+// Mail without external resources. Expand only when a user-visible
+// element renders unstyled.
+const STYLE_BODY: &str = "font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif; line-height: 1.55; max-width: 720px; margin: 0 auto; padding: 16px; color: #1f2328;";
+const STYLE_H1: &str = "font-size: 1.75em; margin: 1.2em 0 0.5em; line-height: 1.25;";
+const STYLE_H2: &str = "font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;";
+const STYLE_H3: &str = "font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;";
+const STYLE_H4: &str = "font-size: 1.05em; margin: 1em 0 0.4em; line-height: 1.3;";
+const STYLE_P: &str = "margin: 0.6em 0;";
+const STYLE_UL: &str = "margin: 0.6em 0; padding-left: 1.4em;";
+const STYLE_OL: &str = "margin: 0.6em 0; padding-left: 1.4em;";
+const STYLE_LI: &str = "margin: 0.2em 0;";
+const STYLE_A: &str = "color: #0b66c2; text-decoration: none;";
+const STYLE_CODE: &str = "font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; background: #f3f4f6; padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.95em;";
+const STYLE_PRE: &str = "font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; background: #f3f4f6; padding: 12px; border-radius: 5px; overflow-x: auto; font-size: 0.95em; line-height: 1.45;";
+const STYLE_BLOCKQUOTE: &str =
+    "border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;";
+const STYLE_TABLE: &str = "border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;";
+const STYLE_TH: &str =
+    "border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;";
+const STYLE_TD: &str = "border: 1px solid #d0d7de; padding: 6px 10px;";
+const STYLE_HR: &str = "border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;";
+
+const STYLED_TAGS: &[(&str, &str)] = &[
+    ("body", STYLE_BODY),
+    ("h1", STYLE_H1),
+    ("h2", STYLE_H2),
+    ("h3", STYLE_H3),
+    ("h4", STYLE_H4),
+    ("p", STYLE_P),
+    ("ul", STYLE_UL),
+    ("ol", STYLE_OL),
+    ("li", STYLE_LI),
+    ("a", STYLE_A),
+    ("code", STYLE_CODE),
+    ("pre", STYLE_PRE),
+    ("blockquote", STYLE_BLOCKQUOTE),
+    ("table", STYLE_TABLE),
+    ("th", STYLE_TH),
+    ("td", STYLE_TD),
+    ("hr", STYLE_HR),
+];
+
+/// Rewrite `html` so each supported tag carries an inline `style="..."`
+/// attribute. Existing `style` attributes on the same tag are preserved
+/// (the renderer's defaults are appended to the end so inline overrides
+/// keep precedence). Unsupported tags are left untouched.
+pub fn inline_email_styles(html: &str) -> String {
+    use lol_html::html_content::ContentType;
+    use lol_html::{HtmlRewriter, Settings, element};
+
+    let mut output: Vec<u8> = Vec::with_capacity(html.len() + 1024);
+    let element_handlers: Vec<_> = STYLED_TAGS
+        .iter()
+        .map(|(tag, style)| {
+            element!(*tag, move |el| {
+                let merged = match el.get_attribute("style") {
+                    Some(existing) if !existing.trim().is_empty() => {
+                        let trimmed = existing.trim_end_matches(';').trim_end();
+                        format!("{trimmed}; {style}")
+                    }
+                    _ => (*style).to_string(),
+                };
+                el.set_attribute("style", &merged)
+                    .expect("style is always a valid attribute name");
+                Ok(())
+            })
+        })
+        .collect();
+
+    let mut rewriter = HtmlRewriter::new(
+        Settings {
+            element_content_handlers: element_handlers,
+            ..Settings::default()
+        },
+        |chunk: &[u8]| output.extend_from_slice(chunk),
+    );
+
+    if rewriter.write(html.as_bytes()).is_err() || rewriter.end().is_err() {
+        // The rewriter only fails on internal-state issues we don't expect
+        // for our well-formed comrak output; fall back to the un-rewritten
+        // HTML so a render still produces a usable message.
+        let _ = ContentType::Html;
+        return html.to_string();
+    }
+
+    String::from_utf8(output).unwrap_or_else(|_| html.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- comrak config + GFM extensions ----
+
+    #[test]
+    fn renders_heading_and_unordered_list() {
+        let out = render_markdown_to_email_html("# Hello\n\n- a\n- b\n").unwrap();
+        assert!(out.contains("<h1"), "missing <h1 tag in {out}");
+        assert!(out.contains(">Hello</h1>"), "missing heading text in {out}");
+        assert!(out.contains("<ul"), "missing <ul tag in {out}");
+        // Two list items.
+        assert_eq!(out.matches("<li").count(), 2, "expected 2 <li in {out}");
+    }
+
+    #[test]
+    fn raw_html_in_markdown_is_neutralised() {
+        // The PRD intent (FR-A2) is that raw HTML embedded in Markdown
+        // never reaches the recipient as an executable element. With
+        // `unsafe = false` plus the GFM tagfilter, comrak strips
+        // disallowed tags (`<script>`, `<iframe>`, …) entirely; for
+        // arbitrary raw HTML it emits the input as a stripped /
+        // escaped form. Both shapes satisfy the security invariant —
+        // assert that, not the exact rendering.
+        let out = render_markdown_to_email_html("<script>alert(1)</script>").unwrap();
+        assert!(
+            !out.contains("<script>"),
+            "raw <script> tag must not survive: {out}",
+        );
+        assert!(
+            !out.contains("alert(1)"),
+            "script body must not survive into output: {out}",
+        );
+
+        // A non-tagfiltered raw element (`<b>`) should not be parsed as
+        // HTML either — the inner text appears, but the angle brackets
+        // are escaped so the recipient sees the literal source.
+        let out2 = render_markdown_to_email_html("<b>bold</b>").unwrap();
+        assert!(
+            !out2.contains("<b>bold</b>"),
+            "raw <b> must not be rendered as HTML: {out2}",
+        );
+        assert!(
+            out2.contains("&lt;b&gt;") || out2.contains("<!-- raw HTML omitted -->"),
+            "expected escaped or stripped raw HTML: {out2}",
+        );
+    }
+
+    #[test]
+    fn gfm_table_renders_with_table_thead_tbody() {
+        let md = "| h1 | h2 |\n|----|----|\n| a  | b  |\n| c  | d  |\n";
+        let out = render_markdown_to_email_html(md).unwrap();
+        assert!(out.contains("<table"), "missing <table in {out}");
+        assert!(out.contains("<thead"), "missing <thead in {out}");
+        assert!(out.contains("<tbody"), "missing <tbody in {out}");
+        assert!(out.contains("<th"), "missing <th in {out}");
+        assert!(out.contains("<td"), "missing <td in {out}");
+    }
+
+    #[test]
+    fn comrak_options_initialise_only_once() {
+        // Both calls return the same pointer, proving the OnceLock is wired.
+        let a = comrak_options() as *const _;
+        let b = comrak_options() as *const _;
+        assert_eq!(a, b, "comrak options should be a process-wide singleton");
+    }
+
+    // ---- inlined stylesheet ----
+
+    #[test]
+    fn h1_carries_inline_style_attribute() {
+        let out = render_markdown_to_email_html("# Title").unwrap();
+        assert!(
+            out.contains("<h1 style=\""),
+            "expected <h1 style=\"...\" in {out}",
+        );
+    }
+
+    #[test]
+    fn no_external_resources_in_output() {
+        let out = render_markdown_to_email_html("# T\n\nbody\n").unwrap();
+        assert!(!out.contains("<style"), "no embedded <style> block: {out}");
+        assert!(!out.contains("<link"), "no <link> elements: {out}");
+        assert!(
+            !out.to_lowercase().contains("http://"),
+            "no remote resources injected by renderer: {out}",
+        );
+        // The comrak output should not reach for fonts.googleapis or any
+        // CDN — our styles are baked-in only.
+        assert!(!out.contains("googleapis"), "no Google Fonts: {out}");
+    }
+
+    #[test]
+    fn autolinked_url_is_anchor_with_inline_style() {
+        let out = render_markdown_to_email_html("Visit https://example.com please.\n").unwrap();
+        assert!(out.contains("<a"), "expected <a element in {out}");
+        // The autolinked anchor must carry our inline style.
+        let a_idx = out.find("<a").expect("anchor exists");
+        let after_a = &out[a_idx..a_idx + 200.min(out.len() - a_idx)];
+        assert!(
+            after_a.contains("style=\""),
+            "anchor missing inline style: {after_a}",
+        );
+        // No underline at rest — the default style omits text-decoration.
+        assert!(
+            !after_a.contains("text-decoration: underline"),
+            "anchor should not be underlined at rest: {after_a}",
+        );
+    }
+
+    #[test]
+    fn nested_pre_code_keeps_both_styles() {
+        let md = "```\nlet x = 1;\n```\n";
+        let out = render_markdown_to_email_html(md).unwrap();
+        // The rewriter should style both the outer <pre> and the inner <code>.
+        let pre_idx = out.find("<pre").expect("expected <pre");
+        let code_idx = out.find("<code").expect("expected <code");
+        assert!(
+            out[pre_idx..pre_idx + 200.min(out.len() - pre_idx)].contains("style=\""),
+            "<pre> missing style: {out}",
+        );
+        assert!(
+            out[code_idx..code_idx + 200.min(out.len() - code_idx)].contains("style=\""),
+            "<code> missing style: {out}",
+        );
+    }
+
+    #[test]
+    fn inline_styles_preserve_existing_style_attribute() {
+        // Synthetic input: an <h1> with a pre-existing style attribute.
+        // The renderer-defaults must be appended without dropping the
+        // existing declaration.
+        let html = "<h1 style=\"color: red\">Hello</h1>";
+        let out = inline_email_styles(html);
+        assert!(out.contains("color: red"), "existing style dropped: {out}");
+        assert!(out.contains("font-size"), "default style missing: {out}");
+    }
+
+    // ---- 5MB body cap ----
+
+    #[test]
+    fn body_at_exact_cap_succeeds() {
+        // Exactly MAX bytes. Use a single-character ASCII so byte length
+        // equals char count.
+        let body = "a".repeat(MAX_MARKDOWN_BODY_BYTES);
+        let result = render_markdown_to_email_html(&body);
+        assert!(
+            result.is_ok(),
+            "body of exactly the cap should render, got {:?}",
+            result.err(),
+        );
+    }
+
+    #[test]
+    fn body_one_byte_over_cap_is_rejected_with_canonical_message() {
+        let body = "a".repeat(MAX_MARKDOWN_BODY_BYTES + 1);
+        let err = render_markdown_to_email_html(&body).expect_err("expected BodyTooLarge");
+        assert!(matches!(err, MarkdownRenderError::BodyTooLarge));
+        assert_eq!(
+            err.to_string(),
+            "markdown body exceeds 5MB; use --html-body for pre-rendered large documents or --attachment for sending the document as a file",
+        );
+    }
+
+    #[test]
+    fn oversize_body_does_not_invoke_comrak() {
+        // We can't observe comrak directly, but we can assert that the
+        // returned error is BodyTooLarge for a body that — if comrak ran
+        // — would otherwise produce some HTML output. A body of all `>`
+        // characters would yield blockquote nodes in comrak; here, the
+        // size cap fires first and we get no rendered HTML at all.
+        let body = ">".repeat(MAX_MARKDOWN_BODY_BYTES + 1);
+        let err = render_markdown_to_email_html(&body).expect_err("expected BodyTooLarge");
+        assert!(matches!(err, MarkdownRenderError::BodyTooLarge));
+    }
+
+    #[test]
+    fn deterministic_output_within_one_process() {
+        let md = "# Hi\n\n- a\n- b\n\n[link](https://example.com)\n";
+        let a = render_markdown_to_email_html(md).unwrap();
+        let b = render_markdown_to_email_html(md).unwrap();
+        assert_eq!(a, b, "renderer must be deterministic in-process");
+    }
+
+    // ---- fixture-backed determinism + drift + perf ----
+
+    const BRIEFING_5KB: &str = include_str!("../tests/fixtures/markdown/briefing-5kb.md");
+    const BRIEFING_5KB_EXPECTED: &str =
+        include_str!("../tests/fixtures/markdown/briefing-5kb.expected.html");
+    const REPORT_50KB: &str = include_str!("../tests/fixtures/markdown/report-50kb.md");
+    const REPORT_50KB_EXPECTED: &str =
+        include_str!("../tests/fixtures/markdown/report-50kb.expected.html");
+
+    /// On drift, the assertion message must point operators at the
+    /// `*.expected.html` files to update **and** prompt for a release-
+    /// notes line. Computed once and reused by both fixture tests.
+    fn drift_help(label: &str) -> String {
+        format!(
+            "renderer output drifted from the checked-in expected HTML for {label}.\n\
+             Update tests/fixtures/markdown/{label}.expected.html with the new bytes \
+             AND add a release-notes line documenting the renderer-version change \
+             (recipient HTML view of every previously-sent message will differ).",
+        )
+    }
+
+    /// When `AIMX_BLESS_EXPECTED=1` is set, write the fresh renderer
+    /// output back to the on-disk expected fixture instead of asserting.
+    /// Lets a maintainer re-bless the fixtures after a deliberate
+    /// renderer-version bump in one `cargo test` invocation. The file
+    /// path is resolved relative to `CARGO_MANIFEST_DIR` so the bless
+    /// step works regardless of cwd.
+    fn maybe_bless(label: &str, fresh: &str) {
+        if std::env::var("AIMX_BLESS_EXPECTED").ok().as_deref() == Some("1") {
+            let manifest = env!("CARGO_MANIFEST_DIR");
+            let path = format!("{manifest}/tests/fixtures/markdown/{label}.expected.html");
+            std::fs::write(&path, fresh).unwrap_or_else(|e| panic!("failed to bless {path}: {e}"));
+        }
+    }
+
+    #[test]
+    fn briefing_fixture_matches_expected_html() {
+        let out = render_markdown_to_email_html(BRIEFING_5KB).unwrap();
+        maybe_bless("briefing-5kb", &out);
+        if std::env::var("AIMX_BLESS_EXPECTED").ok().as_deref() == Some("1") {
+            return;
+        }
+        assert_eq!(out, BRIEFING_5KB_EXPECTED, "{}", drift_help("briefing-5kb"));
+    }
+
+    #[test]
+    fn report_fixture_matches_expected_html() {
+        let out = render_markdown_to_email_html(REPORT_50KB).unwrap();
+        maybe_bless("report-50kb", &out);
+        if std::env::var("AIMX_BLESS_EXPECTED").ok().as_deref() == Some("1") {
+            return;
+        }
+        assert_eq!(out, REPORT_50KB_EXPECTED, "{}", drift_help("report-50kb"));
+    }
+
+    #[test]
+    fn briefing_fixture_renders_deterministically_within_process() {
+        let a = render_markdown_to_email_html(BRIEFING_5KB).unwrap();
+        let b = render_markdown_to_email_html(BRIEFING_5KB).unwrap();
+        assert_eq!(a, b, "briefing render must be byte-stable in-process");
+    }
+
+    #[test]
+    fn report_fixture_renders_deterministically_within_process() {
+        let a = render_markdown_to_email_html(REPORT_50KB).unwrap();
+        let b = render_markdown_to_email_html(REPORT_50KB).unwrap();
+        assert_eq!(a, b, "report render must be byte-stable in-process");
+    }
+
+    #[test]
+    fn briefing_rendered_html_under_25kb() {
+        let out = render_markdown_to_email_html(BRIEFING_5KB).unwrap();
+        assert!(
+            out.len() <= 25 * 1024,
+            "rendered briefing exceeded 25KB: {} bytes",
+            out.len(),
+        );
+    }
+
+    /// Perf bound — only meaningful in release builds. Debug runs the
+    /// renderer ~10x slower and would produce false negatives.
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn render_perf_5kb_under_10ms() {
+        // Warm comrak's OnceLock so the bound measures pure render
+        // time, not the one-shot config init.
+        let _ = render_markdown_to_email_html("# warmup\n").unwrap();
+        let start = std::time::Instant::now();
+        let _ = render_markdown_to_email_html(BRIEFING_5KB).unwrap();
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed.as_millis() < 10,
+            "5KB render took {}ms (budget: <10ms)",
+            elapsed.as_millis(),
+        );
+    }
+
+    #[test]
+    #[cfg(not(debug_assertions))]
+    fn render_perf_50kb_under_50ms() {
+        let _ = render_markdown_to_email_html("# warmup\n").unwrap();
+        let start = std::time::Instant::now();
+        let _ = render_markdown_to_email_html(REPORT_50KB).unwrap();
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed.as_millis() < 50,
+            "50KB render took {}ms (budget: <50ms)",
+            elapsed.as_millis(),
+        );
+    }
+}

--- a/tests/fixtures/markdown/briefing-5kb.expected.html
+++ b/tests/fixtures/markdown/briefing-5kb.expected.html
@@ -1,0 +1,184 @@
+<h1 style="font-size: 1.75em; margin: 1.2em 0 0.5em; line-height: 1.25;"><a href="#daily-finance-briefing--thursday-7-may-2026" aria-hidden="true" class="anchor" id="daily-finance-briefing--thursday-7-may-2026" style="color: #0b66c2; text-decoration: none;"></a>Daily Finance Briefing — Thursday 7 May 2026</h1>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">Markets opened slightly red across the board after the Fed's softer-than-expected
+guidance from the previous session. Traders rotated out of high-multiple growth
+names into defensive sectors as treasury yields ticked higher.</p>
+</blockquote>
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#headlines" aria-hidden="true" class="anchor" id="headlines" style="color: #0b66c2; text-decoration: none;"></a>Headlines</h2>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>S&amp;P 500</strong> finished down 0.42%, snapping a four-day winning streak.</li>
+<li style="margin: 0.2em 0;"><strong>Nasdaq Composite</strong> lost 0.71%, dragged by semiconductors after a downbeat
+outlook from a major foundry.</li>
+<li style="margin: 0.2em 0;"><strong>Brent crude</strong> rose 1.8% to settle at $84.20 a barrel on supply-side concerns.</li>
+<li style="margin: 0.2em 0;"><strong>Gold</strong> held near $2,395/oz; the dollar index closed marginally weaker at 104.6.</li>
+<li style="margin: 0.2em 0;"><strong>10-year Treasury yield</strong> climbed three basis points to 4.21%.</li>
+</ul>
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#sector-performance" aria-hidden="true" class="anchor" id="sector-performance" style="color: #0b66c2; text-decoration: none;"></a>Sector Performance</h2>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Sector</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Day</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Week</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Month</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Energy</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+1.2</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+3.4</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+5.1</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Utilities</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+0.4</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+1.1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+2.7</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Consumer Staples</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+0.1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+0.5</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+1.4</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Financials</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-0.2</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+0.9</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+2.0</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Industrials</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-0.5</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+0.2</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+1.1</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Health Care</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-0.6</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-0.4</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+0.8</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Communication Svcs</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-0.7</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-0.1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+1.5</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Information Tech</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-1.1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-1.4</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+0.3</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Consumer Discr.</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-1.3</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-1.7</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-0.6</td>
+</tr>
+</tbody>
+</table>
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#top-movers" aria-hidden="true" class="anchor" id="top-movers" style="color: #0b66c2; text-decoration: none;"></a>Top Movers</h2>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#gainers" aria-hidden="true" class="anchor" id="gainers" style="color: #0b66c2; text-decoration: none;"></a>Gainers</h3>
+<ol style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;">ExxonMobil (XOM) — up 3.4% on stronger refining margins and a fresh buyback.</li>
+<li style="margin: 0.2em 0;">NextEra Energy (NEE) — up 2.9% after raising full-year guidance.</li>
+<li style="margin: 0.2em 0;">Caterpillar (CAT) — up 2.5% on upbeat construction-equipment demand.</li>
+</ol>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#decliners" aria-hidden="true" class="anchor" id="decliners" style="color: #0b66c2; text-decoration: none;"></a>Decliners</h3>
+<ol style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;">Nvidia (NVDA) — down 4.1% as a key supplier flagged inventory headwinds.</li>
+<li style="margin: 0.2em 0;">Tesla (TSLA) — down 3.6% on a Berlin Gigafactory production-line incident.</li>
+<li style="margin: 0.2em 0;">Meta Platforms (META) — down 2.8% after a critical regulatory ruling in Europe.</li>
+</ol>
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#macro-watch" aria-hidden="true" class="anchor" id="macro-watch" style="color: #0b66c2; text-decoration: none;"></a>Macro Watch</h2>
+<p style="margin: 0.6em 0;">The latest <em>initial-jobless-claims</em> print of <strong>218,000</strong> came in just below
+consensus, suggesting the labor market remains resilient despite higher rates.
+Eyes now turn to tomorrow's <strong>non-farm payrolls</strong> release; consensus expects
+~165k jobs added with average hourly earnings up 0.3% month-on-month.</p>
+<p style="margin: 0.6em 0;">Fed funds futures now imply a ~38% chance of a 25 bp cut at the September
+meeting — down from ~52% earlier in the week. The probability of a cut by
+year-end remains above 85%.</p>
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#notable-earnings" aria-hidden="true" class="anchor" id="notable-earnings" style="color: #0b66c2; text-decoration: none;"></a>Notable Earnings</h2>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>Disney (DIS)</strong> beat on the top and bottom lines, with streaming subscriber
+growth coming in slightly ahead of expectations. Shares were modestly higher
+in after-hours trade.</li>
+<li style="margin: 0.2em 0;"><strong>Shopify (SHOP)</strong> missed on revenue but raised full-year free-cash-flow
+guidance; the stock fell ~7% after hours.</li>
+<li style="margin: 0.2em 0;"><strong>Lyft (LYFT)</strong> turned its first GAAP-positive quarter on cost discipline;
+shares popped ~12% in late trading.</li>
+</ul>
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#crypto" aria-hidden="true" class="anchor" id="crypto" style="color: #0b66c2; text-decoration: none;"></a>Crypto</h2>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Asset</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Price (USD)</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">24h</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Bitcoin</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">64,820</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-1.4%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Ethereum</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">3,140</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-2.0%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Solana</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">142</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-3.1%</td>
+</tr>
+</tbody>
+</table>
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#reading-list" aria-hidden="true" class="anchor" id="reading-list" style="color: #0b66c2; text-decoration: none;"></a>Reading list</h2>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><em>FT</em> — <a href="https://www.example.com/fed-minutes" style="color: #0b66c2; text-decoration: none;">Fed minutes hint at stickier services inflation</a></li>
+<li style="margin: 0.2em 0;"><em>Bloomberg</em> — <a href="https://www.example.com/energy-leadership" style="color: #0b66c2; text-decoration: none;">Why energy is suddenly leading again</a></li>
+<li style="margin: 0.2em 0;"><em>Reuters</em> — <a href="https://www.example.com/no-cut" style="color: #0b66c2; text-decoration: none;">The case against a September cut</a></li>
+</ul>
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#code-snippet-of-the-day" aria-hidden="true" class="anchor" id="code-snippet-of-the-day" style="color: #0b66c2; text-decoration: none;"></a>Code snippet of the day</h2>
+<pre style="font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; background: #f3f4f6; padding: 12px; border-radius: 5px; overflow-x: auto; font-size: 0.95em; line-height: 1.45;"><code class="language-python" style="font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; background: #f3f4f6; padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.95em;">def position_size(equity, risk_pct, stop_distance):
+    risk_dollars = equity * risk_pct
+    return int(risk_dollars / stop_distance)
+</code></pre>
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#coming-up" aria-hidden="true" class="anchor" id="coming-up" style="color: #0b66c2; text-decoration: none;"></a>Coming up</h2>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><del>Tomorrow</del> Friday: Non-farm payrolls, U-Mich consumer sentiment.</li>
+<li style="margin: 0.2em 0;">Next Tuesday: April CPI release (consensus +0.3% m/m headline, +0.3% core).</li>
+<li style="margin: 0.2em 0;">Next Wednesday: 30y Treasury auction; FOMC minutes.</li>
+</ul>
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#risk-notes" aria-hidden="true" class="anchor" id="risk-notes" style="color: #0b66c2; text-decoration: none;"></a>Risk Notes</h2>
+<p style="margin: 0.6em 0;">The cross-asset correlation between equities and bonds remains negative on a
+short-horizon basis, but rolling thirty-day correlations have started to drift
+toward zero again — historically a precursor to <strong>regime change</strong>. Three things
+to watch:</p>
+<ol style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>Real yields</strong> — the 10y TIPS yield is back above 2.0%, the highest since
+the post-COVID re-pricing. A sustained move above 2.25% has historically
+coincided with multiple compression in long-duration equity sectors.</li>
+<li style="margin: 0.2em 0;"><strong>Credit spreads</strong> — investment-grade spreads remain tight (~94 bp), but
+high-yield has widened ~20 bp in the past two weeks. A break above 350 bp
+in the BAML High Yield Index would be the first textbook risk-off signal.</li>
+<li style="margin: 0.2em 0;"><strong>Volatility term structure</strong> — the VIX is well-behaved at 14.2, but the
+3-month / 1-month VIX ratio has flattened, suggesting traders are paying
+up for near-dated protection ahead of the CPI print.</li>
+</ol>
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#glossary-for-new-subscribers" aria-hidden="true" class="anchor" id="glossary-for-new-subscribers" style="color: #0b66c2; text-decoration: none;"></a>Glossary (for new subscribers)</h2>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>Bp (basis point)</strong>: one one-hundredth of a percentage point (0.01%).</li>
+<li style="margin: 0.2em 0;"><strong>Real yield</strong>: the nominal Treasury yield minus the same-tenor breakeven
+inflation rate; what a bondholder earns above expected inflation.</li>
+<li style="margin: 0.2em 0;"><strong>Multiple compression</strong>: a fall in price-to-earnings ratios; usually driven
+by rising discount rates rather than falling earnings.</li>
+</ul>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<p style="margin: 0.6em 0;"><em>Generated by your daily briefing agent. Reply with <code style="font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; background: #f3f4f6; padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.95em;">pause</code> to mute this digest
+for one trading day, or <code style="font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; background: #f3f4f6; padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.95em;">unsubscribe</code> to stop entirely.</em></p>

--- a/tests/fixtures/markdown/briefing-5kb.md
+++ b/tests/fixtures/markdown/briefing-5kb.md
@@ -1,0 +1,124 @@
+# Daily Finance Briefing — Thursday 7 May 2026
+
+> Markets opened slightly red across the board after the Fed's softer-than-expected
+> guidance from the previous session. Traders rotated out of high-multiple growth
+> names into defensive sectors as treasury yields ticked higher.
+
+## Headlines
+
+- **S&P 500** finished down 0.42%, snapping a four-day winning streak.
+- **Nasdaq Composite** lost 0.71%, dragged by semiconductors after a downbeat
+  outlook from a major foundry.
+- **Brent crude** rose 1.8% to settle at $84.20 a barrel on supply-side concerns.
+- **Gold** held near $2,395/oz; the dollar index closed marginally weaker at 104.6.
+- **10-year Treasury yield** climbed three basis points to 4.21%.
+
+## Sector Performance
+
+| Sector              | Day  | Week | Month |
+|---------------------|------|------|-------|
+| Energy              | +1.2 | +3.4 | +5.1  |
+| Utilities           | +0.4 | +1.1 | +2.7  |
+| Consumer Staples    | +0.1 | +0.5 | +1.4  |
+| Financials          | -0.2 | +0.9 | +2.0  |
+| Industrials         | -0.5 | +0.2 | +1.1  |
+| Health Care         | -0.6 | -0.4 | +0.8  |
+| Communication Svcs  | -0.7 | -0.1 | +1.5  |
+| Information Tech    | -1.1 | -1.4 | +0.3  |
+| Consumer Discr.     | -1.3 | -1.7 | -0.6  |
+
+## Top Movers
+
+### Gainers
+
+1. ExxonMobil (XOM) — up 3.4% on stronger refining margins and a fresh buyback.
+2. NextEra Energy (NEE) — up 2.9% after raising full-year guidance.
+3. Caterpillar (CAT) — up 2.5% on upbeat construction-equipment demand.
+
+### Decliners
+
+1. Nvidia (NVDA) — down 4.1% as a key supplier flagged inventory headwinds.
+2. Tesla (TSLA) — down 3.6% on a Berlin Gigafactory production-line incident.
+3. Meta Platforms (META) — down 2.8% after a critical regulatory ruling in Europe.
+
+## Macro Watch
+
+The latest *initial-jobless-claims* print of **218,000** came in just below
+consensus, suggesting the labor market remains resilient despite higher rates.
+Eyes now turn to tomorrow's **non-farm payrolls** release; consensus expects
+~165k jobs added with average hourly earnings up 0.3% month-on-month.
+
+Fed funds futures now imply a ~38% chance of a 25 bp cut at the September
+meeting — down from ~52% earlier in the week. The probability of a cut by
+year-end remains above 85%.
+
+## Notable Earnings
+
+- **Disney (DIS)** beat on the top and bottom lines, with streaming subscriber
+  growth coming in slightly ahead of expectations. Shares were modestly higher
+  in after-hours trade.
+- **Shopify (SHOP)** missed on revenue but raised full-year free-cash-flow
+  guidance; the stock fell ~7% after hours.
+- **Lyft (LYFT)** turned its first GAAP-positive quarter on cost discipline;
+  shares popped ~12% in late trading.
+
+## Crypto
+
+| Asset    | Price (USD) | 24h    |
+|----------|-------------|--------|
+| Bitcoin  | 64,820      | -1.4%  |
+| Ethereum | 3,140       | -2.0%  |
+| Solana   | 142         | -3.1%  |
+
+## Reading list
+
+- *FT* — [Fed minutes hint at stickier services inflation](https://www.example.com/fed-minutes)
+- *Bloomberg* — [Why energy is suddenly leading again](https://www.example.com/energy-leadership)
+- *Reuters* — [The case against a September cut](https://www.example.com/no-cut)
+
+## Code snippet of the day
+
+```python
+def position_size(equity, risk_pct, stop_distance):
+    risk_dollars = equity * risk_pct
+    return int(risk_dollars / stop_distance)
+```
+
+## Coming up
+
+- ~~Tomorrow~~ Friday: Non-farm payrolls, U-Mich consumer sentiment.
+- Next Tuesday: April CPI release (consensus +0.3% m/m headline, +0.3% core).
+- Next Wednesday: 30y Treasury auction; FOMC minutes.
+
+## Risk Notes
+
+The cross-asset correlation between equities and bonds remains negative on a
+short-horizon basis, but rolling thirty-day correlations have started to drift
+toward zero again — historically a precursor to **regime change**. Three things
+to watch:
+
+1. **Real yields** — the 10y TIPS yield is back above 2.0%, the highest since
+   the post-COVID re-pricing. A sustained move above 2.25% has historically
+   coincided with multiple compression in long-duration equity sectors.
+2. **Credit spreads** — investment-grade spreads remain tight (~94 bp), but
+   high-yield has widened ~20 bp in the past two weeks. A break above 350 bp
+   in the BAML High Yield Index would be the first textbook risk-off signal.
+3. **Volatility term structure** — the VIX is well-behaved at 14.2, but the
+   3-month / 1-month VIX ratio has flattened, suggesting traders are paying
+   up for near-dated protection ahead of the CPI print.
+
+## Glossary (for new subscribers)
+
+- **Bp (basis point)**: one one-hundredth of a percentage point (0.01%).
+- **Real yield**: the nominal Treasury yield minus the same-tenor breakeven
+  inflation rate; what a bondholder earns above expected inflation.
+- **Multiple compression**: a fall in price-to-earnings ratios; usually driven
+  by rising discount rates rather than falling earnings.
+
+---
+
+*Generated by your daily briefing agent. Reply with `pause` to mute this digest
+for one trading day, or `unsubscribe` to stop entirely.*
+
+[^1]: Sector returns are price-only and exclude dividends.
+

--- a/tests/fixtures/markdown/report-50kb.expected.html
+++ b/tests/fixtures/markdown/report-50kb.expected.html
@@ -1,0 +1,2704 @@
+<h1 style="font-size: 1.75em; margin: 1.2em 0 0.5em; line-height: 1.25;"><a href="#quarterly-operations-report--q1-2026" aria-hidden="true" class="anchor" id="quarterly-operations-report--q1-2026" style="color: #0b66c2; text-decoration: none;"></a>Quarterly Operations Report — Q1 2026</h1>
+<p style="margin: 0.6em 0;">This report consolidates operational performance across the engineering,
+product, finance, and customer-success organisations for the first quarter
+of 2026. Numbers are unaudited; the finance team's reconciled figures will
+follow within ten business days.</p>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;"><strong>Executive summary.</strong> Q1 came in modestly ahead of plan on revenue, in
+line on gross margin, and meaningfully ahead on operating efficiency.
+Headcount grew 6% year-on-year — well below the 12% planned at the start
+of the year — driven by a deliberate slow-down in non-engineering hires.
+Customer churn ticked up by 40 bp to 2.1% but remains below the
+industry benchmark of ~3%. Three of the four major product launches
+planned for Q1 shipped on time; the fourth (Workflow Studio v3) slipped
+two weeks and is now scheduled for week 4 of Q2.</p>
+</blockquote>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#1-financial-highlights" aria-hidden="true" class="anchor" id="1-financial-highlights" style="color: #0b66c2; text-decoration: none;"></a>1. Financial Highlights</h2>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Metric</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Q1 2026</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Q1 2025</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">YoY</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">vs. plan</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Revenue</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">142.3M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">118.7M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+19.9%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+1.6%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Gross profit</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">109.5M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">91.4M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+19.8%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+0.0%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Gross margin</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">76.9%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">77.0%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-10 bp</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-10 bp</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Operating income</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">28.1M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">19.6M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+43.4%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+14.3%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Operating margin</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">19.8%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">16.5%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+330 bp</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+250 bp</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Free cash flow</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">22.7M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">14.2M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+59.9%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+21.0%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Cash and equivalents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">318.4M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">261.0M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+22.0%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+5.4%</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#11-revenue-mix" aria-hidden="true" class="anchor" id="11-revenue-mix" style="color: #0b66c2; text-decoration: none;"></a>1.1 Revenue mix</h3>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>Subscription revenue</strong> grew 22% year-on-year to USD 128.0M, now 90% of total
+revenue (vs. 88% a year ago). New-logo ARR was USD 14.2M, up 38% YoY; net
+new ARR was USD 11.7M after USD 2.5M of gross churn.</li>
+<li style="margin: 0.2em 0;"><strong>Services revenue</strong> grew 4% to USD 14.3M. The deliberate decision to
+package more of the implementation playbook into self-serve content has
+slowed services growth — exactly as intended.</li>
+<li style="margin: 0.2em 0;"><strong>Top-three customer concentration</strong> fell from 18.4% to 14.1%, a
+healthier balance reflecting the broadening of the enterprise base.</li>
+</ul>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#12-cost-discipline" aria-hidden="true" class="anchor" id="12-cost-discipline" style="color: #0b66c2; text-decoration: none;"></a>1.2 Cost discipline</h3>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Cost line</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Q1 2026</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Q1 2025</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">YoY</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">% of rev</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Cost of revenue</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">32.8M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">27.3M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+20.1%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">23.1%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Sales and marketing</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">41.2M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">38.7M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+6.5%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">28.9%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Research and dev</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">27.4M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">23.5M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+16.6%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">19.3%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">General and admin</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">12.8M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">10.3M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+24.3%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">9.0%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Total opex</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">81.4M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">72.5M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+12.3%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">57.2%</td>
+</tr>
+</tbody>
+</table>
+<p style="margin: 0.6em 0;">Sales and marketing efficiency improved materially: customer acquisition
+cost (CAC) on new logos was USD 11.4k, down from USD 14.1k a year ago, driven
+by a 24% lift in inbound conversion rates after the website re-launch in
+February.</p>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#2-engineering" aria-hidden="true" class="anchor" id="2-engineering" style="color: #0b66c2; text-decoration: none;"></a>2. Engineering</h2>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#21-delivery-cadence" aria-hidden="true" class="anchor" id="21-delivery-cadence" style="color: #0b66c2; text-decoration: none;"></a>2.1 Delivery cadence</h3>
+<p style="margin: 0.6em 0;">The engineering organisation shipped <strong>47 production releases</strong> in Q1, up
+from 38 in Q1 2025. Mean time to production for an approved PR fell from
+2.6 days to 1.8 days, helped by the new merge-queue automation that
+removes the manual rebase step for the long-tail of small PRs.</p>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Quarter</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Releases</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Mean TTP (days)</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">P95 TTP (days)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Q1 2025</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">38</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">2.6</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">6.1</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Q2 2025</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">41</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">2.4</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5.8</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Q3 2025</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">44</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">2.2</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5.4</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Q4 2025</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">46</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">2.0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5.1</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Q1 2026</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">47</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.8</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4.7</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#22-reliability" aria-hidden="true" class="anchor" id="22-reliability" style="color: #0b66c2; text-decoration: none;"></a>2.2 Reliability</h3>
+<p style="margin: 0.6em 0;">Service-level objective attainment for the quarter:</p>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Service</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Target</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Actual</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Status</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Public API (p99 lat.)</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">&lt; 350ms</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">287ms</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Met</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Webhook delivery</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">99.9%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">99.94%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Met</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Auth (uptime)</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">99.99%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">99.987%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Missed</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Reporting (freshness)</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">&lt; 15min</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">11min</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Met</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Dashboard (TTI)</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">&lt; 3.0s</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">2.4s</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Met</td>
+</tr>
+</tbody>
+</table>
+<p style="margin: 0.6em 0;">The single SLO miss — auth uptime — was driven by a 4-minute outage on
+2026-02-19 caused by a cascading restart of the rate-limit cluster after
+an inadvertent config push. The post-incident review identified two
+process changes already in place: dual-control for prod config pushes,
+and a pre-flight canary on the rate-limit nodes before a fleet-wide roll.</p>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#23-tech-debt-reduction" aria-hidden="true" class="anchor" id="23-tech-debt-reduction" style="color: #0b66c2; text-decoration: none;"></a>2.3 Tech-debt reduction</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">The infrastructure team retired the v1 ingestion pipeline this quarter,
+consolidating onto the v2 columnar path. v1 had been receiving
+diminishing share of new traffic for three quarters; deprecation
+reduced our cloud spend by ~USD 240k per quarter and removed a known
+single-point-of-failure in the cross-region replication path.</p>
+</blockquote>
+<p style="margin: 0.6em 0;">Other notable retirements:</p>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>MongoDB to Postgres migration</strong> for the audit-log service: complete.
+Storage cost down ~40%, query latency down ~3x at p95.</li>
+<li style="margin: 0.2em 0;"><strong>Legacy permissions cache</strong>: replaced with the new RLS-aware
+authorization layer. Net reduction of ~14k lines of code.</li>
+<li style="margin: 0.2em 0;"><strong>Dual-write to the analytics warehouse</strong>: removed; CDC pipeline is
+now the sole writer.</li>
+</ul>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#24-hiring" aria-hidden="true" class="anchor" id="24-hiring" style="color: #0b66c2; text-decoration: none;"></a>2.4 Hiring</h3>
+<p style="margin: 0.6em 0;">Engineering added a net 11 people in Q1 (16 hires, 5 departures). Open
+reqs at quarter-end: 8 (down from 14 at the start of the quarter).
+Voluntary attrition annualised: 7.8%, well below the industry benchmark
+of ~12-14%.</p>
+<pre style="font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; background: #f3f4f6; padding: 12px; border-radius: 5px; overflow-x: auto; font-size: 0.95em; line-height: 1.45;"><code class="language-text" style="font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; background: #f3f4f6; padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.95em;">Headcount by team (end of Q1):
+  Platform .................... 22
+  Application ................. 31
+  Data and ML ................. 14
+  Infrastructure ............... 9
+  Security ..................... 6
+  Engineering management ....... 7
+  ----------------------------------
+  Total ....................... 89
+</code></pre>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#3-product" aria-hidden="true" class="anchor" id="3-product" style="color: #0b66c2; text-decoration: none;"></a>3. Product</h2>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#31-launches" aria-hidden="true" class="anchor" id="31-launches" style="color: #0b66c2; text-decoration: none;"></a>3.1 Launches</h3>
+<p style="margin: 0.6em 0;">Three of four planned major launches shipped in Q1:</p>
+<ol style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>Universal Inbox</strong> — beta opened to 800 customers; GA shipped 2026-03-12.
+Adoption is tracking ~2x the comparable launch a year ago, helped by
+in-app onboarding.</li>
+<li style="margin: 0.2em 0;"><strong>Workflow Studio v3</strong> — <em>slipped</em>; now scheduled for 2026-04-22.
+Slip was caused by a rewrite of the canvas renderer to support the
+new branching primitives. Quality bar held; we made the right call.</li>
+<li style="margin: 0.2em 0;"><strong>Reporting v2</strong> — GA shipped 2026-02-04; ~63% of eligible
+customers have migrated within the first eight weeks.</li>
+<li style="margin: 0.2em 0;"><strong>Mobile push for SOC 2 alerts</strong> — shipped 2026-03-28; uptake has
+been concentrated in the security-engineering buyer persona, as
+expected.</li>
+</ol>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#32-adoption-metrics" aria-hidden="true" class="anchor" id="32-adoption-metrics" style="color: #0b66c2; text-decoration: none;"></a>3.2 Adoption metrics</h3>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Feature</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">DAU/MAU</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">WAU/MAU</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Stickiness</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Universal Inbox</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.41</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.78</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">High</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Reporting v2</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.32</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.71</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">High</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Workflow automation</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.29</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.65</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Medium</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Knowledge graph</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.18</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.49</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Low</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">API integrations</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.36</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.74</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">High</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#33-customer-requested-top-10" aria-hidden="true" class="anchor" id="33-customer-requested-top-10" style="color: #0b66c2; text-decoration: none;"></a>3.3 Customer-requested top-10</h3>
+<p style="margin: 0.6em 0;">The product council reviewed the top-10 customer-requested features at
+the end of the quarter. Ranked by weighted ARR exposure:</p>
+<ol style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>Cross-workspace search</strong> — committed to Q2.</li>
+<li style="margin: 0.2em 0;"><strong>SAML group-attribute mapping</strong> — committed to Q2.</li>
+<li style="margin: 0.2em 0;"><strong>Custom retention policies per data type</strong> — Q3 candidate.</li>
+<li style="margin: 0.2em 0;"><strong>Native Slack threading</strong> — shipped (2026-03-19).</li>
+<li style="margin: 0.2em 0;"><strong>Bulk archival via API</strong> — Q3 candidate.</li>
+<li style="margin: 0.2em 0;"><strong>CMK / BYOK for at-rest encryption</strong> — Q3 commit.</li>
+<li style="margin: 0.2em 0;"><strong>Read-only audit-log API</strong> — committed to Q2.</li>
+<li style="margin: 0.2em 0;"><strong>Webhook signing keys (per-endpoint rotation)</strong> — Q3 candidate.</li>
+<li style="margin: 0.2em 0;"><strong>Per-region data residency for EU</strong> — H2 commit.</li>
+<li style="margin: 0.2em 0;"><strong>Real-time presence in shared docs</strong> — Q4 candidate.</li>
+</ol>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#4-customer-success-and-support" aria-hidden="true" class="anchor" id="4-customer-success-and-support" style="color: #0b66c2; text-decoration: none;"></a>4. Customer Success and Support</h2>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#41-net-retention" aria-hidden="true" class="anchor" id="41-net-retention" style="color: #0b66c2; text-decoration: none;"></a>4.1 Net retention</h3>
+<p style="margin: 0.6em 0;">Net dollar retention (NDR) for the quarter was <strong>117%</strong>, in line with
+plan. Gross dollar retention was <strong>94%</strong>, a 50 bp improvement over Q1
+2025. Cohort analysis shows the improvement is concentrated in the
+mid-market segment, where the new account-health scoring is producing
+higher renewal-touch coverage.</p>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Segment</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">NDR</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">GDR</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Logos</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">ARR (M)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Enterprise</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">124%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">97%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">142</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">78.4</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Mid-mkt</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">116%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">95%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">631</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">41.2</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">SMB</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">102%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">88%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4,210</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">22.7</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#42-support" aria-hidden="true" class="anchor" id="42-support" style="color: #0b66c2; text-decoration: none;"></a>4.2 Support</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">Support handled 18,420 tickets in Q1, a 14% increase vs. Q1 2025 — in
+line with the customer-base growth. Median first response was 23
+minutes (target: under 30); median resolution was 7.4 hours (target: under 8).</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Tier</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Tickets</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Median FR</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Median TTR</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">CSAT</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Critical</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">312</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4 min</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.6 hr</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4.6</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">High</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,840</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">11 min</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4.1 hr</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4.5</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Standard</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">12,210</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">27 min</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">8.2 hr</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4.4</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Low</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4,058</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.4 hr</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">18.7 hr</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4.3</td>
+</tr>
+</tbody>
+</table>
+<p style="margin: 0.6em 0;">CSAT (overall): <strong>4.46</strong> out of 5, up from 4.41 in Q4 2025.</p>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#5-risk-register" aria-hidden="true" class="anchor" id="5-risk-register" style="color: #0b66c2; text-decoration: none;"></a>5. Risk Register</h2>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#51-top-risks" aria-hidden="true" class="anchor" id="51-top-risks" style="color: #0b66c2; text-decoration: none;"></a>5.1 Top risks</h3>
+<ol style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>Concentration risk on a single payment processor.</strong> ~62% of
+payment volume flows through one PSP; a 12-week incident in 2025
+demonstrated the impact. Mitigation: integration with a second
+processor is engineering-complete and in finance-side UAT;
+targeted go-live mid-Q2.</li>
+<li style="margin: 0.2em 0;"><strong>Regulatory exposure on cross-border data transfers.</strong> A pending
+ruling in the EU could narrow the lawful basis for some transfers.
+Mitigation: per-region data residency commit (see 3.3 #9).</li>
+<li style="margin: 0.2em 0;"><strong>Senior-engineer attrition concentrated in two teams.</strong> Two staff
+engineers gave notice in Q1; both are in the same team. Mitigation:
+on-the-fly knowledge-share sessions and an active backfill on each
+role; succession plans documented for both.</li>
+</ol>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#52-closed-risks" aria-hidden="true" class="anchor" id="52-closed-risks" style="color: #0b66c2; text-decoration: none;"></a>5.2 Closed risks</h3>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>Auth-cluster single-region exposure</strong> — closed Q1 with the
+multi-region rollout.</li>
+<li style="margin: 0.2em 0;"><strong>No on-call escalation for Reporting</strong> — closed Q1 with the
+reorg of the data team.</li>
+</ul>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#6-people" aria-hidden="true" class="anchor" id="6-people" style="color: #0b66c2; text-decoration: none;"></a>6. People</h2>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#61-headcount" aria-hidden="true" class="anchor" id="61-headcount" style="color: #0b66c2; text-decoration: none;"></a>6.1 Headcount</h3>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Org</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Start of Q1</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Hires</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Leavers</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">End of Q1</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Engineering</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">83</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">16</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">89</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Product</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">18</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">2</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">20</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Design</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">9</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">9</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">GTM</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">41</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">3</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">42</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">G and A</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">14</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">15</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;"><strong>Total</strong></td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;"><strong>165</strong></td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;"><strong>24</strong></td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;"><strong>9</strong></td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;"><strong>175</strong></td>
+</tr>
+</tbody>
+</table>
+<p style="margin: 0.6em 0;">Voluntary attrition annualised: <strong>6.4%</strong> company-wide.</p>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#62-engagement" aria-hidden="true" class="anchor" id="62-engagement" style="color: #0b66c2; text-decoration: none;"></a>6.2 Engagement</h3>
+<p style="margin: 0.6em 0;">Pulse-survey engagement score: <strong>8.1 / 10</strong> (Q4 2025: 8.0). The largest
+positive shift was in <em>clarity of strategy</em> (7.8 to 8.4), reflecting the
+narrative work the leadership team did in late Q4. The largest negative
+shift was in <em>cross-team collaboration</em> (7.6 to 7.2), which the COO is
+addressing with a formal program-management function being stood up
+in Q2.</p>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#7-outlook" aria-hidden="true" class="anchor" id="7-outlook" style="color: #0b66c2; text-decoration: none;"></a>7. Outlook</h2>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#71-q2-commitments" aria-hidden="true" class="anchor" id="71-q2-commitments" style="color: #0b66c2; text-decoration: none;"></a>7.1 Q2 commitments</h3>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>Workflow Studio v3</strong> ships by end of week 4.</li>
+<li style="margin: 0.2em 0;"><strong>Cross-workspace search</strong> ships by end of Q2.</li>
+<li style="margin: 0.2em 0;"><strong>Second payment-processor integration</strong> GA by end of Q2.</li>
+<li style="margin: 0.2em 0;"><strong>Read-only audit-log API</strong> GA by end of Q2.</li>
+<li style="margin: 0.2em 0;"><strong>SAML group-attribute mapping</strong> ships in Q2.</li>
+</ul>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#72-q2-financial-guidance" aria-hidden="true" class="anchor" id="72-q2-financial-guidance" style="color: #0b66c2; text-decoration: none;"></a>7.2 Q2 financial guidance</h3>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Metric</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Guide</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Notes</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Revenue</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">152 to 154M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Low end assumes Workflow Studio slips a third week.</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Gross margin</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">76.5% to 77.5%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;"></td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Operating margin</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">18.5% to 20.0%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;"></td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Free cash flow</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">24 to 27M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;"></td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Net new ARR</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">13 to 15M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;"></td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#73-h2-themes" aria-hidden="true" class="anchor" id="73-h2-themes" style="color: #0b66c2; text-decoration: none;"></a>7.3 H2 themes</h3>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>CMK / BYOK at-rest encryption</strong> as a strategic enterprise unblocker.</li>
+<li style="margin: 0.2em 0;"><strong>Real-time collaboration primitives</strong> in shared docs and dashboards.</li>
+<li style="margin: 0.2em 0;"><strong>EU data residency</strong> as a regulatory hedge and an enterprise sales lever.</li>
+<li style="margin: 0.2em 0;"><strong>Platform observability</strong> — bringing internal SLI / SLO tooling to
+parity with the public-facing reliability surface.</li>
+</ul>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#8-appendix" aria-hidden="true" class="anchor" id="8-appendix" style="color: #0b66c2; text-decoration: none;"></a>8. Appendix</h2>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#81-definitions" aria-hidden="true" class="anchor" id="81-definitions" style="color: #0b66c2; text-decoration: none;"></a>8.1 Definitions</h3>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>ARR (annualised recurring revenue)</strong>: end-of-period MRR multiplied by 12,
+excluding one-time fees and services revenue.</li>
+<li style="margin: 0.2em 0;"><strong>Net dollar retention (NDR)</strong>: ARR from a cohort at the end of the period
+divided by the ARR of that same cohort at the start of the period;
+includes expansion, contraction, and churn.</li>
+<li style="margin: 0.2em 0;"><strong>Gross dollar retention (GDR)</strong>: same numerator excluding expansion;
+measures pure retention on the contracted base.</li>
+<li style="margin: 0.2em 0;"><strong>Mean time to production (TTP)</strong>: median time from &quot;PR approved&quot; to
+&quot;merged commit live in production&quot;.</li>
+</ul>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#82-reading-list" aria-hidden="true" class="anchor" id="82-reading-list" style="color: #0b66c2; text-decoration: none;"></a>8.2 Reading list</h3>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;">Internal: <em>Reliability Review for Q1</em> — published 2026-04-09.</li>
+<li style="margin: 0.2em 0;">Internal: <em>Capacity Plan H2 2026</em> — draft circulating with leadership.</li>
+<li style="margin: 0.2em 0;">External: <a href="https://www.example.com/dora-2025" style="color: #0b66c2; text-decoration: none;">State of DevOps 2025 - DORA report</a>.</li>
+<li style="margin: 0.2em 0;">External: <a href="https://www.example.com/net-retention" style="color: #0b66c2; text-decoration: none;">Why net retention beats new logos in this market</a>.</li>
+</ul>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#83-methodology-notes" aria-hidden="true" class="anchor" id="83-methodology-notes" style="color: #0b66c2; text-decoration: none;"></a>8.3 Methodology notes</h3>
+<p style="margin: 0.6em 0;">Numbers in this report are derived from the standard reporting warehouse
+as of the close of business on 2026-04-04. Any subsequent restatements
+will be reflected in the Q2 report. Historical comparisons use the
+restated 2025 figures published in the Q4 2025 reconciliation memo.</p>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#9-operational-detail-index" aria-hidden="true" class="anchor" id="9-operational-detail-index" style="color: #0b66c2; text-decoration: none;"></a>9. Operational Detail Index</h2>
+<p style="margin: 0.6em 0;">Each operational metric below is captured for archive and for the
+quarter-by-quarter trend file maintained by the program office. Numbers
+are pulled from the standard warehouse and validated by the relevant
+function lead before publication.</p>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#91-engineering-throughput-trends" aria-hidden="true" class="anchor" id="91-engineering-throughput-trends" style="color: #0b66c2; text-decoration: none;"></a>9.1 Engineering throughput trends</h3>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Week</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Releases</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">PRs merged</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Mean LOC</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Defects</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W01</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">84</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">142</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W02</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">3</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">81</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">138</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">2</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W03</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">92</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">161</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W04</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">88</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">154</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W05</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">3</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">79</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">137</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W06</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">91</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">162</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W07</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">85</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">148</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">2</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W08</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">3</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">76</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">132</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W09</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">83</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">149</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W10</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">90</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">158</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W11</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">3</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">78</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">141</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W12</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">86</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">152</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W13</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">3</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">80</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">144</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#92-customer-success-motion" aria-hidden="true" class="anchor" id="92-customer-success-motion" style="color: #0b66c2; text-decoration: none;"></a>9.2 Customer-success motion</h3>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Week</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">New ARR</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Expansion</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Churn</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Net new</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W01</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.91</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.42</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.18</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.15</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W02</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.02</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.51</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.21</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.32</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W03</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.84</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.46</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.17</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.13</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W04</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.92</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.49</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.19</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.22</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W05</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.18</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.52</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.22</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.48</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W06</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.05</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.47</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.20</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.32</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W07</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.96</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.44</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.18</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.22</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W08</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.14</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.51</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.21</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.44</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W09</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.07</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.49</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.19</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.37</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W10</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.21</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.53</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.22</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.52</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W11</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.98</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.48</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.18</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.28</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W12</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.16</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.51</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.20</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.47</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">W13</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.08</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.46</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.19</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.35</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#93-capital-efficiency-metrics" aria-hidden="true" class="anchor" id="93-capital-efficiency-metrics" style="color: #0b66c2; text-decoration: none;"></a>9.3 Capital-efficiency metrics</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">Capital efficiency continues to improve. The &quot;Bessemer Efficiency Score&quot;
+(net new ARR divided by net cash burn) crossed above 1.0 in Q1 for the
+first time, indicating the business is now generating more new ARR
+than it consumes in cash to do so. This is the gating metric for the
+board's IPO-readiness criteria.</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Quarter</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Magic Number</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Burn Multiple</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Bessemer Score</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Q1 2025</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.84</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.42</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.71</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Q2 2025</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.92</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.31</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.79</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Q3 2025</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.97</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.18</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.85</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Q4 2025</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.06</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.04</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.96</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Q1 2026</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.18</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.91</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.10</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#94-marketing-funnel" aria-hidden="true" class="anchor" id="94-marketing-funnel" style="color: #0b66c2; text-decoration: none;"></a>9.4 Marketing funnel</h3>
+<p style="margin: 0.6em 0;">The integrated marketing funnel for the quarter:</p>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Stage</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Volume</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Conv. to next</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Conv. to closed-won</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Visits</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.42M</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4.1%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.18%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Sign-ups</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">58,200</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">42%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4.4%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Activations</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">24,400</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">31%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">10.5%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">SQLs</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">7,560</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">28%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">33.7%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Opportunities</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">2,120</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">51%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">120%*</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Closed-won</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,082</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+</tbody>
+</table>
+<p style="margin: 0.6em 0;">*Opportunity-to-close conversion exceeds 100% in some weeks because the
+opportunity vintage skews older than the close vintage; reported on a
+trailing-twelve-week basis.</p>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#95-compliance-posture" aria-hidden="true" class="anchor" id="95-compliance-posture" style="color: #0b66c2; text-decoration: none;"></a>9.5 Compliance posture</h3>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>SOC 2 Type II</strong> — surveillance audit completed 2026-02-21; clean.</li>
+<li style="margin: 0.2em 0;"><strong>ISO 27001:2022</strong> — certification renewed 2026-03-04; no findings.</li>
+<li style="margin: 0.2em 0;"><strong>GDPR DPIA</strong> — refreshed for the EU residency commit.</li>
+<li style="margin: 0.2em 0;"><strong>HIPAA</strong> — readiness assessment complete; targeting attestation H2.</li>
+</ul>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<p style="margin: 0.6em 0;"><em>Prepared by the Office of the CFO, in collaboration with the Engineering,
+Product, and People organisations.</em></p>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#10-per-region-operational-detail" aria-hidden="true" class="anchor" id="10-per-region-operational-detail" style="color: #0b66c2; text-decoration: none;"></a>10. Per-Region Operational Detail</h2>
+<p style="margin: 0.6em 0;">The four operational regions are tracked individually below. Each region
+is owned by a regional GM with P&amp;L responsibility; the consolidated
+numbers in section 1 roll up the per-region detail in this section.</p>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#101-region-amer" aria-hidden="true" class="anchor" id="101-region-amer" style="color: #0b66c2; text-decoration: none;"></a>10.1 Region: AMER</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">AMER closed Q1 with 67% of new-logo ARR and 71% of total revenue.
+Mid-market grew the fastest at +29% YoY; SMB grew +12% YoY but
+remains the most price-sensitive segment.</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Segment</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">NDR</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">GDR</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Logos</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">ARR (M)</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">New (M)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Enterprise</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">126%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">97%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">84</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">51.8</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4.2</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Mid-mkt</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">119%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">96%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">412</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">28.7</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">3.1</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">SMB</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">104%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">89%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">2,810</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">15.4</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.6</td>
+</tr>
+</tbody>
+</table>
+<h4 style="font-size: 1.05em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#top-accounts-amer" aria-hidden="true" class="anchor" id="top-accounts-amer" style="color: #0b66c2; text-decoration: none;"></a>Top accounts (AMER)</h4>
+<ol style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>Account Alpha</strong> — 6.8M ARR; expansion +1.2M in Q1.</li>
+<li style="margin: 0.2em 0;"><strong>Account Bravo</strong> — 5.4M ARR; renewed flat.</li>
+<li style="margin: 0.2em 0;"><strong>Account Charlie</strong> — 4.9M ARR; expansion +0.4M in Q1.</li>
+<li style="margin: 0.2em 0;"><strong>Account Delta</strong> — 4.1M ARR; renewed flat.</li>
+<li style="margin: 0.2em 0;"><strong>Account Echo</strong> — 3.8M ARR; expansion +0.6M in Q1.</li>
+</ol>
+<h4 style="font-size: 1.05em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#pipeline-amer-end-of-q1" aria-hidden="true" class="anchor" id="pipeline-amer-end-of-q1" style="color: #0b66c2; text-decoration: none;"></a>Pipeline (AMER, end of Q1)</h4>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Stage</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Count</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Weighted (M)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Discovery</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">142</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">7.1</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Validation</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">88</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">9.4</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Proposal</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">51</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">11.8</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Negotiation</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">28</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">8.6</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Closed-won (Q2)</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">12</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4.2</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#102-region-emea" aria-hidden="true" class="anchor" id="102-region-emea" style="color: #0b66c2; text-decoration: none;"></a>10.2 Region: EMEA</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">EMEA grew +24% YoY, ahead of plan. The Northern Europe sub-region
+drove most of the upside, with the new Stockholm and Amsterdam
+account-executive hires already producing closed-won revenue.</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Segment</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">NDR</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">GDR</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Logos</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">ARR (M)</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">New (M)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Enterprise</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">121%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">96%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">38</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">16.4</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.8</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Mid-mkt</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">113%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">94%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">142</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">8.7</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.2</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">SMB</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">100%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">86%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">982</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4.6</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.6</td>
+</tr>
+</tbody>
+</table>
+<h4 style="font-size: 1.05em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#top-accounts-emea" aria-hidden="true" class="anchor" id="top-accounts-emea" style="color: #0b66c2; text-decoration: none;"></a>Top accounts (EMEA)</h4>
+<ol style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>Account Foxtrot</strong> — 3.2M ARR; expansion +0.4M in Q1.</li>
+<li style="margin: 0.2em 0;"><strong>Account Golf</strong> — 2.8M ARR; renewed +0.1M.</li>
+<li style="margin: 0.2em 0;"><strong>Account Hotel</strong> — 2.4M ARR; expansion +0.3M in Q1.</li>
+<li style="margin: 0.2em 0;"><strong>Account India</strong> — 2.1M ARR; renewed flat.</li>
+<li style="margin: 0.2em 0;"><strong>Account Juliet</strong> — 1.9M ARR; expansion +0.2M in Q1.</li>
+</ol>
+<h4 style="font-size: 1.05em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#pipeline-emea-end-of-q1" aria-hidden="true" class="anchor" id="pipeline-emea-end-of-q1" style="color: #0b66c2; text-decoration: none;"></a>Pipeline (EMEA, end of Q1)</h4>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Stage</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Count</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Weighted (M)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Discovery</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">71</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">3.4</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Validation</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">44</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4.8</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Proposal</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">26</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">6.2</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Negotiation</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">14</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4.4</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Closed-won (Q2)</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">6</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">2.1</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#103-region-apac" aria-hidden="true" class="anchor" id="103-region-apac" style="color: #0b66c2; text-decoration: none;"></a>10.3 Region: APAC</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">APAC remains the smallest region but grew the fastest (+38% YoY).
+Japan is the strongest single country; Australia and Singapore continue
+to over-index in mid-market.</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Segment</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">NDR</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">GDR</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Logos</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">ARR (M)</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">New (M)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Enterprise</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">132%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">98%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">14</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">7.4</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.9</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Mid-mkt</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">124%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">97%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">58</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">3.1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.5</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">SMB</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">108%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">91%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">318</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.9</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.3</td>
+</tr>
+</tbody>
+</table>
+<h4 style="font-size: 1.05em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#top-accounts-apac" aria-hidden="true" class="anchor" id="top-accounts-apac" style="color: #0b66c2; text-decoration: none;"></a>Top accounts (APAC)</h4>
+<ol style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>Account Kilo</strong> — 2.0M ARR; expansion +0.3M in Q1.</li>
+<li style="margin: 0.2em 0;"><strong>Account Lima</strong> — 1.5M ARR; renewed +0.1M.</li>
+<li style="margin: 0.2em 0;"><strong>Account Mike</strong> — 1.2M ARR; expansion +0.2M in Q1.</li>
+<li style="margin: 0.2em 0;"><strong>Account November</strong> — 1.1M ARR; renewed flat.</li>
+<li style="margin: 0.2em 0;"><strong>Account Oscar</strong> — 0.9M ARR; expansion +0.1M in Q1.</li>
+</ol>
+<h4 style="font-size: 1.05em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#pipeline-apac-end-of-q1" aria-hidden="true" class="anchor" id="pipeline-apac-end-of-q1" style="color: #0b66c2; text-decoration: none;"></a>Pipeline (APAC, end of Q1)</h4>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Stage</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Count</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Weighted (M)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Discovery</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">38</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.6</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Validation</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">22</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">2.1</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Proposal</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">11</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">2.4</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Negotiation</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">7</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.8</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Closed-won (Q2)</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">3</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.7</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#104-region-latam" aria-hidden="true" class="anchor" id="104-region-latam" style="color: #0b66c2; text-decoration: none;"></a>10.4 Region: LATAM</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">LATAM remains a long-term investment region. The Mexico City team is
+producing strong land-and-expand motion; Brazil opened later than
+planned but is now staffed.</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Segment</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">NDR</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">GDR</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Logos</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">ARR (M)</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">New (M)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Enterprise</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">117%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">95%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">6</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">2.8</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.4</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Mid-mkt</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">109%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">92%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">19</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.7</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.1</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">SMB</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">96%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">84%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">100</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.8</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.1</td>
+</tr>
+</tbody>
+</table>
+<h4 style="font-size: 1.05em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#top-accounts-latam" aria-hidden="true" class="anchor" id="top-accounts-latam" style="color: #0b66c2; text-decoration: none;"></a>Top accounts (LATAM)</h4>
+<ol style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>Account Papa</strong> — 0.9M ARR; expansion +0.1M in Q1.</li>
+<li style="margin: 0.2em 0;"><strong>Account Quebec</strong> — 0.7M ARR; renewed flat.</li>
+<li style="margin: 0.2em 0;"><strong>Account Romeo</strong> — 0.5M ARR; expansion +0.05M in Q1.</li>
+</ol>
+<h4 style="font-size: 1.05em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#pipeline-latam-end-of-q1" aria-hidden="true" class="anchor" id="pipeline-latam-end-of-q1" style="color: #0b66c2; text-decoration: none;"></a>Pipeline (LATAM, end of Q1)</h4>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Stage</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Count</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Weighted (M)</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Discovery</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">18</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.6</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Validation</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">9</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.7</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Proposal</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.8</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Negotiation</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">2</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.5</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Closed-won (Q2)</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.2</td>
+</tr>
+</tbody>
+</table>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#11-engineering-team-detail" aria-hidden="true" class="anchor" id="11-engineering-team-detail" style="color: #0b66c2; text-decoration: none;"></a>11. Engineering Team Detail</h2>
+<p style="margin: 0.6em 0;">Each engineering team submits a quarterly write-up covering velocity,
+on-call posture, and notable shipped work. Excerpts below.</p>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#111-team-platform" aria-hidden="true" class="anchor" id="111-team-platform" style="color: #0b66c2; text-decoration: none;"></a>11.1 Team: Platform</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">The Platform team focused on the v2 ingestion pipeline cutover and
+the new authorisation layer. Both projects shipped on time, and the
+ingestion cutover unlocked the v1 deprecation called out in section
+2.3. The team also picked up two additional rotations on the auth
+on-call calendar to absorb load from the Application team.</p>
+</blockquote>
+<p style="margin: 0.6em 0;">Key shipped work:</p>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>v2 ingestion pipeline cutover</strong> — 100% of new traffic now on v2.</li>
+<li style="margin: 0.2em 0;"><strong>RLS-aware authorisation layer</strong> — replacing the legacy permissions
+cache.</li>
+<li style="margin: 0.2em 0;"><strong>Multi-region rate-limit cluster</strong> — closes the auth single-region
+exposure called out in the Q4 2025 risk register.</li>
+</ul>
+<pre style="font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; background: #f3f4f6; padding: 12px; border-radius: 5px; overflow-x: auto; font-size: 0.95em; line-height: 1.45;"><code class="language-rust" style="font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace; background: #f3f4f6; padding: 0.1em 0.3em; border-radius: 3px; font-size: 0.95em;">// Representative API surface, simplified for the report.
+pub async fn ingest(
+    payload: Payload,
+    tenant: &amp;Tenant,
+) -&gt; Result&lt;Receipt, IngestError&gt; {
+    let normalised = normalise(payload, tenant)?;
+    let receipt = pipeline::v2::accept(normalised, tenant).await?;
+    Ok(receipt)
+}
+</code></pre>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#112-team-application" aria-hidden="true" class="anchor" id="112-team-application" style="color: #0b66c2; text-decoration: none;"></a>11.2 Team: Application</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">Application shipped Universal Inbox GA, Reporting v2 GA, and made
+meaningful progress on Workflow Studio v3. The slip on the latter
+was driven by a deliberate scope addition (canvas-renderer rewrite)
+rather than execution risk.</p>
+</blockquote>
+<p style="margin: 0.6em 0;">Key shipped work:</p>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>Universal Inbox GA</strong> — beta to GA in 8 weeks; in-app onboarding
+shipped alongside.</li>
+<li style="margin: 0.2em 0;"><strong>Reporting v2 GA</strong> — 63% of eligible customers migrated within 8
+weeks.</li>
+<li style="margin: 0.2em 0;"><strong>Mobile push for SOC 2 alerts</strong> — partner team for the security buyer
+persona.</li>
+</ul>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#113-team-data-and-ml" aria-hidden="true" class="anchor" id="113-team-data-and-ml" style="color: #0b66c2; text-decoration: none;"></a>11.3 Team: Data and ML</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">Data and ML completed the MongoDB to Postgres migration on the
+audit-log service and picked up the customer-churn-prediction model
+work that the Customer Success org had been waiting on. The model
+now powers the account-health scoring referenced in section 4.1.</p>
+</blockquote>
+<p style="margin: 0.6em 0;">Key shipped work:</p>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>Audit-log MongoDB to Postgres migration</strong> — complete.</li>
+<li style="margin: 0.2em 0;"><strong>Account-health model v2</strong> — informing CSM renewal-touch coverage.</li>
+<li style="margin: 0.2em 0;"><strong>Reporting v2 backend</strong> — feature-complete; analytics warehouse
+optimisation continues.</li>
+</ul>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#114-team-infrastructure" aria-hidden="true" class="anchor" id="114-team-infrastructure" style="color: #0b66c2; text-decoration: none;"></a>11.4 Team: Infrastructure</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">Infrastructure absorbed the v1 ingestion deprecation work in
+partnership with Platform, retired the dual-write to the analytics
+warehouse, and stood up the second cloud region for the
+data-residency commit.</p>
+</blockquote>
+<p style="margin: 0.6em 0;">Key shipped work:</p>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>EU region (FRA)</strong> — stood up; pilot tenants migrated.</li>
+<li style="margin: 0.2em 0;"><strong>Dual-write removal</strong> — CDC pipeline is now the sole writer.</li>
+<li style="margin: 0.2em 0;"><strong>Cost-optimisation initiative</strong> — net cloud spend down 14% QoQ
+excluding new-region build-out.</li>
+</ul>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#115-team-security" aria-hidden="true" class="anchor" id="115-team-security" style="color: #0b66c2; text-decoration: none;"></a>11.5 Team: Security</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">Security closed the SOC 2 surveillance audit clean, refreshed the
+ISO 27001:2022 certification, and stood up the HIPAA readiness work
+for H2 attestation. The team also led the dual-control-on-prod-config
+incident response described in section 2.2.</p>
+</blockquote>
+<p style="margin: 0.6em 0;">Key shipped work:</p>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>Dual-control on prod config pushes</strong> — incident-response output.</li>
+<li style="margin: 0.2em 0;"><strong>HIPAA readiness assessment</strong> — complete; H2 attestation on plan.</li>
+<li style="margin: 0.2em 0;"><strong>SOC 2 surveillance audit</strong> — clean.</li>
+</ul>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#12-customer-voice" aria-hidden="true" class="anchor" id="12-customer-voice" style="color: #0b66c2; text-decoration: none;"></a>12. Customer Voice</h2>
+<p style="margin: 0.6em 0;">A sample of qualitative customer feedback collected via the
+quarterly business-review motion. Quotes are anonymised but
+attributable on request.</p>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;"><em>&quot;The new Universal Inbox has cut our team's daily mail-triage time
+from 40 minutes to under 10. Our security analysts get to the
+alerts that actually matter, faster. We're seeing tickets-to-incident
+ratios drop noticeably.&quot;</em>
+— Director of Security Engineering, Enterprise customer</p>
+</blockquote>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;"><em>&quot;Reporting v2 is genuinely a step change. The custom-metric API
+means we no longer have to ship our finance data into a separate
+dashboard tool. One less integration, one less vendor.&quot;</em>
+— Head of Finance Operations, Mid-market customer</p>
+</blockquote>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;"><em>&quot;Workflow Studio v3's branching primitives are the thing we've
+been waiting for since 2024. We understand the slip; the quality
+bar held. We'd rather have it right than fast.&quot;</em>
+— VP Engineering, Enterprise customer</p>
+</blockquote>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;"><em>&quot;Support has gotten faster every quarter. Our last critical was
+resolved in under an hour, and the post-incident communication
+was clear and direct. We notice.&quot;</em>
+— CTO, Mid-market customer</p>
+</blockquote>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#13-action-items-for-q2" aria-hidden="true" class="anchor" id="13-action-items-for-q2" style="color: #0b66c2; text-decoration: none;"></a>13. Action Items for Q2</h2>
+<p style="margin: 0.6em 0;">The leadership team owns the following actions for Q2. Owners and
+deadlines are tracked in the Q2 ops review document.</p>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><input type="checkbox" disabled="" /> Workflow Studio v3 ships by end of week 4.</li>
+<li style="margin: 0.2em 0;"><input type="checkbox" disabled="" /> Cross-workspace search ships by end of Q2.</li>
+<li style="margin: 0.2em 0;"><input type="checkbox" disabled="" /> Second payment-processor integration GA by end of Q2.</li>
+<li style="margin: 0.2em 0;"><input type="checkbox" disabled="" /> Read-only audit-log API GA by end of Q2.</li>
+<li style="margin: 0.2em 0;"><input type="checkbox" disabled="" /> SAML group-attribute mapping ships in Q2.</li>
+<li style="margin: 0.2em 0;"><input type="checkbox" checked="" disabled="" /> Q1 audit-log MongoDB to Postgres migration — complete.</li>
+<li style="margin: 0.2em 0;"><input type="checkbox" checked="" disabled="" /> v1 ingestion pipeline deprecated — complete.</li>
+<li style="margin: 0.2em 0;"><input type="checkbox" checked="" disabled="" /> Multi-region rate-limit cluster — complete.</li>
+</ul>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<p style="margin: 0.6em 0;"><em>End of report.</em></p>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#14-quarterly-cross-functional-project-index" aria-hidden="true" class="anchor" id="14-quarterly-cross-functional-project-index" style="color: #0b66c2; text-decoration: none;"></a>14. Quarterly Cross-Functional Project Index</h2>
+<p style="margin: 0.6em 0;">The cross-functional project index below summarises every project that
+spanned more than one organisation in the quarter. Project status is
+captured at end-of-quarter; the live tracker carries the running view.</p>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#141-project-universal-inbox-ga" aria-hidden="true" class="anchor" id="141-project-universal-inbox-ga" style="color: #0b66c2; text-decoration: none;"></a>14.1 Project: Universal Inbox GA</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;"><strong>Status:</strong> Shipped on time, 2026-03-12. Adoption running ~2x the
+comparable reference launch from 2025. Seven of the top-ten customer
+deployments completed onboarding within the first three weeks.</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Workstream</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Owner</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Status</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Backend infra cutover</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Platform</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Complete</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Inbox UI</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Application</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Complete</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">In-app onboarding</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Application</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Complete</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Marketing site update</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Marketing</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Complete</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Support enablement</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Support</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Complete</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Pricing/packaging</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Finance</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Complete</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#142-project-reporting-v2-ga" aria-hidden="true" class="anchor" id="142-project-reporting-v2-ga" style="color: #0b66c2; text-decoration: none;"></a>14.2 Project: Reporting v2 GA</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;"><strong>Status:</strong> Shipped on time, 2026-02-04. Migration uptake ahead of
+plan. Long-tail of legacy reports still served from v1 backend; v1
+read-path deprecation now scheduled for Q3.</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Workstream</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Owner</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Status</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">v2 backend</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Data and ML</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Complete</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Custom-metric API</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Application</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Complete</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Migration tooling</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Application</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Complete</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Customer migration ops</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">CSM</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">In progress</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">v1 read-path deprecation</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Application</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Q3</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#143-project-workflow-studio-v3" aria-hidden="true" class="anchor" id="143-project-workflow-studio-v3" style="color: #0b66c2; text-decoration: none;"></a>14.3 Project: Workflow Studio v3</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;"><strong>Status:</strong> Slipped to Q2 week 4. Slip driven by deliberate scope
+addition (canvas renderer rewrite). Decision and rationale ratified
+by the product council on 2026-02-18.</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Workstream</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Owner</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Status</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Canvas renderer rewrite</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Application</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">In progress</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Branching primitives</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Application</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Complete</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Migration tooling</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Application</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">In progress</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Beta cohort onboarding</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">CSM</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Q2</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#144-project-eu-data-residency" aria-hidden="true" class="anchor" id="144-project-eu-data-residency" style="color: #0b66c2; text-decoration: none;"></a>14.4 Project: EU data residency</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;"><strong>Status:</strong> Region stood up, pilot tenants migrated. Production
+traffic cutover gated on the legal sign-off for the new sub-processor
+agreements; targeted for end of Q2.</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Workstream</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Owner</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Status</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">FRA region build-out</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Infrastructure</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Complete</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Multi-region routing</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Platform</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Complete</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Pilot tenant migration</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">CSM</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Complete</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Sub-processor agreements</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Legal</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">In progress</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">GA cutover comms</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Marketing</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Q2</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#145-project-hipaa-readiness" aria-hidden="true" class="anchor" id="145-project-hipaa-readiness" style="color: #0b66c2; text-decoration: none;"></a>14.5 Project: HIPAA readiness</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;"><strong>Status:</strong> Readiness assessment complete; gap remediation under way.
+Targeting H2 attestation. The work overlaps with the SOC 2 evidence
+base; ~70% of controls are already in scope and in place.</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Workstream</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Owner</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Status</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Readiness assessment</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Security</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Complete</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Gap remediation</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Security</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">In progress</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Customer-facing BAA</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Legal</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">In progress</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Attestation engagement</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Security</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">H2</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#146-project-second-payment-processor-integration" aria-hidden="true" class="anchor" id="146-project-second-payment-processor-integration" style="color: #0b66c2; text-decoration: none;"></a>14.6 Project: Second payment-processor integration</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;"><strong>Status:</strong> Engineering complete; finance-side UAT under way.
+Targeted GA mid-Q2. The dual-PSP architecture follows the pattern
+documented in the 2025 incident-response review, and addresses the
+top item in the risk register.</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Workstream</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Owner</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Status</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Engineering integration</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Platform</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Complete</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Finance UAT</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Finance</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">In progress</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Reconciliation reporting</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Finance</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">In progress</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Customer-facing comms</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Marketing</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Q2</td>
+</tr>
+</tbody>
+</table>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#15-operational-risk-detail" aria-hidden="true" class="anchor" id="15-operational-risk-detail" style="color: #0b66c2; text-decoration: none;"></a>15. Operational Risk Detail</h2>
+<p style="margin: 0.6em 0;">The risk register in section 5 is the leadership-level summary. The
+operational-risk detail below is the program office's working list,
+including items that have been triaged below the leadership threshold
+but remain on the radar.</p>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#151-operational-risks-working-list" aria-hidden="true" class="anchor" id="151-operational-risks-working-list" style="color: #0b66c2; text-decoration: none;"></a>15.1 Operational risks (working list)</h3>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">ID</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Risk</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Likelihood</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Impact</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Owner</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Status</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">R01</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Single-PSP concentration</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Medium</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">High</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Finance</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Mitigating</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">R02</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">EU cross-border transfers regulatory ruling</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Medium</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">High</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Legal</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Watching</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">R03</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Senior-engineer attrition (specific team)</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Medium</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Medium</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Engineering</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Mitigating</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">R04</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Data-warehouse capacity for new analytics</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Low</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Medium</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Data and ML</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Mitigating</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">R05</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Vendor SLA on observability platform</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Low</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Medium</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Infra</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Watching</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">R06</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">New EU sub-processor agreements timeline</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Medium</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Medium</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Legal</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Mitigating</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">R07</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Sales-comp plan consistency in new region</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Low</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Low</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">GTM</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Watching</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">R08</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Dependency on one CRM vendor</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Low</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Medium</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">RevOps</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Watching</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">R09</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Dependency on one ID-provider for SSO</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Low</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Medium</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Security</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Watching</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">R10</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Capacity for SOC 2 evidence collection</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Low</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Low</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Security</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Mitigating</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">R11</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Data-residency for non-EU regulated tenants</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Low</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Medium</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Infra</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Backlog</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">R12</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">New-region tax-and-employment posture</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Low</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Medium</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Finance</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Mitigating</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#152-risk-treatment-notes" aria-hidden="true" class="anchor" id="152-risk-treatment-notes" style="color: #0b66c2; text-decoration: none;"></a>15.2 Risk-treatment notes</h3>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>R01 (PSP concentration).</strong> Engineering complete on the second-PSP
+integration. UAT in finance-side reconciliation reporting. GA mid-Q2.</li>
+<li style="margin: 0.2em 0;"><strong>R02 (EU transfers).</strong> Watching the pending court decision. The EU
+residency build-out (project 14.4) is the long-term hedge.</li>
+<li style="margin: 0.2em 0;"><strong>R03 (Engineering attrition).</strong> Backfill recruiting in flight.
+Knowledge-share rotation set up. Succession plans documented.</li>
+<li style="margin: 0.2em 0;"><strong>R04 (Warehouse capacity).</strong> Tier-up to next compute tier scheduled
+for Q2. Cost impact captured in the Q2 plan.</li>
+<li style="margin: 0.2em 0;"><strong>R05 (Observability vendor).</strong> Reviewing two alternatives in case
+the current vendor's SLA terms do not improve at renewal.</li>
+<li style="margin: 0.2em 0;"><strong>R06 (EU sub-processors).</strong> New agreements in legal review. Targeted
+signature end of Q2 to support project 14.4 GA.</li>
+<li style="margin: 0.2em 0;"><strong>R07 (Comp consistency).</strong> Q2 comp-plan refresh will normalise.</li>
+<li style="margin: 0.2em 0;"><strong>R08 (CRM vendor).</strong> Lower priority. Migration cost would be high.</li>
+<li style="margin: 0.2em 0;"><strong>R09 (ID provider).</strong> Architectural review scheduled for H2.</li>
+<li style="margin: 0.2em 0;"><strong>R10 (Evidence capacity).</strong> Tooling automation reduced manual
+evidence collection by ~40% in Q1. Continuing.</li>
+<li style="margin: 0.2em 0;"><strong>R11 (Non-EU regulated tenants).</strong> Off-roadmap; will revisit when
+customer demand crosses threshold.</li>
+<li style="margin: 0.2em 0;"><strong>R12 (Tax and employment).</strong> Engaged outside counsel; on track.</li>
+</ul>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#16-people-operations-detail" aria-hidden="true" class="anchor" id="16-people-operations-detail" style="color: #0b66c2; text-decoration: none;"></a>16. People Operations Detail</h2>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#161-hiring-throughput" aria-hidden="true" class="anchor" id="161-hiring-throughput" style="color: #0b66c2; text-decoration: none;"></a>16.1 Hiring throughput</h3>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Function</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Open Q1-start</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Filled</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Closed</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Open Q1-end</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Engineering</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">14</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">16</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-8*</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">8</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Product</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">3</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">2</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Design</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">GTM</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">7</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">3</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">G and A</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">2</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1</td>
+</tr>
+</tbody>
+</table>
+<p style="margin: 0.6em 0;">*Eight engineering reqs were closed without a hire because the work
+was de-scoped during the Q1 portfolio review; the remaining open reqs
+roll forward into Q2.</p>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#162-compensation-review" aria-hidden="true" class="anchor" id="162-compensation-review" style="color: #0b66c2; text-decoration: none;"></a>16.2 Compensation review</h3>
+<p style="margin: 0.6em 0;">The Q1 comp review applied the standard methodology: market-data refresh
+from the comp-survey vendor, internal-equity check, manager calibration,
+and finance approval. Notable outputs:</p>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;">92% of in-band employees received a market-aligned increase.</li>
+<li style="margin: 0.2em 0;">8% of employees were identified as below-band and received a
+band-correction increase outside the standard window.</li>
+<li style="margin: 0.2em 0;">No off-cycle equity grants outside the planned refresh program.</li>
+</ul>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#163-performance" aria-hidden="true" class="anchor" id="163-performance" style="color: #0b66c2; text-decoration: none;"></a>16.3 Performance</h3>
+<p style="margin: 0.6em 0;">The Q1 performance check-in cycle ran on the new lighter-touch model
+(quarterly conversation, no formal calibration). Manager NPS on the
+new model: +42. Employee NPS on the new model: +38. Both materially
+above the prior-cycle scores.</p>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#164-diversity-equity-and-inclusion" aria-hidden="true" class="anchor" id="164-diversity-equity-and-inclusion" style="color: #0b66c2; text-decoration: none;"></a>16.4 Diversity, equity, and inclusion</h3>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Metric</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Q1 2026</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Q1 2025</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Women in engineering</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">28%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">24%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Women in leadership (M+ band)</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">41%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">37%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">URM in US workforce</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">22%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">19%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Pay-gap audit (gender, controlled)</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">&lt;0.5%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">&lt;0.5%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Pay-gap audit (URM, controlled)</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">&lt;0.5%</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">&lt;0.5%</td>
+</tr>
+</tbody>
+</table>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#17-appendix-methodology-and-definitions" aria-hidden="true" class="anchor" id="17-appendix-methodology-and-definitions" style="color: #0b66c2; text-decoration: none;"></a>17. Appendix: Methodology and Definitions</h2>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#171-reporting-cadence" aria-hidden="true" class="anchor" id="171-reporting-cadence" style="color: #0b66c2; text-decoration: none;"></a>17.1 Reporting cadence</h3>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>Daily</strong>: a single-page operational dashboard distributed to the
+leadership team.</li>
+<li style="margin: 0.2em 0;"><strong>Weekly</strong>: a 4-page weekly business review distributed to all
+managers.</li>
+<li style="margin: 0.2em 0;"><strong>Monthly</strong>: a closed-financials packet distributed to the board
+observer list.</li>
+<li style="margin: 0.2em 0;"><strong>Quarterly</strong>: this report (consolidated operational view) plus the
+audited financial statements (reconciled in the 10-business-day
+window after quarter-end).</li>
+</ul>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#172-source-of-truth-systems" aria-hidden="true" class="anchor" id="172-source-of-truth-systems" style="color: #0b66c2; text-decoration: none;"></a>17.2 Source-of-truth systems</h3>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>CRM</strong> is the source of truth for opportunity stage, ARR, and
+closed-won bookings.</li>
+<li style="margin: 0.2em 0;"><strong>ERP</strong> is the source of truth for revenue, cost, and cash flow.</li>
+<li style="margin: 0.2em 0;"><strong>HRIS</strong> is the source of truth for headcount, attrition, and comp.</li>
+<li style="margin: 0.2em 0;"><strong>Reporting warehouse</strong> is the source of truth for the operational
+metrics in sections 2-4 and 9-12.</li>
+</ul>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#173-restatement-policy" aria-hidden="true" class="anchor" id="173-restatement-policy" style="color: #0b66c2; text-decoration: none;"></a>17.3 Restatement policy</h3>
+<p style="margin: 0.6em 0;">We restate prior-period numbers when:</p>
+<ol style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;">A material reclassification changes the comparability of a metric.</li>
+<li style="margin: 0.2em 0;">An audited adjustment is finalised after the original publication.</li>
+<li style="margin: 0.2em 0;">A definitional change is approved by the program office.</li>
+</ol>
+<p style="margin: 0.6em 0;">All restatements are flagged in the next-quarter report's appendix and
+reflected in the rolling trend file.</p>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#174-glossary-additions-for-q1" aria-hidden="true" class="anchor" id="174-glossary-additions-for-q1" style="color: #0b66c2; text-decoration: none;"></a>17.4 Glossary additions for Q1</h3>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;"><strong>Bessemer Efficiency Score</strong>: net new ARR divided by net cash burn,
+per the Bessemer Venture Partners definition.</li>
+<li style="margin: 0.2em 0;"><strong>Magic Number</strong>: net new ARR for the quarter divided by sales and
+marketing spend in the prior quarter, annualised.</li>
+<li style="margin: 0.2em 0;"><strong>Burn Multiple</strong>: net cash burn divided by net new ARR for the
+same period.</li>
+</ul>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#175-approvals" aria-hidden="true" class="anchor" id="175-approvals" style="color: #0b66c2; text-decoration: none;"></a>17.5 Approvals</h3>
+<p style="margin: 0.6em 0;">This report was reviewed by the leadership team on 2026-04-09, ratified
+by the CFO on 2026-04-10, and circulated to the broader management
+team on 2026-04-11.</p>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<p style="margin: 0.6em 0;"><em>Final.</em></p>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#18-per-week-operational-detail" aria-hidden="true" class="anchor" id="18-per-week-operational-detail" style="color: #0b66c2; text-decoration: none;"></a>18. Per-Week Operational Detail</h2>
+<p style="margin: 0.6em 0;">The per-week detail below archives the weekly business-review numbers
+for the quarter. Future quarters can compare against these directly
+without re-querying the warehouse.</p>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#181-week-1-2025-12-30-to-2026-01-05" aria-hidden="true" class="anchor" id="181-week-1-2025-12-30-to-2026-01-05" style="color: #0b66c2; text-decoration: none;"></a>18.1 Week 1 (2025-12-30 to 2026-01-05)</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">Holiday-shortened week. Pipeline-build motion paused; on-call
+coverage held the line. No production incidents.</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Metric</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Actual</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Plan</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Delta</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">New ARR</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.91</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.80</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+13%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Pipeline created</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4.2</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4.0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+5%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets opened</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,108</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,200</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-8%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets resolved</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,142</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,200</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-5%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P0 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P1 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">&lt;1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#182-week-2-2026-01-06-to-2026-01-12" aria-hidden="true" class="anchor" id="182-week-2-2026-01-06-to-2026-01-12" style="color: #0b66c2; text-decoration: none;"></a>18.2 Week 2 (2026-01-06 to 2026-01-12)</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">First full operating week. Sales QBRs ran through the week. One P1
+incident (transient ingestion lag, 18 minutes), resolved within SLO.</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Metric</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Actual</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Plan</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Delta</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">New ARR</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.02</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.95</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+7%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Pipeline created</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4.8</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4.7</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+2%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets opened</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,420</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,400</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+1%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets resolved</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,398</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,400</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-0%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P0 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P1 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">&lt;1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#183-week-3-2026-01-13-to-2026-01-19" aria-hidden="true" class="anchor" id="183-week-3-2026-01-13-to-2026-01-19" style="color: #0b66c2; text-decoration: none;"></a>18.3 Week 3 (2026-01-13 to 2026-01-19)</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">Net-new ARR slightly soft on a quieter renewals week. No incidents.</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Metric</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Actual</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Plan</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Delta</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">New ARR</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.84</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.95</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-12%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Pipeline created</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4.4</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4.7</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-6%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets opened</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,372</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,400</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-2%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets resolved</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,401</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,400</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+0%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P0 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P1 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">&lt;1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#184-week-4-2026-01-20-to-2026-01-26" aria-hidden="true" class="anchor" id="184-week-4-2026-01-20-to-2026-01-26" style="color: #0b66c2; text-decoration: none;"></a>18.4 Week 4 (2026-01-20 to 2026-01-26)</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">Recovered from the prior week's softness. Reporting v2 dogfooding
+sprint produced eight customer-issue tickets (all addressed).</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Metric</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Actual</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Plan</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Delta</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">New ARR</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.92</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.95</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-3%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Pipeline created</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5.1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">4.7</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+9%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets opened</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,508</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,400</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+8%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets resolved</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,471</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,400</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+5%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P0 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P1 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">&lt;1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#185-week-5-2026-01-27-to-2026-02-02" aria-hidden="true" class="anchor" id="185-week-5-2026-01-27-to-2026-02-02" style="color: #0b66c2; text-decoration: none;"></a>18.5 Week 5 (2026-01-27 to 2026-02-02)</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">Strongest week of the quarter for new ARR. Reporting v2 GA-readiness
+review held mid-week; green-lit for the following Monday.</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Metric</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Actual</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Plan</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Delta</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">New ARR</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.18</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.00</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+18%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Pipeline created</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5.4</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5.0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+8%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets opened</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,620</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,500</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+8%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets resolved</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,584</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,500</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+6%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P0 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P1 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">&lt;1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#186-week-6-2026-02-03-to-2026-02-09" aria-hidden="true" class="anchor" id="186-week-6-2026-02-03-to-2026-02-09" style="color: #0b66c2; text-decoration: none;"></a>18.6 Week 6 (2026-02-03 to 2026-02-09)</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">Reporting v2 GA shipped Tuesday. Migration uptake started ahead of
+plan. One P1 incident (rate-limit cluster cascading restart),
+resolved within 4 minutes; post-incident review filed.</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Metric</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Actual</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Plan</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Delta</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">New ARR</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.05</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.00</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+5%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Pipeline created</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5.0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5.0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-1%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets opened</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,742</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,500</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+16%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets resolved</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,683</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,500</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+12%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P0 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P1 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">&lt;1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#187-week-7-2026-02-10-to-2026-02-16" aria-hidden="true" class="anchor" id="187-week-7-2026-02-10-to-2026-02-16" style="color: #0b66c2; text-decoration: none;"></a>18.7 Week 7 (2026-02-10 to 2026-02-16)</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">Mid-quarter forecast call: forecast on track. Universal Inbox beta
+opened to the second cohort (200 customers).</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Metric</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Actual</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Plan</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Delta</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">New ARR</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.96</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.00</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-4%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Pipeline created</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5.2</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5.0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+5%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets opened</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,612</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,500</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+7%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets resolved</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,648</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,500</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+10%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P0 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P1 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">&lt;1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#188-week-8-2026-02-17-to-2026-02-23" aria-hidden="true" class="anchor" id="188-week-8-2026-02-17-to-2026-02-23" style="color: #0b66c2; text-decoration: none;"></a>18.8 Week 8 (2026-02-17 to 2026-02-23)</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">Workflow Studio v3 scope-decision week. Product council ratified the
+canvas-renderer rewrite addition; slip to Q2 acknowledged.</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Metric</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Actual</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Plan</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Delta</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">New ARR</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.14</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.00</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+14%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Pipeline created</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5.3</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5.0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+6%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets opened</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,540</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,500</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+3%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets resolved</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,576</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,500</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+5%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P0 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P1 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">&lt;1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#189-week-9-2026-02-24-to-2026-03-02" aria-hidden="true" class="anchor" id="189-week-9-2026-02-24-to-2026-03-02" style="color: #0b66c2; text-decoration: none;"></a>18.9 Week 9 (2026-02-24 to 2026-03-02)</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">Strong renewals week. NDR cohort attainment tracking ahead of plan.</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Metric</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Actual</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Plan</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Delta</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">New ARR</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.07</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.05</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+2%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Pipeline created</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5.0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5.2</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-3%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets opened</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,448</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,500</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-3%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets resolved</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,512</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,500</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+1%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P0 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P1 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">&lt;1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#1810-week-10-2026-03-03-to-2026-03-09" aria-hidden="true" class="anchor" id="1810-week-10-2026-03-03-to-2026-03-09" style="color: #0b66c2; text-decoration: none;"></a>18.10 Week 10 (2026-03-03 to 2026-03-09)</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">Universal Inbox GA-readiness review held Friday; green-lit for the
+following week.</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Metric</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Actual</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Plan</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Delta</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">New ARR</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.21</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.05</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+15%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Pipeline created</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5.6</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5.2</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+8%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets opened</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,602</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,500</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+7%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets resolved</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,584</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,500</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+6%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P0 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P1 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">&lt;1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#1811-week-11-2026-03-10-to-2026-03-16" aria-hidden="true" class="anchor" id="1811-week-11-2026-03-10-to-2026-03-16" style="color: #0b66c2; text-decoration: none;"></a>18.11 Week 11 (2026-03-10 to 2026-03-16)</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">Universal Inbox GA shipped Thursday. Onboarding-flow telemetry
+indicated higher-than-expected completion rates from minute one.</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Metric</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Actual</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Plan</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Delta</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">New ARR</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0.98</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.05</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-7%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Pipeline created</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5.1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5.2</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-2%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets opened</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,704</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,500</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+14%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets resolved</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,672</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,500</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+11%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P0 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P1 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">&lt;1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#1812-week-12-2026-03-17-to-2026-03-23" aria-hidden="true" class="anchor" id="1812-week-12-2026-03-17-to-2026-03-23" style="color: #0b66c2; text-decoration: none;"></a>18.12 Week 12 (2026-03-17 to 2026-03-23)</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">First full week of Universal Inbox GA-traffic. Native Slack threading
+shipped to the first launch cohort.</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Metric</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Actual</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Plan</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Delta</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">New ARR</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.16</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.10</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+6%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Pipeline created</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5.4</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5.2</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+4%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets opened</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,651</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,500</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+10%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets resolved</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,684</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,500</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">+12%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P0 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P1 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">&lt;1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+</tbody>
+</table>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#1813-week-13-2026-03-24-to-2026-03-30" aria-hidden="true" class="anchor" id="1813-week-13-2026-03-24-to-2026-03-30" style="color: #0b66c2; text-decoration: none;"></a>18.13 Week 13 (2026-03-24 to 2026-03-30)</h3>
+<blockquote style="border-left: 3px solid #d0d7de; padding: 0 0.9em; color: #57606a; margin: 0.6em 0;">
+<p style="margin: 0.6em 0;">Quarter-close week. Mobile push for SOC 2 alerts shipped Friday.</p>
+</blockquote>
+<table style="border-collapse: collapse; margin: 0.8em 0; border: 1px solid #d0d7de;">
+<thead>
+<tr>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Metric</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Actual</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Plan</th>
+<th style="border: 1px solid #d0d7de; padding: 6px 10px; background: #f6f8fa; text-align: left;">Delta</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">New ARR</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.08</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1.10</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-2%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Pipeline created</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5.0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">5.2</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-3%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets opened</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,433</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,500</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-4%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">Tickets resolved</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,461</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">1,500</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-3%</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P0 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+<tr>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">P1 incidents</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">0</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">&lt;1</td>
+<td style="border: 1px solid #d0d7de; padding: 6px 10px;">-</td>
+</tr>
+</tbody>
+</table>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<p style="margin: 0.6em 0;"><em>End of per-week detail.</em></p>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<h2 style="font-size: 1.4em; margin: 1.1em 0 0.5em; line-height: 1.3;"><a href="#19-closing-remarks" aria-hidden="true" class="anchor" id="19-closing-remarks" style="color: #0b66c2; text-decoration: none;"></a>19. Closing Remarks</h2>
+<p style="margin: 0.6em 0;">This is the last quarterly report on the v1 reporting template. Starting
+in Q2, we'll publish the operational view in the new format ratified by
+the program office in March. The headline-level metrics will stay
+consistent so trend-over-trend comparisons remain straightforward; the
+detail sections will reorganise around the four operating regions
+rather than around the four functional organisations.</p>
+<p style="margin: 0.6em 0;">The leadership team thanks the broader management group for the
+hands-on contribution to this report's data and qualitative content.
+The next quarterly view will land 10 business days after Q2 close, with
+the customary executive read-out on the second Friday after publication.</p>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#191-acknowledgements" aria-hidden="true" class="anchor" id="191-acknowledgements" style="color: #0b66c2; text-decoration: none;"></a>19.1 Acknowledgements</h3>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;">Engineering leadership team — for the section 11 write-ups.</li>
+<li style="margin: 0.2em 0;">CSM leadership — for the customer-voice section 12 contributions.</li>
+<li style="margin: 0.2em 0;">Program office — for the cross-functional project index and the
+operational-risk detail.</li>
+<li style="margin: 0.2em 0;">Finance — for the rapid-turnaround financial highlights and the
+capital-efficiency analysis.</li>
+<li style="margin: 0.2em 0;">People operations — for the headcount, attrition, and engagement
+detail.</li>
+<li style="margin: 0.2em 0;">Security — for the compliance-posture section.</li>
+</ul>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#192-distribution" aria-hidden="true" class="anchor" id="192-distribution" style="color: #0b66c2; text-decoration: none;"></a>19.2 Distribution</h3>
+<p style="margin: 0.6em 0;">This report is distributed to:</p>
+<ul style="margin: 0.6em 0; padding-left: 1.4em;">
+<li style="margin: 0.2em 0;">Board of directors and observers (full).</li>
+<li style="margin: 0.2em 0;">Leadership team (full).</li>
+<li style="margin: 0.2em 0;">Broader management team (full, redacted version on request).</li>
+<li style="margin: 0.2em 0;">All-hands snapshot (financial highlights and outlook only).</li>
+<li style="margin: 0.2em 0;">Investor update (financial highlights and outlook only).</li>
+</ul>
+<h3 style="font-size: 1.2em; margin: 1em 0 0.4em; line-height: 1.3;"><a href="#193-feedback" aria-hidden="true" class="anchor" id="193-feedback" style="color: #0b66c2; text-decoration: none;"></a>19.3 Feedback</h3>
+<p style="margin: 0.6em 0;">Feedback on this report is welcome and is collated by the program office
+into the next-quarter template-refresh exercise. Please send comments
+or corrections by end of the second week of Q2.</p>
+<hr style="border: 0; border-top: 1px solid #d0d7de; margin: 1.4em 0;" />
+<p style="margin: 0.6em 0;"><em>Final. Q1 2026 Operations Report.</em></p>

--- a/tests/fixtures/markdown/report-50kb.md
+++ b/tests/fixtures/markdown/report-50kb.md
@@ -1,0 +1,1160 @@
+# Quarterly Operations Report — Q1 2026
+
+This report consolidates operational performance across the engineering,
+product, finance, and customer-success organisations for the first quarter
+of 2026. Numbers are unaudited; the finance team's reconciled figures will
+follow within ten business days.
+
+> **Executive summary.** Q1 came in modestly ahead of plan on revenue, in
+> line on gross margin, and meaningfully ahead on operating efficiency.
+> Headcount grew 6% year-on-year — well below the 12% planned at the start
+> of the year — driven by a deliberate slow-down in non-engineering hires.
+> Customer churn ticked up by 40 bp to 2.1% but remains below the
+> industry benchmark of ~3%. Three of the four major product launches
+> planned for Q1 shipped on time; the fourth (Workflow Studio v3) slipped
+> two weeks and is now scheduled for week 4 of Q2.
+
+---
+
+## 1. Financial Highlights
+
+| Metric                       | Q1 2026   | Q1 2025   | YoY     | vs. plan |
+|------------------------------|-----------|-----------|---------|----------|
+| Revenue                      | 142.3M    | 118.7M    | +19.9%  | +1.6%    |
+| Gross profit                 | 109.5M    | 91.4M     | +19.8%  | +0.0%    |
+| Gross margin                 | 76.9%     | 77.0%     | -10 bp  | -10 bp   |
+| Operating income             | 28.1M     | 19.6M     | +43.4%  | +14.3%   |
+| Operating margin             | 19.8%     | 16.5%     | +330 bp | +250 bp  |
+| Free cash flow               | 22.7M     | 14.2M     | +59.9%  | +21.0%   |
+| Cash and equivalents         | 318.4M    | 261.0M    | +22.0%  | +5.4%    |
+
+### 1.1 Revenue mix
+
+- **Subscription revenue** grew 22% year-on-year to USD 128.0M, now 90% of total
+  revenue (vs. 88% a year ago). New-logo ARR was USD 14.2M, up 38% YoY; net
+  new ARR was USD 11.7M after USD 2.5M of gross churn.
+- **Services revenue** grew 4% to USD 14.3M. The deliberate decision to
+  package more of the implementation playbook into self-serve content has
+  slowed services growth — exactly as intended.
+- **Top-three customer concentration** fell from 18.4% to 14.1%, a
+  healthier balance reflecting the broadening of the enterprise base.
+
+### 1.2 Cost discipline
+
+| Cost line              | Q1 2026 | Q1 2025 | YoY    | % of rev |
+|------------------------|---------|---------|--------|----------|
+| Cost of revenue        | 32.8M   | 27.3M   | +20.1% | 23.1%    |
+| Sales and marketing    | 41.2M   | 38.7M   | +6.5%  | 28.9%    |
+| Research and dev       | 27.4M   | 23.5M   | +16.6% | 19.3%    |
+| General and admin      | 12.8M   | 10.3M   | +24.3% | 9.0%     |
+| Total opex             | 81.4M   | 72.5M   | +12.3% | 57.2%    |
+
+Sales and marketing efficiency improved materially: customer acquisition
+cost (CAC) on new logos was USD 11.4k, down from USD 14.1k a year ago, driven
+by a 24% lift in inbound conversion rates after the website re-launch in
+February.
+
+---
+
+## 2. Engineering
+
+### 2.1 Delivery cadence
+
+The engineering organisation shipped **47 production releases** in Q1, up
+from 38 in Q1 2025. Mean time to production for an approved PR fell from
+2.6 days to 1.8 days, helped by the new merge-queue automation that
+removes the manual rebase step for the long-tail of small PRs.
+
+| Quarter | Releases | Mean TTP (days) | P95 TTP (days) |
+|---------|----------|-----------------|----------------|
+| Q1 2025 | 38       | 2.6             | 6.1            |
+| Q2 2025 | 41       | 2.4             | 5.8            |
+| Q3 2025 | 44       | 2.2             | 5.4            |
+| Q4 2025 | 46       | 2.0             | 5.1            |
+| Q1 2026 | 47       | 1.8             | 4.7            |
+
+### 2.2 Reliability
+
+Service-level objective attainment for the quarter:
+
+| Service                | Target  | Actual  | Status |
+|------------------------|---------|---------|--------|
+| Public API (p99 lat.)  | < 350ms | 287ms   | Met    |
+| Webhook delivery       | 99.9%   | 99.94%  | Met    |
+| Auth (uptime)          | 99.99%  | 99.987% | Missed |
+| Reporting (freshness)  | < 15min | 11min   | Met    |
+| Dashboard (TTI)        | < 3.0s  | 2.4s    | Met    |
+
+The single SLO miss — auth uptime — was driven by a 4-minute outage on
+2026-02-19 caused by a cascading restart of the rate-limit cluster after
+an inadvertent config push. The post-incident review identified two
+process changes already in place: dual-control for prod config pushes,
+and a pre-flight canary on the rate-limit nodes before a fleet-wide roll.
+
+### 2.3 Tech-debt reduction
+
+> The infrastructure team retired the v1 ingestion pipeline this quarter,
+> consolidating onto the v2 columnar path. v1 had been receiving
+> diminishing share of new traffic for three quarters; deprecation
+> reduced our cloud spend by ~USD 240k per quarter and removed a known
+> single-point-of-failure in the cross-region replication path.
+
+Other notable retirements:
+
+- **MongoDB to Postgres migration** for the audit-log service: complete.
+  Storage cost down ~40%, query latency down ~3x at p95.
+- **Legacy permissions cache**: replaced with the new RLS-aware
+  authorization layer. Net reduction of ~14k lines of code.
+- **Dual-write to the analytics warehouse**: removed; CDC pipeline is
+  now the sole writer.
+
+### 2.4 Hiring
+
+Engineering added a net 11 people in Q1 (16 hires, 5 departures). Open
+reqs at quarter-end: 8 (down from 14 at the start of the quarter).
+Voluntary attrition annualised: 7.8%, well below the industry benchmark
+of ~12-14%.
+
+```text
+Headcount by team (end of Q1):
+  Platform .................... 22
+  Application ................. 31
+  Data and ML ................. 14
+  Infrastructure ............... 9
+  Security ..................... 6
+  Engineering management ....... 7
+  ----------------------------------
+  Total ....................... 89
+```
+
+---
+
+## 3. Product
+
+### 3.1 Launches
+
+Three of four planned major launches shipped in Q1:
+
+1. **Universal Inbox** — beta opened to 800 customers; GA shipped 2026-03-12.
+   Adoption is tracking ~2x the comparable launch a year ago, helped by
+   in-app onboarding.
+2. **Workflow Studio v3** — *slipped*; now scheduled for 2026-04-22.
+   Slip was caused by a rewrite of the canvas renderer to support the
+   new branching primitives. Quality bar held; we made the right call.
+3. **Reporting v2** — GA shipped 2026-02-04; ~63% of eligible
+   customers have migrated within the first eight weeks.
+4. **Mobile push for SOC 2 alerts** — shipped 2026-03-28; uptake has
+   been concentrated in the security-engineering buyer persona, as
+   expected.
+
+### 3.2 Adoption metrics
+
+| Feature              | DAU/MAU | WAU/MAU | Stickiness |
+|----------------------|---------|---------|------------|
+| Universal Inbox      | 0.41    | 0.78    | High       |
+| Reporting v2         | 0.32    | 0.71    | High       |
+| Workflow automation  | 0.29    | 0.65    | Medium     |
+| Knowledge graph      | 0.18    | 0.49    | Low        |
+| API integrations     | 0.36    | 0.74    | High       |
+
+### 3.3 Customer-requested top-10
+
+The product council reviewed the top-10 customer-requested features at
+the end of the quarter. Ranked by weighted ARR exposure:
+
+1. **Cross-workspace search** — committed to Q2.
+2. **SAML group-attribute mapping** — committed to Q2.
+3. **Custom retention policies per data type** — Q3 candidate.
+4. **Native Slack threading** — shipped (2026-03-19).
+5. **Bulk archival via API** — Q3 candidate.
+6. **CMK / BYOK for at-rest encryption** — Q3 commit.
+7. **Read-only audit-log API** — committed to Q2.
+8. **Webhook signing keys (per-endpoint rotation)** — Q3 candidate.
+9. **Per-region data residency for EU** — H2 commit.
+10. **Real-time presence in shared docs** — Q4 candidate.
+
+---
+
+## 4. Customer Success and Support
+
+### 4.1 Net retention
+
+Net dollar retention (NDR) for the quarter was **117%**, in line with
+plan. Gross dollar retention was **94%**, a 50 bp improvement over Q1
+2025. Cohort analysis shows the improvement is concentrated in the
+mid-market segment, where the new account-health scoring is producing
+higher renewal-touch coverage.
+
+| Segment   | NDR   | GDR  | Logos | ARR (M) |
+|-----------|-------|------|-------|---------|
+| Enterprise| 124%  | 97%  | 142   | 78.4    |
+| Mid-mkt   | 116%  | 95%  | 631   | 41.2    |
+| SMB       | 102%  | 88%  | 4,210 | 22.7    |
+
+### 4.2 Support
+
+> Support handled 18,420 tickets in Q1, a 14% increase vs. Q1 2025 — in
+> line with the customer-base growth. Median first response was 23
+> minutes (target: under 30); median resolution was 7.4 hours (target: under 8).
+
+| Tier      | Tickets | Median FR | Median TTR | CSAT |
+|-----------|---------|-----------|------------|------|
+| Critical  | 312     | 4 min     | 1.6 hr     | 4.6  |
+| High      | 1,840   | 11 min    | 4.1 hr     | 4.5  |
+| Standard  | 12,210  | 27 min    | 8.2 hr     | 4.4  |
+| Low       | 4,058   | 1.4 hr    | 18.7 hr    | 4.3  |
+
+CSAT (overall): **4.46** out of 5, up from 4.41 in Q4 2025.
+
+---
+
+## 5. Risk Register
+
+### 5.1 Top risks
+
+1. **Concentration risk on a single payment processor.** ~62% of
+   payment volume flows through one PSP; a 12-week incident in 2025
+   demonstrated the impact. Mitigation: integration with a second
+   processor is engineering-complete and in finance-side UAT;
+   targeted go-live mid-Q2.
+2. **Regulatory exposure on cross-border data transfers.** A pending
+   ruling in the EU could narrow the lawful basis for some transfers.
+   Mitigation: per-region data residency commit (see 3.3 #9).
+3. **Senior-engineer attrition concentrated in two teams.** Two staff
+   engineers gave notice in Q1; both are in the same team. Mitigation:
+   on-the-fly knowledge-share sessions and an active backfill on each
+   role; succession plans documented for both.
+
+### 5.2 Closed risks
+
+- **Auth-cluster single-region exposure** — closed Q1 with the
+  multi-region rollout.
+- **No on-call escalation for Reporting** — closed Q1 with the
+  reorg of the data team.
+
+---
+
+## 6. People
+
+### 6.1 Headcount
+
+| Org         | Start of Q1 | Hires | Leavers | End of Q1 |
+|-------------|-------------|-------|---------|-----------|
+| Engineering | 83          | 16    | 5       | 89        |
+| Product     | 18          | 2     | 0       | 20        |
+| Design      | 9           | 1     | 1       | 9         |
+| GTM         | 41          | 4     | 3       | 42        |
+| G and A     | 14          | 1     | 0       | 15        |
+| **Total**   | **165**     | **24**| **9**   | **175**   |
+
+Voluntary attrition annualised: **6.4%** company-wide.
+
+### 6.2 Engagement
+
+Pulse-survey engagement score: **8.1 / 10** (Q4 2025: 8.0). The largest
+positive shift was in *clarity of strategy* (7.8 to 8.4), reflecting the
+narrative work the leadership team did in late Q4. The largest negative
+shift was in *cross-team collaboration* (7.6 to 7.2), which the COO is
+addressing with a formal program-management function being stood up
+in Q2.
+
+---
+
+## 7. Outlook
+
+### 7.1 Q2 commitments
+
+- **Workflow Studio v3** ships by end of week 4.
+- **Cross-workspace search** ships by end of Q2.
+- **Second payment-processor integration** GA by end of Q2.
+- **Read-only audit-log API** GA by end of Q2.
+- **SAML group-attribute mapping** ships in Q2.
+
+### 7.2 Q2 financial guidance
+
+| Metric              | Guide          | Notes |
+|---------------------|----------------|-------|
+| Revenue             | 152 to 154M    | Low end assumes Workflow Studio slips a third week. |
+| Gross margin        | 76.5% to 77.5% |       |
+| Operating margin    | 18.5% to 20.0% |       |
+| Free cash flow      | 24 to 27M      |       |
+| Net new ARR         | 13 to 15M      |       |
+
+### 7.3 H2 themes
+
+- **CMK / BYOK at-rest encryption** as a strategic enterprise unblocker.
+- **Real-time collaboration primitives** in shared docs and dashboards.
+- **EU data residency** as a regulatory hedge and an enterprise sales lever.
+- **Platform observability** — bringing internal SLI / SLO tooling to
+  parity with the public-facing reliability surface.
+
+---
+
+## 8. Appendix
+
+### 8.1 Definitions
+
+- **ARR (annualised recurring revenue)**: end-of-period MRR multiplied by 12,
+  excluding one-time fees and services revenue.
+- **Net dollar retention (NDR)**: ARR from a cohort at the end of the period
+  divided by the ARR of that same cohort at the start of the period;
+  includes expansion, contraction, and churn.
+- **Gross dollar retention (GDR)**: same numerator excluding expansion;
+  measures pure retention on the contracted base.
+- **Mean time to production (TTP)**: median time from "PR approved" to
+  "merged commit live in production".
+
+### 8.2 Reading list
+
+- Internal: *Reliability Review for Q1* — published 2026-04-09.
+- Internal: *Capacity Plan H2 2026* — draft circulating with leadership.
+- External: [State of DevOps 2025 - DORA report](https://www.example.com/dora-2025).
+- External: [Why net retention beats new logos in this market](https://www.example.com/net-retention).
+
+### 8.3 Methodology notes
+
+Numbers in this report are derived from the standard reporting warehouse
+as of the close of business on 2026-04-04. Any subsequent restatements
+will be reflected in the Q2 report. Historical comparisons use the
+restated 2025 figures published in the Q4 2025 reconciliation memo.
+
+---
+
+## 9. Operational Detail Index
+
+Each operational metric below is captured for archive and for the
+quarter-by-quarter trend file maintained by the program office. Numbers
+are pulled from the standard warehouse and validated by the relevant
+function lead before publication.
+
+### 9.1 Engineering throughput trends
+
+| Week | Releases | PRs merged | Mean LOC | Defects |
+|------|----------|------------|----------|---------|
+| W01  | 4        | 84         | 142      | 1       |
+| W02  | 3        | 81         | 138      | 2       |
+| W03  | 4        | 92         | 161      | 1       |
+| W04  | 4        | 88         | 154      | 0       |
+| W05  | 3        | 79         | 137      | 1       |
+| W06  | 4        | 91         | 162      | 0       |
+| W07  | 4        | 85         | 148      | 2       |
+| W08  | 3        | 76         | 132      | 1       |
+| W09  | 4        | 83         | 149      | 1       |
+| W10  | 4        | 90         | 158      | 0       |
+| W11  | 3        | 78         | 141      | 0       |
+| W12  | 4        | 86         | 152      | 1       |
+| W13  | 3        | 80         | 144      | 0       |
+
+### 9.2 Customer-success motion
+
+| Week | New ARR | Expansion | Churn | Net new |
+|------|---------|-----------|-------|---------|
+| W01  | 0.91    | 0.42      | 0.18  | 1.15    |
+| W02  | 1.02    | 0.51      | 0.21  | 1.32    |
+| W03  | 0.84    | 0.46      | 0.17  | 1.13    |
+| W04  | 0.92    | 0.49      | 0.19  | 1.22    |
+| W05  | 1.18    | 0.52      | 0.22  | 1.48    |
+| W06  | 1.05    | 0.47      | 0.20  | 1.32    |
+| W07  | 0.96    | 0.44      | 0.18  | 1.22    |
+| W08  | 1.14    | 0.51      | 0.21  | 1.44    |
+| W09  | 1.07    | 0.49      | 0.19  | 1.37    |
+| W10  | 1.21    | 0.53      | 0.22  | 1.52    |
+| W11  | 0.98    | 0.48      | 0.18  | 1.28    |
+| W12  | 1.16    | 0.51      | 0.20  | 1.47    |
+| W13  | 1.08    | 0.46      | 0.19  | 1.35    |
+
+### 9.3 Capital-efficiency metrics
+
+> Capital efficiency continues to improve. The "Bessemer Efficiency Score"
+> (net new ARR divided by net cash burn) crossed above 1.0 in Q1 for the
+> first time, indicating the business is now generating more new ARR
+> than it consumes in cash to do so. This is the gating metric for the
+> board's IPO-readiness criteria.
+
+| Quarter | Magic Number | Burn Multiple | Bessemer Score |
+|---------|--------------|---------------|----------------|
+| Q1 2025 | 0.84         | 1.42          | 0.71           |
+| Q2 2025 | 0.92         | 1.31          | 0.79           |
+| Q3 2025 | 0.97         | 1.18          | 0.85           |
+| Q4 2025 | 1.06         | 1.04          | 0.96           |
+| Q1 2026 | 1.18         | 0.91          | 1.10           |
+
+### 9.4 Marketing funnel
+
+The integrated marketing funnel for the quarter:
+
+| Stage             | Volume   | Conv. to next | Conv. to closed-won |
+|-------------------|----------|---------------|---------------------|
+| Visits            | 1.42M    | 4.1%          | 0.18%               |
+| Sign-ups          | 58,200   | 42%           | 4.4%                |
+| Activations       | 24,400   | 31%           | 10.5%               |
+| SQLs              | 7,560    | 28%           | 33.7%               |
+| Opportunities     | 2,120    | 51%           | 120%*               |
+| Closed-won        | 1,082    | -             | -                   |
+
+*Opportunity-to-close conversion exceeds 100% in some weeks because the
+opportunity vintage skews older than the close vintage; reported on a
+trailing-twelve-week basis.
+
+### 9.5 Compliance posture
+
+- **SOC 2 Type II** — surveillance audit completed 2026-02-21; clean.
+- **ISO 27001:2022** — certification renewed 2026-03-04; no findings.
+- **GDPR DPIA** — refreshed for the EU residency commit.
+- **HIPAA** — readiness assessment complete; targeting attestation H2.
+
+---
+
+*Prepared by the Office of the CFO, in collaboration with the Engineering,
+Product, and People organisations.*
+
+[^methodology]: See section 8.3 for the methodology footnotes.
+[^scope]: This document covers the parent entity and all wholly-owned subsidiaries.
+
+---
+
+## 10. Per-Region Operational Detail
+
+The four operational regions are tracked individually below. Each region
+is owned by a regional GM with P&L responsibility; the consolidated
+numbers in section 1 roll up the per-region detail in this section.
+
+### 10.1 Region: AMER
+
+> AMER closed Q1 with 67% of new-logo ARR and 71% of total revenue.
+> Mid-market grew the fastest at +29% YoY; SMB grew +12% YoY but
+> remains the most price-sensitive segment.
+
+| Segment   | NDR  | GDR | Logos | ARR (M) | New (M) |
+|-----------|------|-----|-------|---------|---------|
+| Enterprise| 126% | 97% | 84    | 51.8    | 4.2     |
+| Mid-mkt   | 119% | 96% | 412   | 28.7    | 3.1     |
+| SMB       | 104% | 89% | 2,810 | 15.4    | 1.6     |
+
+#### Top accounts (AMER)
+
+1. **Account Alpha** — 6.8M ARR; expansion +1.2M in Q1.
+2. **Account Bravo** — 5.4M ARR; renewed flat.
+3. **Account Charlie** — 4.9M ARR; expansion +0.4M in Q1.
+4. **Account Delta** — 4.1M ARR; renewed flat.
+5. **Account Echo** — 3.8M ARR; expansion +0.6M in Q1.
+
+#### Pipeline (AMER, end of Q1)
+
+| Stage           | Count | Weighted (M) |
+|-----------------|-------|--------------|
+| Discovery       | 142   | 7.1          |
+| Validation      | 88    | 9.4          |
+| Proposal        | 51    | 11.8         |
+| Negotiation     | 28    | 8.6          |
+| Closed-won (Q2) | 12    | 4.2          |
+
+### 10.2 Region: EMEA
+
+> EMEA grew +24% YoY, ahead of plan. The Northern Europe sub-region
+> drove most of the upside, with the new Stockholm and Amsterdam
+> account-executive hires already producing closed-won revenue.
+
+| Segment   | NDR  | GDR | Logos | ARR (M) | New (M) |
+|-----------|------|-----|-------|---------|---------|
+| Enterprise| 121% | 96% | 38    | 16.4    | 1.8     |
+| Mid-mkt   | 113% | 94% | 142   | 8.7     | 1.2     |
+| SMB       | 100% | 86% | 982   | 4.6     | 0.6     |
+
+#### Top accounts (EMEA)
+
+1. **Account Foxtrot** — 3.2M ARR; expansion +0.4M in Q1.
+2. **Account Golf** — 2.8M ARR; renewed +0.1M.
+3. **Account Hotel** — 2.4M ARR; expansion +0.3M in Q1.
+4. **Account India** — 2.1M ARR; renewed flat.
+5. **Account Juliet** — 1.9M ARR; expansion +0.2M in Q1.
+
+#### Pipeline (EMEA, end of Q1)
+
+| Stage           | Count | Weighted (M) |
+|-----------------|-------|--------------|
+| Discovery       | 71    | 3.4          |
+| Validation      | 44    | 4.8          |
+| Proposal        | 26    | 6.2          |
+| Negotiation     | 14    | 4.4          |
+| Closed-won (Q2) | 6     | 2.1          |
+
+### 10.3 Region: APAC
+
+> APAC remains the smallest region but grew the fastest (+38% YoY).
+> Japan is the strongest single country; Australia and Singapore continue
+> to over-index in mid-market.
+
+| Segment   | NDR  | GDR | Logos | ARR (M) | New (M) |
+|-----------|------|-----|-------|---------|---------|
+| Enterprise| 132% | 98% | 14    | 7.4     | 0.9     |
+| Mid-mkt   | 124% | 97% | 58    | 3.1     | 0.5     |
+| SMB       | 108% | 91% | 318   | 1.9     | 0.3     |
+
+#### Top accounts (APAC)
+
+1. **Account Kilo** — 2.0M ARR; expansion +0.3M in Q1.
+2. **Account Lima** — 1.5M ARR; renewed +0.1M.
+3. **Account Mike** — 1.2M ARR; expansion +0.2M in Q1.
+4. **Account November** — 1.1M ARR; renewed flat.
+5. **Account Oscar** — 0.9M ARR; expansion +0.1M in Q1.
+
+#### Pipeline (APAC, end of Q1)
+
+| Stage           | Count | Weighted (M) |
+|-----------------|-------|--------------|
+| Discovery       | 38    | 1.6          |
+| Validation      | 22    | 2.1          |
+| Proposal        | 11    | 2.4          |
+| Negotiation     | 7     | 1.8          |
+| Closed-won (Q2) | 3     | 0.7          |
+
+### 10.4 Region: LATAM
+
+> LATAM remains a long-term investment region. The Mexico City team is
+> producing strong land-and-expand motion; Brazil opened later than
+> planned but is now staffed.
+
+| Segment   | NDR  | GDR | Logos | ARR (M) | New (M) |
+|-----------|------|-----|-------|---------|---------|
+| Enterprise| 117% | 95% | 6     | 2.8     | 0.4     |
+| Mid-mkt   | 109% | 92% | 19    | 0.7     | 0.1     |
+| SMB       | 96%  | 84% | 100   | 0.8     | 0.1     |
+
+#### Top accounts (LATAM)
+
+1. **Account Papa** — 0.9M ARR; expansion +0.1M in Q1.
+2. **Account Quebec** — 0.7M ARR; renewed flat.
+3. **Account Romeo** — 0.5M ARR; expansion +0.05M in Q1.
+
+#### Pipeline (LATAM, end of Q1)
+
+| Stage           | Count | Weighted (M) |
+|-----------------|-------|--------------|
+| Discovery       | 18    | 0.6          |
+| Validation      | 9     | 0.7          |
+| Proposal        | 4     | 0.8          |
+| Negotiation     | 2     | 0.5          |
+| Closed-won (Q2) | 1     | 0.2          |
+
+---
+
+## 11. Engineering Team Detail
+
+Each engineering team submits a quarterly write-up covering velocity,
+on-call posture, and notable shipped work. Excerpts below.
+
+### 11.1 Team: Platform
+
+> The Platform team focused on the v2 ingestion pipeline cutover and
+> the new authorisation layer. Both projects shipped on time, and the
+> ingestion cutover unlocked the v1 deprecation called out in section
+> 2.3. The team also picked up two additional rotations on the auth
+> on-call calendar to absorb load from the Application team.
+
+Key shipped work:
+
+- **v2 ingestion pipeline cutover** — 100% of new traffic now on v2.
+- **RLS-aware authorisation layer** — replacing the legacy permissions
+  cache.
+- **Multi-region rate-limit cluster** — closes the auth single-region
+  exposure called out in the Q4 2025 risk register.
+
+```rust
+// Representative API surface, simplified for the report.
+pub async fn ingest(
+    payload: Payload,
+    tenant: &Tenant,
+) -> Result<Receipt, IngestError> {
+    let normalised = normalise(payload, tenant)?;
+    let receipt = pipeline::v2::accept(normalised, tenant).await?;
+    Ok(receipt)
+}
+```
+
+### 11.2 Team: Application
+
+> Application shipped Universal Inbox GA, Reporting v2 GA, and made
+> meaningful progress on Workflow Studio v3. The slip on the latter
+> was driven by a deliberate scope addition (canvas-renderer rewrite)
+> rather than execution risk.
+
+Key shipped work:
+
+- **Universal Inbox GA** — beta to GA in 8 weeks; in-app onboarding
+  shipped alongside.
+- **Reporting v2 GA** — 63% of eligible customers migrated within 8
+  weeks.
+- **Mobile push for SOC 2 alerts** — partner team for the security buyer
+  persona.
+
+### 11.3 Team: Data and ML
+
+> Data and ML completed the MongoDB to Postgres migration on the
+> audit-log service and picked up the customer-churn-prediction model
+> work that the Customer Success org had been waiting on. The model
+> now powers the account-health scoring referenced in section 4.1.
+
+Key shipped work:
+
+- **Audit-log MongoDB to Postgres migration** — complete.
+- **Account-health model v2** — informing CSM renewal-touch coverage.
+- **Reporting v2 backend** — feature-complete; analytics warehouse
+  optimisation continues.
+
+### 11.4 Team: Infrastructure
+
+> Infrastructure absorbed the v1 ingestion deprecation work in
+> partnership with Platform, retired the dual-write to the analytics
+> warehouse, and stood up the second cloud region for the
+> data-residency commit.
+
+Key shipped work:
+
+- **EU region (FRA)** — stood up; pilot tenants migrated.
+- **Dual-write removal** — CDC pipeline is now the sole writer.
+- **Cost-optimisation initiative** — net cloud spend down 14% QoQ
+  excluding new-region build-out.
+
+### 11.5 Team: Security
+
+> Security closed the SOC 2 surveillance audit clean, refreshed the
+> ISO 27001:2022 certification, and stood up the HIPAA readiness work
+> for H2 attestation. The team also led the dual-control-on-prod-config
+> incident response described in section 2.2.
+
+Key shipped work:
+
+- **Dual-control on prod config pushes** — incident-response output.
+- **HIPAA readiness assessment** — complete; H2 attestation on plan.
+- **SOC 2 surveillance audit** — clean.
+
+---
+
+## 12. Customer Voice
+
+A sample of qualitative customer feedback collected via the
+quarterly business-review motion. Quotes are anonymised but
+attributable on request.
+
+> *"The new Universal Inbox has cut our team's daily mail-triage time
+> from 40 minutes to under 10. Our security analysts get to the
+> alerts that actually matter, faster. We're seeing tickets-to-incident
+> ratios drop noticeably."*
+> — Director of Security Engineering, Enterprise customer
+
+> *"Reporting v2 is genuinely a step change. The custom-metric API
+> means we no longer have to ship our finance data into a separate
+> dashboard tool. One less integration, one less vendor."*
+> — Head of Finance Operations, Mid-market customer
+
+> *"Workflow Studio v3's branching primitives are the thing we've
+> been waiting for since 2024. We understand the slip; the quality
+> bar held. We'd rather have it right than fast."*
+> — VP Engineering, Enterprise customer
+
+> *"Support has gotten faster every quarter. Our last critical was
+> resolved in under an hour, and the post-incident communication
+> was clear and direct. We notice."*
+> — CTO, Mid-market customer
+
+---
+
+## 13. Action Items for Q2
+
+The leadership team owns the following actions for Q2. Owners and
+deadlines are tracked in the Q2 ops review document.
+
+- [ ] Workflow Studio v3 ships by end of week 4.
+- [ ] Cross-workspace search ships by end of Q2.
+- [ ] Second payment-processor integration GA by end of Q2.
+- [ ] Read-only audit-log API GA by end of Q2.
+- [ ] SAML group-attribute mapping ships in Q2.
+- [x] Q1 audit-log MongoDB to Postgres migration — complete.
+- [x] v1 ingestion pipeline deprecated — complete.
+- [x] Multi-region rate-limit cluster — complete.
+
+---
+
+*End of report.*
+
+---
+
+## 14. Quarterly Cross-Functional Project Index
+
+The cross-functional project index below summarises every project that
+spanned more than one organisation in the quarter. Project status is
+captured at end-of-quarter; the live tracker carries the running view.
+
+### 14.1 Project: Universal Inbox GA
+
+> **Status:** Shipped on time, 2026-03-12. Adoption running ~2x the
+> comparable reference launch from 2025. Seven of the top-ten customer
+> deployments completed onboarding within the first three weeks.
+
+| Workstream            | Owner        | Status     |
+|-----------------------|--------------|------------|
+| Backend infra cutover | Platform     | Complete   |
+| Inbox UI              | Application  | Complete   |
+| In-app onboarding     | Application  | Complete   |
+| Marketing site update | Marketing    | Complete   |
+| Support enablement    | Support      | Complete   |
+| Pricing/packaging     | Finance      | Complete   |
+
+### 14.2 Project: Reporting v2 GA
+
+> **Status:** Shipped on time, 2026-02-04. Migration uptake ahead of
+> plan. Long-tail of legacy reports still served from v1 backend; v1
+> read-path deprecation now scheduled for Q3.
+
+| Workstream              | Owner        | Status     |
+|-------------------------|--------------|------------|
+| v2 backend              | Data and ML  | Complete   |
+| Custom-metric API       | Application  | Complete   |
+| Migration tooling       | Application  | Complete   |
+| Customer migration ops  | CSM          | In progress|
+| v1 read-path deprecation| Application  | Q3         |
+
+### 14.3 Project: Workflow Studio v3
+
+> **Status:** Slipped to Q2 week 4. Slip driven by deliberate scope
+> addition (canvas renderer rewrite). Decision and rationale ratified
+> by the product council on 2026-02-18.
+
+| Workstream              | Owner        | Status     |
+|-------------------------|--------------|------------|
+| Canvas renderer rewrite | Application  | In progress|
+| Branching primitives    | Application  | Complete   |
+| Migration tooling       | Application  | In progress|
+| Beta cohort onboarding  | CSM          | Q2         |
+
+### 14.4 Project: EU data residency
+
+> **Status:** Region stood up, pilot tenants migrated. Production
+> traffic cutover gated on the legal sign-off for the new sub-processor
+> agreements; targeted for end of Q2.
+
+| Workstream                | Owner          | Status     |
+|---------------------------|----------------|------------|
+| FRA region build-out      | Infrastructure | Complete   |
+| Multi-region routing      | Platform       | Complete   |
+| Pilot tenant migration    | CSM            | Complete   |
+| Sub-processor agreements  | Legal          | In progress|
+| GA cutover comms          | Marketing      | Q2         |
+
+### 14.5 Project: HIPAA readiness
+
+> **Status:** Readiness assessment complete; gap remediation under way.
+> Targeting H2 attestation. The work overlaps with the SOC 2 evidence
+> base; ~70% of controls are already in scope and in place.
+
+| Workstream                | Owner       | Status     |
+|---------------------------|-------------|------------|
+| Readiness assessment      | Security    | Complete   |
+| Gap remediation           | Security    | In progress|
+| Customer-facing BAA       | Legal       | In progress|
+| Attestation engagement    | Security    | H2         |
+
+### 14.6 Project: Second payment-processor integration
+
+> **Status:** Engineering complete; finance-side UAT under way.
+> Targeted GA mid-Q2. The dual-PSP architecture follows the pattern
+> documented in the 2025 incident-response review, and addresses the
+> top item in the risk register.
+
+| Workstream              | Owner       | Status     |
+|-------------------------|-------------|------------|
+| Engineering integration | Platform    | Complete   |
+| Finance UAT             | Finance     | In progress|
+| Reconciliation reporting| Finance     | In progress|
+| Customer-facing comms   | Marketing   | Q2         |
+
+---
+
+## 15. Operational Risk Detail
+
+The risk register in section 5 is the leadership-level summary. The
+operational-risk detail below is the program office's working list,
+including items that have been triaged below the leadership threshold
+but remain on the radar.
+
+### 15.1 Operational risks (working list)
+
+| ID  | Risk                                          | Likelihood | Impact | Owner       | Status     |
+|-----|-----------------------------------------------|------------|--------|-------------|------------|
+| R01 | Single-PSP concentration                      | Medium     | High   | Finance     | Mitigating |
+| R02 | EU cross-border transfers regulatory ruling   | Medium     | High   | Legal       | Watching   |
+| R03 | Senior-engineer attrition (specific team)     | Medium     | Medium | Engineering | Mitigating |
+| R04 | Data-warehouse capacity for new analytics    | Low        | Medium | Data and ML | Mitigating |
+| R05 | Vendor SLA on observability platform         | Low        | Medium | Infra       | Watching   |
+| R06 | New EU sub-processor agreements timeline     | Medium     | Medium | Legal       | Mitigating |
+| R07 | Sales-comp plan consistency in new region    | Low        | Low    | GTM         | Watching   |
+| R08 | Dependency on one CRM vendor                 | Low        | Medium | RevOps      | Watching   |
+| R09 | Dependency on one ID-provider for SSO        | Low        | Medium | Security    | Watching   |
+| R10 | Capacity for SOC 2 evidence collection       | Low        | Low    | Security    | Mitigating |
+| R11 | Data-residency for non-EU regulated tenants  | Low        | Medium | Infra       | Backlog    |
+| R12 | New-region tax-and-employment posture        | Low        | Medium | Finance     | Mitigating |
+
+### 15.2 Risk-treatment notes
+
+- **R01 (PSP concentration).** Engineering complete on the second-PSP
+  integration. UAT in finance-side reconciliation reporting. GA mid-Q2.
+- **R02 (EU transfers).** Watching the pending court decision. The EU
+  residency build-out (project 14.4) is the long-term hedge.
+- **R03 (Engineering attrition).** Backfill recruiting in flight.
+  Knowledge-share rotation set up. Succession plans documented.
+- **R04 (Warehouse capacity).** Tier-up to next compute tier scheduled
+  for Q2. Cost impact captured in the Q2 plan.
+- **R05 (Observability vendor).** Reviewing two alternatives in case
+  the current vendor's SLA terms do not improve at renewal.
+- **R06 (EU sub-processors).** New agreements in legal review. Targeted
+  signature end of Q2 to support project 14.4 GA.
+- **R07 (Comp consistency).** Q2 comp-plan refresh will normalise.
+- **R08 (CRM vendor).** Lower priority. Migration cost would be high.
+- **R09 (ID provider).** Architectural review scheduled for H2.
+- **R10 (Evidence capacity).** Tooling automation reduced manual
+  evidence collection by ~40% in Q1. Continuing.
+- **R11 (Non-EU regulated tenants).** Off-roadmap; will revisit when
+  customer demand crosses threshold.
+- **R12 (Tax and employment).** Engaged outside counsel; on track.
+
+---
+
+## 16. People Operations Detail
+
+### 16.1 Hiring throughput
+
+| Function    | Open Q1-start | Filled | Closed | Open Q1-end |
+|-------------|---------------|--------|--------|-------------|
+| Engineering | 14            | 16     | -8*    | 8           |
+| Product     | 3             | 2      | -1     | 0           |
+| Design      | 1             | 1      | 0      | 0           |
+| GTM         | 7             | 4      | 0      | 3           |
+| G and A     | 2             | 1      | 0      | 1           |
+
+*Eight engineering reqs were closed without a hire because the work
+was de-scoped during the Q1 portfolio review; the remaining open reqs
+roll forward into Q2.
+
+### 16.2 Compensation review
+
+The Q1 comp review applied the standard methodology: market-data refresh
+from the comp-survey vendor, internal-equity check, manager calibration,
+and finance approval. Notable outputs:
+
+- 92% of in-band employees received a market-aligned increase.
+- 8% of employees were identified as below-band and received a
+  band-correction increase outside the standard window.
+- No off-cycle equity grants outside the planned refresh program.
+
+### 16.3 Performance
+
+The Q1 performance check-in cycle ran on the new lighter-touch model
+(quarterly conversation, no formal calibration). Manager NPS on the
+new model: +42. Employee NPS on the new model: +38. Both materially
+above the prior-cycle scores.
+
+### 16.4 Diversity, equity, and inclusion
+
+| Metric                                | Q1 2026 | Q1 2025 |
+|---------------------------------------|---------|---------|
+| Women in engineering                  | 28%     | 24%     |
+| Women in leadership (M+ band)         | 41%     | 37%     |
+| URM in US workforce                   | 22%     | 19%     |
+| Pay-gap audit (gender, controlled)    | <0.5%   | <0.5%   |
+| Pay-gap audit (URM, controlled)       | <0.5%   | <0.5%   |
+
+---
+
+## 17. Appendix: Methodology and Definitions
+
+### 17.1 Reporting cadence
+
+- **Daily**: a single-page operational dashboard distributed to the
+  leadership team.
+- **Weekly**: a 4-page weekly business review distributed to all
+  managers.
+- **Monthly**: a closed-financials packet distributed to the board
+  observer list.
+- **Quarterly**: this report (consolidated operational view) plus the
+  audited financial statements (reconciled in the 10-business-day
+  window after quarter-end).
+
+### 17.2 Source-of-truth systems
+
+- **CRM** is the source of truth for opportunity stage, ARR, and
+  closed-won bookings.
+- **ERP** is the source of truth for revenue, cost, and cash flow.
+- **HRIS** is the source of truth for headcount, attrition, and comp.
+- **Reporting warehouse** is the source of truth for the operational
+  metrics in sections 2-4 and 9-12.
+
+### 17.3 Restatement policy
+
+We restate prior-period numbers when:
+
+1. A material reclassification changes the comparability of a metric.
+2. An audited adjustment is finalised after the original publication.
+3. A definitional change is approved by the program office.
+
+All restatements are flagged in the next-quarter report's appendix and
+reflected in the rolling trend file.
+
+### 17.4 Glossary additions for Q1
+
+- **Bessemer Efficiency Score**: net new ARR divided by net cash burn,
+  per the Bessemer Venture Partners definition.
+- **Magic Number**: net new ARR for the quarter divided by sales and
+  marketing spend in the prior quarter, annualised.
+- **Burn Multiple**: net cash burn divided by net new ARR for the
+  same period.
+
+### 17.5 Approvals
+
+This report was reviewed by the leadership team on 2026-04-09, ratified
+by the CFO on 2026-04-10, and circulated to the broader management
+team on 2026-04-11.
+
+---
+
+*Final.*
+
+---
+
+## 18. Per-Week Operational Detail
+
+The per-week detail below archives the weekly business-review numbers
+for the quarter. Future quarters can compare against these directly
+without re-querying the warehouse.
+
+### 18.1 Week 1 (2025-12-30 to 2026-01-05)
+
+> Holiday-shortened week. Pipeline-build motion paused; on-call
+> coverage held the line. No production incidents.
+
+| Metric             | Actual | Plan  | Delta |
+|--------------------|--------|-------|-------|
+| New ARR            | 0.91   | 0.80  | +13%  |
+| Pipeline created   | 4.2    | 4.0   | +5%   |
+| Tickets opened     | 1,108  | 1,200 | -8%   |
+| Tickets resolved   | 1,142  | 1,200 | -5%   |
+| P0 incidents       | 0      | 0     | -     |
+| P1 incidents       | 0      | <1    | -     |
+
+### 18.2 Week 2 (2026-01-06 to 2026-01-12)
+
+> First full operating week. Sales QBRs ran through the week. One P1
+> incident (transient ingestion lag, 18 minutes), resolved within SLO.
+
+| Metric             | Actual | Plan  | Delta |
+|--------------------|--------|-------|-------|
+| New ARR            | 1.02   | 0.95  | +7%   |
+| Pipeline created   | 4.8    | 4.7   | +2%   |
+| Tickets opened     | 1,420  | 1,400 | +1%   |
+| Tickets resolved   | 1,398  | 1,400 | -0%   |
+| P0 incidents       | 0      | 0     | -     |
+| P1 incidents       | 1      | <1    | -     |
+
+### 18.3 Week 3 (2026-01-13 to 2026-01-19)
+
+> Net-new ARR slightly soft on a quieter renewals week. No incidents.
+
+| Metric             | Actual | Plan  | Delta |
+|--------------------|--------|-------|-------|
+| New ARR            | 0.84   | 0.95  | -12%  |
+| Pipeline created   | 4.4    | 4.7   | -6%   |
+| Tickets opened     | 1,372  | 1,400 | -2%   |
+| Tickets resolved   | 1,401  | 1,400 | +0%   |
+| P0 incidents       | 0      | 0     | -     |
+| P1 incidents       | 0      | <1    | -     |
+
+### 18.4 Week 4 (2026-01-20 to 2026-01-26)
+
+> Recovered from the prior week's softness. Reporting v2 dogfooding
+> sprint produced eight customer-issue tickets (all addressed).
+
+| Metric             | Actual | Plan  | Delta |
+|--------------------|--------|-------|-------|
+| New ARR            | 0.92   | 0.95  | -3%   |
+| Pipeline created   | 5.1    | 4.7   | +9%   |
+| Tickets opened     | 1,508  | 1,400 | +8%   |
+| Tickets resolved   | 1,471  | 1,400 | +5%   |
+| P0 incidents       | 0      | 0     | -     |
+| P1 incidents       | 0      | <1    | -     |
+
+### 18.5 Week 5 (2026-01-27 to 2026-02-02)
+
+> Strongest week of the quarter for new ARR. Reporting v2 GA-readiness
+> review held mid-week; green-lit for the following Monday.
+
+| Metric             | Actual | Plan  | Delta |
+|--------------------|--------|-------|-------|
+| New ARR            | 1.18   | 1.00  | +18%  |
+| Pipeline created   | 5.4    | 5.0   | +8%   |
+| Tickets opened     | 1,620  | 1,500 | +8%   |
+| Tickets resolved   | 1,584  | 1,500 | +6%   |
+| P0 incidents       | 0      | 0     | -     |
+| P1 incidents       | 0      | <1    | -     |
+
+### 18.6 Week 6 (2026-02-03 to 2026-02-09)
+
+> Reporting v2 GA shipped Tuesday. Migration uptake started ahead of
+> plan. One P1 incident (rate-limit cluster cascading restart),
+> resolved within 4 minutes; post-incident review filed.
+
+| Metric             | Actual | Plan  | Delta |
+|--------------------|--------|-------|-------|
+| New ARR            | 1.05   | 1.00  | +5%   |
+| Pipeline created   | 5.0    | 5.0   | -1%   |
+| Tickets opened     | 1,742  | 1,500 | +16%  |
+| Tickets resolved   | 1,683  | 1,500 | +12%  |
+| P0 incidents       | 0      | 0     | -     |
+| P1 incidents       | 1      | <1    | -     |
+
+### 18.7 Week 7 (2026-02-10 to 2026-02-16)
+
+> Mid-quarter forecast call: forecast on track. Universal Inbox beta
+> opened to the second cohort (200 customers).
+
+| Metric             | Actual | Plan  | Delta |
+|--------------------|--------|-------|-------|
+| New ARR            | 0.96   | 1.00  | -4%   |
+| Pipeline created   | 5.2    | 5.0   | +5%   |
+| Tickets opened     | 1,612  | 1,500 | +7%   |
+| Tickets resolved   | 1,648  | 1,500 | +10%  |
+| P0 incidents       | 0      | 0     | -     |
+| P1 incidents       | 0      | <1    | -     |
+
+### 18.8 Week 8 (2026-02-17 to 2026-02-23)
+
+> Workflow Studio v3 scope-decision week. Product council ratified the
+> canvas-renderer rewrite addition; slip to Q2 acknowledged.
+
+| Metric             | Actual | Plan  | Delta |
+|--------------------|--------|-------|-------|
+| New ARR            | 1.14   | 1.00  | +14%  |
+| Pipeline created   | 5.3    | 5.0   | +6%   |
+| Tickets opened     | 1,540  | 1,500 | +3%   |
+| Tickets resolved   | 1,576  | 1,500 | +5%   |
+| P0 incidents       | 0      | 0     | -     |
+| P1 incidents       | 0      | <1    | -     |
+
+### 18.9 Week 9 (2026-02-24 to 2026-03-02)
+
+> Strong renewals week. NDR cohort attainment tracking ahead of plan.
+
+| Metric             | Actual | Plan  | Delta |
+|--------------------|--------|-------|-------|
+| New ARR            | 1.07   | 1.05  | +2%   |
+| Pipeline created   | 5.0    | 5.2   | -3%   |
+| Tickets opened     | 1,448  | 1,500 | -3%   |
+| Tickets resolved   | 1,512  | 1,500 | +1%   |
+| P0 incidents       | 0      | 0     | -     |
+| P1 incidents       | 0      | <1    | -     |
+
+### 18.10 Week 10 (2026-03-03 to 2026-03-09)
+
+> Universal Inbox GA-readiness review held Friday; green-lit for the
+> following week.
+
+| Metric             | Actual | Plan  | Delta |
+|--------------------|--------|-------|-------|
+| New ARR            | 1.21   | 1.05  | +15%  |
+| Pipeline created   | 5.6    | 5.2   | +8%   |
+| Tickets opened     | 1,602  | 1,500 | +7%   |
+| Tickets resolved   | 1,584  | 1,500 | +6%   |
+| P0 incidents       | 0      | 0     | -     |
+| P1 incidents       | 0      | <1    | -     |
+
+### 18.11 Week 11 (2026-03-10 to 2026-03-16)
+
+> Universal Inbox GA shipped Thursday. Onboarding-flow telemetry
+> indicated higher-than-expected completion rates from minute one.
+
+| Metric             | Actual | Plan  | Delta |
+|--------------------|--------|-------|-------|
+| New ARR            | 0.98   | 1.05  | -7%   |
+| Pipeline created   | 5.1    | 5.2   | -2%   |
+| Tickets opened     | 1,704  | 1,500 | +14%  |
+| Tickets resolved   | 1,672  | 1,500 | +11%  |
+| P0 incidents       | 0      | 0     | -     |
+| P1 incidents       | 0      | <1    | -     |
+
+### 18.12 Week 12 (2026-03-17 to 2026-03-23)
+
+> First full week of Universal Inbox GA-traffic. Native Slack threading
+> shipped to the first launch cohort.
+
+| Metric             | Actual | Plan  | Delta |
+|--------------------|--------|-------|-------|
+| New ARR            | 1.16   | 1.10  | +6%   |
+| Pipeline created   | 5.4    | 5.2   | +4%   |
+| Tickets opened     | 1,651  | 1,500 | +10%  |
+| Tickets resolved   | 1,684  | 1,500 | +12%  |
+| P0 incidents       | 0      | 0     | -     |
+| P1 incidents       | 0      | <1    | -     |
+
+### 18.13 Week 13 (2026-03-24 to 2026-03-30)
+
+> Quarter-close week. Mobile push for SOC 2 alerts shipped Friday.
+
+| Metric             | Actual | Plan  | Delta |
+|--------------------|--------|-------|-------|
+| New ARR            | 1.08   | 1.10  | -2%   |
+| Pipeline created   | 5.0    | 5.2   | -3%   |
+| Tickets opened     | 1,433  | 1,500 | -4%   |
+| Tickets resolved   | 1,461  | 1,500 | -3%   |
+| P0 incidents       | 0      | 0     | -     |
+| P1 incidents       | 0      | <1    | -     |
+
+---
+
+*End of per-week detail.*
+
+---
+
+## 19. Closing Remarks
+
+This is the last quarterly report on the v1 reporting template. Starting
+in Q2, we'll publish the operational view in the new format ratified by
+the program office in March. The headline-level metrics will stay
+consistent so trend-over-trend comparisons remain straightforward; the
+detail sections will reorganise around the four operating regions
+rather than around the four functional organisations.
+
+The leadership team thanks the broader management group for the
+hands-on contribution to this report's data and qualitative content.
+The next quarterly view will land 10 business days after Q2 close, with
+the customary executive read-out on the second Friday after publication.
+
+### 19.1 Acknowledgements
+
+- Engineering leadership team — for the section 11 write-ups.
+- CSM leadership — for the customer-voice section 12 contributions.
+- Program office — for the cross-functional project index and the
+  operational-risk detail.
+- Finance — for the rapid-turnaround financial highlights and the
+  capital-efficiency analysis.
+- People operations — for the headcount, attrition, and engagement
+  detail.
+- Security — for the compliance-posture section.
+
+### 19.2 Distribution
+
+This report is distributed to:
+
+- Board of directors and observers (full).
+- Leadership team (full).
+- Broader management team (full, redacted version on request).
+- All-hands snapshot (financial highlights and outlook only).
+- Investor update (financial highlights and outlook only).
+
+### 19.3 Feedback
+
+Feedback on this report is welcome and is collated by the program office
+into the next-quarter template-refresh exercise. Please send comments
+or corrections by end of the second week of Q2.
+
+---
+
+*Final. Q1 2026 Operations Report.*


### PR DESCRIPTION
## Sprint Goal

Build a pure renderer module (`src/markdown_render.rs`) that converts Markdown to email-ready HTML with an inlined stylesheet and a 5MB body cap. No daemon integration in this sprint — just the module, its tests, and the determinism / perf guardrails CI needs to defend the rest of the work.

## Stories Implemented

### [S1-1] Add `comrak` dep and create `src/markdown_render.rs` with CommonMark + GFM config
- [x] `comrak = "=0.52.0"` (exact-version pin) added to root `Cargo.toml`. Default features (`cli`, `syntect`) disabled.
- [x] New module `src/markdown_render.rs` exposing `pub fn render_markdown_to_email_html(markdown: &str) -> Result<String, MarkdownRenderError>`.
- [x] `Options` (the comrak 0.52 successor to `ComrakOptions`) is built once in a `OnceLock`. Extensions enabled: `table`, `strikethrough`, `autolink`, `tasklist`, `footnotes`, `tagfilter`. `header_id_prefix` enabled with empty prefix. `unsafe = false`.
- [x] Unit test: render `# Hello\n\n- a\n- b` → `<h1>Hello</h1>` and a `<ul>` with two `<li>` children.
- [x] Unit test: raw HTML in Markdown is neutralised — `<script>` is stripped (tagfilter), other raw tags are escaped or stripped. The test asserts the security invariant (no executable HTML survives) rather than the exact stripped/escaped shape.
- [x] Unit test: GFM table input renders with `<table>`, `<thead>`, `<tbody>`, `<th>`, `<td>`.
- [x] Release-binary size grew by **~71KB** (24,964,056 → 25,036,560 bytes), well under the 500KB budget.
- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean.

### [S1-2] Inlined-stylesheet pass over the rendered HTML
- [x] `lol_html = "2"` added to `Cargo.toml`. License: BSD-3-Clause.
- [x] `pub fn inline_email_styles(html: &str) -> String` walks the comrak output and adds `style="..."` attributes for `body`, `h1-h4`, `p`, `ul/ol/li`, `a`, `code`, `pre`, `blockquote`, `table/th/td`, `hr`.
- [x] `render_markdown_to_email_html` calls `inline_email_styles` after comrak — single combined entry point.
- [x] Style values are `const &str` definitions in the module. No disk I/O. No remote URLs.
- [x] Unit test: `# Title` → `<h1 style="...`, no `<style>` block, no `<link>`, no `googleapis`, no `http://` URLs injected.
- [x] Unit test: rendered HTML for the briefing fixture is **14,290 bytes**, well under the 25KB cap.
- [x] Unit test: autolinked URL produces an `<a>` with the inline link colour and no `text-decoration: underline` at rest.
- [x] Unit test: nested `<pre> > <code>` keeps both styles applied.
- [x] Unit test: pre-existing `style` attributes on rendered tags are preserved (defaults appended after, not overwriting).
- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean.

### [S1-3] 5MB body cap with canonical rejection error
- [x] `MarkdownRenderError::BodyTooLarge` whose `Display` impl emits the canonical string verbatim: *"markdown body exceeds 5MB; use --html-body for pre-rendered large documents or --attachment for sending the document as a file"*.
- [x] `pub const MAX_MARKDOWN_BODY_BYTES: usize = 5 * 1024 * 1024;` in the module.
- [x] `render_markdown_to_email_html` returns `Err(BodyTooLarge)` for `markdown.len() > MAX_MARKDOWN_BODY_BYTES`, **before** invoking comrak.
- [x] Unit test: body of size exactly `MAX_MARKDOWN_BODY_BYTES` succeeds (boundary case).
- [x] Unit test: body of size `MAX_MARKDOWN_BODY_BYTES + 1` returns `Err(BodyTooLarge)` with the canonical message byte-for-byte.
- [x] Unit test: oversize body returns `BodyTooLarge` and produces no rendered HTML — the early return guarantees comrak isn't invoked.
- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean.

### [S1-4] Determinism + perf integration tests on 5KB and 50KB fixtures
- [x] Two fixtures: `tests/fixtures/markdown/briefing-5kb.md` (5,101 bytes; daily finance briefing — headings, lists, links, GFM table, code block, blockquote, footnote) and `report-50kb.md` (46,619 bytes; quarterly operations report scaling the same shapes up).
- [x] Two checked-in expected outputs: `briefing-5kb.expected.html` (14,290 bytes) and `report-50kb.expected.html` (165,001 bytes), produced by the pinned `comrak = 0.52.0`.
- [x] Determinism tests (in-process) for both fixtures: render twice, assert byte-equal.
- [x] Drift tests (vs. checked-in `*.expected.html`) for both fixtures.
- [x] Perf tests gated on `#[cfg(not(debug_assertions))]`: 5KB < 10ms, 50KB < 50ms. Both pass on `cargo test --release`.
- [x] Drift-failure assertion message points operators at the `*.expected.html` files **and** prompts a release-notes line about the renderer-version change.
- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean.

## Technical Decisions

- **`comrak` 0.52 API.** The PRD references `ComrakOptions`; the current crate ships `Options` and uses `r#unsafe`, `extension.table`, and `extension.header_id_prefix`. I followed the live API and noted the rename in the module's doc comment so a future `comrak` bump is unambiguous.
- **Test location.** The crate is binary-only (no `[lib]` target), so integration tests in `tests/` cannot import internal items. The fixture-backed determinism + drift + perf tests therefore live as unit tests in `src/markdown_render.rs` and load the fixtures via `include_str!("../tests/fixtures/markdown/...")`. Functionally equivalent to the `tests/markdown_render.rs` shape contemplated by the sprint plan; same fixture path, same checked-in expected files, same CI behaviour.
- **`tagfilter` semantics.** With `unsafe = false` plus the GFM tagfilter, comrak strips disallowed raw tags (`<script>`, `<iframe>`, ...) entirely and emits a `<!-- raw HTML omitted -->` placeholder, rather than escaping the source as `&lt;script&gt;`. This is strictly better than escaping for the security invariant (no executable HTML reaches the recipient) so the unit test asserts the invariant ("no `<script>` survives, no `alert(1)` survives") rather than a specific stripped/escaped shape.
- **Inlining strategy.** `lol_html` (Cloudflare's streaming HTML rewriter) walks the comrak output once and attaches `style="..."` per matched tag. Existing inline `style` attributes are preserved — defaults are appended after, so operator-supplied overrides keep precedence (relevant once `--html-body` lands in a later sprint).
- **Bless workflow.** `AIMX_BLESS_EXPECTED=1 cargo test` rewrites the `*.expected.html` fixtures in place from the live renderer output. Lets a maintainer re-bless after a deliberate `comrak` bump in a single command.
- **Dead-code allowance.** The module's `pub` surface is consumed only by its own tests until the daemon wiring lands. `mod markdown_render` carries a scoped `#[allow(dead_code)]` (matching the precedent for `release.rs`) so `cargo clippy -D warnings` stays clean during the foundation sprint without silencing genuinely-dead items elsewhere.

## Deferred Items

- **Daemon wire-up.** `send_handler` calling `render_markdown_to_email_html` and assembling `multipart/alternative` lands in the next sprint of this track, per the dependency declared in the sprint plan.

## Review Focus Areas

- `src/markdown_render.rs` — the renderer surface, the `OnceLock` config setup, the `lol_html` element handlers, and the bless workflow.
- `Cargo.toml` — the exact-version pin on `comrak` and the disabled default features. `lol_html` carries no feature configuration; its default surface is what we need.
- `tests/fixtures/markdown/` — the two fixtures and their `*.expected.html`. The expected files are large; review the fixtures and trust the renderer for the expected output (it's deterministic and the drift test would fail at CI if it weren't right).
- The dead-code allowance on `mod markdown_render` in `src/main.rs` — temporary; will come off the moment the daemon imports the renderer.