### PR TITLE
[Sprint 4] MCP + sent storage + docs + release notes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -19,7 +19,7 @@ dependencies = [
 
 [[package]]
 name = "aimx"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "assert_cmd",
  "base64",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "aimx"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 rust-version = "1.88.0"
 authors = ["U-Zyn Chua <chua@uzyn.com>"]

--- a/agents/common/aimx-primer.md
+++ b/agents/common/aimx-primer.md
@@ -103,15 +103,23 @@ surface.
   metadata, sorted descending by filename (newest first). `folder` is
   `"inbox"` (default) or `"sent"`. `limit` defaults to 50, max 200; values
   above 200 are silently clamped. Returns a JSON array — agents
-  filter client-side (e.g. `read == false` for triage). aimx never
+  filter client-side (e.g. `read == false` for triage). AIMX never
   scans on your behalf; pass `offset` to page deeper.
 - `email_read(mailbox, id, folder?)`: return the full Markdown file
   (frontmatter + body) for one email.
-- `email_send(from_mailbox, to, subject, body, attachments?)`: compose,
-  DKIM-sign, and deliver an email. `from_mailbox` must be a mailbox you
-  own.
-- `email_reply(mailbox, id, body)`: reply to an existing email. aimx sets
-  `In-Reply-To`, `References`, and `Re:` subject automatically.
+- `email_send(from_mailbox, to, subject, body, attachments?, text_only?, html_body?)`:
+  compose, DKIM-sign, and deliver an email. **`body` is interpreted as
+  Markdown** (CommonMark + GFM extensions). AIMX renders it to HTML and
+  sends as `multipart/alternative` — recipients on rich-capable clients
+  see styled HTML; recipients on text-only clients see the Markdown
+  source. Set `text_only: true` for plain-text-only sends (e.g. OTPs,
+  transactional one-liners). Set `html_body` to override the
+  auto-rendered HTML with your own template. `text_only` and `html_body`
+  are mutually exclusive. `from_mailbox` must be a mailbox you own.
+- `email_reply(mailbox, id, body, text_only?, html_body?)`: reply to an
+  existing email. `body` is Markdown by default with the same `text_only` /
+  `html_body` escape hatches as `email_send`. AIMX sets `In-Reply-To`,
+  `References`, and `Re:` subject automatically.
 - `email_mark_read(mailbox, id)`: mark a single inbox email as read.
 - `email_mark_unread(mailbox, id)`: mark a single inbox email as unread.
 
@@ -247,22 +255,30 @@ tools (or call `email_read` if you prefer the daemon-mediated path), then
 
 ### 2. Send an email
 
+`body` is **Markdown by default** — AIMX renders it to HTML and sends
+as `multipart/alternative`, so recipients on rich clients see styled
+HTML and text-only clients see the Markdown source. Use Markdown for
+headings, tables, links, code blocks, and lists.
+
 ```
 email_send(
   from_mailbox: "agent",
   to: "alice@example.com",
   subject: "Weekly report",
-  body: "Here is the summary..."
+  body: "# Weekly report\n\n- Highlight one\n- Highlight two\n\nDetails: [dashboard](https://example.com/dash)."
 )
 ```
 
+For plain-text sends (OTPs, transactional one-liners) pass
+`text_only: true` to ship `body` verbatim as `text/plain`. For custom
+branded HTML layouts, pass `html_body` (used verbatim as the HTML part)
+and keep `body` as the plain-text fallback. `text_only` and `html_body`
+are mutually exclusive.
+
 The mailbox must exist and you must own it. Provision new mailboxes
-via `mailbox_create(name)` (owned by your uid) or, when the operator
-needs to create one owned by a different user, via
-`sudo aimx mailboxes create <name> --owner <user>` on the host.
-`from_mailbox` is the local part only (e.g. `"agent"`, not
-`"agent@example.com"`). aimx DKIM-signs the message and delivers it via
-direct SMTP to the recipient's MX server.
+via `mailbox_create(name)` (owned by your uid). `from_mailbox` is the
+local part only (e.g. `"agent"`, not `"agent@example.com"`). AIMX
+DKIM-signs the message and delivers it via direct SMTP.
 
 ### 3. Reply to a message
 

--- a/agents/common/references/mcp-tools.md
+++ b/agents/common/references/mcp-tools.md
@@ -251,6 +251,21 @@ Compose, DKIM-sign, and deliver an email. The message is submitted to
 `aimx serve` via UDS, which signs it with the server's DKIM key and delivers
 directly to the recipient's MX server.
 
+`body` is interpreted as **Markdown by default** (CommonMark + GFM
+extensions: tables, strikethrough, autolinks, task lists, footnotes).
+AIMX renders the Markdown to HTML with an inlined stylesheet and ships
+a `multipart/alternative` — recipients on rich-capable clients see
+styled HTML; recipients on text-only clients see the Markdown source.
+
+Two escape hatches cover the edge cases:
+
+- `text_only: true` — ship `body` verbatim as `text/plain`. No
+  rendering. Use for OTPs, transactional one-liners, and existing
+  scripts that must not change shape.
+- `html_body: "<custom html>"` — supply a custom HTML template that
+  AIMX uses verbatim as the `text/html` part. `body` is the
+  `text/plain` fallback. Mutually exclusive with `text_only`.
+
 **Parameters:**
 | Name           | Type     | Required | Description |
 |---------------|----------|----------|-------------|
@@ -258,9 +273,11 @@ directly to the recipient's MX server.
 | `to`           | string   | yes      | Recipient email address |
 | `subject`      | string   | yes      | Email subject |
 | `reply_to`     | string   | no       | Message-ID of the email being replied to. Sets `In-Reply-To`. When `references` is omitted, `References` is built automatically from this value. Required to enable threading. Without `reply_to`, any `references` value is silently ignored and no threading headers are emitted |
-| `body`         | string   | yes      | Email body text |
+| `body`         | string   | yes      | Email body. Interpreted as Markdown by default (CommonMark + GFM). Used verbatim as `text/plain` when `text_only: true`; used as the `text/plain` fallback when `html_body` is set |
 | `attachments`  | string[] | no       | Absolute file paths to attach |
 | `references`   | string   | no       | Full `References` header chain (space-separated Message-IDs). **Only applied when `reply_to` is also set.** Supplied alone, it is silently ignored |
+| `text_only`    | boolean  | no       | When `true`, ship `body` verbatim as `text/plain` with no Markdown rendering and no HTML alternative part. Mutually exclusive with `html_body` |
+| `html_body`    | string   | no       | Custom HTML for the `text/html` part. Operator-supplied; bypasses the renderer. Mutually exclusive with `text_only` |
 
 For simple replies to a single sender, prefer `email_reply`. It reads the
 original email and fills in threading headers and the `Re:` subject
@@ -270,15 +287,37 @@ custom threading chain.
 
 **Returns:** Confirmation with Message-ID.
 
-**Example, plain text:**
+**Example, default Markdown:**
 ```
 email_send(
   from_mailbox: "agent",
   to: "alice@example.com",
   subject: "Status Update",
-  body: "All systems operational."
+  body: "# Status\n\n- All systems operational.\n- See [dashboard](https://example.com/dash) for details."
 )
 → "Sent. Message-ID: <abc123@domain.com>"
+```
+
+**Example, plain-text only (OTP):**
+```
+email_send(
+  from_mailbox: "agent",
+  to: "alice@example.com",
+  subject: "Verification code",
+  body: "Your code: 184293",
+  text_only: true
+)
+```
+
+**Example, custom HTML layout:**
+```
+email_send(
+  from_mailbox: "agent",
+  to: "bob@example.com",
+  subject: "Newsletter",
+  body: "Plain-text fallback for text-only clients.",
+  html_body: "<!DOCTYPE html><html><body><h1>Newsletter</h1>...</body></html>"
+)
 ```
 
 **Example, with attachments:**
@@ -287,7 +326,7 @@ email_send(
   from_mailbox: "agent",
   to: "bob@example.com",
   subject: "Report",
-  body: "Please see attached.",
+  body: "# Report\n\nSee the attached files.",
   attachments: ["/tmp/report.csv", "/tmp/chart.png"]
 )
 ```
@@ -315,31 +354,48 @@ email_send(
 - Daemon not running (socket missing).
 - Sender domain mismatch.
 - Delivery failure (remote MX rejected).
+- `text_only` and `html_body` both set: `AIMX/1 SEND: --text-only and --html-body are mutually exclusive`.
+- Markdown body exceeds 5MB: `markdown body exceeds 5MB; use --html-body for pre-rendered large documents or --attachment for sending the document as a file`.
 
 ---
 
 ### `email_reply`
 
-Reply to an existing email. aimx automatically sets `In-Reply-To`,
+Reply to an existing email. AIMX automatically sets `In-Reply-To`,
 `References`, and prepends `Re:` to the subject.
 
+`body` is interpreted as **Markdown by default** with the same
+`text_only` / `html_body` escape hatches as `email_send`.
+
 **Parameters:**
-| Name      | Type   | Required | Description |
-|-----------|--------|----------|-------------|
-| `mailbox` | string | yes      | Mailbox containing the email to reply to (must be owned by you) |
-| `id`      | string | yes      | Email ID to reply to |
-| `body`    | string | yes      | Reply body text |
+| Name        | Type    | Required | Description |
+|-------------|---------|----------|-------------|
+| `mailbox`   | string  | yes      | Mailbox containing the email to reply to (must be owned by you) |
+| `id`        | string  | yes      | Email ID to reply to |
+| `body`      | string  | yes      | Reply body. Interpreted as Markdown by default. With `text_only: true`, shipped verbatim as `text/plain`. With `html_body`, used as the `text/plain` fallback |
+| `text_only` | boolean | no       | When `true`, ship `body` verbatim as `text/plain` with no Markdown rendering. Mutually exclusive with `html_body` |
+| `html_body` | string  | no       | Custom HTML for the `text/html` part. Operator-supplied; bypasses the renderer. Mutually exclusive with `text_only` |
 
 **Returns:** Confirmation with Message-ID.
 
-**Example:**
+**Example, default Markdown reply:**
 ```
 email_reply(
   mailbox: "agent",
   id: "2026-04-15-143022-meeting-notes",
-  body: "Thanks, I'll review the notes."
+  body: "Thanks — I'll review the notes.\n\n- Quick follow-up: meet again Friday?"
 )
 → "Sent. Message-ID: <def456@domain.com>"
+```
+
+**Example, plain-text reply:**
+```
+email_reply(
+  mailbox: "agent",
+  id: "2026-04-15-143022-meeting-notes",
+  body: "Acknowledged.",
+  text_only: true
+)
 ```
 
 ---

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -8,6 +8,7 @@
 - [Configuration](configuration.md)
 - [Security](security.md)
 - [Mailboxes & Email](mailboxes.md)
+- [Markdown Email](markdown-email.md)
 - [Hooks & Trust](hooks.md)
 - [Hook Recipes](hook-recipes.md)
 - [MCP Server](mcp.md)

--- a/book/cli.md
+++ b/book/cli.md
@@ -78,7 +78,14 @@ Tail or follow the `aimx serve` service log. Wraps `journalctl -u aimx` on syste
 
 ### `aimx send`
 
-Compose an RFC 5322 message and submit it to `aimx serve` via `/run/aimx/aimx.sock`. Refuses root. The daemon handles DKIM signing and MX delivery.
+Compose a message and submit it to `aimx serve` via `/run/aimx/aimx.sock`. Refuses root. The daemon handles Markdown rendering, DKIM signing, and MX delivery.
+
+`--body` is interpreted as **Markdown** (CommonMark + GFM extensions: tables, strikethrough, autolinks, task lists, footnotes). The daemon renders it to HTML with an inlined stylesheet and ships a `multipart/alternative` message — the recipient sees rich text on Gmail / Outlook / Apple Mail and the Markdown source on text-only clients. Two escape hatches are available:
+
+- **`--text-only`** — ship the body verbatim as `text/plain`. No rendering. Use for OTPs, transactional one-liners, and existing scripts that must not change shape.
+- **`--html-body <html>`** — supply a custom HTML template for the `text/html` part. AIMX uses your HTML verbatim and uses `--body` as the `text/plain` fallback. Mutually exclusive with `--text-only`.
+
+For an in-depth tour of the rendering pipeline and the inlined stylesheet, see [Markdown Email](markdown-email.md).
 
 The caller's euid must own the mailbox resolved from the `From:` local part; sends from another owner's mailbox are rejected with `not authorized: <local_part>@<domain>`. The catchall (`*@domain`) is inbound-only and is never accepted as an outbound sender. See [Security: Per-action authorization](security.md#per-action-authorization).
 
@@ -87,10 +94,38 @@ The caller's euid must own the mailbox resolved from the `From:` local part; sen
 | `--from <addr>` | Sender address. Must resolve to an explicitly configured (non-wildcard) mailbox owned by the caller. |
 | `--to <addr>` | Recipient address. |
 | `--subject <text>` | Subject line. |
-| `--body <text>` | Plain-text body. |
+| `--body <text>` | Body content. Interpreted as Markdown by default. With `--text-only`, shipped verbatim as `text/plain`. With `--html-body`, used as the `text/plain` fallback. |
+| `--text-only` | Ship `--body` verbatim as `text/plain`. Skips Markdown rendering and the HTML alternative part. Mutually exclusive with `--html-body`. |
+| `--html-body <html>` | Custom HTML for the `text/html` part. Operator-supplied; bypasses the renderer. Use the shell pattern `--html-body "$(cat template.html)"` for templates that don't fit on one command line. Mutually exclusive with `--text-only`. |
 | `--reply-to <msg-id>` | Sets the `In-Reply-To` header for threading. |
 | `--references <chain>` | Sets the full `References` header. Needed only for multi-step threads where `In-Reply-To` alone is insufficient. |
-| `--attachment <path>` | Attach a file. Repeatable for multiple attachments. |
+| `--attachment <path>` | Attach a file. Repeatable. With Markdown / `--html-body`, attachments wrap the alternative part in a `multipart/mixed`. |
+
+Examples:
+
+```bash
+# Default: Markdown body → recipient sees rendered HTML inline.
+aimx send --from alice@example.com --to bob@example.com \
+  --subject "Daily briefing" \
+  --body "# Daily briefing\n\n- item one\n- item two"
+
+# Plain-text only (e.g. OTPs, scripts that must not change shape).
+aimx send --from alice@example.com --to bob@example.com \
+  --subject "Verification code" --body "Your code: 184293" --text-only
+
+# Custom branded HTML layout — operator owns the rendering.
+aimx send --from alice@example.com --to bob@example.com \
+  --subject "Newsletter" --body "Plain-text fallback for text-only clients." \
+  --html-body "$(cat newsletter.html)"
+
+# Markdown body + attachment.
+aimx send --from alice@example.com --to bob@example.com \
+  --subject "Q4 report" --body "See attached PDF." --attachment ./report.pdf
+```
+
+If both `--text-only` and `--html-body` are supplied, clap rejects the invocation before any UDS round-trip. The same canonical error fires server-side on the MCP `email_send` / `email_reply` tools so operators see one consistent message regardless of the surface.
+
+The sent record under `sent/<mailbox>/` always stores the **Markdown source** (or, for `--text-only`, the literal text — or for `--html-body`, the `--body` text part). The recipient's HTML view is recoverable by re-running the same renderer; AIMX does not duplicate the rendered HTML alongside the source. See [Markdown Email: Sent storage](markdown-email.md#sent-storage).
 
 See [Mailboxes: Sending email](mailboxes.md#sending-email).
 

--- a/book/mailboxes.md
+++ b/book/mailboxes.md
@@ -267,30 +267,46 @@ The `email_list` MCP tool returns the `read` flag on every inbox row. Agents pag
 
 ## Sending email
 
+`--body` is interpreted as **Markdown** by default — recipients on rich-capable clients see styled HTML, recipients on text-only clients see the Markdown source. Two escape hatches cover the edge cases: `--text-only` for plain-text-only sends, `--html-body` for custom HTML templates. See [Markdown Email](markdown-email.md) for a full tour of the rendering pipeline and the inlined stylesheet.
+
 ### Via CLI
 
 ```bash
-# Basic send
+# Basic send: --body is Markdown by default.
 aimx send --from support@agent.yourdomain.com \
           --to recipient@gmail.com \
           --subject "Hello" \
-          --body "Message body"
+          --body "# Hello\n\nThanks for reaching out — happy to help!"
 
-# With attachments
+# Plain text only (e.g. OTPs, transactional one-liners).
+aimx send --from support@agent.yourdomain.com \
+          --to recipient@gmail.com \
+          --subject "Verification code" \
+          --body "Your code: 184293" \
+          --text-only
+
+# Custom HTML layout (operator-supplied template).
+aimx send --from support@agent.yourdomain.com \
+          --to recipient@gmail.com \
+          --subject "Newsletter" \
+          --body "Plain-text fallback for text-only clients." \
+          --html-body "$(cat newsletter.html)"
+
+# With attachments (Markdown body + PDF).
 aimx send --from support@agent.yourdomain.com \
           --to recipient@gmail.com \
           --subject "Report" \
-          --body "See attached." \
+          --body "See the attached PDF." \
           --attachment /path/to/report.pdf
 
-# Reply to a message (preserves threading)
+# Reply to a message (preserves threading).
 aimx send --from support@agent.yourdomain.com \
           --to recipient@gmail.com \
           --subject "Re: Hello" \
           --body "Reply body" \
           --reply-to "<original-message-id@example.com>"
 
-# Advanced: supply the full References header for deep threading
+# Advanced: supply the full References header for deep threading.
 aimx send --from support@agent.yourdomain.com \
           --to recipient@gmail.com \
           --subject "Re: Hello" \

--- a/book/markdown-email.md
+++ b/book/markdown-email.md
@@ -1,0 +1,189 @@
+# Markdown Email
+
+AIMX is Markdown-native end-to-end. Inbound mail is stored as Markdown for direct LLM consumption; outbound `--body` is interpreted as Markdown by default and rendered to HTML on the wire. Agents read Markdown, write Markdown, and the binary handles the MIME plumbing.
+
+## How a default send is delivered
+
+1. **Caller submits Markdown.** `aimx send --body "..."` (or the MCP `email_send` tool with `body: "..."`) ships the Markdown source to the daemon over the local UDS.
+2. **Daemon appends the per-mailbox signature** to the Markdown body so the signature renders as part of the HTML output. Markdown link syntax in the signature renders as a clickable HTML anchor.
+3. **Daemon renders Markdown to HTML.** The renderer uses [`comrak`](https://github.com/kivikakk/comrak) configured for CommonMark + GFM extensions (tables, strikethrough, autolinks, task lists, footnotes, tag filter for unsafe tags). Raw HTML embedded in Markdown is escaped, not rendered — operators wanting raw HTML use `--html-body` instead.
+4. **Inlined stylesheet pass.** The renderer walks the rendered HTML tree and adds `style="..."` attributes per element. Inlining is required because Gmail, Outlook for Web, and Yahoo Mail strip or limit `<style>` blocks.
+5. **Multipart assembly.** The daemon builds a `multipart/alternative` MIME message with the **Markdown source** as the `text/plain` part and the **rendered HTML** as the `text/html` part. With one or more attachments, the `multipart/alternative` is wrapped in an outer `multipart/mixed` so attachments sit as siblings of the alternative block.
+6. **DKIM signing.** The signed body bytes are the canonical message body — the new MIME shape doesn't affect the signing logic, and DKIM verification works identically across plain-text, Markdown-rendered, and `--html-body` paths.
+7. **MX delivery.** The daemon resolves the recipient domain via MX records and delivers the signed message.
+
+The recipient sees:
+
+- **Rich-text clients (Gmail, Outlook, Apple Mail, Thunderbird):** the rendered HTML with headings, links, tables, blockquotes, code blocks — all styled by the inlined stylesheet.
+- **Text-only clients (`mutt`, `mailx`, screen readers in plain mode):** the Markdown source verbatim. Markdown is good plain text by design — `# Heading` is clear, `[link](url)` shows the URL inline, bullets with `-` look like bullets.
+
+## Supported Markdown features
+
+The default render path supports CommonMark plus GFM extensions:
+
+| Feature | Markdown input | Renders as |
+|---------|----------------|------------|
+| Headings | `# H1` … `#### H4` | `<h1>` … `<h4>` with sized typography |
+| Paragraphs | blank-line separated | `<p>` with comfortable line-height |
+| Bold / italic | `**bold**`, `*italic*` | `<strong>`, `<em>` |
+| Strikethrough (GFM) | `~~strike~~` | `<del>` |
+| Links | `[text](https://url)` | `<a>` with non-default link color, no underline at rest |
+| Autolinks (GFM) | bare `https://example.com` | `<a>` |
+| Inline code | `` `code` `` | `<code>` with monospace + light gray background |
+| Code blocks | ` ```lang … ``` ` | `<pre><code>` with monospace + padded background |
+| Blockquotes | `> quoted` | `<blockquote>` with left border |
+| Horizontal rule | `---` | `<hr>` thin neutral rule |
+| Unordered list | `- item` | `<ul><li>` with sensible spacing |
+| Ordered list | `1. item` | `<ol><li>` with sensible spacing |
+| Tables (GFM) | `\| h1 \| h2 \|` / `\|---\|---\|` / cells | `<table>` with collapsed borders and subtle row separators |
+| Task lists (GFM) | `- [x] done` / `- [ ] todo` | checkbox-prefixed list items |
+| Footnotes (GFM) | `text[^1]` … `[^1]: note` | numbered footnote anchor + reference list |
+| Tag filter (GFM) | `<script>...</script>` | stripped (security) |
+
+## Built-in stylesheet
+
+The inlined stylesheet covers the elements above. It is intentionally minimal — operators wanting custom CSS use `--html-body` for now.
+
+| Element | Style intent |
+|---------|--------------|
+| `body` | sans-serif font stack, `line-height: 1.55`, `max-width: 720px`, comfortable padding |
+| `h1`, `h2`, `h3`, `h4` | size scale, modest top margin |
+| `p`, `ul`, `ol`, `li` | sensible spacing |
+| `a` | non-default link color (avoids the browser-default purple-after-visit), no underline at rest |
+| `code`, `pre` | monospace, light gray background, padding |
+| `blockquote` | left border, dim foreground |
+| `table`, `th`, `td` | collapsed borders, subtle row separators |
+| `hr` | thin neutral rule |
+
+The stylesheet is self-contained: no `<link>` to Google Fonts, no remote CSS, no remote images injected by the renderer. Privacy-conscious clients and corporate firewalls do not strip the rendering. The total rendered HTML for a typical 5KB Markdown briefing fits comfortably under 25KB.
+
+If your content uses an HTML element the inlined stylesheet does not cover (e.g. `<details>`, `<sub>`), it renders unstyled (browser defaults). The element list above is the v1 scope; expand on real demand.
+
+## Body size limit
+
+The renderer enforces a **5MB cap** on the Markdown source byte length. Above the cap, the daemon refuses with the canonical error:
+
+```
+markdown body exceeds 5MB; use --html-body for pre-rendered large documents or --attachment for sending the document as a file
+```
+
+Rationale: a 5MB Markdown body renders to roughly 15–25MB on the wire (Markdown source + HTML + inlined styles, with ~37% base64 overhead). That sits at the edge of mainstream receiver caps — Gmail 25MB, Outlook.com / iCloud 20MB, Microsoft 365 up to 150MB. Send anything larger as an attachment, not as a body.
+
+The cap is enforced at the renderer entry point so all callers (`aimx send`, MCP `email_send`, future cron jobs) share one limit. Operators on the wire surface that scripts can branch on the failure see the dedicated `ERR BODY_TOO_LARGE` ack code; the canonical reason string survives in the wire response for human readers.
+
+## Escape hatches
+
+### `--text-only`
+
+Forces the wire to single-part `text/plain` with `--body` shipped verbatim. No Markdown rendering, no HTML part, no `multipart/alternative` wrapper.
+
+```bash
+aimx send --from alice@example.com --to bob@example.com \
+  --subject "Verification code" \
+  --body "Your code: 184293" \
+  --text-only
+```
+
+The per-mailbox signature is **not** auto-appended on this path — the operator already chose plain-text shape; the binary stays out of the way.
+
+Use for:
+- OTPs, transactional one-liners, system-generated alerts.
+- Migrating existing scripts that depended on `--body` shipping `text/plain`. Adding `--text-only` preserves the old shape exactly.
+
+### `--html-body`
+
+Supplies a custom HTML body. AIMX uses `<html>` verbatim as the `text/html` part and uses `--body` as the `text/plain` fallback so text-only clients still see something readable.
+
+```bash
+aimx send --from alice@example.com --to bob@example.com \
+  --subject "Newsletter" \
+  --body "Plain-text fallback for text-only clients." \
+  --html-body "$(cat newsletter.html)"
+```
+
+The shell pattern `--html-body "$(cat template.html)"` reads the template from a file and passes it on the command line. Linux's typical `ARG_MAX` is around 1MB, well above any reasonable HTML email size. For templates that exceed `ARG_MAX`, write the template to a tempfile and use a wrapper script — but at that size you should consider attaching the document instead.
+
+`--html-body` and `--text-only` are mutually exclusive. clap rejects the invocation before any UDS round-trip. The same canonical error fires server-side on the MCP `email_send` / `email_reply` tools so operators see one consistent message regardless of the surface.
+
+The per-mailbox signature is **not** auto-appended on this path — operator-supplied content is verbatim. Include any signature inside your template.
+
+`--html-body` bypasses the renderer's tag-filter and other safety checks; the operator owns the consequences. Do not pass user-controlled HTML through this flag.
+
+## Sent storage
+
+Sent records under `sent/<mailbox>/` always store the **Markdown source** (or the literal text for `--text-only`, or the `--body` text part for `--html-body`). The recipient's HTML view is recoverable by re-running the same renderer on the stored Markdown — output is deterministic given the pinned `comrak` version.
+
+The frontmatter declares the wire shape so an operator browsing `sent/` can tell at a glance what the recipient saw:
+
+| `outbound_format` | Wire shape | Sent body content |
+|-------------------|------------|-------------------|
+| `"markdown"` | `multipart/alternative` (text + rendered HTML) | Markdown source verbatim (signature appended before render) |
+| `"text"` | single-part `text/plain` | literal text verbatim |
+| `"html"` | `multipart/alternative` (text + custom HTML) | the `--body` text part (custom HTML is **not** stored) |
+
+The `outbound_format` field appears immediately after `outbound = true` in the Outbound block of the frontmatter:
+
+```toml
+outbound = true
+outbound_format = "markdown"
+delivery_status = "delivered"
+```
+
+Pre-feature sent records lack the field; on read, those default to `"text"` (the historic single-part `text/plain` shape) so legacy records keep parsing cleanly.
+
+**No `.html` sibling file is ever written.** Operators who need a record of the exact custom HTML they sent should keep their template under version control — the `--html-body` payload is not persisted by AIMX.
+
+## Determinism
+
+The renderer is deterministic: the same Markdown input produces byte-identical HTML output across two invocations. This is what justifies dropping the rendered HTML from sent storage — the recipient's view is recoverable. `comrak` is pinned to an exact minor version in `Cargo.toml`; bumping it requires re-blessing the renderer fixtures and noting the change in the release notes.
+
+CI defends the determinism guarantee with two checked-in fixtures (`tests/fixtures/markdown/briefing-5kb.md` and `tests/fixtures/markdown/report-50kb.md`) and their pinned expected outputs. A `comrak` bump that changes whitespace or attribute ordering surfaces at CI time, not in production.
+
+## Worked example
+
+Input Markdown:
+
+````markdown
+# Daily briefing — 2026-05-07
+
+## Open positions
+
+| Symbol | Shares | Cost basis |
+|--------|-------:|-----------:|
+| AAPL   | 100    | $150.00    |
+| GOOG   | 50     | $2,800.00  |
+
+## Notes
+
+- Earnings season starts next week.
+- See the [shareholder letter](https://example.com/letter) for context.
+
+> The market always overreacts in the short term.
+
+```python
+def total(positions):
+    return sum(s * p for s, p in positions)
+```
+````
+
+What the recipient sees:
+
+- **Gmail / Outlook / Apple Mail:** rendered `<h1>`, `<h2>`, a styled `<table>`, a clickable `<a>` link, a `<blockquote>` with a left border, and a `<pre><code>` block with monospace background.
+- **Text-only client:** the Markdown source verbatim — readable, with hierarchy preserved by `#` and `##`, the table cells visible as pipes-and-dashes.
+
+What gets stored in `sent/alice/2026-05-07-120000-daily-briefing-2026-05-07.md`:
+
+```markdown
++++
+id = "2026-05-07-120000-daily-briefing-2026-05-07"
+# ... (other frontmatter fields) ...
+outbound = true
+outbound_format = "markdown"
+delivery_status = "delivered"
++++
+
+# Daily briefing — 2026-05-07
+# ... (Markdown source verbatim) ...
+```
+
+Re-running the daemon's renderer on the stored body reproduces the recipient's HTML view exactly.

--- a/book/release-notes.md
+++ b/book/release-notes.md
@@ -2,6 +2,33 @@
 
 Version-by-version changelog of operator-visible behavior changes. Use this as the canonical source for "what changed" between aimx releases; individual book chapters describe the current behavior only.
 
+> **Hard break (Unreleased): `aimx send --body` is now interpreted as Markdown by default.** The daemon renders Markdown to HTML and ships a `multipart/alternative` — recipients on rich-capable clients see styled HTML inline. To preserve the previous plain-text behavior in existing scripts, add `--text-only`. The MCP `email_send` / `email_reply` tools shift in the same way; pass `text_only: true` to keep plain-text output. See [Markdown Email](markdown-email.md) for the full rendering pipeline, supported features, and the inlined stylesheet's element scope.
+
+## Unreleased — Markdown-native outbound (rich-text email)
+
+AIMX now treats Markdown as the canonical send format. The CLI's `--body` flag and the MCP `email_send` / `email_reply` tools interpret their `body` input as CommonMark + GFM Markdown, render it to HTML with an inlined stylesheet, and ship a `multipart/alternative` over the wire. Recipients on Gmail, Outlook, Apple Mail, and other rich-capable clients see styled HTML; recipients on text-only clients see the Markdown source.
+
+### What changed
+
+- **`aimx send --body` is Markdown.** The daemon renders the body using `comrak` (CommonMark + GFM extensions: tables, strikethrough, autolinks, task lists, footnotes, tag filter for unsafe HTML), applies an inlined stylesheet, and assembles a `multipart/alternative` with the Markdown source as the `text/plain` part and the rendered HTML as the `text/html` part. With one or more attachments, the alternative is wrapped in an outer `multipart/mixed` so attachments sit as siblings of the alternative block.
+- **Two CLI escape hatches.** `--text-only` ships `--body` verbatim as `text/plain` with no rendering or HTML alternative — use for OTPs, transactional one-liners, and existing scripts. `--html-body "<custom html>"` supplies an operator-owned HTML template that AIMX uses verbatim as the `text/html` part. The two flags are mutually exclusive at the clap layer.
+- **MCP tools mirror the CLI.** `email_send` and `email_reply` accept optional `text_only: bool` and `html_body: string` parameters with the same semantics. The MCP-side mutual-exclusion check fires server-side before the UDS is opened, returning the canonical wording `AIMX/1 SEND: --text-only and --html-body are mutually exclusive`.
+- **Sent storage stays single-file `.md`.** Sent records under `sent/<mailbox>/` continue to be single-file Markdown (or Zola-style bundles when attachments are present). The body content is the Markdown source for the default path, the literal text for `--text-only`, or the `--body` text part for `--html-body`. The custom HTML supplied via `--html-body` is **not** stored — operators who need a record of the exact HTML sent should keep their template under version control.
+- **`outbound_format` frontmatter field.** The Outbound block in sent records gains an `outbound_format` field (`"markdown"`, `"text"`, or `"html"`) immediately after `outbound = true`. Pre-feature sent records lack the field; on read, those default to `"text"` (the historic single-part `text/plain` shape) so legacy records keep parsing cleanly.
+- **5MB body cap.** The renderer rejects Markdown bodies larger than 5MB at the entry point with the canonical error `"markdown body exceeds 5MB; use --html-body for pre-rendered large documents or --attachment for sending the document as a file"`. The dedicated `ERR BODY_TOO_LARGE` ack code lets scripts branch on the failure without parsing the reason string.
+- **DKIM verification preserved.** The signed body bytes are the canonical message body; DKIM canonicalization is unaffected by the new MIME shape. CI exercises end-to-end DKIM verification across all three send paths (default Markdown, `--text-only`, `--html-body`).
+
+### Migration
+
+- **Plain-English content with no special chars renders identically.** A body like `"Hello — see you Friday."` produces the same recipient experience as before; the rendered HTML is essentially a styled `<p>` with the same text.
+- **Bodies that contain `*`, `_`, `#`, `[...](...)`, or other Markdown punctuation will render as styled HTML.** If your existing scripts ship that kind of content as opaque plain text, add `--text-only` (CLI) or `text_only: true` (MCP) to preserve the previous behavior exactly.
+- **Bodies that ship raw HTML through `--body`** (treating it as opaque text) will now have the HTML escaped by the renderer. Pass that content through `--html-body` instead, or use `--text-only` if you want it shipped as a literal text/plain part with no rendering.
+- **There is no automatic migration.** The fix is one-flag-per-call-site at the operator's discretion.
+
+### Why now
+
+Outbound rich text was the longest-standing rough edge in AIMX. `--body` always shipped `text/plain`, so agents that wanted styled email had to attach a hand-written `.html` file — Gmail, Outlook, and Apple Mail then rendered it as a downloadable attachment, not as inline content. AIMX is built around Markdown (the LLM's native format) for inbound storage; the send surface now matches that, end-to-end.
+
 ## Unreleased — MCP email and hook tools now work for non-root operators
 
 The mailbox-lifecycle ship below covered the three MCP tools that an agent uses to provision its own mailboxes. A post-ship audit found that the remaining nine tools — every email and hook tool — still failed for the exact persona the design targeted: a non-root operator running an MCP client against a real install with `/etc/aimx/config.toml` at `0600 root:root`. This release closes that gap and adds the regression guard that should have caught it.

--- a/src/frontmatter.rs
+++ b/src/frontmatter.rs
@@ -211,6 +211,17 @@ pub struct OutboundFrontmatter {
 
     // -- Outbound block --
     pub outbound: bool,
+    /// Wire shape used by the daemon when assembling the outbound
+    /// message. One of `"markdown"` (default — body rendered as
+    /// CommonMark+GFM into a `multipart/alternative`), `"text"`
+    /// (`--text-only` / MCP `text_only=true` — single-part `text/plain`),
+    /// or `"html"` (`--html-body` / MCP `html_body=...` — operator-supplied
+    /// HTML in the alternative part). Pre-feature sent records lack the
+    /// field; on read those default to `"text"` (the old `text/plain`-only
+    /// behavior) so the audit trail is honest about what the recipient
+    /// actually saw.
+    #[serde(default = "default_outbound_format")]
+    pub outbound_format: String,
     pub delivery_status: DeliveryStatus,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub bcc: Option<Vec<String>>,
@@ -218,6 +229,15 @@ pub struct OutboundFrontmatter {
     pub delivered_at: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub delivery_details: Option<String>,
+}
+
+/// Backward-compatibility default for `OutboundFrontmatter::outbound_format`.
+/// New writes pick a concrete value at the call site (`"markdown"`,
+/// `"text"`, or `"html"`); reads of pre-feature sent records hit this
+/// default — `"text"` matches the historic single-part `text/plain`
+/// shape the daemon used before Markdown rendering shipped.
+fn default_outbound_format() -> String {
+    "text".to_string()
 }
 
 pub fn format_outbound_frontmatter(meta: &OutboundFrontmatter, body: &str) -> String {
@@ -797,6 +817,7 @@ mod tests {
             read: false,
             labels: vec![],
             outbound: true,
+            outbound_format: "markdown".to_string(),
             delivery_status: DeliveryStatus::Delivered,
             bcc: None,
             delivered_at: Some("2025-01-01T12:00:05Z".to_string()),
@@ -839,6 +860,9 @@ mod tests {
         // Inbound block first, then outbound block at the end.
         // `received_at` is omitted because it is empty on outbound messages
         // (skip_serializing_if = "String::is_empty").
+        // `outbound_format` lands immediately after `outbound` so the
+        // wire-shape audit-trail field is colocated with the boolean
+        // that flags the record as outbound in the first place.
         let expected_keys = vec![
             "id",
             "message_id",
@@ -856,6 +880,7 @@ mod tests {
             "mailbox",
             "read",
             "outbound",
+            "outbound_format",
             "delivery_status",
             "delivered_at",
             "delivery_details",
@@ -940,5 +965,84 @@ mod tests {
             !toml_str.contains("received_at"),
             "empty received_at must be omitted on outbound files; got:\n{toml_str}"
         );
+    }
+
+    /// New writes carry an explicit `outbound_format` value so the
+    /// audit trail is honest about the wire shape used. The sample
+    /// fixture exercises the canonical `"markdown"` default that
+    /// `assemble_wire_message` produces for the rendered path.
+    #[test]
+    fn outbound_format_serializes_immediately_after_outbound() {
+        let fm = sample_outbound_frontmatter();
+        let toml_str = toml::to_string(&fm).unwrap();
+        assert!(
+            toml_str.contains("outbound_format = \"markdown\""),
+            "outbound_format must be written verbatim; got:\n{toml_str}"
+        );
+        let outbound_pos = toml_str.find("outbound = ").expect("outbound line missing");
+        let format_pos = toml_str
+            .find("outbound_format = ")
+            .expect("outbound_format line missing");
+        assert!(
+            format_pos > outbound_pos,
+            "outbound_format must follow outbound; got:\n{toml_str}"
+        );
+        // Nothing else may sit between `outbound = ...` and
+        // `outbound_format = ...` — they live as a tightly-coupled pair
+        // per the spec.
+        let between = &toml_str[outbound_pos..format_pos];
+        let line_count = between.lines().count();
+        assert_eq!(
+            line_count, 1,
+            "outbound_format must be the very next line after outbound; got between:\n{between}"
+        );
+    }
+
+    /// Parsing an outbound frontmatter that lacks `outbound_format`
+    /// must succeed and yield `"text"` — the historic single-part
+    /// `text/plain` shape pre-Markdown-rendering. This is the
+    /// backward-compat contract that lets older sent records keep
+    /// rendering correctly through `email_list` / `email_read`.
+    #[test]
+    fn outbound_format_missing_field_defaults_to_text() {
+        let toml_str = r#"
+id = "2025-01-01-120000-hello"
+message_id = "<abc@example.com>"
+thread_id = "a1b2c3d4e5f6a7b8"
+from = "alice@example.com"
+to = "bob@example.com"
+delivered_to = "bob@example.com"
+subject = "Hello"
+date = "2025-01-01T12:00:00Z"
+size_bytes = 256
+dkim = "pass"
+spf = "none"
+dmarc = "none"
+trusted = "none"
+mailbox = "alice"
+read = false
+outbound = true
+delivery_status = "delivered"
+delivered_at = "2025-01-01T12:00:05Z"
+"#;
+        let parsed: OutboundFrontmatter =
+            toml::from_str(toml_str).expect("legacy outbound record must parse");
+        assert_eq!(
+            parsed.outbound_format, "text",
+            "missing outbound_format must default to \"text\" for backward compat",
+        );
+    }
+
+    /// Round-trip: an explicit `outbound_format = "html"` survives
+    /// serialize → parse. Catches a regression where the field is
+    /// silently dropped from the toml output.
+    #[test]
+    fn outbound_format_round_trips_explicit_value() {
+        let mut fm = sample_outbound_frontmatter();
+        fm.outbound_format = "html".to_string();
+        let toml_str = toml::to_string(&fm).unwrap();
+        let parsed: OutboundFrontmatter =
+            toml::from_str(&toml_str).expect("html outbound_format must round-trip");
+        assert_eq!(parsed.outbound_format, "html");
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -5,7 +5,6 @@ use crate::frontmatter::InboundFrontmatter;
 use crate::send;
 use crate::send_protocol::{
     self, ErrCode, HookCreateRequest, HookDeleteRequest, MailboxLifecycleRequest, MarkRequest,
-    SendRequest,
 };
 
 use rmcp::handler::server::router::tool::ToolRouter;
@@ -76,7 +75,11 @@ pub struct EmailSendParams {
                        When set, References is built automatically unless overridden by the references field."
     )]
     pub reply_to: Option<String>,
-    #[schemars(description = "Email body text")]
+    #[schemars(description = "Email body. Interpreted as Markdown by default \
+                       (CommonMark + GFM extensions). AIMX renders it to HTML and \
+                       sends as multipart/alternative. Set text_only=true for \
+                       plain-text-only sends. Set html_body to override the \
+                       auto-rendered HTML.")]
     pub body: String,
     #[schemars(description = "File paths to attach")]
     pub attachments: Option<Vec<String>>,
@@ -85,6 +88,18 @@ pub struct EmailSendParams {
                        Only applied when reply_to is also set. Supplied alone, it is silently ignored."
     )]
     pub references: Option<String>,
+    #[schemars(
+        description = "When true, send body verbatim as text/plain (no Markdown \
+                       rendering, no HTML alternative part). Mutually exclusive with html_body."
+    )]
+    pub text_only: Option<bool>,
+    #[schemars(
+        description = "Custom HTML body shipped verbatim as the text/html part of \
+                       a multipart/alternative. Use body for the text/plain fallback. \
+                       Operator-supplied content; bypasses sanitization. Mutually \
+                       exclusive with text_only."
+    )]
+    pub html_body: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, schemars::JsonSchema)]
@@ -93,8 +108,24 @@ pub struct EmailReplyParams {
     pub mailbox: String,
     #[schemars(description = "Email ID to reply to (e.g. 2025-01-01-001)")]
     pub id: String,
-    #[schemars(description = "Reply body text")]
+    #[schemars(description = "Reply body. Interpreted as Markdown by default \
+                       (CommonMark + GFM extensions). AIMX renders it to HTML and \
+                       sends as multipart/alternative. Set text_only=true for \
+                       plain-text-only sends. Set html_body to override the \
+                       auto-rendered HTML.")]
     pub body: String,
+    #[schemars(
+        description = "When true, send body verbatim as text/plain (no Markdown \
+                       rendering, no HTML alternative part). Mutually exclusive with html_body."
+    )]
+    pub text_only: Option<bool>,
+    #[schemars(
+        description = "Custom HTML body shipped verbatim as the text/html part of \
+                       a multipart/alternative. Use body for the text/plain fallback. \
+                       Operator-supplied content; bypasses sanitization. Mutually \
+                       exclusive with text_only."
+    )]
+    pub html_body: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, schemars::JsonSchema)]
@@ -346,7 +377,11 @@ impl AimxMcpServer {
 
     #[tool(
         name = "email_send",
-        description = "Submit an email for DKIM signing and delivery via the aimx daemon"
+        description = "Submit an email for DKIM signing and delivery via the aimx daemon. \
+                       `body` is interpreted as Markdown (CommonMark + GFM extensions). \
+                       AIMX renders it to HTML and sends as multipart/alternative. \
+                       Set `text_only: true` for plain-text-only sends. \
+                       Set `html_body` to override the auto-rendered HTML with your own template."
     )]
     fn email_send(
         &self,
@@ -370,6 +405,16 @@ impl AimxMcpServer {
             ));
         }
 
