### PR TITLE
wire_assembly: decode quoted-pair escapes; drop FR-F refs (PR #206 review followup)

### DIFF
--- a/src/send_handler.rs
+++ b/src/send_handler.rs
@@ -1835,9 +1835,9 @@ mod tests {
     }
 
     /// No `.html` sibling file is written next to the sent record on
-    /// any of the three send paths. Pin the FR-F2 invariant at the
-    /// unit-test level so a future change to the persistence path that
-    /// introduces an HTML twin file is caught immediately.
+    /// any of the three send paths. Pin the single-file-`.md`
+    /// persistence invariant at the unit-test level so a future change
+    /// that introduces an HTML twin file is caught immediately.
     #[tokio::test]
     async fn sent_record_never_writes_html_sibling() {
         for req in [

--- a/src/wire_assembly.rs
+++ b/src/wire_assembly.rs
@@ -399,8 +399,11 @@ fn extract_name_param(content_type: &str) -> Option<String> {
 /// header value's primary value or another `;`-separated segment, so
 /// asking for `name` will NOT spuriously match the `name=` substring
 /// inside `filename=`. Parameter name comparison is case-insensitive.
-/// Quoted values strip the surrounding `"` and stop at the closing `"`;
-/// unquoted values run until the next `;` or whitespace.
+/// Quoted values strip the surrounding `"` and decode RFC 2822
+/// quoted-pair escapes (`\\` → `\`, `\"` → `"`, `\X` → `X`); the closing
+/// `"` is the first unescaped one. Unquoted values run until the next
+/// `;` or whitespace. Returns `None` if a quoted value is unterminated
+/// (e.g. a trailing lone `\` consumes the closing `"`).
 fn extract_quoted_param(s: &str, name: &str) -> Option<String> {
     let lower_name = name.to_ascii_lowercase();
     // Skip the primary value (everything before the first `;`); parameters
@@ -417,8 +420,7 @@ fn extract_quoted_param(s: &str, name: &str) -> Option<String> {
         }
         let value = raw_value.trim_start();
         if let Some(stripped) = value.strip_prefix('"') {
-            let end = stripped.find('"')?;
-            return Some(stripped[..end].to_string());
+            return decode_quoted_value(stripped);
         }
         let end = value
             .find(|c: char| c == ';' || c.is_whitespace())
@@ -427,6 +429,34 @@ fn extract_quoted_param(s: &str, name: &str) -> Option<String> {
             return None;
         }
         return Some(value[..end].to_string());
+    }
+    None
+}
+
+/// Decode the body of an RFC 2822 quoted-string. Input is the substring
+/// **after** the opening `"`. A backslash escapes the next character
+/// (`\\` → `\`, `\"` → `"`, `\X` → `X` for any other X); the value
+/// terminates at the first unescaped `"`. Returns `None` if the value
+/// is unterminated (no closing `"`, possibly because a trailing `\`
+/// consumed it).
+fn decode_quoted_value(stripped: &str) -> Option<String> {
+    let mut out = String::with_capacity(stripped.len());
+    let mut chars = stripped.chars();
+    while let Some(c) = chars.next() {
+        match c {
+            '\\' => {
+                // RFC 2822 §3.2.5 quoted-pair: `\` followed by any
+                // char emits that char literally. A trailing `\` with
+                // no following char is malformed — fall through to
+                // the `None` at the end.
+                let next = chars.next()?;
+                out.push(next);
+            }
+            '"' => {
+                return Some(out);
+            }
+            other => out.push(other),
+        }
     }
     None
 }
@@ -1263,6 +1293,86 @@ mod tests {
         // filename value.
         let ct = "application/pdf; filename=\"doc.pdf\"";
         assert_eq!(extract_name_param(ct), None);
+    }
+
+    /// `escape_filename` on the client side replaces a literal `"` with
+    /// `\"` to keep the wire RFC 2822-clean. The daemon's parser must
+    /// honour the escape and return the original `"` rather than
+    /// terminating the value early at the first `"` it sees.
+    #[test]
+    fn extract_quoted_param_decodes_escaped_quote() {
+        let header = "application/pdf; filename=\"my\\\"file.pdf\"";
+        assert_eq!(
+            extract_quoted_param(header, "filename"),
+            Some("my\"file.pdf".to_string())
+        );
+    }
+
+    /// `escape_filename` doubles a literal `\` to `\\`. The parser must
+    /// collapse it back so the filename round-trips verbatim.
+    #[test]
+    fn extract_quoted_param_decodes_escaped_backslash() {
+        let header = "application/pdf; filename=\"a\\\\b.pdf\"";
+        assert_eq!(
+            extract_quoted_param(header, "filename"),
+            Some("a\\b.pdf".to_string())
+        );
+    }
+
+    /// A trailing lone `\` inside a quoted value (no following char) is
+    /// not a legal RFC 2822 quoted-pair. The parser must reject it
+    /// rather than silently truncating or buffer-overrunning.
+    #[test]
+    fn extract_quoted_param_rejects_unterminated_escape() {
+        let header = "application/pdf; filename=\"trailing\\\"";
+        assert_eq!(extract_quoted_param(header, "filename"), None);
+    }
+
+    /// End-to-end: a multipart request whose attachment filename
+    /// contains `"` (escaped on the wire as `\"` by the client's
+    /// `escape_filename`) round-trips through `assemble_wire_message`
+    /// and re-emerges with the same `\"` escape on the wire — i.e. the
+    /// daemon's reassembly preserves the escape rather than dropping
+    /// or doubling it. Pins the contract between client-side
+    /// `escape_filename` and daemon-side `extract_quoted_param`.
+    #[test]
+    fn attachment_filename_with_escaped_quote_round_trips_through_assembler() {
+        let body = concat!(
+            "--BND\r\n",
+            "Content-Type: text/plain; charset=utf-8\r\n",
+            "\r\n",
+            "Body.\r\n",
+            "--BND\r\n",
+            "Content-Type: application/pdf; name=\"my\\\"file.pdf\"\r\n",
+            "Content-Disposition: attachment; filename=\"my\\\"file.pdf\"\r\n",
+            "Content-Transfer-Encoding: base64\r\n",
+            "\r\n",
+            "UERG\r\n",
+            "--BND--\r\n",
+        );
+        let req = build_request(
+            "From: a@b.com\nTo: c@d.com\nSubject: T\nMIME-Version: 1.0\nContent-Type: multipart/mixed; boundary=\"BND\"\n",
+            body,
+        );
+        let out = assemble_wire_message(&req, "", false, None).unwrap();
+        let text = String::from_utf8_lossy(&out);
+        // The escaped quote survives daemon round-trip on both the
+        // Content-Type `name=` and the Content-Disposition `filename=`.
+        assert!(
+            text.contains("name=\"my\\\"file.pdf\""),
+            "Content-Type name= must keep escaped quote, got:\n{text}"
+        );
+        assert!(
+            text.contains("filename=\"my\\\"file.pdf\""),
+            "Content-Disposition filename= must keep escaped quote, got:\n{text}"
+        );
+        // The truncated form (`my\\` with no rest) must not appear —
+        // that was the pre-fix behaviour where the parser stopped at
+        // the embedded `"`.
+        assert!(
+            !text.contains("filename=\"my\\\"\r\n"),
+            "filename must not be truncated at the embedded quote, got:\n{text}"
+        );
     }
 
     #[test]

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -2919,7 +2919,7 @@ fn send_uds_end_to_end_emits_multipart_alternative_for_markdown_body() {
         "sent record body should preserve the Markdown source verbatim"
     );
     // The audit-trail field declares the wire shape: default Markdown
-    // path stamps `outbound_format = "markdown"` (FR-F3).
+    // path stamps `outbound_format = "markdown"`.
     assert!(
         sent_content.contains("outbound_format = \"markdown\""),
         "sent record must declare outbound_format = \"markdown\":\n{sent_content}"
@@ -3312,9 +3312,9 @@ fn mcp_email_send_text_only_emits_single_part_text_plain() {
 /// MCP `email_send` with `html_body` produces a `multipart/alternative`
 /// where the operator's HTML appears in the `text/html` part verbatim
 /// (no inline `style="..."` attributes the renderer would have added).
-/// The custom HTML is NOT persisted to the sent record (FR-F5: only the
-/// `body` text part is stored; the operator's template is the source of
-/// truth elsewhere).
+/// The custom HTML is NOT persisted to the sent record — only the
+/// `body` text part is stored; the operator's template is the source
+/// of truth elsewhere.
 #[cfg(unix)]
 #[test]
 fn mcp_email_send_html_body_uses_supplied_html_verbatim() {


### PR DESCRIPTION
## Summary

Address the non-blocker and the first nice-to-have from the review on the epic integration PR (#206). Targets `epic/html-email` so the fixes land before the human merges the epic to `main`.

### Non-blocker — quoted-pair escape decoding in `extract_quoted_param`

The client's `escape_filename` (`src/send.rs:33-38`, mirrored in `src/wire_assembly.rs:865-870`) replaces a literal `"` with `\"` and a literal `\` with `\\` to keep the multipart wire RFC 2822-clean. The daemon's new `extract_quoted_param` parser, however, terminated on the first `"` it encountered inside a quoted value — including escaped ones. For an attachment with filename `my"file.pdf`, the wire carried `filename="my\"file.pdf"`, and the parser returned `my\` (truncated at the embedded `"`). The recipient would have received the attachment under a malformed name ending in a literal backslash.

**Fix.** New `decode_quoted_value` helper that walks the value char-by-char and honours RFC 2822 §3.2.5 quoted-pair semantics: `\\` → `\`, `\"` → `"`, `\X` → `X`. The closing `"` is the first unescaped one. A trailing lone `\` that consumes the closing quote leaves the value unterminated and the parser returns `None`.

**Regression tests** (4 new):
- `extract_quoted_param_decodes_escaped_quote` — pins the `\"` → `"` decode.
- `extract_quoted_param_decodes_escaped_backslash` — pins the `\\` → `\` decode.
- `extract_quoted_param_rejects_unterminated_escape` — pins the trailing-`\` rejection.
- `attachment_filename_with_escaped_quote_round_trips_through_assembler` — end-to-end round-trip pinning the contract between client-side `escape_filename` and daemon-side `extract_quoted_param` on both the Content-Type `name=` and the Content-Disposition `filename=`.

### Nice-to-have — drop `FR-F*` planning-doc references

The reviewer noted three `FR-F2` / `FR-F3` / `FR-F5` references the CLAUDE.local.md regex didn't catch (it matches digit-prefixed FR ids only). Dropped from `src/send_handler.rs:1838`, `tests/integration.rs:2922`, and `tests/integration.rs:3315`. Technical content is preserved verbatim; only the cross-references go away.

## Items NOT addressed in this PR

- The other nice-to-have — literal `Sprint` tokens in PR #206's description and in the most recent commit message — is harder to address cleanly. Commit messages of merged commits can't be rewritten without rewriting history. The PR #206 description can be edited via `gh pr edit 206 --body ...`; happy to do that as a separate non-code action if you'd like.

## Test plan

- [x] `cargo test --bin aimx` — 1142 passed, 0 failed
- [x] `cargo test --test integration` — 116 passed, 0 failed
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] CLAUDE.local.md banned-token check on the diff — zero hits