### PR TITLE
Markdown-native outbound: signature on every path + directive MCP guidance

### DIFF
--- a/agents/common/aimx-primer.md
+++ b/agents/common/aimx-primer.md
@@ -123,9 +123,9 @@ surface.
 - `email_read(mailbox, id, folder?)`: return the full Markdown file
   (frontmatter + body) for one email.
 - `email_send(from_mailbox, to, subject, body, attachments?, text_only?, html_body?)`:
-  compose, DKIM-sign, and deliver. `body` is Markdown by default;
-  `text_only` / `html_body` are mutually-exclusive escape hatches (see
-  "Send an email" below). `from_mailbox` must be a mailbox you own.
+  compose, DKIM-sign, deliver. `body` is Markdown → `multipart/alternative` by default
+  — **do NOT pass `text_only: true`** for formatted content (see "Send an email"
+  below). `from_mailbox` must be a mailbox you own.
 - `email_reply(mailbox, id, body, text_only?, html_body?)`: reply with the
   same Markdown semantics; AIMX sets `In-Reply-To`, `References`, and `Re:`
   automatically.
@@ -278,10 +278,10 @@ email_send(
 )
 ```
 
-For OTPs / transactional one-liners pass `text_only: true` to ship
-`body` verbatim as `text/plain`. For branded HTML layouts pass
-`html_body` verbatim as the HTML part with `body` as the plain-text
-fallback. The two flags are mutually exclusive.
+**Do NOT pass `text_only: true`** for prose, briefs, or any body with Markdown
+syntax — it ships raw markers (`#` / `**bold**` / `-`) as `text/plain`. Reserve
+it for unformatted one-liners (OTPs, verification codes). For branded HTML,
+pass `html_body` as the HTML part with `body` as the plain-text fallback (mutually exclusive with `text_only`).
 
 The mailbox must exist and you must own it. Provision via
 `mailbox_create(name)`, or `sudo aimx mailboxes create <name> --owner <user>` for cross-user mailboxes.

--- a/agents/common/references/mcp-tools.md
+++ b/agents/common/references/mcp-tools.md
@@ -261,9 +261,13 @@ styled HTML; recipients on text-only clients see the Markdown source.
 
 Two escape hatches cover the edge cases:
 
-- `text_only: true` — ship `body` verbatim as `text/plain`. No
-  rendering. Use for OTPs, transactional one-liners, and existing
-  scripts that must not change shape.
+- `text_only: true` — **DO NOT use for prose, briefs, summaries,
+  reports, or any body containing Markdown syntax.** That ships the
+  raw Markdown source as `text/plain` and the recipient sees `#` /
+  `**bold**` / `-` markers instead of rendered HTML. Use only for
+  short transactional one-liners with no formatting (OTPs,
+  verification codes, single-line confirmations) and existing scripts
+  that must not change shape.
 - `html_body: "<custom html>"` — supply a custom HTML template that
   AIMX uses verbatim as the `text/html` part. `body` is the
   `text/plain` fallback. Mutually exclusive with `text_only`.
@@ -278,7 +282,7 @@ Two escape hatches cover the edge cases:
 | `body`         | string   | yes      | Email body. Interpreted as Markdown by default (CommonMark + GFM). Used verbatim as `text/plain` when `text_only: true`; used as the `text/plain` fallback when `html_body` is set |
 | `attachments`  | string[] | no       | Absolute file paths to attach |
 | `references`   | string   | no       | Full `References` header chain (space-separated Message-IDs). **Only applied when `reply_to` is also set.** Supplied alone, it is silently ignored |
-| `text_only`    | boolean  | no       | When `true`, ship `body` verbatim as `text/plain` with no Markdown rendering and no HTML alternative part. Mutually exclusive with `html_body` |
+| `text_only`    | boolean  | no       | Use only for plain, unformatted bodies (OTPs, verification codes, single-line transactional notes). **DO NOT set `true` for prose or any body containing Markdown syntax** — it ships the raw Markdown source as `text/plain` and breaks rendering. When `true`, ships `body` verbatim as `text/plain` with no Markdown rendering and no HTML alternative part. Mutually exclusive with `html_body` |
 | `html_body`    | string   | no       | Custom HTML for the `text/html` part. Operator-supplied; bypasses the renderer. Mutually exclusive with `text_only` |
 
 For simple replies to a single sender, prefer `email_reply`. It reads the
@@ -370,7 +374,9 @@ Reply to an existing email. AIMX automatically sets `In-Reply-To`,
 `References`, and prepends `Re:` to the subject.
 
 `body` is interpreted as **Markdown by default** with the same
