### PR TITLE
Drop unused rand dep and redundant dev-dep duplicates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,6 @@ dependencies = [
  "nix",
  "predicates",
  "psl",
- "rand 0.10.1",
  "rcgen",
  "rmcp",
  "rsa",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,7 +51,6 @@ include_dir = "0.7"
 sha2 = "0.11"
 psl = "2"
 unicode-normalization = "0.1"
-rand = "0.10"
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", default-features = false, features = ["fmt", "env-filter"] }
 dialoguer = { version = "0.12", default-features = false }
@@ -105,7 +104,6 @@ assert_cmd = "2"
 predicates = "3"
 wait-timeout = "0.2"
 rcgen = "0.14"
-sha2 = "0.11"
 tracing-subscriber = { version = "0.3", features = ["fmt"] }
 tracing-test = "0.2"
 serial_test = "3"
@@ -114,24 +112,3 @@ serial_test = "3"
 # `include_str!` + substring grep with a proper syn visitor that matches
 # on `ItemFn` signatures rather than source text.
 syn = { version = "2", features = ["full", "visit"] }
-# Dev-only: the Tier-2 integration test in
-# `tests/release_integration.rs` fetches release assets from GitHub.
-# Pulled under the `integration` feature via `cargo test --features
-# integration`; compiled unconditionally here because cargo does not
-# support feature-gated `dev-dependencies`. Kept in sync with the main
-# crate's `ureq` feature shape.
-ureq = { version = "3", default-features = false, features = ["rustls-no-provider", "rustls-webpki-roots", "gzip", "json"] }
-serde_json = "1"
-# Dev-only: needed by the Tier-2 integration test to install
-# the process-default rustls CryptoProvider before `ureq` (built with
-# `rustls-no-provider`) performs its first TLS handshake. Mirrors the
-# feature shape used by the main crate so we don't link a second
-# crypto backend.
-rustls = { version = "0.23", default-features = false, features = ["aws-lc-rs", "std"] }
-# Dev-only: the upgrade-end-to-end test in
-# `tests/release_integration.rs` uses `libc::geteuid` to detect whether
-# the integration test is running as root; in that case it drives the
-# real `aimx upgrade --dry-run` path end-to-end against the fixture
-# release, exercising `RealReleaseOps::fetch_asset` with the full TLS
-# wiring.
-libc = "0.2"


### PR DESCRIPTION
## Summary

- Remove `rand = "0.10"` from `[dependencies]` — it has no direct usage in `src/` or `tests/`. The only nearby reference is `rsa::rand_core::OsRng` in `src/dkim.rs`, which comes from `rsa`'s own re-export of the separate `rand_core` crate, not the top-level `rand`.
- Remove five `[dev-dependencies]` entries (`sha2`, `libc`, `ureq`, `serde_json`, `rustls`) that duplicate normal deps with equal-or-superset feature sets. Normal deps are already visible to tests, so the dev-deps re-declarations were no-ops. The associated comment blocks went with them.
- `tracing-subscriber`'s dev-deps entry is intentionally left in place — its feature shape differs from the normal dep in a way that affects feature unification, so removing it would not be a no-op.

Net diff: `Cargo.toml` -23 lines, `Cargo.lock` -1 line. No source code touched.

## Test plan

- [x] `cargo check --all-targets`
- [x] `cargo clippy --all-targets -- -D warnings`
- [x] `cargo fmt -- --check`
- [x] `cargo test` — 1146 passed, 8 ignored, 3 pre-existing macOS-only failures in `src/uds_authz.rs::tests` (the tests assume UID `4_294_967_294` is unmapped, but on macOS `id -u nobody` is exactly that value; CI runs on ubuntu-latest where these pass)
- [x] `services/verifier` `cargo check --all-targets` (not modified, sanity-checked)