+        // Server-side mutual-exclusion check — fires before the UDS is
+        // opened so the agent gets a clean tool error rather than a
+        // codec error percolating back through the rmcp framing. The
+        // wording matches the codec's canonical message so operators
+        // see the same string regardless of where validation tripped.
+        validate_text_only_html_body_exclusion(
+            params.text_only.unwrap_or(false),
+            params.html_body.as_deref(),
+        )?;
+
         let args = build_send_args(params, from_address);
 
         submit_via_daemon(&args)
@@ -377,7 +422,11 @@ impl AimxMcpServer {
 
     #[tool(
         name = "email_reply",
-        description = "Reply to an email with correct threading headers"
+        description = "Reply to an email with correct threading headers. \
+                       `body` is interpreted as Markdown (CommonMark + GFM extensions). \
+                       AIMX renders it to HTML and sends as multipart/alternative. \
+                       Set `text_only: true` for plain-text-only replies. \
+                       Set `html_body` to override the auto-rendered HTML with your own template."
     )]
     fn email_reply(
         &self,
@@ -385,6 +434,16 @@ impl AimxMcpServer {
     ) -> Result<String, String> {
         validate_email_id(&params.id)?;
         let row = lookup_mailbox_row(&params.mailbox)?;
+
+        // Mutual-exclusion check fires before any IO so the failure is
+        // cheap and never opens the UDS. Same wording as the codec
+        // (`AIMX/1 SEND: --text-only and --html-body are mutually
+        // exclusive`) so operators see one consistent string regardless
+        // of layer.
+        validate_text_only_html_body_exclusion(
+            params.text_only.unwrap_or(false),
+            params.html_body.as_deref(),
+        )?;
 
         let mailbox_dir = folder_path_from_row(&row, Folder::Inbox);
         // `email_reply` reads the parent message to inherit threading
@@ -439,8 +498,8 @@ impl AimxMcpServer {
             reply_to: reply_to_id,
             references,
             attachments: vec![],
-            text_only: false,
-            html_body: None,
+            text_only: params.text_only.unwrap_or(false),
+            html_body: params.html_body,
         };
 
         submit_via_daemon(&args)
@@ -649,6 +708,11 @@ impl AimxMcpServer {
 /// address. Pure and side-effect-free so it can be unit-tested without
 /// the daemon; keeps the `params.reply_to` / `params.references`
 /// forwarding explicit (see the deserialization tests below).
+///
+/// The mutual-exclusion check (`text_only` vs `html_body`) is run by
+/// the caller via `validate_text_only_html_body_exclusion` before this
+/// function is invoked, so this builder trusts both fields and forwards
+/// them unchanged.
 fn build_send_args(params: EmailSendParams, from_address: &str) -> SendArgs {
     SendArgs {
         from: from_address.to_string(),
@@ -658,9 +722,30 @@ fn build_send_args(params: EmailSendParams, from_address: &str) -> SendArgs {
         reply_to: params.reply_to,
         references: params.references,
         attachments: params.attachments.unwrap_or_default(),
-        text_only: false,
-        html_body: None,
+        text_only: params.text_only.unwrap_or(false),
+        html_body: params.html_body,
     }
+}
+
+/// Server-side mutual-exclusion check for the MCP `email_send` /
+/// `email_reply` tools. Mirrors the clap-level `conflicts_with` rule on
+/// the CLI's `SendArgs` and the codec-level rejection in the SEND
+/// frame parser. Returns the canonical error string (matching the
+/// codec) when both inputs would be carried on the wire — the daemon
+/// would refuse such a frame, but firing here keeps the failure cheap
+/// and avoids opening the UDS at all.
+fn validate_text_only_html_body_exclusion(
+    text_only: bool,
+    html_body: Option<&str>,
+) -> Result<(), String> {
+    let html_body_present = html_body.map(|s| !s.is_empty()).unwrap_or(false);
+    if text_only && html_body_present {
+        // Match the wire-codec phrasing in `src/send_protocol.rs` so
+        // the operator sees the same wording regardless of which layer
+        // tripped the check.
+        return Err("AIMX/1 SEND: --text-only and --html-body are mutually exclusive".to_string());
+    }
+    Ok(())
 }
 
 /// Compose `args` into an `AIMX/1 SEND` request and submit it to
@@ -670,15 +755,12 @@ fn build_send_args(params: EmailSendParams, from_address: &str) -> SendArgs {
 /// `From:` out of the composed body itself and resolves the sender
 /// mailbox against its in-memory Config.
 fn submit_via_daemon(args: &SendArgs) -> Result<String, String> {
-    let composed = send::compose_request(args).map_err(|e| e.to_string())?;
-    let request = SendRequest {
-        body: composed.message,
-        // The MCP `text_only` / `html_body` parameter surface lands in
-        // a follow-on sprint. For now MCP submissions take the default
-        // Markdown render path, mirroring today's behaviour.
-        text_only: false,
-        html_body: None,
-    };
+    // Build the SEND frame via the shared helper used by `aimx send`
+    // so MCP and CLI submit byte-identical requests for the same
+    // `SendArgs`. `build_request` honors `args.text_only` /
+    // `args.html_body` and applies the same CRLF normalization the CLI
+    // uses for the optional second body section.
+    let request = send::build_request(args)?;
     let socket = crate::serve::aimx_socket_path();
 
     let rt = tokio::runtime::Handle::try_current();
@@ -2341,6 +2423,8 @@ mod schema_order_tests {
                 "body",
                 "attachments",
                 "references",
+                "text_only",
+                "html_body",
             ],
         );
     }
@@ -2349,7 +2433,7 @@ mod schema_order_tests {
     fn email_reply_params_property_order() {
         assert_eq!(
             property_keys::<EmailReplyParams>(),
-            vec!["mailbox", "id", "body"],
+            vec!["mailbox", "id", "body", "text_only", "html_body"],
         );
     }
 
@@ -2435,5 +2519,158 @@ mod socket_missing_tests {
                 "expected {kind:?} to NOT count as socket-missing"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod text_only_html_body_tests {
+    //! Unit coverage for the MCP-side mutual-exclusion check and the
+    //! `build_send_args` plumbing that forwards `text_only` /
+    //! `html_body` from `EmailSendParams` into `SendArgs`. The
+    //! integration suite covers the full UDS round-trip; these tests
+    //! pin the pure plumbing without paying daemon spawn cost.
+
+    use super::*;
+
+    #[test]
+    fn validate_allows_neither_set() {
+        assert!(validate_text_only_html_body_exclusion(false, None).is_ok());
+        assert!(validate_text_only_html_body_exclusion(false, Some("")).is_ok());
+    }
+
+    #[test]
+    fn validate_allows_text_only_alone() {
+        assert!(validate_text_only_html_body_exclusion(true, None).is_ok());
+        // Empty html_body is treated as "not supplied" — same shape as
+        // an absent field, so the mutual-exclusion check ignores it.
+        assert!(validate_text_only_html_body_exclusion(true, Some("")).is_ok());
+    }
+
+    #[test]
+    fn validate_allows_html_body_alone() {
+        assert!(validate_text_only_html_body_exclusion(false, Some("<p>hi</p>")).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_both_set_with_canonical_error() {
+        let err = validate_text_only_html_body_exclusion(true, Some("<p>hi</p>")).unwrap_err();
+        // Wording must match the codec's canonical error so operators
+        // see one consistent string regardless of which layer fired.
+        assert_eq!(
+            err,
+            "AIMX/1 SEND: --text-only and --html-body are mutually exclusive"
+        );
+    }
+
+    #[test]
+    fn build_send_args_defaults_when_new_params_absent() {
+        let params = EmailSendParams {
+            from_mailbox: "alice".into(),
+            to: "rcpt@example.com".into(),
+            subject: "S".into(),
+            reply_to: None,
+            body: "hello".into(),
+            attachments: None,
+            references: None,
+            text_only: None,
+            html_body: None,
+        };
+        let args = build_send_args(params, "alice@example.com");
+        assert!(!args.text_only);
+        assert!(args.html_body.is_none());
+    }
+
+    #[test]
+    fn build_send_args_forwards_text_only_true() {
+        let params = EmailSendParams {
+            from_mailbox: "alice".into(),
+            to: "rcpt@example.com".into(),
+            subject: "S".into(),
+            reply_to: None,
+            body: "Your code: 9999".into(),
+            attachments: None,
+            references: None,
+            text_only: Some(true),
+            html_body: None,
+        };
+        let args = build_send_args(params, "alice@example.com");
+        assert!(args.text_only);
+        assert!(args.html_body.is_none());
+    }
+
+    #[test]
+    fn build_send_args_forwards_html_body() {
+        let params = EmailSendParams {
+            from_mailbox: "alice".into(),
+            to: "rcpt@example.com".into(),
+            subject: "S".into(),
+            reply_to: None,
+            body: "fallback".into(),
+            attachments: None,
+            references: None,
+            text_only: None,
+            html_body: Some("<p>custom</p>".into()),
+        };
+        let args = build_send_args(params, "alice@example.com");
+        assert!(!args.text_only);
+        assert_eq!(args.html_body.as_deref(), Some("<p>custom</p>"));
+    }
+
+    #[test]
+    fn email_send_params_omitting_new_fields_parses() {
+        // Backward compat: existing MCP clients that don't know the new
+        // parameters keep working — both fields are `Option<...>` so
+        // omission deserializes cleanly to `None`.
+        let json = serde_json::json!({
+            "from_mailbox": "alice",
+            "to": "rcpt@example.com",
+            "subject": "hi",
+            "body": "hello",
+        });
+        let params: EmailSendParams =
+            serde_json::from_value(json).expect("missing-field params must parse");
+        assert!(params.text_only.is_none());
+        assert!(params.html_body.is_none());
+    }
+
+    #[test]
+    fn email_send_params_accepts_text_only_true() {
+        let json = serde_json::json!({
+            "from_mailbox": "alice",
+            "to": "rcpt@example.com",
+            "subject": "OTP",
+            "body": "Your code: 9999",
+            "text_only": true,
+        });
+        let params: EmailSendParams =
+            serde_json::from_value(json).expect("text_only=true must parse");
+        assert_eq!(params.text_only, Some(true));
+    }
+
+    #[test]
+    fn email_send_params_accepts_html_body() {
+        let json = serde_json::json!({
+            "from_mailbox": "alice",
+            "to": "rcpt@example.com",
+            "subject": "Branded",
+            "body": "fallback",
+            "html_body": "<p>custom</p>",
+        });
+        let params: EmailSendParams = serde_json::from_value(json).expect("html_body must parse");
+        assert_eq!(params.html_body.as_deref(), Some("<p>custom</p>"));
+    }
+
+    #[test]
+    fn email_reply_params_accepts_new_fields() {
+        let json = serde_json::json!({
+            "mailbox": "alice",
+            "id": "2025-06-15-120000-hello",
+            "body": "thanks",
+            "text_only": true,
+        });
+        let params: EmailReplyParams =
+            serde_json::from_value(json).expect("text_only on reply must parse");
+        assert_eq!(params.text_only, Some(true));
+        assert!(params.html_body.is_none());
     }
 }

--- a/src/send_handler.rs
+++ b/src/send_handler.rs
@@ -307,6 +307,21 @@ where
     let references_val = headers.get("References").cloned();
     let date_header = headers.get("Date").cloned();
 
+    // Audit-trail field for the sent record. Mirrors the wire-shape
+    // branch picked in `assemble_wire_message` above:
+    //   - `text_only=true`            → `"text"`  (single-part text/plain)
+    //   - `html_body=Some(...)`       → `"html"`  (custom HTML alternative)
+    //   - default                     → `"markdown"` (rendered alternative)
+    // The two escape hatches are mutually exclusive at the codec layer,
+    // so this match is exhaustive without a tie-breaker.
+    let outbound_format = if req.text_only {
+        "text"
+    } else if req.html_body.is_some() {
+        "html"
+    } else {
+        "markdown"
+    };
+
     let send_result = ctx.transport.send(&from_header, &recipient_bare, &signed);
 
     let (send_status, persisted_path, response) = match send_result {
@@ -327,6 +342,7 @@ where
                 DeliveryStatus::Delivered,
                 Some(&delivered_at),
                 None,
+                outbound_format,
             );
             (
                 SendStatus::Delivered,
@@ -362,6 +378,7 @@ where
                     DeliveryStatus::Failed,
                     None,
                     Some(&msg),
+                    outbound_format,
                 )
             } else {
                 None
@@ -574,6 +591,7 @@ fn persist_sent_file(
     delivery_status: DeliveryStatus,
     delivered_at: Option<&str>,
     delivery_details: Option<&str>,
+    outbound_format: &str,
 ) -> Option<PathBuf> {
     let sent_dir = ctx.data_dir.join("sent").join(from_mailbox);
     if let Err(e) = std::fs::create_dir_all(&sent_dir) {
@@ -637,6 +655,7 @@ fn persist_sent_file(
         read: false,
         labels: vec![],
         outbound: true,
+        outbound_format: outbound_format.to_string(),
         delivery_status,
         bcc: None,
         delivered_at: delivered_at.map(|s| s.to_string()),
@@ -1737,5 +1756,129 @@ mod tests {
             !delivered.contains("Sent from AIMX."),
             "--html-body must not append the default signature: {delivered}"
         );
+    }
+
+    // ------------------------------------------------------------------
+    // `outbound_format` audit-trail field on the persisted sent record.
+    // Asserts each of the three wire-shape branches stamps the correct
+    // value into the `OutboundFrontmatter`. Sent body content + the
+    // "no .html sibling" invariant land in the integration suite; here
+    // we just pin the frontmatter contract.
+    // ------------------------------------------------------------------
+
+    fn read_sent_outbound_format(data_dir: &std::path::Path) -> String {
+        let sent_dir = data_dir.join("sent").join("alice");
+        let entry = std::fs::read_dir(&sent_dir)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .next()
+            .expect("sent record must exist");
+        let content = std::fs::read_to_string(entry.path()).unwrap();
+        let parts: Vec<&str> = content.splitn(3, "+++").collect();
+        let toml_str = parts[1].trim();
+        let parsed: crate::frontmatter::OutboundFrontmatter =
+            toml::from_str(toml_str).expect("frontmatter must parse");
+        parsed.outbound_format
+    }
+
+    #[tokio::test]
+    async fn default_markdown_send_persists_outbound_format_markdown() {
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Ok,
+        });
+        let ctx = test_ctx_with_data_dir(mock, Some(data_dir.path().to_path_buf()));
+        let req = SendRequest {
+            body: body("alice@example.com"),
+            ..Default::default()
+        };
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
+        assert!(matches!(resp, SendResponse::Ok { .. }));
+        assert_eq!(read_sent_outbound_format(data_dir.path()), "markdown");
+    }
+
+    #[tokio::test]
+    async fn text_only_send_persists_outbound_format_text() {
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Ok,
+        });
+        let ctx = test_ctx_with_data_dir(mock, Some(data_dir.path().to_path_buf()));
+        let req = SendRequest {
+            body: body("alice@example.com"),
+            text_only: true,
+            html_body: None,
+        };
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
+        assert!(matches!(resp, SendResponse::Ok { .. }));
+        assert_eq!(read_sent_outbound_format(data_dir.path()), "text");
+    }
+
+    #[tokio::test]
+    async fn html_body_send_persists_outbound_format_html() {
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Ok,
+        });
+        let ctx = test_ctx_with_data_dir(mock, Some(data_dir.path().to_path_buf()));
+        let req = SendRequest {
+            body: body("alice@example.com"),
+            text_only: false,
+            html_body: Some(b"<p>custom</p>".to_vec()),
+        };
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
+        assert!(matches!(resp, SendResponse::Ok { .. }));
+        assert_eq!(read_sent_outbound_format(data_dir.path()), "html");
+    }
+
+    /// No `.html` sibling file is written next to the sent record on
+    /// any of the three send paths. Pin the FR-F2 invariant at the
+    /// unit-test level so a future change to the persistence path that
+    /// introduces an HTML twin file is caught immediately.
+    #[tokio::test]
+    async fn sent_record_never_writes_html_sibling() {
+        for req in [
+            SendRequest {
+                body: body("alice@example.com"),
+                ..Default::default()
+            },
+            SendRequest {
+                body: body("alice@example.com"),
+                text_only: true,
+                html_body: None,
+            },
+            SendRequest {
+                body: body("alice@example.com"),
+                text_only: false,
+                html_body: Some(b"<p>custom</p>".to_vec()),
+            },
+        ] {
+            let data_dir = tempfile::TempDir::new().unwrap();
+            let mock = Arc::new(MockTransport {
+                captured: Mutex::new(vec![]),
+                behavior: Behavior::Ok,
+            });
+            let ctx = test_ctx_with_data_dir(mock, Some(data_dir.path().to_path_buf()));
+            let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
+            assert!(matches!(resp, SendResponse::Ok { .. }));
+
+            let sent_dir = data_dir.path().join("sent").join("alice");
+            let any_html = std::fs::read_dir(&sent_dir)
+                .unwrap()
+                .filter_map(|e| e.ok())
+                .any(|e| {
+                    e.path()
+                        .extension()
+                        .is_some_and(|ext| ext.eq_ignore_ascii_case("html"))
+                });
+            assert!(
+                !any_html,
+                "no .html sibling file should appear under {}",
+                sent_dir.display()
+            );
+        }
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2918,6 +2918,12 @@ fn send_uds_end_to_end_emits_multipart_alternative_for_markdown_body() {
         sent_content.contains("# Hello"),
         "sent record body should preserve the Markdown source verbatim"
     );
+    // The audit-trail field declares the wire shape: default Markdown
+    // path stamps `outbound_format = "markdown"` (FR-F3).
+    assert!(
+        sent_content.contains("outbound_format = \"markdown\""),
+        "sent record must declare outbound_format = \"markdown\":\n{sent_content}"
+    );
     // No `.html` sibling appears.
     let any_html_sibling = std::fs::read_dir(&sent_dir)
         .unwrap()
@@ -3089,9 +3095,10 @@ fn send_uds_end_to_end_text_only_emits_single_part_text_plain() {
         "DKIM body hash must verify on text-only wire: signed={signed_header}, computed={computed}"
     );
 
-    // Sent record exists and carries the body verbatim. The
-    // `outbound_format = "text"` frontmatter field lands in a follow-on
-    // sprint; here we only assert the body content.
+    // Sent record exists and carries the body verbatim. The audit
+    // trail declares `outbound_format = "text"` so an operator
+    // browsing `sent/` can tell at a glance the recipient saw plain
+    // text — distinct from a default Markdown send (`"markdown"`).
     let sent_dir = tmp.path().join("sent").join("alice");
     let entries: Vec<_> = std::fs::read_dir(&sent_dir)
         .unwrap()
@@ -3102,6 +3109,10 @@ fn send_uds_end_to_end_text_only_emits_single_part_text_plain() {
     assert!(
         sent_content.contains("Your code: 9999"),
         "sent record body must carry the plain text verbatim"
+    );
+    assert!(
+        sent_content.contains("outbound_format = \"text\""),
+        "sent record must declare outbound_format = \"text\" on --text-only path:\n{sent_content}"
     );
 
     stop_serve(child);
@@ -3216,12 +3227,15 @@ fn send_uds_end_to_end_html_body_uses_supplied_html_verbatim() {
         sent_content.contains("fallback text"),
         "sent record body must carry the --body text"
     );
-    // The custom HTML is part of the signed wire bytes (which the sent
-    // record persists in full), so we cannot assert its absence
-    // verbatim — but the .md body section that comes from `--body`
-    // must NOT be the custom HTML. A future `outbound_format = "html"`
-    // field plus single-source-of-truth body persistence will tighten
-    // this further.
+    // Audit-trail field declares the wire shape: `--html-body` path
+    // stamps `outbound_format = "html"` so an operator browsing
+    // `sent/` knows the recipient saw an operator-supplied HTML
+    // template (and that re-rendering the stored Markdown body would
+    // NOT reproduce the recipient's view).
+    assert!(
+        sent_content.contains("outbound_format = \"html\""),
+        "sent record must declare outbound_format = \"html\" on --html-body path:\n{sent_content}"
+    );
 
     // No `.html` sibling appears next to the sent record.
     let any_html_sibling = std::fs::read_dir(&sent_dir)
@@ -3238,6 +3252,228 @@ fn send_uds_end_to_end_html_body_uses_supplied_html_verbatim() {
     );
 
     stop_serve(child);
+}
+
+/// MCP `email_send` with `text_only=true` ships a single-part
+/// `text/plain` message verbatim — no Markdown rendering, no
+/// multipart wrapper. End-to-end: MCP stdio client → daemon UDS →
+/// file-drop transport → captured wire bytes. Mirrors the CLI-side
+/// `send_uds_end_to_end_text_only_emits_single_part_text_plain` so a
+/// regression in either layer surfaces independently.
+#[cfg(unix)]
+#[test]
+fn mcp_email_send_text_only_emits_single_part_text_plain() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let port = find_free_port();
+    let mail_drop = tmp.path().join("outbound.log");
+    let (child, _sock) = start_serve_with_mail_drop(tmp.path(), port, &mail_drop);
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    let resp = client.call_tool(
+        "email_send",
+        serde_json::json!({
+            "from_mailbox": "alice",
+            "to": "recipient@example.com",
+            "subject": "OTP delivery",
+            "body": "Your code: 9999",
+            "text_only": true,
+        }),
+    );
+    assert!(!is_tool_error(&resp), "email_send should succeed: {resp:?}");
+
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    let payload = drop_payload(&mail_drop);
+    let payload_str = String::from_utf8_lossy(&payload);
+    assert!(
+        payload_str.contains("Content-Type: text/plain"),
+        "MCP text_only must produce text/plain wire: {payload_str}"
+    );
+    assert!(
+        !payload_str.contains("multipart/"),
+        "MCP text_only must produce single-part wire: {payload_str}"
+    );
+    assert!(
+        !payload_str.contains("Content-Type: text/html"),
+        "MCP text_only must not produce a text/html part: {payload_str}"
+    );
+    assert!(
+        payload_str.contains("Your code: 9999"),
+        "body must reach the wire verbatim: {payload_str}"
+    );
+
+    client.shutdown();
+    stop_serve(child);
+}
+
+/// MCP `email_send` with `html_body` produces a `multipart/alternative`
+/// where the operator's HTML appears in the `text/html` part verbatim
+/// (no inline `style="..."` attributes the renderer would have added).
+/// The custom HTML is NOT persisted to the sent record (FR-F5: only the
+/// `body` text part is stored; the operator's template is the source of
+/// truth elsewhere).
+#[cfg(unix)]
+#[test]
+fn mcp_email_send_html_body_uses_supplied_html_verbatim() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let port = find_free_port();
+    let mail_drop = tmp.path().join("outbound.log");
+    let (child, _sock) = start_serve_with_mail_drop(tmp.path(), port, &mail_drop);
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    let resp = client.call_tool(
+        "email_send",
+        serde_json::json!({
+            "from_mailbox": "alice",
+            "to": "recipient@example.com",
+            "subject": "Custom HTML layout",
+            "body": "fallback text",
+            "html_body": "<p>custom <b>html</b></p>",
+        }),
+    );
+    assert!(!is_tool_error(&resp), "email_send should succeed: {resp:?}");
+
+    std::thread::sleep(std::time::Duration::from_millis(200));
+
+    let payload = drop_payload(&mail_drop);
+    let payload_str = String::from_utf8_lossy(&payload);
+    assert!(
+        payload_str.contains("Content-Type: multipart/alternative"),
+        "html_body wire must be multipart/alternative: {payload_str}"
+    );
+    assert!(
+        payload_str.contains("Content-Type: text/plain"),
+        "text part missing"
+    );
+    assert!(
+        payload_str.contains("Content-Type: text/html"),
+        "text/html part missing"
+    );
+    assert!(
+        payload_str.contains("fallback text"),
+        "text part must carry body verbatim: {payload_str}"
+    );
+    let html_idx = payload_str
+        .find("Content-Type: text/html")
+        .expect("text/html part missing");
+    let html_section = &payload_str[html_idx..];
+    assert!(
+        html_section.contains("<p>custom <b>html</b></p>"),
+        "html part must carry html_body verbatim: {html_section}"
+    );
+    assert!(
+        !html_section.contains("style=\""),
+        "renderer must not be invoked on html_body MCP path: {html_section}"
+    );
+
+    client.shutdown();
+    stop_serve(child);
+}
+
+/// MCP `email_send` with both `text_only=true` and `html_body` set is
+/// rejected server-side before the UDS is opened. The error wording
+/// matches the codec's canonical message so operators see the same
+/// string regardless of which layer (clap, MCP, codec) fired the check.
+#[cfg(unix)]
+#[test]
+fn mcp_email_send_text_only_plus_html_body_rejected() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    let resp = client.call_tool(
+        "email_send",
+        serde_json::json!({
+            "from_mailbox": "alice",
+            "to": "recipient@example.com",
+            "subject": "conflict",
+            "body": "fallback",
+            "text_only": true,
+            "html_body": "<p>x</p>",
+        }),
+    );
+    assert!(
+        is_tool_error(&resp),
+        "MCP must reject text_only + html_body before opening UDS: {resp:?}"
+    );
+    let text = get_tool_text(&resp);
+    assert!(
+        text.contains("--text-only") && text.contains("--html-body"),
+        "MCP rejection must name both flags (matching the codec wording): {text}"
+    );
+    assert!(
+        text.contains("mutually exclusive"),
+        "MCP rejection must use the canonical 'mutually exclusive' wording: {text}"
+    );
+
+    client.shutdown();
+    stop_serve(daemon);
+}
+
+/// MCP `email_reply` with both `text_only=true` and `html_body` set is
+/// rejected server-side with the same canonical wording as
+/// `email_send`. The reply path has its own validation call site so a
+/// regression on one tool does not silently fix itself by leaning on
+/// the other tool's check.
+#[cfg(unix)]
+#[test]
+fn mcp_email_reply_text_only_plus_html_body_rejected() {
+    let tmp = TempDir::new().unwrap();
+    setup_test_env(tmp.path());
+
+    let port = find_free_port();
+    let daemon = start_serve(tmp.path(), port);
+    let sock = tmp.path().join("run").join("aimx.sock");
+    assert!(
+        wait_for_socket(&sock, std::time::Duration::from_secs(5)),
+        "UDS socket never appeared"
+    );
+
+    let mut client = McpClient::spawn(tmp.path());
+    client.initialize();
+
+    // The id need not exist — mutual-exclusion fires before the
+    // `validate_email_id` / `lookup_mailbox_row` walk would have
+    // returned a different error. The response wording proves the
+    // check fired in the right order (no UDS open, no parent-message
+    // read).
+    let resp = client.call_tool(
+        "email_reply",
+        serde_json::json!({
+            "mailbox": "alice",
+            "id": "2099-12-31-235959-nope",
+            "body": "fallback",
+            "text_only": true,
+            "html_body": "<p>x</p>",
+        }),
+    );
+    assert!(
+        is_tool_error(&resp),
+        "email_reply must reject text_only + html_body: {resp:?}"
+    );
+    let text = get_tool_text(&resp);
+    assert!(
+        text.contains("mutually exclusive"),
+        "reply rejection must use the canonical 'mutually exclusive' wording: {text}"
+    );
+
+    client.shutdown();
+    stop_serve(daemon);
 }
 
 /// `aimx send --text-only --html-body ...` is rejected at the CLI


### PR DESCRIPTION
## Sprint Goal
MCP `email_send` and `email_reply` mirror the CLI surface (`text_only` / `html_body`); `OutboundFrontmatter` gains `outbound_format`; sent storage stays single-file `.md` for all three paths; book / agent primer / release-notes ship the hard-break advisory; `aimx --version` bumps.

## Stories Implemented

### [S4-1] `email_send` and `email_reply` MCP tools gain `text_only` and `html_body` parameters
- [x] Both tools accept optional `text_only: bool` and `html_body: string` parameters with the same docstring guidance.
- [x] Server-side mutual-exclusion check fires before the UDS is opened. Error wording matches the codec's canonical message (`AIMX/1 SEND: --text-only and --html-body are mutually exclusive`) so operators see one consistent string regardless of which layer tripped.
- [x] `EmailSendParams` / `EmailReplyParams` schema property order pinned by snapshot tests (existing pattern in `mcp::schema_order_tests`).
- [x] Default-Markdown render path preserved when both new params absent — backward compat verified via deserialization tests.
- [x] New unit tests for `validate_text_only_html_body_exclusion`, `build_send_args` forwarding, and the new params' deserialization.
- [x] New integration tests: `mcp_email_send_text_only_emits_single_part_text_plain`, `mcp_email_send_html_body_uses_supplied_html_verbatim`, `mcp_email_send_text_only_plus_html_body_rejected`, `mcp_email_reply_text_only_plus_html_body_rejected`.
- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean.

### [S4-2] `OutboundFrontmatter::outbound_format` field + sent-storage tests
- [x] `OutboundFrontmatter::outbound_format: String` added in `src/frontmatter.rs`. Default value `"markdown"` on writes from the new code paths.
- [x] `format_outbound_frontmatter` writes the field in the Outbound block, immediately after `outbound`. Field ordering verified by `outbound_format_serializes_immediately_after_outbound`.
- [x] Reader: parsing an outbound frontmatter that lacks `outbound_format` treats it as `"text"` (backward compat, verified by `outbound_format_missing_field_defaults_to_text`).
- [x] `persist_sent_file` accepts the format and stamps it; the daemon derives the value from the SEND request's `text_only` / `html_body` fields.
- [x] Sent-storage integration tests for all three paths now also assert `outbound_format = "..."`.
- [x] Unit-level invariant: no `.html` sibling appears for any of the three paths (`sent_record_never_writes_html_sibling`).
- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean.

### [S4-3] `book/cli.md` rewrite + new `book/markdown-email.md` chapter
- [x] `book/cli.md` `aimx send` section rewritten to lead with the Markdown default; `--text-only` and `--html-body` documented as escape hatches; `--html-body \"\$(cat ...)\"` shell pattern shown in an example; mutual-exclusion behavior noted; sent-storage pointer added.
- [x] New `book/markdown-email.md` chapter covers: rendering pipeline, supported Markdown features (table), inlined stylesheet's element scope (table), 5MB body cap with canonical error, both escape hatches with worked examples, sent-storage `outbound_format` table, deterministic re-render guarantee, and a worked example.
- [x] `book/SUMMARY.md` registers the new chapter.
- [x] `book/mailboxes.md` "Sending email" section refreshed with Markdown / text-only / html-body examples.
- [x] No planning-doc cross-references in any modified file (verified by the `rg` regex check from `CLAUDE.local.md`).
- [x] `mdbook build website/` succeeds with the new chapter rendered.
- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean.

### [S4-4] Agent primer + `references/mcp-tools.md` updates + release notes hard-break
- [x] `agents/common/aimx-primer.md` email-tools section rewritten: `email_send` / `email_reply` now lead with Markdown default; new `text_only` / `html_body` parameters documented; "Send an email" workflow shows all three send shapes.
- [x] `agents/common/references/mcp-tools.md` `email_send` and `email_reply` rows updated: new parameter table rows, new docstring guidance, three new examples (default Markdown, plain-text OTP, custom HTML), and the new error wording (mutual exclusion + 5MB cap).
- [x] `book/release-notes.md` carries a hard-break advisory at the very top (`> Hard break (Unreleased): aimx send --body is now interpreted as Markdown by default...`) plus a full release block describing the new behavior, migration story, and rationale.
- [x] `aimx --version` bumped from `0.1.0` to `0.2.0` in `Cargo.toml` so operators on older builds know to re-read the changelog.
- [x] No planning-doc cross-references introduced anywhere outside `docs/`.
- [x] `cargo build` succeeds and the rebuilt agent skill bundles ship the new primer text (`aimx agents setup claude-code --print` shows the new lead-in).
- [x] `cargo test`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt -- --check` clean.

## Technical Decisions

- **MCP submit path now uses `send::build_request` instead of building a `SendRequest` inline.** The previous MCP path hardcoded `text_only=false` / `html_body=None`. Switching to the shared `build_request` helper means MCP and CLI submit byte-identical SEND frames for the same `SendArgs`, removes a hardcoded bug class, and applies the same CRLF normalization to `html_body` automatically.
- **Server-side mutual-exclusion check on the MCP surface, not just the codec.** The codec already rejects both-set frames, but firing the check server-side in the MCP tool body avoids opening the UDS at all and gives the agent a clean tool error rather than a codec error percolating back through the rmcp framing. The wording is intentionally identical so operators see one canonical string regardless of layer.
- **`outbound_format = "text"` as the read-side default for missing field.** Pre-feature sent records were always single-part `text/plain` — defaulting the missing field to `"text"` keeps the audit trail honest about what those legacy records actually shipped. Defaulting to `"markdown"` would have lied about the wire shape.
- **Version bump to `0.2.0` (minor) rather than `0.1.1` (patch).** Markdown is a hard break per the PRD; pre-1.0 semver allows minor bumps to signal breaking changes. The version is the operator's signal to re-read the changelog.
- **Trimmed primer aggressively to stay under the 500-line bundling target.** Initial draft of the "Send an email" workflow was verbose; pulled the `attachments` example and the operator-side `aimx mailboxes create` aside out to keep the primer's size within the existing CI guard. The full content survives in `references/mcp-tools.md`.

## Deferred Items

None — the entire sprint shipped.

## Review Focus Areas

- **`src/mcp.rs` `validate_text_only_html_body_exclusion` + `submit_via_daemon` rewrite.** The new helper is the single point of truth for the MCP-side check; verify the wording matches the codec exactly and the call sites in both `email_send` and `email_reply` invoke it before any IO.
- **`src/frontmatter.rs` `outbound_format` field.** Default-on-read = `"text"`, default-on-write (via the sample fixture) = `"markdown"`. The asymmetry is deliberate — pre-feature records ship `"text"`, new code paths ship a concrete value picked at the call site.
- **`src/send_handler.rs` `outbound_format` derivation.** Three-branch match on `req.text_only` / `req.html_body.is_some()`. The codec rejects both-set frames so the match is exhaustive without a tie-breaker.
- **`book/markdown-email.md`.** The big new docs surface for this PRD. Worth a careful read for accuracy on the rendering pipeline description, the styled-element table (vs. FR-C2), and the sent-storage section's `outbound_format` table.
- **`book/release-notes.md` hard-break advisory.** First line is the operator's first signal; the wording is load-bearing.