-`text_only` / `html_body` escape hatches as `email_send`.
+`text_only` / `html_body` escape hatches as `email_send`. The same
+DO-NOT-pass-`text_only`-for-formatted-content rule applies: replies
+containing Markdown syntax must not set `text_only: true`.
 
 **Parameters:**
 | Name        | Type    | Required | Description |
@@ -378,7 +384,7 @@ Reply to an existing email. AIMX automatically sets `In-Reply-To`,
 | `mailbox`   | string  | yes      | Mailbox containing the email to reply to (must be owned by you) |
 | `id`        | string  | yes      | Email ID to reply to |
 | `body`      | string  | yes      | Reply body. Interpreted as Markdown by default. With `text_only: true`, shipped verbatim as `text/plain`. With `html_body`, used as the `text/plain` fallback |
-| `text_only` | boolean | no       | When `true`, ship `body` verbatim as `text/plain` with no Markdown rendering. Mutually exclusive with `html_body` |
+| `text_only` | boolean | no       | Use only for plain, unformatted replies (acknowledgements, OTPs, single-line confirmations). **DO NOT set `true` for replies containing Markdown syntax** — it ships the raw source as `text/plain` and breaks rendering. When `true`, ships `body` verbatim as `text/plain` with no Markdown rendering. Mutually exclusive with `html_body` |
 | `html_body` | string  | no       | Custom HTML for the `text/html` part. Operator-supplied; bypasses the renderer. Mutually exclusive with `text_only` |
 
 **Returns:** Confirmation with Message-ID.

--- a/book/markdown-email.md
+++ b/book/markdown-email.md
@@ -5,7 +5,7 @@ AIMX is Markdown-native end-to-end. Inbound mail is stored as Markdown for direc
 ## How a default send is delivered
 
 1. **Caller submits Markdown.** `aimx send --body "..."` (or the MCP `email_send` tool with `body: "..."`) ships the Markdown source to the daemon over the local UDS.
-2. **Daemon appends the per-mailbox signature** to the Markdown body so the signature renders as part of the HTML output. Markdown link syntax in the signature renders as a clickable HTML anchor.
+2. **Daemon appends the per-mailbox signature** to the body so the recipient always sees it in the `text/plain` region. On the default Markdown path the signature is part of the Markdown source, so it also renders into the HTML alternative (and a `[link](url)` in the signature becomes a clickable `<a>`).
 3. **Daemon renders Markdown to HTML.** The renderer uses [`comrak`](https://github.com/kivikakk/comrak) configured for CommonMark + GFM extensions (tables, strikethrough, autolinks, task lists, footnotes, tag filter for unsafe tags). Raw HTML embedded in Markdown is escaped, not rendered — operators wanting raw HTML use `--html-body` instead.
 4. **Inlined stylesheet pass.** The renderer walks the rendered HTML tree and adds `style="..."` attributes per element. Inlining is required because Gmail, Outlook for Web, and Yahoo Mail strip or limit `<style>` blocks.
 5. **Multipart assembly.** The daemon builds a `multipart/alternative` MIME message with the **Markdown source** as the `text/plain` part and the **rendered HTML** as the `text/html` part. With one or more attachments, the `multipart/alternative` is wrapped in an outer `multipart/mixed` so attachments sit as siblings of the alternative block.
@@ -84,7 +84,7 @@ aimx send --from alice@example.com --to bob@example.com \
   --text-only
 ```
 
-The per-mailbox signature is **not** auto-appended on this path — the operator already chose plain-text shape; the binary stays out of the way.
+The per-mailbox signature **is** auto-appended on this path. AIMX appends the configured signature (or the built-in default) to the body before encoding, so even one-liner text-only sends carry the configured footer. Disable globally with `signature = ""` in `config.toml` if your one-liner shape really needs to ship verbatim.
 
 Use for:
 - OTPs, transactional one-liners, system-generated alerts.
@@ -105,7 +105,7 @@ The shell pattern `--html-body "$(cat template.html)"` reads the template from a
 
 `--html-body` and `--text-only` are mutually exclusive. clap rejects the invocation before any UDS round-trip. The same canonical error fires server-side on the MCP `email_send` / `email_reply` tools so operators see one consistent message regardless of the surface.
 
-The per-mailbox signature is **not** auto-appended on this path — operator-supplied content is verbatim. Include any signature inside your template.
+The per-mailbox signature **is** appended to the `text/plain` fallback so text-only readers still see it. The supplied HTML stays operator-verbatim — if you want the signature visible in the HTML view, include it inside your template. Disable globally with `signature = ""` in `config.toml` if you want the text fallback to ship verbatim too.
 
 `--html-body` bypasses the renderer's tag-filter and other safety checks; the operator owns the consequences. Do not pass user-controlled HTML through this flag.
 
@@ -117,9 +117,9 @@ The frontmatter declares the wire shape so an operator browsing `sent/` can tell
 
 | `outbound_format` | Wire shape | Sent body content |
 |-------------------|------------|-------------------|
-| `"markdown"` | `multipart/alternative` (text + rendered HTML) | Markdown source verbatim (signature appended before render) |
-| `"text"` | single-part `text/plain` | literal text verbatim |
-| `"html"` | `multipart/alternative` (text + custom HTML) | the `--body` text part (custom HTML is **not** stored) |
+| `"markdown"` | `multipart/alternative` (text + rendered HTML) | Markdown source with signature appended before render |
+| `"text"` | single-part `text/plain` | body with signature appended |
+| `"html"` | `multipart/alternative` (text + custom HTML) | the `--body` text part with signature appended (custom HTML is **not** stored) |
 
 The `outbound_format` field appears immediately after `outbound = true` in the Outbound block of the frontmatter:
 

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -75,11 +75,13 @@ pub struct EmailSendParams {
                        When set, References is built automatically unless overridden by the references field."
     )]
     pub reply_to: Option<String>,
-    #[schemars(description = "Email body. Interpreted as Markdown by default \
-                       (CommonMark + GFM extensions). AIMX renders it to HTML and \
-                       sends as multipart/alternative. Set text_only=true for \
-                       plain-text-only sends. Set html_body to override the \
-                       auto-rendered HTML.")]
+    #[schemars(
+        description = "Email body. Rendered as Markdown (CommonMark + GFM: tables, \
+                       strikethrough, autolinks, task lists, footnotes) into \
+                       multipart/alternative HTML+text by default. The recipient sees \
+                       styled HTML on Gmail / Outlook / Apple Mail and the Markdown source \
+                       on text-only clients. See the text_only field before opting out."
+    )]
     pub body: String,
     #[schemars(description = "File paths to attach")]
     pub attachments: Option<Vec<String>>,
@@ -89,8 +91,12 @@ pub struct EmailSendParams {
     )]
     pub references: Option<String>,
     #[schemars(
-        description = "When true, send body verbatim as text/plain (no Markdown \
-                       rendering, no HTML alternative part). Mutually exclusive with html_body."
+        description = "DO NOT set true for prose, briefs, summaries, reports, or any body \
+                       containing Markdown syntax — it ships the raw Markdown source as \
+                       text/plain and the recipient sees `#` `**bold**` `-` markers instead \
+                       of rendered HTML. Only set true for short transactional one-liners with \
+                       no formatting (OTPs, verification codes, single-line confirmations) and \
+                       existing scripts that must not change shape. Mutually exclusive with html_body."
     )]
     pub text_only: Option<bool>,
     #[schemars(
