### PR TITLE
fix: prevent duplicate hook fires on slow inbound deliveries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,6 +55,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "sha2",
+ "sparkv",
  "syn",
  "tar",
  "tempfile",
@@ -2833,6 +2834,12 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "sparkv"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e3eef4e6fb0a66200df893d1292b96cb92e4f8a43864fd938ba2f96cd345c40"
 
 [[package]]
 name = "spin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,6 +90,15 @@ lol_html = "2"
 # (not just dev-deps) so `run_upgrade` can call `tempfile::tempdir`
 # directly rather than re-implementing tempdir cleanup by hand.
 tempfile = "3"
+# Per-mailbox Message-Id dedup cache for inbound ingest. SMTP MTAs
+# legitimately retry deliveries when an ACK is delayed or lost; without
+# dedup, every retry would re-fire `on_receive` hooks. SparKV gives us
+# an in-memory KV with per-entry TTL plus auto-eviction, so the cache
+# stays bounded (24h retention window) without us hand-rolling a TTL
+# heap. The cache is rebuilt lazily from disk on first ingest per
+# mailbox; the disk frontmatter (`message_id`, `received_at`) remains
+# the source of truth.
+sparkv = "0.1"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/hook_handler.rs
+++ b/src/hook_handler.rs
@@ -158,8 +158,8 @@ pub async fn handle_hook_create(
     // Acquire the same lock hierarchy mailbox CRUD takes: outer per-
     // mailbox lock (shared with ingest / MARK-* / MAILBOX-CRUD), inner
     // process-wide config write lock. Always outer → inner.
-    let lock = state_ctx.lock_for(&req.mailbox);
-    let _guard = lock.lock().await;
+    let state = state_ctx.lock_for(&req.mailbox);
+    let _guard = state.lock.lock().await;
     let _config_guard = CONFIG_WRITE_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
@@ -255,8 +255,8 @@ pub async fn handle_hook_delete(
         };
     }
 
