### PR TITLE
html-email cleanup: address Sprint 4 review non-blockers

### DIFF
--- a/book/markdown-email.md
+++ b/book/markdown-email.md
@@ -92,7 +92,7 @@ Use for:
 
 ### `--html-body`
 
-Supplies a custom HTML body. AIMX uses `<html>` verbatim as the `text/html` part and uses `--body` as the `text/plain` fallback so text-only clients still see something readable.
+Supplies a custom HTML body. AIMX uses the `--html-body` value verbatim as the `text/html` part and uses `--body` as the `text/plain` fallback so text-only clients still see something readable.
 
 ```bash
 aimx send --from alice@example.com --to bob@example.com \
@@ -135,7 +135,7 @@ Pre-feature sent records lack the field; on read, those default to `"text"` (the
 
 ## Determinism
 
-The renderer is deterministic: the same Markdown input produces byte-identical HTML output across two invocations. This is what justifies dropping the rendered HTML from sent storage — the recipient's view is recoverable. `comrak` is pinned to an exact minor version in `Cargo.toml`; bumping it requires re-blessing the renderer fixtures and noting the change in the release notes.
+The renderer is deterministic: the same Markdown input produces byte-identical HTML output across two invocations. This is what justifies dropping the rendered HTML from sent storage — the recipient's view is recoverable. `comrak` is pinned to an exact patch version in `Cargo.toml` (currently `=0.52.0`); bumping it requires re-blessing the renderer fixtures and noting the change in the release notes.
 
 CI defends the determinism guarantee with two checked-in fixtures (`tests/fixtures/markdown/briefing-5kb.md` and `tests/fixtures/markdown/report-50kb.md`) and their pinned expected outputs. A `comrak` bump that changes whitespace or attribute ordering surfaces at CI time, not in production.
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -387,6 +387,16 @@ impl AimxMcpServer {
         &self,
         Parameters(params): Parameters<EmailSendParams>,
     ) -> Result<String, String> {
+        // Mutual-exclusion check runs first so the failure is the
+        // cheapest possible: no daemon round-trip, no mailbox lookup,
+        // no IO. The wording matches the codec's canonical message so
+        // operators see the same string regardless of where validation
+        // tripped.
+        validate_text_only_html_body_exclusion(
+            params.text_only.unwrap_or(false),
+            params.html_body.as_deref(),
+        )?;
+
         // The daemon's MAILBOX-LIST row carries the registered address
         // verbatim. We derive the from-address (and only secondarily
         // the domain) from it without reading root-owned
@@ -405,16 +415,6 @@ impl AimxMcpServer {
             ));
         }
 
-        // Server-side mutual-exclusion check — fires before the UDS is
-        // opened so the agent gets a clean tool error rather than a
-        // codec error percolating back through the rmcp framing. The
-        // wording matches the codec's canonical message so operators
-        // see the same string regardless of where validation tripped.
-        validate_text_only_html_body_exclusion(
-            params.text_only.unwrap_or(false),
-            params.html_body.as_deref(),
-        )?;
-
         let args = build_send_args(params, from_address);
 
         submit_via_daemon(&args)
@@ -432,11 +432,8 @@ impl AimxMcpServer {
         &self,
         Parameters(params): Parameters<EmailReplyParams>,
     ) -> Result<String, String> {
-        validate_email_id(&params.id)?;
-        let row = lookup_mailbox_row(&params.mailbox)?;
-
-        // Mutual-exclusion check fires before any IO so the failure is
-        // cheap and never opens the UDS. Same wording as the codec
+        // Mutual-exclusion check runs first — same fast-fail principle
+        // as `email_send`, and same canonical wording as the codec
         // (`AIMX/1 SEND: --text-only and --html-body are mutually
         // exclusive`) so operators see one consistent string regardless
         // of layer.
@@ -444,6 +441,9 @@ impl AimxMcpServer {
             params.text_only.unwrap_or(false),
             params.html_body.as_deref(),
         )?;
+
+        validate_email_id(&params.id)?;
+        let row = lookup_mailbox_row(&params.mailbox)?;
 
         let mailbox_dir = folder_path_from_row(&row, Folder::Inbox);
         // `email_reply` reads the parent message to inherit threading