@@ -108,15 +114,21 @@ pub struct EmailReplyParams {
     pub mailbox: String,
     #[schemars(description = "Email ID to reply to (e.g. 2025-01-01-001)")]
     pub id: String,
-    #[schemars(description = "Reply body. Interpreted as Markdown by default \
-                       (CommonMark + GFM extensions). AIMX renders it to HTML and \
-                       sends as multipart/alternative. Set text_only=true for \
-                       plain-text-only sends. Set html_body to override the \
-                       auto-rendered HTML.")]
+    #[schemars(
+        description = "Reply body. Rendered as Markdown (CommonMark + GFM: tables, \
+                       strikethrough, autolinks, task lists, footnotes) into \
+                       multipart/alternative HTML+text by default. The recipient sees \
+                       styled HTML on Gmail / Outlook / Apple Mail and the Markdown source \
+                       on text-only clients. See the text_only field before opting out."
+    )]
     pub body: String,
     #[schemars(
-        description = "When true, send body verbatim as text/plain (no Markdown \
-                       rendering, no HTML alternative part). Mutually exclusive with html_body."
+        description = "DO NOT set true for prose, briefs, summaries, reports, or any body \
+                       containing Markdown syntax — it ships the raw Markdown source as \
+                       text/plain and the recipient sees `#` `**bold**` `-` markers instead \
+                       of rendered HTML. Only set true for short transactional one-liners with \
+                       no formatting (OTPs, verification codes, single-line confirmations) and \
+                       existing scripts that must not change shape. Mutually exclusive with html_body."
     )]
     pub text_only: Option<bool>,
     #[schemars(