-    let lock = state_ctx.lock_for(mailbox_name);
-    let _guard = lock.lock().await;
+    let state = state_ctx.lock_for(mailbox_name);
+    let _guard = state.lock.lock().await;
     let _config_guard = CONFIG_WRITE_LOCK
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -42,6 +42,14 @@ pub enum HookMode {
 /// older entries are auto-evicted by SparKV. 24h sits comfortably
 /// above any practical SMTP retry window: most retries land within
 /// minutes, and even pathological MTAs give up well before a day.
+///
+/// Tradeoff: RFC 5321 §4.5.4.1 allows MTAs to retry for up to 4-5
+/// days, and Gmail/Postfix defaults sit in that range. A legitimate
+/// retry past the 24h mark — rare but possible during prolonged
+/// inbound outages — will be treated as a fresh delivery and re-fire
+/// `on_receive`. We accept that edge case in exchange for a bounded
+/// cache footprint; raising the TTL is a knob, not an absolute, and
+/// the value is intentionally lower than the RFC retry ceiling.
 const DEDUP_TTL: Duration = Duration::from_secs(24 * 60 * 60);
 
 /// Safety cap on the per-mailbox dedup cache. SparKV's default
@@ -345,6 +353,16 @@ pub fn ingest_email(
     // slow-hook → DATA timeout interaction before this change — would
     // re-fire `on_receive`. The cache is lazily rebuilt from disk on
     // first ingest into the mailbox after daemon startup.
+    //
+    // Empty-`Message-Id` gap: real-world MTAs always emit a
+    // `Message-Id`, so the gate below is a no-op for compliant
+    // senders. A hand-crafted SMTP client (or a buggy custom retry
+    // path) that omits the header would slip past dedup and re-fire
+    // the hook on every retry. We deliberately do not synthesize a
+    // content digest fallback — it would mask broken-sender bugs that
+    // an operator probably wants to see. If "why did this hook fire
+    // N×?" ever surfaces, an absent `Message-Id` is the first thing
+    // to check on the source `.eml`.
     if !message_id.is_empty() {
         let mut cache_guard = state
             .seen_message_ids
@@ -494,6 +512,16 @@ pub fn ingest_email(
                 ""
             };
             if let Err(e) = cache.set_with_ttl(&meta.message_id, value, DEDUP_TTL) {
+                // Failure mode at scale: SparKV returns `Err(MaxItemsExceeded)`
+                // when this mailbox accumulates more than `DEDUP_MAX_ITEMS`
+                // (100k) live entries inside the 24h window — roughly 1.2
+                // sustained inbound messages/second per mailbox, which is
+                // absurd for any realistic aimx deployment. When that
+                // does happen, the next retry of this Message-Id misses
+                // the cache and re-fires the hook (i.e. silently regresses
+                // to the exact bug this dedup layer exists to prevent).
+                // The `tracing::warn!` below is the operator's signal;
+                // raise `DEDUP_MAX_ITEMS` if you ever actually see it.
                 tracing::warn!(
                     target: "aimx::ingest",
                     "dedup cache insert failed mailbox={mailbox} message_id={message_id}: {err:?}",
@@ -517,46 +545,56 @@ pub fn ingest_email(
                 hook::execute_on_receive(config, mailbox_config, &ctx);
             }
             HookMode::Async => {
-                // Detach hook execution onto a fresh OS thread so the
-                // calling SMTP DATA handler can return immediately. We
-                // own all the data the hook needs; clone it into the
-                // closure to give the thread a self-contained snapshot.
-                let config_owned = config.clone();
-                let mailbox_name = mailbox.clone();
-                let mailbox_name_for_log = mailbox_name.clone();
-                let thread_name = format!("aimx-hook-{mailbox_name}");
-                let md_path_owned = md_path.clone();
-                let meta_owned = meta.clone();
-                if let Err(e) = std::thread::Builder::new()
-                    .name(thread_name)
-                    .spawn(move || {
-                        let Some(mb_cfg) = config_owned.mailboxes.get(&mailbox_name) else {
-                            return;
-                        };
-                        let ctx = OnReceiveContext {
-                            filepath: &md_path_owned,
-                            metadata: &meta_owned,
-                        };
-                        hook::execute_on_receive(&config_owned, mb_cfg, &ctx);
-                    })
-                {
-                    // Falling back to a synchronous fire on spawn
-                    // failure would re-introduce the SMTP-blocking bug
-                    // this branch exists to fix; swallow the error and
-                    // log instead. The email is still on disk so the
-                    // operator can re-fire the hook manually if needed.
-                    tracing::warn!(
-                        target: "aimx::hook",
-                        "failed to spawn async hook thread mailbox={mailbox_name}: {err}",
-                        mailbox_name = mailbox_name_for_log,
-                        err = e,
-                    );
-                }
+                spawn_on_receive_async(config, &mailbox, &md_path, &meta);
             }
         }
     }
 
     Ok(())
+}
+
+/// Detach `on_receive` hook execution onto a fresh OS thread so the
+/// calling SMTP DATA handler can return `250 OK` immediately. We own
+/// all the data the hook needs; clone it into the closure to give the
+/// thread a self-contained snapshot.
+///
+/// Spawn-failure policy: falling back to a synchronous fire on spawn
+/// failure would re-introduce the SMTP-blocking bug this branch
+/// exists to fix; swallow the error and log instead. The email is
+/// still on disk so the operator can re-fire the hook manually if
+/// needed.
+fn spawn_on_receive_async(
+    config: &Config,
+    mailbox: &str,
+    md_path: &Path,
+    meta: &InboundFrontmatter,
+) {
+    let config_owned = config.clone();
+    let mailbox_name = mailbox.to_string();
+    let mailbox_name_for_log = mailbox_name.clone();
+    let thread_name = format!("aimx-hook-{mailbox_name}");
+    let md_path_owned = md_path.to_path_buf();
+    let meta_owned = meta.clone();
+    if let Err(e) = std::thread::Builder::new()
+        .name(thread_name)
+        .spawn(move || {
+            let Some(mb_cfg) = config_owned.mailboxes.get(&mailbox_name) else {
+                return;
+            };
+            let ctx = OnReceiveContext {
+                filepath: &md_path_owned,
+                metadata: &meta_owned,
+            };
+            hook::execute_on_receive(&config_owned, mb_cfg, &ctx);
+        })
+    {
+        tracing::warn!(
+            target: "aimx::hook",
+            "failed to spawn async hook thread mailbox={mailbox_name}: {err}",
+            mailbox_name = mailbox_name_for_log,
+            err = e,
+        );
+    }
 }
 
 fn extract_header_value(message: &mail_parser::Message, name: &str) -> Option<String> {
@@ -627,14 +665,29 @@ fn build_dedup_cache_from_disk(inbox_dir: &Path) -> sparkv::SparKV {
 }
 
 /// Read just the frontmatter `message_id` and `received_at` from a
-/// `.md` file. Opens at most the first 4 KiB so a huge body (rare on
+/// `.md` file. Opens at most the first 16 KiB so a huge body (rare on
 /// inbound, but possible) doesn't cost the dedup-rebuild path. Returns
 /// `None` when the frontmatter is malformed, the keys are missing, or
 /// `received_at` doesn't parse as RFC-3339.
+///
+/// Why 16 KiB: typical inbound frontmatter is well under 1 KiB, but a
+/// long `References` chain combined with many `cc` recipients (common
+/// on busy mailing lists) can push the closing `+++` past the 4 KiB
+/// mark and silently drop the entry from the rebuilt cache. 16 KiB
+/// covers every realistic frontmatter size we expect on inbound.
+///
+/// Parser limitations: this is a hand-rolled subset of TOML that only
+/// understands `key = "value"` double-quoted strings on a single line
+/// (the shape `format_frontmatter` emits). Multi-line strings, TOML
+/// literal strings (single-quoted), or any other TOML feature will
+/// return `None` for the affected key. That's intentional — keeping
+/// the parser tiny avoids pulling `serde`/`toml` into the cold
+/// rebuild path — but it does mean any future schema change in
+/// `frontmatter.rs` needs to touch this parser too.
 fn read_frontmatter_id_pair(md_path: &Path) -> Option<(String, chrono::DateTime<chrono::Utc>)> {
     use std::io::Read as _;
     let mut file = std::fs::File::open(md_path).ok()?;
-    let mut buf = [0u8; 4096];
+    let mut buf = [0u8; 16 * 1024];
     let n = file.read(&mut buf).ok()?;
     let head = std::str::from_utf8(&buf[..n]).ok()?;
 
@@ -682,6 +735,14 @@ fn read_frontmatter_id_pair(md_path: &Path) -> Option<(String, chrono::DateTime<
 /// already stripped the key, so `after_key` looks like ` = "..."`. We
 /// accept double-quoted strings only — TOML literals (single-quoted)
 /// are never emitted by `format_frontmatter`.
+///
+/// Parser limitations: this is the minimal subset of TOML that
+/// matches what `format_frontmatter` emits today. Multi-line strings
+/// (`"""…"""`), TOML literals (`'…'`), and any escape sequence that
+/// embeds an unescaped `"` inside the value will all return the wrong
+/// answer or `None`. If `frontmatter.rs` ever grows a field that
+/// needs multi-line strings or non-trivial escaping, swap this for a
+/// real `toml` crate call rather than expanding the regex-in-disguise.
 fn parse_toml_string_value(after_key: &str) -> Option<String> {
     let rest = after_key.trim_start();
     let rest = rest.strip_prefix('=')?.trim_start();

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -12,6 +12,49 @@ use std::io::Read;
 use std::net::IpAddr;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::Duration;
+
+/// How `ingest_email` runs `on_receive` hooks after the email is on disk.
+///
+/// `Sync` blocks the caller until every hook subprocess exits. `Async`
+/// spawns hooks into a detached `std::thread` so the caller returns as
+/// soon as the email is durable on disk. The SMTP DATA handler uses
+/// `Async` so the `250 OK` reply is not gated on hook duration — a 5+
+/// minute hook would otherwise exceed the remote MTA's DATA-reply
+/// timeout and trigger a re-delivery (re-firing the hook on every
+/// retry).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum HookMode {
+    /// Fire `on_receive` hooks synchronously. Used by the `aimx ingest`
+    /// CLI path and by tests so the call brackets the full hook
+    /// lifetime.
+    Sync,
+    /// Spawn `on_receive` hooks in a detached `std::thread`. Used by
+    /// the SMTP DATA handler so `250 OK` is not delayed by hook
+    /// duration. The hook subprocess itself is sandboxed via
+    /// `systemd-run` and survives a daemon restart; only the
+    /// in-process logging of its outcome is lost on shutdown.
+    Async,
+}
+
+/// Retention window for the per-mailbox Message-Id dedup cache. Inbound
+/// `Message-Id`s persist in the cache for this long after receipt;
+/// older entries are auto-evicted by SparKV. 24h sits comfortably
+/// above any practical SMTP retry window: most retries land within
+/// minutes, and even pathological MTAs give up well before a day.
+const DEDUP_TTL: Duration = Duration::from_secs(24 * 60 * 60);
+
+/// Safety cap on the per-mailbox dedup cache. SparKV's default
+/// (10_000) would silently start rejecting inserts on very busy
+/// mailboxes. 100k is roughly 10MB of string overhead at typical
+/// `<id@host>` lengths — still cheap, but well above the inbound rate
+/// of any realistic single-mailbox aimx deployment.
+const DEDUP_MAX_ITEMS: usize = 100_000;
+
+/// Max size of a single value stored in the dedup cache. We only store
+/// the email's filesystem `id` (a fixed-shape `YYYY-MM-DD-HHMMSS-<slug>`
+/// stem) as a debug aid, so 256 bytes is more than enough.
+const DEDUP_MAX_VALUE_SIZE: usize = 256;
 
 /// Decide whether a recipient address routes to a configured mailbox.
 ///
@@ -52,7 +95,18 @@ pub fn run(rcpt: &str, config: Config) -> Result<(), Box<dyn std::error::Error>>
     // process with a single ingest so contention isn't possible. The
     // daemon path shares its map across all writers.
     let locks = Arc::new(MailboxLocks::new());
-    ingest_email(&config, &locks, rcpt, &raw, sentinel_ip, None)
+    // Manual stdin path is a short-lived process; wait for any
+    // `on_receive` hook so the CLI doesn't exit before the hook
+    // finishes (the spawned thread would be killed).
+    ingest_email(
+        &config,
+        &locks,
+        rcpt,
+        &raw,
+        sentinel_ip,
+        None,
+        HookMode::Sync,
+    )
 }
 
 /// Inbound ingest entry point.
@@ -71,6 +125,7 @@ pub fn ingest_email(
     raw: &[u8],
     received_from_ip: IpAddr,
     envelope_mail_from: Option<&str>,
+    hook_mode: HookMode,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // Test-only seam: force a synthetic ingest failure for a specific
     // recipient so we can drive the DATA partial-success contract
@@ -280,8 +335,33 @@ pub fn ingest_email(
     // final `.md` write sequence; readers of the mailbox directory
     // observe either the pre-state or the post-state, never a half-
     // written bundle.
-    let lock = locks.lock_for(&mailbox);
-    let _guard = lock.blocking_lock();
+    let state = locks.lock_for(&mailbox);
+    let _guard = state.lock.blocking_lock();
+
+    // Message-Id dedup: if this exact Message-Id was already ingested
+    // within the SMTP-retry window, skip storage + hook firing but
+    // still return Ok so the caller emits `250 OK`. Without this,
+    // every MTA retry — including the ones triggered by our own
+    // slow-hook → DATA timeout interaction before this change — would
+    // re-fire `on_receive`. The cache is lazily rebuilt from disk on
+    // first ingest into the mailbox after daemon startup.
+    if !message_id.is_empty() {
+        let mut cache_guard = state
+            .seen_message_ids
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        let cache = cache_guard.get_or_insert_with(|| build_dedup_cache_from_disk(&inbox_dir));
+        if cache.get(&message_id).is_some() {
+            tracing::info!(
+                target: "aimx::ingest",
+                "duplicate message_id, skipping rcpt={rcpt} mailbox={mailbox} message_id={message_id}",
+                rcpt = rcpt,
+                mailbox = mailbox,
+                message_id = message_id,
+            );
+            return Ok(());
+        }
+    }
 
     let md_path = allocate_filename(&inbox_dir, timestamp, &slug, has_attachments);
     let parent_dir = md_path
@@ -392,14 +472,88 @@ pub fn ingest_email(
         attachments = attachments_count,
     );
 
+    // Record the Message-Id in the dedup cache before releasing the
+    // per-mailbox lock so a concurrent retry from a different SMTP
+    // session can never observe a state where the `.md` is on disk
+    // but the cache has not been updated yet.
+    if !meta.message_id.is_empty() {
+        let mut cache_guard = state
+            .seen_message_ids
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
+        if let Some(cache) = cache_guard.as_mut() {
+            // Truncate values that exceed SparKV's per-item cap. The id
+            // here is the filesystem stem (a known-bounded shape), so
+            // truncation should never actually trigger in practice; the
+            // check is belt-and-braces against the cache's `set_with_ttl`
+            // returning `Err(ItemSizeExceeded)` and silently dropping the
+            // dedup record.
+            let value: &str = if meta.id.len() <= DEDUP_MAX_VALUE_SIZE {
+                meta.id.as_str()
+            } else {
+                ""
+            };
+            if let Err(e) = cache.set_with_ttl(&meta.message_id, value, DEDUP_TTL) {
+                tracing::warn!(
+                    target: "aimx::ingest",
+                    "dedup cache insert failed mailbox={mailbox} message_id={message_id}: {err:?}",
+                    mailbox = mailbox,
+                    message_id = meta.message_id,
+                    err = e,
+                );
+            }
+        }
+    }
+
     drop(_guard);
 
     if let Some(mailbox_config) = config.mailboxes.get(&mailbox) {
-        let ctx = OnReceiveContext {
-            filepath: &md_path,
-            metadata: &meta,
-        };
-        hook::execute_on_receive(config, mailbox_config, &ctx);
+        match hook_mode {
+            HookMode::Sync => {
+                let ctx = OnReceiveContext {
+                    filepath: &md_path,
+                    metadata: &meta,
+                };
+                hook::execute_on_receive(config, mailbox_config, &ctx);
+            }
+            HookMode::Async => {
+                // Detach hook execution onto a fresh OS thread so the
+                // calling SMTP DATA handler can return immediately. We
+                // own all the data the hook needs; clone it into the
+                // closure to give the thread a self-contained snapshot.
+                let config_owned = config.clone();
+                let mailbox_name = mailbox.clone();
+                let mailbox_name_for_log = mailbox_name.clone();
+                let thread_name = format!("aimx-hook-{mailbox_name}");
+                let md_path_owned = md_path.clone();
+                let meta_owned = meta.clone();
+                if let Err(e) = std::thread::Builder::new()
+                    .name(thread_name)
+                    .spawn(move || {
+                        let Some(mb_cfg) = config_owned.mailboxes.get(&mailbox_name) else {
+                            return;
+                        };
+                        let ctx = OnReceiveContext {
+                            filepath: &md_path_owned,
+                            metadata: &meta_owned,
+                        };
+                        hook::execute_on_receive(&config_owned, mb_cfg, &ctx);
+                    })
+                {
+                    // Falling back to a synchronous fire on spawn
+                    // failure would re-introduce the SMTP-blocking bug
+                    // this branch exists to fix; swallow the error and
+                    // log instead. The email is still on disk so the
+                    // operator can re-fire the hook manually if needed.
+                    tracing::warn!(
+                        target: "aimx::hook",
+                        "failed to spawn async hook thread mailbox={mailbox_name}: {err}",
+                        mailbox_name = mailbox_name_for_log,
+                        err = e,
+                    );
+                }
+            }
+        }
     }
 
     Ok(())
@@ -409,6 +563,144 @@ fn extract_header_value(message: &mail_parser::Message, name: &str) -> Option<St
     let val = message.header_raw(name)?;
     let s = val.trim().to_string();
     if s.is_empty() { None } else { Some(s) }
+}
+
+/// Build a fresh dedup cache by scanning the mailbox inbox once. Walks
+/// flat `<stem>.md` files and bundle dirs `<stem>/<stem>.md`,
+/// filtering by filename date prefix so a giant historical mailbox
+/// doesn't open every file. Each loaded entry's TTL is adjusted so it
+/// expires `DEDUP_TTL` after its original `received_at`, not
+/// `DEDUP_TTL` from now — a daemon restart cannot extend the dedup
+/// window past its real lifetime.
+fn build_dedup_cache_from_disk(inbox_dir: &Path) -> sparkv::SparKV {
+    let mut kv = make_dedup_sparkv();
+    let now = chrono::Utc::now();
+    let cutoff_dt =
+        now - chrono::Duration::from_std(DEDUP_TTL).unwrap_or(chrono::Duration::days(1));
+    let cutoff_date_prefix = cutoff_dt.format("%Y-%m-%d").to_string();
+
+    let rd = match std::fs::read_dir(inbox_dir) {
+        Ok(rd) => rd,
+        Err(_) => return kv,
+    };
+    for entry in rd.flatten() {
+        let path = entry.path();
+        let Some(file_name) = entry.file_name().to_str().map(str::to_string) else {
+            continue;
+        };
+
+        // Skip anything dated before the retention cutoff. Filenames
+        // always start with `YYYY-MM-DD-HHMMSS-`; lex compare on the
+        // first 10 chars matches date order. Files whose name is too
+        // short to carry a date prefix are inspected (don't filter
+        // overzealously — they may be legitimate non-standard fixtures).
+        if file_name.len() >= 10 {
+            let date_prefix = &file_name[..10];
+            if date_prefix < cutoff_date_prefix.as_str() {
+                continue;
+            }
+        }
+
+        let md_path = if path.is_dir() {
+            // Bundle layout: <stem>/<stem>.md
+            path.join(format!("{file_name}.md"))
+        } else if file_name.ends_with(".md") {
+            path
+        } else {
+            continue;
+        };
+
+        let Some((msg_id, received_at)) = read_frontmatter_id_pair(&md_path) else {
+            continue;
+        };
+
+        let total = chrono::Duration::from_std(DEDUP_TTL).unwrap_or(chrono::Duration::days(1));
+        let elapsed = now - received_at;
+        if elapsed >= total {
+            continue;
+        }
+        let remaining = total - elapsed;
+        let remaining_secs = remaining.num_seconds().max(1) as u64;
+        let _ = kv.set_with_ttl(&msg_id, "loaded", Duration::from_secs(remaining_secs));
+    }
+    kv
+}
+
+/// Read just the frontmatter `message_id` and `received_at` from a
+/// `.md` file. Opens at most the first 4 KiB so a huge body (rare on
+/// inbound, but possible) doesn't cost the dedup-rebuild path. Returns
+/// `None` when the frontmatter is malformed, the keys are missing, or
+/// `received_at` doesn't parse as RFC-3339.
+fn read_frontmatter_id_pair(md_path: &Path) -> Option<(String, chrono::DateTime<chrono::Utc>)> {
+    use std::io::Read as _;
+    let mut file = std::fs::File::open(md_path).ok()?;
+    let mut buf = [0u8; 4096];
+    let n = file.read(&mut buf).ok()?;
+    let head = std::str::from_utf8(&buf[..n]).ok()?;
+
+    let body_after_open = head
+        .strip_prefix("+++\n")
+        .or_else(|| head.strip_prefix("+++\r\n"))?;
+    // Closing delimiter sits on its own line.
+    let end_idx = body_after_open
+        .find("\n+++")
+        .or_else(|| body_after_open.find("\r\n+++"))?;
+    let toml_block = &body_after_open[..end_idx];
+
+    let mut message_id: Option<String> = None;
+    let mut received_at: Option<String> = None;
+    for raw_line in toml_block.lines() {
+        let line = raw_line.trim_start();
+        if message_id.is_none()
+            && let Some(rest) = line.strip_prefix("message_id")
+            && let Some(val) = parse_toml_string_value(rest)
+        {
+            message_id = Some(val);
+        } else if received_at.is_none()
+            && let Some(rest) = line.strip_prefix("received_at")
+            && let Some(val) = parse_toml_string_value(rest)
+        {
+            received_at = Some(val);
+        }
+        if message_id.is_some() && received_at.is_some() {
+            break;
+        }
+    }
+
+    let msg_id = message_id?;
+    if msg_id.is_empty() {
+        return None;
+    }
+    let received_at_str = received_at?;
+    let dt = chrono::DateTime::parse_from_rfc3339(&received_at_str)
+        .ok()?
+        .with_timezone(&chrono::Utc);
+    Some((msg_id, dt))
+}
+
+/// Parse a value out of a `key = "value"` TOML line. The caller has
+/// already stripped the key, so `after_key` looks like ` = "..."`. We
+/// accept double-quoted strings only — TOML literals (single-quoted)
+/// are never emitted by `format_frontmatter`.
+fn parse_toml_string_value(after_key: &str) -> Option<String> {
+    let rest = after_key.trim_start();
+    let rest = rest.strip_prefix('=')?.trim_start();
+    let rest = rest.strip_prefix('"')?;
+    let end = rest.find('"')?;
+    Some(rest[..end].to_string())
+}
+
+/// Construct a SparKV tuned for the dedup cache: 24h max TTL, a
+/// per-mailbox safety cap on item count, and auto-eviction enabled so
+/// stale entries don't accumulate.
+fn make_dedup_sparkv() -> sparkv::SparKV {
+    let mut config = sparkv::Config::new();
+    config.max_items = DEDUP_MAX_ITEMS;
+    config.max_item_size = DEDUP_MAX_VALUE_SIZE;
+    config.max_ttl = DEDUP_TTL;
+    config.default_ttl = DEDUP_TTL;
+    config.auto_clear_expired = true;
+    sparkv::SparKV::with_config(config)
 }
 
 fn create_resolver() -> Option<mail_auth::MessageAuthenticator> {
@@ -1023,6 +1315,38 @@ mod tests {
           This is a plain text email.\r\n"
     }
 
+    /// Substitute a fresh, monotonically-unique `Message-ID:` header
+    /// into a static `.eml` fixture. The fixtures hard-code a
+    /// Message-Id so they parse to deterministic bytes; the inbound
+    /// Message-Id dedup in `ingest_email` correctly treats two ingests
+    /// of the same fixture as duplicates. Tests that need to observe
+    /// two distinct deliveries swap in a per-call unique Message-Id
+    /// via this helper.
+    fn with_fresh_message_id(eml: &[u8]) -> Vec<u8> {
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let new_id = format!("<test-fresh-{n}@example.test>");
+        let s = std::str::from_utf8(eml).expect("test fixtures are UTF-8");
+        let mut out = String::with_capacity(s.len() + 32);
+        let mut replaced = false;
+        for line in s.split_inclusive('\n') {
+            let trimmed = line.trim_start();
+            if !replaced && trimmed.to_ascii_lowercase().starts_with("message-id:") {
+                let leading_ws = &line[..line.len() - trimmed.len()];
+                let line_ending = if line.ends_with("\r\n") { "\r\n" } else { "\n" };
+                out.push_str(leading_ws);
+                out.push_str("Message-ID: ");
+                out.push_str(&new_id);
+                out.push_str(line_ending);
+                replaced = true;
+            } else {
+                out.push_str(line);
+            }
+        }
+        out.into_bytes()
+    }
+
     fn html_only_eml() -> &'static [u8] {
         b"From: sender@example.com\r\n\
           To: alice@test.com\r\n\
@@ -1147,6 +1471,7 @@ mod tests {
             plain_text_eml(),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -1177,6 +1502,7 @@ mod tests {
             plain_text_eml(),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -1195,6 +1521,7 @@ mod tests {
             plain_text_eml(),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -1228,6 +1555,7 @@ mod tests {
             html_only_eml(),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -1281,6 +1609,7 @@ mod tests {
             multipart_eml(),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -1301,6 +1630,7 @@ mod tests {
             plain_text_eml(),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -1363,6 +1693,7 @@ mod tests {
             plain_text_eml(),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         );
         assert!(result.is_err(), "expected error when no mailbox routes");
     }
@@ -1378,6 +1709,7 @@ mod tests {
             plain_text_eml(),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -1414,18 +1746,20 @@ mod tests {
             &config,
             &test_locks(),
             "alice@test.com",
-            plain_text_eml(),
+            &with_fresh_message_id(plain_text_eml()),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
         ingest_email(
             &config,
             &test_locks(),
             "alice@test.com",
-            plain_text_eml(),
+            &with_fresh_message_id(plain_text_eml()),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -1445,6 +1779,7 @@ mod tests {
             attachment_eml(),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -1488,6 +1823,7 @@ mod tests {
             multi_attachment_eml(),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -1512,18 +1848,20 @@ mod tests {
             &config,
             &test_locks(),
             "alice@test.com",
-            attachment_eml(),
+            &with_fresh_message_id(attachment_eml()),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
         ingest_email(
             &config,
             &test_locks(),
             "alice@test.com",
-            attachment_eml(),
+            &with_fresh_message_id(attachment_eml()),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -1551,6 +1889,7 @@ mod tests {
             plain_text_eml(),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -1721,6 +2060,7 @@ mod tests {
             eml,
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -1778,6 +2118,7 @@ mod tests {
             eml,
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -1869,6 +2210,7 @@ mod tests {
             plain_text_eml(),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -1982,6 +2324,7 @@ mod tests {
             plain_text_eml(),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -2035,6 +2378,7 @@ mod tests {
             raw,
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -2114,14 +2458,18 @@ mod tests {
         for _ in 0..8 {
             let cfg = Arc::clone(&config);
             let locks = Arc::clone(&locks);
+            // Per-thread unique Message-Id so inbound dedup treats
+            // each ingest as a distinct delivery.
+            let eml = with_fresh_message_id(attachment_eml());
             handles.push(thread::spawn(move || {
                 ingest_email(
                     &cfg,
                     &locks,
                     "alice@test.com",
-                    attachment_eml(),
+                    &eml,
                     sentinel_ip(),
                     None,
+                    HookMode::Sync,
                 )
                 .unwrap();
             }));
@@ -2158,18 +2506,20 @@ mod tests {
             &config,
             &test_locks(),
             "alice@test.com",
-            plain_text_eml(),
+            &with_fresh_message_id(plain_text_eml()),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
         ingest_email(
             &config,
             &test_locks(),
             "alice@test.com",
-            plain_text_eml(),
+            &with_fresh_message_id(plain_text_eml()),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -2260,6 +2610,7 @@ mod tests {
             plain_text_eml(),
             ip,
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -2300,6 +2651,7 @@ mod tests {
             plain_text_eml(),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -2331,6 +2683,7 @@ mod tests {
             eml,
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -2363,6 +2716,7 @@ mod tests {
             eml,
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -2386,6 +2740,7 @@ mod tests {
             plain_text_eml(),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -2404,25 +2759,53 @@ mod tests {
 
     #[test]
     fn thread_id_deterministic_for_same_message() {
+        // Two distinct messages that reply to the same parent must
+        // land on the same `thread_id`. We can no longer assert this
+        // by ingesting the same fixture twice — inbound Message-Id
+        // dedup correctly drops the second copy — so the test now
+        // ingests two replies (distinct Message-Ids) sharing an
+        // `In-Reply-To`. The thread-derivation logic is the property
+        // under test, not the dedup boundary.
         let tmp = TempDir::new().unwrap();
         let config = test_config(tmp.path());
+
+        let reply_a = b"From: sender@example.com\r\n\
+                       To: alice@test.com\r\n\
+                       Subject: Re: Hello\r\n\
+                       Date: Thu, 01 Jan 2025 12:00:00 +0000\r\n\
+                       Message-ID: <reply-a@example.com>\r\n\
+                       In-Reply-To: <parent@example.com>\r\n\
+                       References: <parent@example.com>\r\n\
+                       \r\n\
+                       Hello.\r\n";
+        let reply_b = b"From: sender@example.com\r\n\
+                       To: alice@test.com\r\n\
+                       Subject: Re: Hello\r\n\
+                       Date: Thu, 01 Jan 2025 12:00:00 +0000\r\n\
+                       Message-ID: <reply-b@example.com>\r\n\
+                       In-Reply-To: <parent@example.com>\r\n\
+                       References: <parent@example.com>\r\n\
+                       \r\n\
+                       Hi.\r\n";
 
         ingest_email(
             &config,
             &test_locks(),
             "alice@test.com",
-            plain_text_eml(),
+            reply_a,
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
         ingest_email(
             &config,
             &test_locks(),
             "alice@test.com",
-            plain_text_eml(),
+            reply_b,
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -2454,6 +2837,7 @@ mod tests {
             plain_text_eml(),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -2491,6 +2875,7 @@ mod tests {
             attachment_eml(),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -2513,6 +2898,7 @@ mod tests {
             bogus,
             sentinel_ip(),
             None,
+            HookMode::Sync,
         );
         assert!(result.is_err(), "empty input must propagate parse failure");
         assert!(logs_contain("Failed to parse email"));
@@ -2591,6 +2977,7 @@ mod tests {
             multi_attachment_eml(),
             sentinel_ip(),
             None,
+            HookMode::Sync,
         )
         .unwrap();
 
@@ -2624,5 +3011,191 @@ mod tests {
                 );
             }
         }
+    }
+
+    // --- Message-Id dedup ---
+
+    /// Re-ingesting the same Message-Id is silently absorbed: the
+    /// second call returns `Ok(())` (so SMTP returns `250 OK` and the
+    /// remote MTA stops retrying), but no second `.md` is written.
+    #[test]
+    fn ingest_skips_duplicate_message_id() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let locks = test_locks();
+
+        ingest_email(
+            &config,
+            &locks,
+            "alice@test.com",
+            plain_text_eml(),
+            sentinel_ip(),
+            None,
+            HookMode::Sync,
+        )
+        .unwrap();
+        // Same fixture, same Message-Id. Must succeed but not store.
+        ingest_email(
+            &config,
+            &locks,
+            "alice@test.com",
+            plain_text_eml(),
+            sentinel_ip(),
+            None,
+            HookMode::Sync,
+        )
+        .unwrap();
+
+        let entries = collect_md_files(&inbox(tmp.path(), "alice"));
+        assert_eq!(
+            entries.len(),
+            1,
+            "duplicate Message-Id must not produce a second .md"
+        );
+    }
+
+    /// Distinct Message-Ids must both pass through dedup and produce
+    /// two stored `.md` files. Guards against the dedup check being
+    /// overly aggressive (e.g., a stale cache returning true for any
+    /// query).
+    #[test]
+    fn ingest_allows_distinct_message_ids() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+        let locks = test_locks();
+
+        ingest_email(
+            &config,
+            &locks,
+            "alice@test.com",
+            &with_fresh_message_id(plain_text_eml()),
+            sentinel_ip(),
+            None,
+            HookMode::Sync,
+        )
+        .unwrap();
+        ingest_email(
+            &config,
+            &locks,
+            "alice@test.com",
+            &with_fresh_message_id(plain_text_eml()),
+            sentinel_ip(),
+            None,
+            HookMode::Sync,
+        )
+        .unwrap();
+
+        let entries = collect_md_files(&inbox(tmp.path(), "alice"));
+        assert_eq!(entries.len(), 2);
+    }
+
+    /// The dedup cache is rebuilt lazily from disk on the first ingest
+    /// into a mailbox after daemon start. Drive that path by ingesting
+    /// twice through *different* `MailboxLocks` (so the second has no
+    /// in-memory cache and must rebuild from the .md the first ingest
+    /// wrote). Using aimx's own write path on both sides keeps the
+    /// test agnostic to whether `mail-parser` includes angle brackets
+    /// on the Message-Id — whatever shape gets persisted is the same
+    /// shape the second ingest will look up.
+    #[test]
+    fn ingest_dedup_cache_loads_from_disk() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+
+        // First ingest: writes the .md to disk + populates locks_a's
+        // in-memory cache. locks_a is then dropped at scope end.
+        let locks_a = test_locks();
+        ingest_email(
+            &config,
+            &locks_a,
+            "alice@test.com",
+            plain_text_eml(),
+            sentinel_ip(),
+            None,
+            HookMode::Sync,
+        )
+        .unwrap();
+
+        let alice = inbox(tmp.path(), "alice");
+        let entries_after_first = collect_md_files(&alice);
+        assert_eq!(
+            entries_after_first.len(),
+            1,
+            "first ingest must store one .md"
+        );
+
+        // Second ingest with a fresh MailboxLocks (no in-memory cache):
+        // dedup must rebuild from disk and skip the duplicate.
+        let locks_b = test_locks();
+        ingest_email(
+            &config,
+            &locks_b,
+            "alice@test.com",
+            plain_text_eml(),
+            sentinel_ip(),
+            None,
+            HookMode::Sync,
+        )
+        .unwrap();
+
+        let entries = collect_md_files(&alice);
+        assert_eq!(
+            entries.len(),
+            1,
+            "fresh-locks ingest of duplicate Message-Id must use disk-loaded cache and skip"
+        );
+    }
+
+    /// Stale on-disk Message-Ids past the dedup TTL must not appear in
+    /// the rebuilt cache. Pre-stage an `.md` with `received_at` set
+    /// well outside the 24h window; an incoming message reusing that
+    /// Message-Id is treated as a fresh delivery.
+    #[test]
+    fn ingest_dedup_cache_excludes_expired() {
+        let tmp = TempDir::new().unwrap();
+        let config = test_config(tmp.path());
+
+        let alice = inbox(tmp.path(), "alice");
+        std::fs::create_dir_all(&alice).unwrap();
+        // `received_at` 5 days ago — outside the 24h DEDUP_TTL.
+        let received_at = (chrono::Utc::now() - chrono::Duration::days(5)).to_rfc3339();
+        let date_prefix = (chrono::Utc::now() - chrono::Duration::days(5))
+            .format("%Y-%m-%d-%H%M%S")
+            .to_string();
+        let staged = format!(
+            "+++\n\
+             id = \"{date_prefix}-stub\"\n\
+             message_id = \"<stale@example.com>\"\n\
+             received_at = \"{received_at}\"\n\
+             +++\nbody\n"
+        );
+        std::fs::write(alice.join(format!("{date_prefix}-stub.md")), staged).unwrap();
+
+        let incoming = b"From: sender@example.com\r\n\
+                        To: alice@test.com\r\n\
+                        Subject: Hello\r\n\
+                        Date: Thu, 01 Jan 2025 12:00:00 +0000\r\n\
+                        Message-ID: <stale@example.com>\r\n\
+                        \r\n\
+                        Reuse.\r\n";
+
+        let locks = test_locks();
+        ingest_email(
+            &config,
+            &locks,
+            "alice@test.com",
+            incoming,
+            sentinel_ip(),
+            None,
+            HookMode::Sync,
+        )
+        .unwrap();
+
+        let entries = collect_md_files(&alice);
+        assert_eq!(
+            entries.len(),
+            2,
+            "stale on-disk Message-Id must not block a fresh delivery"
+        );
     }
 }

--- a/src/mailbox_handler.rs
+++ b/src/mailbox_handler.rs
@@ -148,8 +148,8 @@ pub async fn handle_mailbox_crud(
         None
     };
 
-    let lock = state_ctx.lock_for(&req.name);
-    let _guard = lock.lock().await;
+    let state = state_ctx.lock_for(&req.name);
+    let _guard = state.lock.lock().await;
 
     // Serialize the load → modify → write → store critical section across
     // *all* mailbox names. The per-mailbox lock above keeps MARK-* on the

--- a/src/mailbox_locks.rs
+++ b/src/mailbox_locks.rs
@@ -1,5 +1,5 @@
-//! Per-mailbox write lock map shared by every path that mutates a
-//! mailbox's on-disk tree.
+//! Per-mailbox write lock map and dedup cache shared by every path
+//! that mutates a mailbox's on-disk tree.
 //!
 //! # Why a shared lock
 //!
@@ -17,9 +17,10 @@
 //!
 //! Always acquire in this order; never the reverse:
 //!
-//! 1. **Outer**: per-mailbox [`tokio::sync::Mutex<()>`] from this map.
-//!    Held for the full read-modify-write critical section on any file
-//!    in `<data_dir>/inbox/<mailbox>/` or `<data_dir>/sent/<mailbox>/`.
+//! 1. **Outer**: per-mailbox [`tokio::sync::Mutex<()>`] held on
+//!    [`MailboxState::lock`]. Held for the full read-modify-write
+//!    critical section on any file in `<data_dir>/inbox/<mailbox>/`
+//!    or `<data_dir>/sent/<mailbox>/`.
 //! 2. **Inner**: process-wide `CONFIG_WRITE_LOCK`
 //!    (`std::sync::Mutex<()>` in [`crate::mailbox_handler`]). Held only
 //!    for the `load → modify → write → store` sequence on
@@ -35,6 +36,16 @@
 //! `MAILBOX-CREATE` on different names both take the config lock, then
 //! race for their per-mailbox locks.
 //!
+//! # Dedup cache
+//!
+//! Each [`MailboxState`] also carries a lazily-initialized SparKV-backed
+//! cache of recently-seen `Message-Id` headers. Inbound ingest consults
+//! it before touching disk so that legitimate SMTP retries (which
+//! re-deliver the same `Message-Id`) don't re-fire `on_receive` hooks.
+//! Entries auto-evict after 24h, matching the practical upper bound of
+//! MTA retry queues. The cache is not the source of truth — it is
+//! rebuilt on demand from the frontmatter of files already on disk.
+//!
 //! # Contention notes
 //!
 //! The map-level `std::sync::Mutex` around the hashmap is held only for
@@ -47,34 +58,59 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use tokio::sync::Mutex as AsyncMutex;
 
-/// Shared per-mailbox lock map. Every writer (inbound ingest, MARK-*,
-/// MAILBOX-*) acquires its mailbox's lock before touching files under
-/// that mailbox's tree.
+/// Per-mailbox state held by [`MailboxLocks`]. Exposes the async write
+/// lock plus a lazily-initialized Message-Id dedup cache.
+pub struct MailboxState {
+    /// Outer lock from the hierarchy described in the module docs.
+    /// Acquired via `.lock().await` from async contexts (UDS handlers)
+    /// and `.blocking_lock()` from sync contexts (ingest under
+    /// `spawn_blocking`).
+    pub lock: AsyncMutex<()>,
+
+    /// Message-Id dedup cache. `None` until the first ingest into this
+    /// mailbox after daemon startup; populated lazily from disk on
+    /// first use. Wrapped in `std::sync::Mutex` because `SparKV`
+    /// mutates on every read/write.
+    pub seen_message_ids: Mutex<Option<sparkv::SparKV>>,
+}
+
+impl MailboxState {
+    fn new() -> Self {
+        Self {
+            lock: AsyncMutex::new(()),
+            seen_message_ids: Mutex::new(None),
+        }
+    }
+}
+
+/// Shared per-mailbox state map. Every writer (inbound ingest, MARK-*,
+/// MAILBOX-*) acquires its mailbox's [`MailboxState::lock`] before
+/// touching files under that mailbox's tree.
 pub struct MailboxLocks {
     // `std::sync::Mutex` around the map itself because the insert-if-
     // absent step is synchronous and uncontended. The per-mailbox
     // `AsyncMutex` is what callers actually hold across `.await` points.
-    locks: Mutex<HashMap<String, Arc<AsyncMutex<()>>>>,
+    states: Mutex<HashMap<String, Arc<MailboxState>>>,
 }
 
 impl MailboxLocks {
     pub fn new() -> Self {
         Self {
-            locks: Mutex::new(HashMap::new()),
+            states: Mutex::new(HashMap::new()),
         }
     }
 
-    /// Return (lazy-inserting if needed) the per-mailbox lock handle.
-    /// The caller decides whether to `.lock().await` (async contexts)
-    /// or `.blocking_lock()` (sync contexts like blocking `ingest_email`
-    /// under `spawn_blocking`).
-    pub fn lock_for(&self, mailbox: &str) -> Arc<AsyncMutex<()>> {
+    /// Return (lazy-inserting if needed) the per-mailbox state handle.
+    /// The caller decides whether to `.lock.lock().await` (async
+    /// contexts) or `.lock.blocking_lock()` (sync contexts like
+    /// blocking `ingest_email` under `spawn_blocking`).
+    pub fn lock_for(&self, mailbox: &str) -> Arc<MailboxState> {
         let mut map = self
-            .locks
+            .states
             .lock()
             .unwrap_or_else(|poisoned| poisoned.into_inner());
         map.entry(mailbox.to_string())
-            .or_insert_with(|| Arc::new(AsyncMutex::new(())))
+            .or_insert_with(|| Arc::new(MailboxState::new()))
             .clone()
     }
 }
@@ -90,16 +126,16 @@ mod tests {
     use super::*;
 
     #[test]
-    fn lock_for_same_mailbox_returns_same_mutex() {
+    fn lock_for_same_mailbox_returns_same_state() {
         let locks = MailboxLocks::new();
         let a = locks.lock_for("alice");
         let b = locks.lock_for("alice");
-        // Same underlying Arc => same semaphore => `Arc::ptr_eq`.
+        // Same underlying Arc => same state struct => `Arc::ptr_eq`.
         assert!(Arc::ptr_eq(&a, &b));
     }
 
     #[test]
-    fn lock_for_different_mailboxes_returns_distinct_mutex() {
+    fn lock_for_different_mailboxes_returns_distinct_state() {
         let locks = MailboxLocks::new();
         let a = locks.lock_for("alice");
         let b = locks.lock_for("bob");
@@ -109,18 +145,26 @@ mod tests {
     #[tokio::test]
     async fn async_lock_serializes_two_holders() {
         let locks = Arc::new(MailboxLocks::new());
-        let l1 = locks.lock_for("alice");
-        let g1 = l1.lock().await;
+        let s1 = locks.lock_for("alice");
+        let g1 = s1.lock.lock().await;
 
         // Second waiter times out fast when the first holder is still up.
-        let l2 = locks.lock_for("alice");
-        let res = tokio::time::timeout(std::time::Duration::from_millis(50), l2.lock()).await;
+        let s2 = locks.lock_for("alice");
+        let res = tokio::time::timeout(std::time::Duration::from_millis(50), s2.lock.lock()).await;
         assert!(res.is_err(), "second lock must block while first is held");
 
         drop(g1);
         // Now acquirable.
-        let _g2 = tokio::time::timeout(std::time::Duration::from_millis(100), l2.lock())
+        let _g2 = tokio::time::timeout(std::time::Duration::from_millis(100), s2.lock.lock())
             .await
             .expect("second lock must acquire once first is dropped");
+    }
+
+    #[test]
+    fn seen_message_ids_starts_uninitialized() {
+        let locks = MailboxLocks::new();
+        let state = locks.lock_for("alice");
+        let guard = state.seen_message_ids.lock().unwrap();
+        assert!(guard.is_none());
     }
 }

--- a/src/mailbox_locks.rs
+++ b/src/mailbox_locks.rs
@@ -46,6 +46,19 @@
 //! MTA retry queues. The cache is not the source of truth — it is
 //! rebuilt on demand from the frontmatter of files already on disk.
 //!
+//! **Per-mailbox keying, by design.** The dedup cache is scoped to the
+//! resolving mailbox name, not globally. Consequence: the same
+//! `Message-Id` delivered to two different RCPTs that route to two
+//! different mailboxes (e.g. `alice@` on the first try, then an
+//! unknown local part that falls through to `catchall` on a retry) is
+//! *not* deduped — the two ingests land in independent caches and
+//! both fire `on_receive`. This matches user-facing intent: each
+//! mailbox is its own "inbox" and a delivery to a different recipient
+//! is a different delivery, even if the sending MTA reused the
+//! Message-Id. If a future requirement needs cross-mailbox dedup,
+//! promote the cache out of [`MailboxState`] onto a process-wide
+//! singleton; doing it per-mailbox here is the conservative default.
+//!
 //! # Contention notes
 //!
 //! The map-level `std::sync::Mutex` around the hashmap is held only for

--- a/src/smtp/session.rs
+++ b/src/smtp/session.rs
@@ -542,6 +542,7 @@ impl SmtpSession {
                     &data,
                     peer.ip(),
                     envelope,
+                    crate::ingest::HookMode::Async,
                 )
                 .map_err(|e| e.to_string())
             })

--- a/src/smtp/tests.rs
+++ b/src/smtp/tests.rs
@@ -1532,3 +1532,159 @@ async fn test_multi_rcpt_all_success_returns_250() {
     assert_eq!(alice_mds.len(), 1);
     assert_eq!(bob_mds.len(), 1);
 }
+
+// ---------------------------------------------------------------------------
+// Async hook detach regression test
+// ---------------------------------------------------------------------------
+//
+// The primary fix in this PR detaches `on_receive` hooks onto a fresh
+// OS thread so the SMTP DATA path returns `250 OK` in seconds rather
+// than after the hook completes. Without this, a multi-minute hook
+// would exceed the remote MTA's DATA-reply timeout, the remote would
+// retry, and aimx would re-ingest and re-fire the hook on every
+// retry. This test pins the timing contract by registering a slow
+// hook (sleep 3s + touch a marker), driving an SMTP DATA transaction,
+// asserting `250 OK` returns well under the hook duration, and then
+// waiting for the marker to confirm the hook eventually runs in the
+// detached thread.
+//
+// Uses the same sandbox-fallback pattern the existing hook unit tests
+// use so it works on a developer workstation without root or
+// `systemd-run`.
+
+fn test_config_with_slow_hook(
+    data_dir: &std::path::Path,
+    marker_path: &std::path::Path,
+    sleep_secs: u32,
+) -> Config {
+    let mut mailboxes = HashMap::new();
+    let hook = crate::hook::Hook {
+        name: Some("slow_test_hook".to_string()),
+        event: crate::hook::HookEvent::OnReceive,
+        r#type: "cmd".to_string(),
+        cmd: vec![
+            "/bin/sh".to_string(),
+            "-c".to_string(),
+            format!("sleep {sleep_secs} && touch {}", marker_path.display()),
+        ],
+        // The test fixture's `From:` has no DKIM/SPF/DMARC, so the
+        // email's effective `trusted` is `none`. `fire_on_untrusted`
+        // lets the hook fire anyway, which is what we want to observe.
+        fire_on_untrusted: true,
+        timeout_secs: crate::hook::DEFAULT_HOOK_TIMEOUT_SECS,
+    };
+    mailboxes.insert(
+        "alice".to_string(),
+        MailboxConfig {
+            // Owner is the current user so post-write chown doesn't
+            // warn-spam on non-root developer workstations.
+            address: "alice@test.local".to_string(),
+            owner: current_user_name_for_test(),
+            hooks: vec![hook],
+            trust: Some("none".to_string()),
+            trusted_senders: Some(vec![]),
+            allow_root_catchall: false,
+        },
+    );
+    Config {
+        domain: "test.local".to_string(),
+        data_dir: data_dir.to_path_buf(),
+        dkim_selector: "aimx".to_string(),
+        trust: "none".to_string(),
+        trusted_senders: vec![],
+        mailboxes,
+        verify_host: None,
+        enable_ipv6: false,
+        signature: None,
+        upgrade: None,
+    }
+}
+
+fn current_user_name_for_test() -> String {
+    let uid = nix::unistd::Uid::current();
+    nix::unistd::User::from_uid(uid)
+        .ok()
+        .flatten()
+        .map(|u| u.name)
+        .unwrap_or_else(|| "nobody".to_string())
+}
+
+/// Regression test for the SMTP-blocking-hook bug.
+///
+/// Registers an `on_receive` hook that sleeps for `HOOK_SLEEP_SECS`
+/// before touching a marker file, drives a single SMTP DATA
+/// transaction, and asserts that:
+///
+/// 1. The `250 OK` response after the dot-terminator returns in less
+///    than half the hook's sleep duration — proving the hook ran
+///    detached, not inline.
+/// 2. The marker file eventually appears, proving the detached hook
+///    actually executed (not just silently dropped on spawn failure).
+///
+/// If `HookMode::Async` is ever changed back to `HookMode::Sync` for
+/// the SMTP DATA path, assertion (1) fails immediately.
+#[tokio::test]
+async fn test_smtp_data_returns_fast_with_slow_on_receive_hook() {
+    // Force the non-systemd-run hook executor so the test works on a
+    // developer workstation without root (mirrors
+    // `force_sandbox_fallback` in `src/hook.rs` tests). SAFETY: this is
+    // a process-wide env var, but the value is invariant across all
+    // tests that set it, so a concurrent test setting the same var to
+    // the same value is benign.
+    unsafe {
+        std::env::set_var("AIMX_SANDBOX_FORCE_FALLBACK", "1");
+    }
+
+    const HOOK_SLEEP_SECS: u32 = 3;
+    let max_response_ms: u128 = (HOOK_SLEEP_SECS as u128) * 1000 / 2;
+
+    let tmp = tempfile::TempDir::new().unwrap();
+    let marker = tmp.path().join("hook_fired.marker");
+    let config = test_config_with_slow_hook(tmp.path(), &marker, HOOK_SLEEP_SECS);
+    let (port, _shutdown) = start_server(config).await;
+    let mut client = TestClient::connect(port).await;
+    client.read_line().await;
+
+    client.send_and_read("EHLO test.com").await;
+    client.send_and_read("MAIL FROM:<sender@example.com>").await;
+    client.send_and_read("RCPT TO:<alice@test.local>").await;
+    client.send_and_read("DATA").await;
+    client.send(test_email()).await;
+
+    let start = std::time::Instant::now();
+    let resp = client.send_and_read(".").await;
+    let elapsed_ms = start.elapsed().as_millis();
+
+    assert!(resp.starts_with("250"), "Expected 250 OK: {resp}");
+    assert!(
+        elapsed_ms < max_response_ms,
+        "250 OK must return well under the hook's {HOOK_SLEEP_SECS}s sleep \
+         (took {elapsed_ms}ms, limit {max_response_ms}ms). If this fails, \
+         the SMTP DATA path is firing on_receive hooks synchronously \
+         again — the exact bug PR #225 fixes.",
+    );
+
+    client.send_and_read("QUIT").await;
+
+    // Wait for the detached hook to finish. Generous slack on top of
+    // the sleep covers slow CI; if it ever doesn't run, the marker
+    // never appears and the test fails after the timeout.
+    let deadline = std::time::Instant::now() + Duration::from_secs((HOOK_SLEEP_SECS as u64) + 10);
+    while std::time::Instant::now() < deadline {
+        if marker.exists() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(100)).await;
+    }
+    assert!(
+        marker.exists(),
+        "detached on_receive hook never ran (marker {} missing); \
+         the spawn path may be silently dropping hooks",
+        marker.display(),
+    );
+
+    // Belt-and-braces: the email itself must still be on disk.
+    let alice_dir = inbox(tmp.path(), "alice");
+    let md_files = collect_md_files(&alice_dir);
+    assert_eq!(md_files.len(), 1, "exactly one .md should be ingested");
+}

--- a/src/smtp/tests.rs
+++ b/src/smtp/tests.rs
@@ -179,6 +179,20 @@ fn test_email() -> &'static str {
     "From: sender@example.com\r\nTo: alice@test.local\r\nSubject: Test\r\nDate: Mon, 01 Jan 2024 00:00:00 +0000\r\nMessage-ID: <test@example.com>\r\n\r\nHello World\r\n"
 }
 
+/// Build a `test_email()`-shaped string with a per-call unique
+/// Message-Id. Inbound Message-Id dedup correctly drops the second
+/// copy of `test_email()` when it appears twice in the same session,
+/// so tests that expect two distinct stored messages need distinct
+/// Message-Ids.
+fn test_email_with_unique_id() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    format!(
+        "From: sender@example.com\r\nTo: alice@test.local\r\nSubject: Test\r\nDate: Mon, 01 Jan 2024 00:00:00 +0000\r\nMessage-ID: <test-unique-{n}@example.com>\r\n\r\nHello World\r\n"
+    )
+}
+
 // --- SMTP state machine tests ---
 
 #[tokio::test]
@@ -1008,18 +1022,22 @@ async fn test_multiple_transactions_per_connection() {
     client.send_and_read("EHLO test.com").await;
 
     // First message
+    let email_a = test_email_with_unique_id();
     client.send_and_read("MAIL FROM:<sender@test.com>").await;
     client.send_and_read("RCPT TO:<alice@test.local>").await;
     client.send_and_read("DATA").await;
-    client.send(test_email()).await;
+    client.send(&email_a).await;
     let resp = client.send_and_read(".").await;
     assert!(resp.starts_with("250"));
 
-    // Second message
+    // Second message (distinct Message-Id so inbound dedup treats it
+    // as a separate delivery, matching real-world clients that
+    // generate one Message-Id per email).
+    let email_b = test_email_with_unique_id();
     client.send_and_read("MAIL FROM:<sender2@test.com>").await;
     client.send_and_read("RCPT TO:<alice@test.local>").await;
     client.send_and_read("DATA").await;
-    client.send(test_email()).await;
+    client.send(&email_b).await;
     let resp = client.send_and_read(".").await;
     assert!(resp.starts_with("250"));
 

--- a/src/state_handler.rs
+++ b/src/state_handler.rs
@@ -25,11 +25,10 @@
 
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use tokio::sync::Mutex as AsyncMutex;
 
 use crate::config::ConfigHandle;
 use crate::frontmatter::InboundFrontmatter;
-use crate::mailbox_locks::MailboxLocks;
+use crate::mailbox_locks::{MailboxLocks, MailboxState};
 use crate::mcp::resolve_email_path_strict;
 use crate::ownership::chown_as_owner;
 use crate::send_protocol::{AckResponse, ErrCode, MarkRequest};
@@ -83,10 +82,11 @@ impl StateContext {
         }
     }
 
-    /// Acquire (lazy-inserting if needed) the per-mailbox write lock.
-    /// Returned `Arc` owns the lock; callers `.lock().await` (async) or
-    /// `.blocking_lock()` (inside `spawn_blocking`) it.
-    pub(crate) fn lock_for(&self, mailbox: &str) -> Arc<AsyncMutex<()>> {
+    /// Acquire (lazy-inserting if needed) the per-mailbox state handle.
+    /// Returned `Arc` owns both the async write lock and the dedup
+    /// cache; callers `.lock.lock().await` (async) or
+    /// `.lock.blocking_lock()` (inside `spawn_blocking`).
+    pub(crate) fn lock_for(&self, mailbox: &str) -> Arc<MailboxState> {
         self.locks.lock_for(mailbox)
     }
 }
@@ -152,8 +152,8 @@ pub async fn handle_mark(ctx: &StateContext, req: &MarkRequest, caller: &Caller)
         };
     }
 
-    let lock = ctx.lock_for(&req.mailbox);
-    let _guard = lock.lock().await;
+    let state = ctx.lock_for(&req.mailbox);
+    let _guard = state.lock.lock().await;
 
     let mailbox_dir = inbox_dir(&ctx.data_dir, &req.mailbox);
     let filepath = match resolve_email_path_strict(&mailbox_dir, &req.id) {


### PR DESCRIPTION
## Summary

- Fixes the bug where a single forwarded email triggered multiple hooks. Root cause: `on_receive` hooks ran synchronously inside `ingest_email`, holding the SMTP `250 OK` reply hostage for the entire hook duration (~7 min in the reported case). Gmail's MTA timed out around 5–7 min, considered delivery failed, retried — and aimx had no `Message-Id` dedup, so each retry ingested the message again and re-fired the hook.
- **Layer 1 (root cause):** new `HookMode::{Sync, Async}` parameter on `ingest_email`. The SMTP DATA handler passes `Async`, which detaches hooks onto `std::thread::spawn` so `250 OK` returns in seconds. The `aimx ingest` CLI and all existing tests keep `Sync`.
- **Layer 2 (defense in depth):** per-mailbox in-memory `Message-Id` cache (backed by [`sparkv`](https://github.com/uzyn/sparkv) with 24h TTL + auto-eviction). Lazily rebuilt from on-disk frontmatter on first ingest after daemon startup. Entries loaded from disk inherit `24h − (now − received_at)` as their TTL, so a daemon restart cannot stretch dedup protection past its real lifetime. Filename date-prefix pre-filter avoids opening files outside the 24h window. Duplicate Message-Ids are silently absorbed (no second `.md`, no second hook fire) but `ingest_email` still returns `Ok` so the SMTP path emits `250 OK` and the remote MTA stops retrying.

## Files changed

| File | Change |
|------|--------|
| `Cargo.toml` | + `sparkv` 0.1 dep |
| `src/mailbox_locks.rs` | `lock_for` now returns `Arc<MailboxState>` (lock + dedup cache) |
| `src/ingest.rs` | `HookMode` enum, dedup check + cache insert, async hook spawn branch, disk-scan helpers, 4 new tests |
| `src/smtp/session.rs` | DATA handler passes `HookMode::Async` |
| `src/state_handler.rs`, `src/hook_handler.rs`, `src/mailbox_handler.rs` | Updated lock-acquisition call sites for the new state shape |
| `src/smtp/tests.rs` | Multi-transaction test now generates per-call unique `Message-Id`s |

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean
- [x] `cargo test --bin aimx` — 1145 pass; 3 macOS-only pre-existing `uds_authz` failures (Linux-only project per CLAUDE.md)
- [x] `cargo test --test integration` — 116/116 pass
- [x] 4 new dedup tests cover: in-memory cache hit, distinct Message-Ids allowed, lazy disk rebuild, expired entries excluded
- [x] Existing tests that re-ingested the same fixture twice updated to generate per-call unique Message-Ids — matching real-world client behavior
- [ ] Manual end-to-end on staging: forward a slow-hook email from Gmail, confirm single `received email` + single `firing hook_name=...` log line, and a single reply lands in inbox

## Out of scope

- TLS `close_notify` graceful shutdown in `src/smtp/mod.rs` — Gmail's "peer closed without close_notify" is a downstream symptom of the timeout. Once `250 OK` lands within seconds (this PR), Gmail closes cleanly. If it persists after deploy, a follow-up to call `tokio_rustls::shutdown().await` before the TCP shutdown is straightforward.
- Admin command to manually purge a Message-Id from the dedup cache (defer until requested).