@@ -738,8 +738,11 @@ fn validate_text_only_html_body_exclusion(
     text_only: bool,
     html_body: Option<&str>,
 ) -> Result<(), String> {
-    let html_body_present = html_body.map(|s| !s.is_empty()).unwrap_or(false);
-    if text_only && html_body_present {
+    // Treat `Some("")` as supplied. The wire codec carries an empty
+    // `Html-Body-Length: 0` payload through and rejects the conflict;
+    // this pre-flight matches that semantic so the failure is identical
+    // regardless of layer.
+    if text_only && html_body.is_some() {
         // Match the wire-codec phrasing in `src/send_protocol.rs` so
         // the operator sees the same wording regardless of which layer
         // tripped the check.
@@ -2541,14 +2544,28 @@ mod text_only_html_body_tests {
     #[test]
     fn validate_allows_text_only_alone() {
         assert!(validate_text_only_html_body_exclusion(true, None).is_ok());
-        // Empty html_body is treated as "not supplied" — same shape as
-        // an absent field, so the mutual-exclusion check ignores it.
-        assert!(validate_text_only_html_body_exclusion(true, Some("")).is_ok());
     }
 
     #[test]
     fn validate_allows_html_body_alone() {
         assert!(validate_text_only_html_body_exclusion(false, Some("<p>hi</p>")).is_ok());
+        // Empty html_body alone (without text_only) is allowed — only
+        // the conflict between the two flags trips the check.
+        assert!(validate_text_only_html_body_exclusion(false, Some("")).is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_text_only_plus_empty_html_body() {
+        // `Some("")` is treated as supplied to match the wire codec,
+        // which carries the empty payload through and rejects the
+        // conflict at the daemon. Pre-flighting here keeps the failure
+        // identical to a non-empty `html_body` so the operator sees the
+        // same wording regardless of which layer tripped.
+        let err = validate_text_only_html_body_exclusion(true, Some("")).unwrap_err();
+        assert_eq!(
+            err,
+            "AIMX/1 SEND: --text-only and --html-body are mutually exclusive"
+        );
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3447,11 +3447,11 @@ fn mcp_email_reply_text_only_plus_html_body_rejected() {
     let mut client = McpClient::spawn(tmp.path());
     client.initialize();
 
-    // The id need not exist — mutual-exclusion fires before the
-    // `validate_email_id` / `lookup_mailbox_row` walk would have
-    // returned a different error. The response wording proves the
-    // check fired in the right order (no UDS open, no parent-message
-    // read).
+    // The id and mailbox need not exist — mutual-exclusion is the
+    // very first check in `email_reply`, ahead of `validate_email_id`
+    // and `lookup_mailbox_row`. The "mutually exclusive" wording in
+    // the response proves the check fired first (no UDS open, no
+    // mailbox lookup, no parent-message read).
     let resp = client.call_tool(
         "email_reply",
         serde_json::json!({


### PR DESCRIPTION
## Summary

Followup cleanup that lands the four non-blocker items the Sprint 4 reviewer flagged. Targets `epic/html-email` so it ships alongside the rest of the track when the epic PR (#206) lands on `main`.

### Changes

1. **MCP fast-fail ordering.** `email_send` and `email_reply` now run the `text_only` / `html_body` mutual-exclusion check first, ahead of `lookup_mailbox_row` (and `validate_email_id` for reply). Failures are now the cheapest possible — no mailbox lookup, no parent-message read, no UDS open. Both tools share the same ordering.

2. **`Some("")` semantic alignment.** `validate_text_only_html_body_exclusion` now treats `Some("")` as supplied (was: treated as not-supplied). The wire codec carries the empty payload through and rejects the conflict, so this matches the codec — failures are now identical regardless of which layer tripped. Tests updated to pin the new contract; new `validate_rejects_text_only_plus_empty_html_body` regression test added.

3. **Test comment correction.** `mcp_email_reply_text_only_plus_html_body_rejected`'s docstring now accurately describes the mutex check as the very first check (true after the reorder above).

4. **`book/markdown-email.md` doc nits:**
   - The `--html-body` description used `<html>` as the placeholder, colliding with the actual HTML element name. Replaced with `the --html-body value` for unambiguous reading.
   - The determinism section called the comrak pin a "minor version" — it's actually an exact patch (`=0.52.0`). Updated to say so explicitly with the version inline.

## Test plan

- [x] `cargo test --bin aimx` — 1134 passed, 0 failed
- [x] `cargo test --test integration` — 116 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `mdbook build website` — clean (only pre-existing README/index warning)
- [x] CLAUDE.local.md banned-token check on the diff — zero hits