@@ -378,9 +390,14 @@ impl AimxMcpServer {
     #[tool(
         name = "email_send",
         description = "Submit an email for DKIM signing and delivery via the aimx daemon. \
-                       `body` is interpreted as Markdown (CommonMark + GFM extensions). \
-                       AIMX renders it to HTML and sends as multipart/alternative. \
-                       Set `text_only: true` for plain-text-only sends. \
+                       `body` is rendered as Markdown (CommonMark + GFM) into \
+                       multipart/alternative HTML+text by default — the recipient sees \
+                       styled HTML on Gmail / Outlook / Apple Mail. \
+                       DO NOT set `text_only: true` for prose, briefs, summaries, reports, \
+                       or any body containing markdown syntax; that ships the raw markdown \
+                       source as `text/plain` and breaks rendering. \
+                       Only set `text_only: true` for short transactional one-liners with \
+                       no formatting (OTPs, verification codes, single-line confirmations). \
                        Set `html_body` to override the auto-rendered HTML with your own template."
     )]
     fn email_send(
@@ -423,9 +440,14 @@ impl AimxMcpServer {
     #[tool(
         name = "email_reply",
         description = "Reply to an email with correct threading headers. \
-                       `body` is interpreted as Markdown (CommonMark + GFM extensions). \
-                       AIMX renders it to HTML and sends as multipart/alternative. \
-                       Set `text_only: true` for plain-text-only replies. \
+                       `body` is rendered as Markdown (CommonMark + GFM) into \
+                       multipart/alternative HTML+text by default — the recipient sees \
+                       styled HTML on Gmail / Outlook / Apple Mail. \
+                       DO NOT set `text_only: true` for prose, briefs, summaries, reports, \
+                       or any body containing markdown syntax; that ships the raw markdown \
+                       source as `text/plain` and breaks rendering. \
+                       Only set `text_only: true` for short transactional one-liners with \
+                       no formatting (OTPs, verification codes, single-line confirmations). \
                        Set `html_body` to override the auto-rendered HTML with your own template."
     )]
     fn email_reply(

--- a/src/send_handler.rs
+++ b/src/send_handler.rs
@@ -252,16 +252,17 @@ where
 
     // Default Markdown send path: render the Markdown body to HTML and
     // assemble the multipart/alternative (or nested multipart/mixed when
-    // the client packed attachments) shape daemon-side. The signature is
-    // appended to the Markdown source before rendering so a Markdown
-    // link in the signature renders as a clickable HTML anchor. The two
-    // escape-hatch fields on the SEND frame select an alternate wire
-    // shape: `text_only=true` ships single-part text/plain, and
-    // `html_body=Some(..)` ships multipart/alternative whose HTML part
-    // is the operator-supplied bytes verbatim. The signature is
-    // appended ONLY on the default Markdown path — escape hatches use
-    // the body verbatim because the operator already chose the
-    // rendering.
+    // the client packed attachments) shape daemon-side. The signature
+    // is appended to the body on every path so the recipient always
+    // sees it in the text/plain region (Markdown source on the default
+    // path, body verbatim on `--text-only`, text fallback on
+    // `--html-body`). The two escape-hatch fields on the SEND frame
+    // select an alternate wire shape: `text_only=true` ships single-part
+    // text/plain, and `html_body=Some(..)` ships multipart/alternative
+    // whose HTML part is the operator-supplied bytes verbatim. Operators
+    // wanting the signature in the HTML view of an `--html-body` send
+    // put it inside their HTML template — the daemon never modifies the
+    // supplied HTML bytes.
     let body_bytes = match crate::wire_assembly::assemble_wire_message(
         &body_with_id,
         config.effective_signature(),
@@ -1603,6 +1604,53 @@ mod tests {
         );
     }
 
+    /// Daemon-level coverage for the text-only path: a custom signature
+    /// configured via `Config::signature` must land in the single-part
+    /// text/plain body shipped by `text_only=true`. Regression for the
+    /// bug where `wire_assembly` dropped the signature on every escape
+    /// hatch.
+    #[tokio::test]
+    async fn custom_signature_appended_on_text_only_path() {
+        let data_dir = tempfile::TempDir::new().unwrap();
+        let mock = Arc::new(MockTransport {
+            captured: Mutex::new(vec![]),
+            behavior: Behavior::Ok,
+        });
+        let ctx = ctx_with_signature(
+            mock.clone(),
+            data_dir.path().to_path_buf(),
+            Some("-- daemon-sig-marker".to_string()),
+        );
+        let req = SendRequest {
+            body: body("alice@example.com"),
+            text_only: true,
+            html_body: None,
+        };
+        let resp = handle_send(req, &ctx, &Caller::internal_root()).await;
+        assert!(matches!(resp, SendResponse::Ok { .. }), "{resp:?}");
+
+        let captured = mock.captured.lock().unwrap();
+        let delivered = String::from_utf8_lossy(&captured[0]);
+        // Single-part text/plain: no multipart wrapping.
+        assert!(
+            !delivered.contains("multipart/"),
+            "text-only must not produce a multipart wire: {delivered}"
+        );
+        // Body and signature both present.
+        assert!(delivered.contains("hello"));
+        assert!(
+            delivered.contains("daemon-sig-marker"),
+            "custom signature must be appended on text-only path: {delivered}"
+        );
+        // Persisted sent record carries the signature too (we read the
+        // stored body off the signed wire, so the signature rides along).
+        let persisted = read_sent_body(data_dir.path());
+        assert!(
+            persisted.contains("daemon-sig-marker"),
+            "persisted sent body must carry the signature: {persisted}"
+        );
+    }
+
     #[tokio::test]
     async fn signature_renders_in_text_and_html_parts_with_attachment() {
         let data_dir = tempfile::TempDir::new().unwrap();
@@ -1668,9 +1716,9 @@ mod tests {
     // Escape-hatch branches end-to-end through `handle_send`.
     // ------------------------------------------------------------------
 
-    /// `text_only=true` skips rendering and ships single-part text/plain.
-    /// The signature is NOT auto-appended on this branch (operator-supplied
-    /// content principle).
+    /// `text_only=true` skips Markdown rendering and ships single-part
+    /// text/plain. The signature IS auto-appended on this branch so the
+    /// recipient always sees the configured footer.
     #[tokio::test]
     async fn text_only_send_emits_single_part_text_plain() {
         let mock = Arc::new(MockTransport {
@@ -1702,18 +1750,21 @@ mod tests {
         // text/plain present, body verbatim.
         assert!(delivered.contains("Content-Type: text/plain"));
         assert!(delivered.contains("hello"));
-        // Signature is NOT appended (default ctx config has no signature
-        // set, so `effective_signature` returns the AIMX default — we
-        // confirm it is *absent* on the text-only path).
+        // The default signature IS appended on the text-only path.
         assert!(
-            !delivered.contains("Sent from AIMX."),
-            "text-only must not append the default signature: {delivered}"
+            delivered.contains("Sent from AIMX."),
+            "text-only must append the default signature: {delivered}"
+        );
+        assert!(
+            delivered.contains("https://aimx.email"),
+            "text-only must carry the default signature URL: {delivered}"
         );
     }
 
-    /// `html_body=Some(html)` skips rendering and uses the operator's
-    /// HTML verbatim. Same operator-content principle: no signature
-    /// appended.
+    /// `html_body=Some(html)` skips Markdown rendering and uses the
+    /// operator's HTML verbatim. The signature is appended to the
+    /// text/plain fallback but the supplied HTML stays untouched —
+    /// operators on `--html-body` already own their HTML rendering.
     #[tokio::test]
     async fn html_body_send_uses_supplied_html_verbatim() {
         let mock = Arc::new(MockTransport {
@@ -1751,10 +1802,18 @@ mod tests {
             !html_section.contains("style=\""),
             "renderer must not be invoked on --html-body path: {html_section}"
         );
-        // Default signature is not appended.
+        // Default signature IS appended to the text/plain fallback so
+        // text-only readers still see it; the operator-supplied HTML
+        // remains verbatim (signature must not appear inside the HTML
+        // part).
         assert!(
-            !delivered.contains("Sent from AIMX."),
-            "--html-body must not append the default signature: {delivered}"
+            delivered.contains("Sent from AIMX."),
+            "--html-body must append the default signature to text/plain: {delivered}"
+        );
+        assert!(
+            !html_section.contains("Sent from AIMX."),
+            "operator-supplied HTML must stay verbatim (signature must not leak into HTML): \
+             {html_section}"
         );
     }
 

--- a/src/wire_assembly.rs
+++ b/src/wire_assembly.rs
@@ -21,12 +21,17 @@
 //!     HTML verbatim)
 //!   - With attachments → `multipart/mixed` wrapping the alternative
 //!
-//! The per-mailbox signature is appended to the Markdown source **before**
-//! rendering so it participates in the HTML output (a `[link](url)`
-//! signature renders as a clickable `<a>` in HTML and stays Markdown in the
-//! plain-text part). The signature is **only** appended on the default
-//! Markdown path — `--text-only` and `--html-body` use the body verbatim
-//! because the operator already chose the final rendering.
+//! The per-mailbox signature is appended to the body on every path so the
+//! recipient always sees it in the `text/plain` region:
+//!
+//! - default Markdown: appended to the Markdown source **before** rendering,
+//!   so a `[link](url)` signature renders as a clickable `<a>` in HTML and
+//!   stays Markdown in the plain-text part.
+//! - `--text-only`: appended to the body before encoding, so even one-liner
+//!   plain-text sends carry it.
+//! - `--html-body`: appended to the `text/plain` fallback. The supplied HTML
+//!   stays operator-verbatim — operators wanting the signature visible in
+//!   the HTML view put it in their template.
 //!
 //! `text/plain` and `text/html` parts use 7bit transfer-encoding when their
 //! bytes are pure ASCII and quoted-printable when they contain non-ASCII —
@@ -98,10 +103,12 @@ impl From<MarkdownRenderError> for AssembleError {
 /// - `multipart/mixed` with the first part `text/plain` (the body text)
 ///   followed by attachment parts.
 ///
-/// `signature` is appended to the body text before rendering on the
-/// default Markdown path. Pass an empty string to disable. On the
-/// `text_only` and `html_body` paths the signature is **never** appended:
-/// the operator picked the final shape and AIMX must not mutate it.
+/// `signature` is appended to the `text/plain` body region on every path
+/// (Markdown source on the default path; body verbatim on `--text-only`;
+/// text fallback on `--html-body`). Pass an empty string to disable. The
+/// supplied HTML on the `--html-body` path is never modified — operators
+/// own that rendering and put the signature into their template if they
+/// want it visible in the HTML view.
 ///
 /// Branches:
 /// - `text_only=false, html_body=None` → default Markdown render path.
@@ -127,6 +134,12 @@ pub fn assemble_wire_message(
     let (body_text, attachments) =
         extract_markdown_and_attachments(&original_headers, body_section);
 
+    // Append the signature once, up-front, so every branch ships a body
+    // that carries it in the `text/plain` region. The escape hatches
+    // still use the body verbatim from this point on — they just don't
+    // get to skip the signature.
+    let body_text = append_signature_to_body(&body_text, signature);
+
     let preserved_headers = strip_outgoing_content_headers(&original_headers);
     let outer = make_boundary();
     let inner = make_boundary();
@@ -143,22 +156,24 @@ pub fn assemble_wire_message(
     };
 
     let body_bytes = if text_only {
-        // Plain-text path: ship the body verbatim. With attachments,
-        // wrap in multipart/mixed so the text part and attachments are
-        // siblings (no inner alternative — there's no rich part).
+        // Plain-text path: ship the body (with signature appended)
+        // verbatim. With attachments, wrap in multipart/mixed so the
+        // text part and attachments are siblings (no inner alternative
+        // — there's no rich part).
         build_text_only_body(&body_text, &attachments, &outer, text_only_top_cte)
     } else if let Some(html) = html_body {
-        // Custom-HTML path: text/plain + supplied HTML verbatim. With
-        // attachments, the alternative becomes the first child of an
-        // outer multipart/mixed.
+        // Custom-HTML path: text/plain (signature appended) + supplied
+        // HTML verbatim. The supplied HTML is never modified — operators
+        // who want the signature visible in the HTML view put it in
+        // their template. With attachments, the alternative becomes the
+        // first child of an outer multipart/mixed.
         let html_str = String::from_utf8_lossy(html).into_owned();
         build_multipart_body(&body_text, &html_str, &attachments, &outer, &inner)
     } else {
-        // Default Markdown path: append signature, render to HTML,
-        // then assemble multipart/alternative.
-        let markdown_with_sig = append_signature_to_markdown(&body_text, signature);
-        let html = render_markdown_to_email_html(&markdown_with_sig)?;
-        build_multipart_body(&markdown_with_sig, &html, &attachments, &outer, &inner)
+        // Default Markdown path: render the (signature-appended)
+        // Markdown to HTML, then assemble multipart/alternative.
+        let html = render_markdown_to_email_html(&body_text)?;
+        build_multipart_body(&body_text, &html, &attachments, &outer, &inner)
     };
 
     let content_headers =
@@ -952,17 +967,19 @@ fn make_boundary() -> String {
     format!("aimx-{}", Uuid::new_v4().simple())
 }
 
-/// Append `signature` to `markdown` separated by a blank line. Empty
-/// signature returns the markdown verbatim. Any trailing whitespace on
-/// the signature is preserved as-is.
-fn append_signature_to_markdown(markdown: &str, signature: &str) -> String {
+/// Append `signature` to `body` separated by a blank line. Empty
+/// signature returns the body verbatim. Any trailing whitespace on the
+/// signature is preserved as-is. Works for both Markdown bodies (where
+/// the rendered HTML inherits the appended signature) and plain-text
+/// bodies on the `--text-only` / `--html-body` paths.
+fn append_signature_to_body(body: &str, signature: &str) -> String {
     if signature.is_empty() {
-        return markdown.to_string();
+        return body.to_string();
     }
     let normalized_sig = signature.replace("\r\n", "\n").replace('\r', "\n");
-    let trimmed_md = markdown.trim_end_matches(['\r', '\n']);
-    let mut out = String::with_capacity(trimmed_md.len() + normalized_sig.len() + 4);
-    out.push_str(trimmed_md);
+    let trimmed_body = body.trim_end_matches(['\r', '\n']);
+    let mut out = String::with_capacity(trimmed_body.len() + normalized_sig.len() + 4);
+    out.push_str(trimmed_body);
     out.push_str("\n\n");
     out.push_str(&normalized_sig);
     out
@@ -1544,11 +1561,13 @@ mod tests {
     // ------------------------------------------------------------------
 
     /// `--text-only` with no attachments: single-part `text/plain`,
-    /// body verbatim, no boundary markers, no rendered HTML.
+    /// body verbatim, no boundary markers, no rendered HTML. The
+    /// signature IS appended to the body so text-only one-liners still
+    /// carry the configured footer.
     #[test]
     fn text_only_no_attachments_emits_single_part_text_plain() {
         let req = build_request("From: a@b.com\nTo: c@d.com\n", "Your code: 9999");
-        let out = assemble_wire_message(&req, "ignored-sig", true, None).unwrap();
+        let out = assemble_wire_message(&req, "aimx-sig-marker", true, None).unwrap();
         let text = String::from_utf8_lossy(&out);
         assert!(text.contains("Content-Type: text/plain; charset=utf-8"));
         assert!(text.contains("Content-Transfer-Encoding: 7bit"));
@@ -1559,9 +1578,11 @@ mod tests {
         // No rendered HTML.
         assert!(!text.contains("<h1"), "{text}");
         assert!(text.contains("Your code: 9999"));
-        // The signature is NOT appended on the text-only path even when
-        // the caller passed one.
-        assert!(!text.contains("ignored-sig"), "{text}");
+        // The signature IS appended on the text-only path.
+        assert!(
+            text.contains("aimx-sig-marker"),
+            "signature must be appended on text-only path: {text}"
+        );
     }
 
     /// Regression: the single-part `--text-only` no-attachments wire
@@ -1719,20 +1740,33 @@ mod tests {
             "From: a@b.com\nTo: c@d.com\nContent-Type: multipart/mixed; boundary=\"BND\"\n",
             body,
         );
-        let out = assemble_wire_message(&req, "ignored-sig", true, None).unwrap();
+        let out = assemble_wire_message(&req, "aimx-sig-marker", true, None).unwrap();
         let text = String::from_utf8_lossy(&out);
 
         // Outer wrap is multipart/mixed; no inner alternative; no HTML
-        // rendering; signature suppressed.
+        // rendering. The signature IS appended to the text part — it
+        // sits inside the first text/plain child, before the first
+        // attachment boundary marker.
         assert!(text.contains("Content-Type: multipart/mixed; boundary=\"aimx-"));
         assert!(!text.contains("multipart/alternative"), "{text}");
         assert!(!text.contains("text/html"), "{text}");
         assert!(!text.contains("<h1"), "{text}");
-        assert!(!text.contains("ignored-sig"), "{text}");
 
-        // Single text part carries the body verbatim.
+        // Single text part carries the body and the signature.
         assert!(text.contains("Content-Type: text/plain; charset=utf-8"));
         assert!(text.contains("Body verbatim."));
+        assert!(
+            text.contains("aimx-sig-marker"),
+            "signature must appear in the text part: {text}"
+        );
+        // Signature sits inside the first text/plain part, before the
+        // first attachment boundary.
+        let sig_pos = text.find("aimx-sig-marker").expect("sig must appear");
+        let pdf_pos = text.find("a.pdf").expect("first attachment must appear");
+        assert!(
+            sig_pos < pdf_pos,
+            "signature must land inside the text part, before the first attachment: {text}"
+        );
 
         // All three attachments preserved as siblings.
         assert!(text.contains("filename=\"a.pdf\""));
@@ -1757,12 +1791,15 @@ mod tests {
     /// `--html-body` with no attachments: `multipart/alternative` with
     /// the body as text/plain and the supplied HTML verbatim. The
     /// renderer must NOT touch the HTML — assert no inlined `style="`
-    /// attributes appear that the renderer would have added.
+    /// attributes appear that the renderer would have added. The
+    /// signature is appended to the text/plain fallback so text-only
+    /// readers still see it; the supplied HTML stays verbatim because
+    /// operators on `--html-body` already own their HTML rendering.
     #[test]
     fn html_body_no_attachments_emits_multipart_alternative_with_verbatim_html() {
         let custom_html = b"<h1>x</h1>";
         let req = build_request("From: a@b.com\nTo: c@d.com\n", "fallback text.");
-        let out = assemble_wire_message(&req, "ignored-sig", false, Some(custom_html)).unwrap();
+        let out = assemble_wire_message(&req, "aimx-sig-marker", false, Some(custom_html)).unwrap();
         let text = String::from_utf8_lossy(&out);
         assert!(text.contains("Content-Type: multipart/alternative; boundary=\"aimx-"));
         assert!(text.contains("Content-Type: text/plain; charset=utf-8"));
@@ -1780,8 +1817,22 @@ mod tests {
             !html_after.contains("style=\""),
             "renderer must not be invoked on --html-body path: {html_after}"
         );
-        // Signature is not appended on the html-body path either.
-        assert!(!text.contains("ignored-sig"), "{text}");
+        // Signature lands in the text/plain part — before the text/html
+        // boundary — and does NOT appear inside the supplied HTML.
+        let sig_pos = text
+            .find("aimx-sig-marker")
+            .expect("signature must appear in the text part");
+        let html_pos = text
+            .find("text/html")
+            .expect("text/html part must exist on html_body path");
+        assert!(
+            sig_pos < html_pos,
+            "signature must sit in the text/plain part, not in the HTML part: {text}"
+        );
+        assert!(
+            !html_after.contains("aimx-sig-marker"),
+            "operator-supplied HTML must stay verbatim (no signature injected): {html_after}"
+        );
     }
 
     /// `--html-body` with attachments: outer `multipart/mixed` wrapping

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -3081,10 +3081,15 @@ fn send_uds_end_to_end_text_only_emits_single_part_text_plain() {
         payload_str.contains("Your code: 9999"),
         "body must reach the wire verbatim: {payload_str}"
     );
-    // No default signature appended (operator-supplied content).
+    // The default signature IS appended on the text-only path so
+    // recipients always see the configured footer.
     assert!(
-        !payload_str.contains("Sent from AIMX."),
-        "text-only path must not append the default signature: {payload_str}"
+        payload_str.contains("Sent from AIMX."),
+        "text-only path must append the default signature: {payload_str}"
+    );
+    assert!(
+        payload_str.contains("https://aimx.email"),
+        "text-only path must carry the default signature URL: {payload_str}"
     );
 
     // DKIM body-hash must verify against the single-part wire shape.
@@ -3198,10 +3203,17 @@ fn send_uds_end_to_end_html_body_uses_supplied_html_verbatim() {
         !html_section.contains("style=\""),
         "renderer must not be invoked on --html-body path: {html_section}"
     );
-    // No default signature appended on the html-body branch.
+    // The default signature IS appended to the text/plain fallback on
+    // the html-body branch so text-only readers still see it. The
+    // operator-supplied HTML stays verbatim (signature must not leak
+    // into the HTML part).
     assert!(
-        !payload_str.contains("Sent from AIMX."),
-        "html-body path must not append the default signature: {payload_str}"
+        payload_str.contains("Sent from AIMX."),
+        "html-body path must append the default signature to the text/plain fallback: {payload_str}"
+    );
+    assert!(
+        !html_section.contains("Sent from AIMX."),
+        "operator-supplied HTML must stay verbatim (no signature in HTML part): {html_section}"
     );
 
     // DKIM body-hash verifies on the alternative wire shape.


### PR DESCRIPTION
## Summary
- The Markdown-Native Outbound epic moved the signature-append step into the default Markdown branch only, so `--text-only` and `--html-body` silently dropped the configured footer — contradicting `book/configuration.md`'s long-standing promise that "every outbound email gets a signature appended." A real `text_only` send via MCP arrived without the `Sent from AIMX.` trailer.
- `assemble_wire_message` in `src/wire_assembly.rs` now appends the signature ahead of the per-branch wire shaping, so the body carried into all three branches already includes it. `--html-body` still passes the operator-supplied HTML verbatim — the signature only lands in the text/plain fallback on that branch — and the default Markdown path renders the signature into both parts as before.
- Helper renamed `append_signature_to_markdown` → `append_signature_to_body` and re-doc'd; module + `send_handler.rs` comments updated. `book/markdown-email.md` (steps, `--text-only` / `--html-body` callouts, sent-storage table) brought in line with the new universal behavior.

## Test plan
- [x] `cargo test wire_assembly` — 39 passed, including the rewritten escape-hatch cases that now assert the signature IS present and (on `--html-body`) does NOT leak into the HTML part.
- [x] `cargo test send_handler` — 41 passed, including the flipped `text_only_send_emits_single_part_text_plain` / `html_body_send_uses_supplied_html_verbatim` and the new `custom_signature_appended_on_text_only_path` regression.
- [x] `cargo test --test integration` — 116 passed (8 ignored, root-only); flipped the text-only and html-body end-to-end assertions to match.
- [x] `cargo fmt -- --check` clean.
- [x] `cargo clippy --all-targets -- -D warnings` clean.
- [ ] After deploy: send a plain MCP `email_send` and confirm the recipient sees the `Sent from AIMX.` + `https://aimx.email` footer (reproducer for the original report).
- [ ] After deploy: `aimx send --text-only --body "hi" --to <addr>` carries the signature; `aimx send --html-body "<p>x</p>" --body fallback --to <addr>` carries it in the text/plain fallback but leaves the operator's HTML verbatim.
