### PR TITLE
setup: don't halt install re-runs + clearer Step 6 handoff

### DIFF
--- a/book/setup.md
+++ b/book/setup.md
@@ -43,16 +43,38 @@ The wizard prints a six-line checklist and walks each step, advancing each entry
 3. **STARTTLS certificate.** Generates a self-signed cert at `/etc/ssl/aimx/`. Skipped on re-entry.
 4. **Trust policy.** Asks for a comma-separated list of addresses or globs (e.g. `you@example.com, *@company.com`). An empty list sets `trust = "none"` with a loud warning that hooks will not fire for inbound email until trusted senders are added. Skipped on re-entry. Under `AIMX_NONINTERACTIVE=1` the prompt is skipped and the warning is logged.
 5. **Install AIMX.** Generates a 2048-bit DKIM keypair under `/etc/aimx/dkim/`, writes `/etc/aimx/config.toml` with the catchall mailbox, creates the `aimx-catchall` system user, generates the systemd (or OpenRC) service unit, starts `aimx serve`, and waits for port 25 to bind. Skipped on re-entry.
-6. **Set up MCP for agent(s).** Prints a guidance section listing every supported AI agent (driven by `agents_setup::registry()` so the list extends automatically) and a `→ aimx agents setup` callout pointing the operator at the per-user agent wiring command. The wizard does not spawn a subprocess — agent wiring is operator-initiated as a separate step (the same idiom as `apt install` / `gh auth login`). Marked `⎘ Handoff` in the closing checklist regardless of `$SUDO_USER` or `AIMX_NONINTERACTIVE`.
+6. **Set up MCP for agent(s).** Prints the `🐦‍⬛ AIMX setup — complete` banner first, then a guidance section listing every supported AI agent and harness (driven by `agents_setup::registry()` so the list extends automatically), and a boxed `→ aimx agents setup` callout under a sentence directing the operator to run the agents guided setup as a regular user (not root). The wizard does not spawn a subprocess — agent wiring is operator-initiated as a separate step (the same idiom as `apt install` / `gh auth login`). Marked `⎘ Handoff` on the checklist regardless of `$SUDO_USER` or `AIMX_NONINTERACTIVE`; the checklist itself is rendered immediately after Step 5 completes (with Step 6 still as `☐`) and is not reprinted under the banner.
 
 After step 6 returns, the wizard prints the final closing message:
 
 ```
-AIMX has been set up successfully.
+🐦‍⬛ AIMX setup — complete
 
-Your agents now have access to set up, send and receive emails from @<DOMAIN> emails.
+Step 6: Set up MCP for agent(s)
 
-Once you have linked up your MCP to your LLM, try asking it to set up a mailbox for you, e.g.
+AIMX bundles MCP and skill files for the following AI agents & harnesses:
+
+  • Claude Code
+  • Codex CLI
+  • OpenCode
+  • Gemini CLI
+  • Goose
+  • OpenClaw
+  • Hermes
+  • NanoClaw
+
+To wire AIMX into the harness you have installed, run the agents guided setup as a regular user (not root):
+
+  ┌─────────────────────────────┐
+  │  → aimx agents setup        │
+  └─────────────────────────────┘
+
+
+☑ AIMX has been set up successfully.
+
+AIMX is now running at @<DOMAIN> and ready to send and receive email.
+
+Once you've wired your MCP to your LLM, try asking your agent, e.g.
   claude -p "Set up agent@<DOMAIN> and respond to me via email the moment you receive my instructions via email."
 ```
 

--- a/install.sh
+++ b/install.sh
@@ -561,6 +561,27 @@ start_service() {
     esac
 }
 
+# True iff `aimx setup` has previously completed on this host — i.e. a
+# service unit is on disk. Setup writes the unit as its final step
+# (src/setup.rs); if neither file is present, an earlier install was
+# interrupted before reaching the service-install stage. Without this
+# gate the upgrade path runs `systemctl start aimx` after the binary
+# swap and bails fatally on "Unit aimx.service not found", trapping the
+# operator: every re-run rolls itself back. Override the probe paths
+# via AIMX_SETUP_COMPLETED_SYSTEMD / AIMX_SETUP_COMPLETED_OPENRC for
+# tests — production callers leave them unset.
+setup_completed() {
+    _systemd_unit="${AIMX_SETUP_COMPLETED_SYSTEMD:-/etc/systemd/system/aimx.service}"
+    _openrc_unit="${AIMX_SETUP_COMPLETED_OPENRC:-/etc/init.d/aimx}"
+    if [ -f "${_systemd_unit}" ]; then
+        return 0
+    fi
+    if [ -f "${_openrc_unit}" ]; then
+        return 0
+    fi
+    return 1
+}
+
 # Detect a manually-launched `aimx serve` process running outside
 # systemd / OpenRC. Used on the upgrade path: when no init system
 # manages the unit but a stray `aimx serve` is still bound to the
@@ -1252,39 +1273,50 @@ main() {
     _installed_tag=""
     _is_upgrade=0
     if [ -x "${_install_path}" ]; then
-        _installed_tag="$(parse_installed_tag "${_install_path}")"
-        if [ -n "${_installed_tag}" ]; then
-            _cmp="$(compare_tags "${_installed_tag}" "${TAG}")"
-            case "${_cmp}" in
-                equal)
-                    if [ "${FORCE}" -eq 1 ]; then
-                        say "re-installing ${TAG} (--force)"
-                        _is_upgrade=1
-                    elif [ "${DRY_RUN}" != "1" ] && prompt_reinstall; then
-                        # Binary is already correct; skip the swap and
-                        # jump straight to the wizard. backup_existing_config
-                        # below covers any partial config from an aborted run.
-                        # Dry-run never prompts — auditing the script must
-                        # stay non-interactive, matching pre-PR behavior on
-                        # the equal-version branch.
-                        _skip_swap=1
-                        _is_upgrade=0
-                    else
-                        say "AIMX ${_installed_tag} is already installed (pass --force to re-install)"
-                        exit 0
-                    fi
-                    ;;
-                newer)
-                    err "installed ${_installed_tag} is newer than target ${TAG}; run 'aimx upgrade --version ${TAG} --force' to downgrade explicitly"
-                    ;;
-                older)
-                    say "upgrading ${_installed_tag} -> ${TAG}"
-                    _is_upgrade=1
-                    ;;
-            esac
+        if ! setup_completed; then
+            # Binary exists but no service unit on disk — `aimx setup`
+            # never reached its final step (typically the operator
+            # Ctrl+C'd partway through). The upgrade branch would try
+            # `systemctl start aimx` on a unit that isn't there and
+            # bail fatally. Fall through to the fresh-install path so
+            # the binary is re-laid at the target tag and the wizard
+            # re-enters cleanly.
+            say "binary present but aimx setup did not complete (no service unit); continuing setup"
         else
-            say "existing binary at ${_install_path} did not report a parseable version; proceeding as upgrade"
-            _is_upgrade=1
+            _installed_tag="$(parse_installed_tag "${_install_path}")"
+            if [ -n "${_installed_tag}" ]; then
+                _cmp="$(compare_tags "${_installed_tag}" "${TAG}")"
+                case "${_cmp}" in
+                    equal)
+                        if [ "${FORCE}" -eq 1 ]; then
+                            say "re-installing ${TAG} (--force)"
+                            _is_upgrade=1
+                        elif [ "${DRY_RUN}" != "1" ] && prompt_reinstall; then
+                            # Binary is already correct; skip the swap and
+                            # jump straight to the wizard. backup_existing_config
+                            # below covers any partial config from an aborted run.
+                            # Dry-run never prompts — auditing the script must
+                            # stay non-interactive, matching pre-PR behavior on
+                            # the equal-version branch.
+                            _skip_swap=1
+                            _is_upgrade=0
+                        else
+                            say "AIMX ${_installed_tag} is already installed (pass --force to re-install)"
+                            exit 0
+                        fi
+                        ;;
+                    newer)
+                        err "installed ${_installed_tag} is newer than target ${TAG}; run 'aimx upgrade --version ${TAG} --force' to downgrade explicitly"
+                        ;;
+                    older)
+                        say "upgrading ${_installed_tag} -> ${TAG}"
+                        _is_upgrade=1
+                        ;;
+                esac
+            else
+                say "existing binary at ${_install_path} did not report a parseable version; proceeding as upgrade"
+                _is_upgrade=1
+            fi
         fi
     fi
 

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1407,13 +1407,21 @@ pub fn display_mcp_section() {
 ///
 /// Shape: a header sentence, a bullet list of every supported agent's
 /// `display_name` (driven by [`crate::agents_setup::registry`] so adding
-/// a new agent automatically appears here), then a closing instruction
-/// to run `aimx agents setup` as the regular user. No per-agent install
+/// a new agent automatically appears here), a brief instruction sentence,
+/// then a labeled, boxed `→ aimx agents setup` callout so the operator's
+/// next concrete action can't be skimmed past. No per-agent install
 /// commands — the picker (`aimx agents setup` with no argument) handles
 /// detection and per-agent dispatch.
+///
+/// The box uses literal `→` (one column) instead of [`term::prompt_mark`]
+/// so the body row's visible width stays fixed at 29 columns regardless
+/// of TTY / `NO_COLOR` — `prompt_mark`'s non-TTY `[>]` fallback would
+/// otherwise widen the row by two columns and misalign the borders.
 pub fn mcp_section_lines() -> Vec<String> {
     let mut lines = Vec::new();
-    lines.push("AIMX bundles MCP and skill files for the following AI agents:".to_string());
+    lines.push(
+        "AIMX bundles MCP and skill files for the following AI agents & harnesses:".to_string(),
+    );
     lines.push(String::new());
 
     for spec in crate::agents_setup::registry() {
@@ -1422,11 +1430,15 @@ pub fn mcp_section_lines() -> Vec<String> {
 
     lines.push(String::new());
     lines.push(
-        "Run as your regular user (not root) to wire AIMX into the agents you have installed:"
+        "To wire AIMX into the harness you have installed, run the agents guided setup \
+         as a regular user (not root):"
             .to_string(),
     );
     lines.push(String::new());
-    lines.push(format!("  {} aimx agents setup", term::prompt_mark()));
+    lines.push("  ┌─────────────────────────────┐".to_string());
+    lines.push("  │  → aimx agents setup        │".to_string());
+    lines.push("  └─────────────────────────────┘".to_string());
+    lines.push(String::new());
     lines.push(String::new());
     lines
 }
@@ -2379,13 +2391,13 @@ pub fn print_welcome_banner(checklist: &Checklist) {
     println!();
 }
 
-/// Print the closing checklist banner. Reprinted with the terminal step
-/// states so the operator sees ☐ flip to ☑ / ☒ at the end of the run.
-pub fn print_final_banner(checklist: &Checklist) {
+/// Print the completion banner that sits between Step 5 and the Step 6
+/// handoff. The per-step checklist was already printed by
+/// `print_step_complete(5)` immediately above; reprinting it under the
+/// banner was noise.
+pub fn print_final_banner() {
     println!();
     println!("{}", term::header("🐦‍⬛ AIMX setup — complete"));
-    println!();
-    print_step_list(checklist);
     println!();
 }
 
@@ -2658,11 +2670,17 @@ pub fn run_setup(
     // interactive picker) to run as themselves. Step 6 is marked
     // `Handoff` (⎘) in the closing checklist — distinct from ☑ Done
     // (the wizard completed it) and ☒ Skipped (the wizard bypassed it).
+    // Banner first — sits between Step 5 (already printed with its
+    // checklist via `print_step_complete(5)` above) and the Step 6
+    // handoff below. The operator's "I'm done" cue arrives BEFORE the
+    // handoff section so the boxed `aimx agents setup` callout that
+    // follows reads as the operator's next concrete action, not as
+    // wizard work still in progress.
+    checklist.set(6, term::StepState::Handoff);
+    print_final_banner();
+
     section_header(6, SETUP_STEPS[5]);
     display_mcp_section();
-
-    checklist.set(6, term::StepState::Handoff);
-    print_final_banner(&checklist);
 
     // Closing message — final thing the operator sees.
     print_closing_message(&domain);
@@ -2674,16 +2692,18 @@ pub fn run_setup(
 /// configured domain into the template the spec mandates.
 fn print_closing_message(domain: &str) {
     println!();
-    println!("{}", term::success("AIMX has been set up successfully."));
+    println!(
+        "{} {}",
+        term::step_glyph(term::StepState::Done),
+        term::success("AIMX has been set up successfully.")
+    );
     println!();
     println!(
-        "Your agents now have access to set up, send and receive emails from {} emails.",
+        "AIMX is now running at {} and ready to send and receive email.",
         term::highlight(&format!("@{domain}"))
     );
     println!();
-    println!(
-        "Once you have linked up your MCP to your LLM, try asking it to set up a mailbox for you, e.g."
-    );
+    println!("Once you've wired your MCP to your LLM, try asking your agent, e.g.");
     println!(
         "  claude -p \"Set up agent@{domain} and respond to me via email the moment you receive my instructions via email.\""
     );
@@ -3934,10 +3954,10 @@ owner = "aimx-catchall"
     fn mcp_section_lines_are_in_documented_order() {
         // Pins the line *flow* of `mcp_section_lines`, not just presence.
         // The contract: header sentence → blank → bullets → blank →
-        // "Run as your regular user..." sentence → blank → callout →
-        // blank. A refactor that scrambles this order (e.g. moves the
-        // bullets below the callout) would still pass the existing
-        // presence-only tests but produce confusing output.
+        // "To wire AIMX..." sentence → blank → box top border → box body
+        // row → box bottom border. A refactor that scrambles this order
+        // (e.g. moves the bullets below the box) would still pass the
+        // presence-only tests but would produce confusing output.
         let lines = mcp_section_lines();
         let header_idx = lines
             .iter()
@@ -3947,28 +3967,81 @@ owner = "aimx-catchall"
             .iter()
             .position(|line| line.starts_with("  • "))
             .expect("at least one bullet must be present");
-        let run_as_user_idx = lines
+        let wire_sentence_idx = lines
             .iter()
-            .position(|line| line.starts_with("Run as your regular user"))
-            .expect("\"Run as your regular user...\" sentence must be present");
-        let callout_idx = lines
+            .position(|line| line.starts_with("To wire AIMX"))
+            .expect("\"To wire AIMX...\" sentence must be present");
+        let top_border_idx = lines
             .iter()
-            .position(|line| line.contains("aimx agents setup") && !line.starts_with("AIMX"))
-            .expect("`aimx agents setup` callout must be present");
+            .position(|line| line.starts_with("  ┌"))
+            .expect("box top border must be present");
+        let body_row_idx = lines
+            .iter()
+            .position(|line| line.contains('│') && line.contains("aimx agents setup"))
+            .expect("box body row with `aimx agents setup` must be present");
+        let bottom_border_idx = lines
+            .iter()
+            .position(|line| line.starts_with("  └"))
+            .expect("box bottom border must be present");
 
         assert!(
             header_idx < first_bullet_idx,
             "header must precede bullets (header={header_idx}, bullets={first_bullet_idx})"
         );
         assert!(
-            first_bullet_idx < run_as_user_idx,
-            "bullets must precede the run-as-user sentence \
-             (bullets={first_bullet_idx}, run_as_user={run_as_user_idx})"
+            first_bullet_idx < wire_sentence_idx,
+            "bullets must precede the wire-up sentence \
+             (bullets={first_bullet_idx}, wire={wire_sentence_idx})"
         );
         assert!(
-            run_as_user_idx < callout_idx,
-            "run-as-user sentence must precede callout \
-             (run_as_user={run_as_user_idx}, callout={callout_idx})"
+            wire_sentence_idx < top_border_idx,
+            "wire-up sentence must precede box top border \
+             (wire={wire_sentence_idx}, top_border={top_border_idx})"
+        );
+        assert!(
+            top_border_idx < body_row_idx,
+            "box top border must precede body row \
+             (top_border={top_border_idx}, body={body_row_idx})"
+        );
+        assert!(
+            body_row_idx < bottom_border_idx,
+            "box body row must precede bottom border \
+             (body={body_row_idx}, bottom_border={bottom_border_idx})"
+        );
+
+        // The three box rows are contiguous (no blank rows inside the box).
+        assert_eq!(
+            body_row_idx,
+            top_border_idx + 1,
+            "box body row must sit directly under the top border"
+        );
+        assert_eq!(
+            bottom_border_idx,
+            body_row_idx + 1,
+            "box bottom border must sit directly under the body row"
+        );
+
+        // Box geometry: top and bottom borders must be the same length,
+        // and the body row must match. Locks in alignment so a future
+        // edit to the literal command can't silently misalign the box.
+        let top = &lines[top_border_idx];
+        let body = &lines[body_row_idx];
+        let bottom = &lines[bottom_border_idx];
+        assert_eq!(
+            top.chars().count(),
+            bottom.chars().count(),
+            "top and bottom box borders must be the same width \
+             (top={:?}, bottom={:?})",
+            top,
+            bottom
+        );
+        assert_eq!(
+            top.chars().count(),
+            body.chars().count(),
+            "box body row width must match border width \
+             (top={:?}, body={:?})",
+            top,
+            body
         );
 
         // Blank-line separators between each landmark.
@@ -3979,22 +4052,16 @@ owner = "aimx-catchall"
             lines[header_idx + 1]
         );
         assert!(
-            lines[run_as_user_idx - 1].is_empty(),
-            "expected blank line before run-as-user sentence at index {}; got {:?}",
-            run_as_user_idx - 1,
-            lines[run_as_user_idx - 1]
+            lines[wire_sentence_idx - 1].is_empty(),
+            "expected blank line before wire-up sentence at index {}; got {:?}",
+            wire_sentence_idx - 1,
+            lines[wire_sentence_idx - 1]
         );
         assert!(
-            lines[run_as_user_idx + 1].is_empty(),
-            "expected blank line after run-as-user sentence at index {}; got {:?}",
-            run_as_user_idx + 1,
-            lines[run_as_user_idx + 1]
-        );
-        assert!(
-            lines[callout_idx - 1].is_empty(),
-            "expected blank line before callout at index {}; got {:?}",
-            callout_idx - 1,
-            lines[callout_idx - 1]
+            lines[top_border_idx - 1].is_empty(),
+            "expected blank line before box top border at index {}; got {:?}",
+            top_border_idx - 1,
+            lines[top_border_idx - 1]
         );
     }
 
@@ -6010,17 +6077,29 @@ owner = "aimx-catchall"
     #[test]
     fn closing_message_carries_required_phrasing() {
         // The wizard closes with the spec-mandated message: a success
-        // banner, the `@<DOMAIN>` line, and the `claude -p` example
-        // prompt. Direct stdout capture is finicky under cargo test, so
-        // grep the source for the load-bearing literals instead.
+        // banner, the `@<DOMAIN>` capability line, the wired-MCP follow-up,
+        // and the `claude -p` example prompt. Direct stdout capture is
+        // finicky under cargo test, so grep the source for the
+        // load-bearing literals instead.
         let source = include_str!("setup.rs");
         assert!(
             source.contains("AIMX has been set up successfully."),
             "closing message must include the success banner"
         );
         assert!(
-            source.contains("Your agents now have access to set up, send and receive emails from"),
-            "closing message must surface agent capabilities"
+            source.contains("AIMX is now running at"),
+            "closing message must surface the running-daemon capability line \
+             (must NOT claim agents already have access — the operator still \
+             needs to run `aimx agents setup`)"
+        );
+        assert!(
+            source.contains("ready to send and receive email"),
+            "closing message capability line must describe AIMX's email role"
+        );
+        assert!(
+            source.contains("Once you've wired your MCP to your LLM"),
+            "closing message must acknowledge the MCP-wiring step before \
+             the `claude -p` example"
         );
         assert!(
             source.contains("claude -p"),
@@ -6029,28 +6108,32 @@ owner = "aimx-catchall"
     }
 
     #[test]
-    fn closing_message_preserves_trailing_emails_word() {
-        // Spec wording explicitly ends with "...emails from @<DOMAIN>
-        // emails." with the trailing "emails" word. Lock in both the
-        // template (what's in the source) and the rendered string (what
-        // an operator actually sees with their domain substituted in).
+    fn closing_message_does_not_overclaim_agent_capability() {
+        // Regression: at the moment Step 6 runs, the daemon is up and the
+        // mailboxes exist but NO agent has its MCP wired yet. The
+        // closing line must not read like agents already have access —
+        // wiring is the operator handoff the wizard just printed above
+        // (boxed `aimx agents setup` callout). The prior wording tripped
+        // this and was rewritten to "AIMX is now running at <domain>..."
         let source = include_str!("setup.rs");
+        // Build the forbidden phrase from split pieces so this very
+        // assertion doesn't put the bytes it's forbidding into the
+        // source file. `include_str!` reads `setup.rs` verbatim, so any
+        // string literal mentioning the old phrase would self-trigger.
+        let forbidden = ["Your agents", " now have access"].concat();
         assert!(
-            source.contains(
-                "Your agents now have access to set up, send and receive emails from {} emails."
-            ),
-            "closing message template must keep the trailing `emails.` word \
-             so the rendered line reads `... from @<DOMAIN> emails.`"
+            !source.contains(&forbidden),
+            "closing message must not overclaim — wiring (`aimx agents setup`) \
+             is still the operator handoff at this point"
         );
 
-        // Cross-check the rendered substring an operator would see.
+        // Cross-check the rendered substring an operator actually sees.
         let domain = "agent.example.com";
-        let rendered = format!(
-            "Your agents now have access to set up, send and receive emails from @{domain} emails."
-        );
+        let rendered =
+            format!("AIMX is now running at @{domain} and ready to send and receive email.");
         assert!(
-            rendered.contains(&format!("emails from @{domain} emails.")),
-            "rendered closing message must contain `emails from @{{domain}} emails.`. \
+            rendered.contains(&format!("at @{domain}")),
+            "rendered capability line must substitute the configured domain. \
              Got: {rendered}"
         );
     }
@@ -6189,7 +6272,10 @@ owner = "aimx-catchall"
     }
 
     #[test]
-    fn final_banner_signals_completion_and_renders_step_list() {
+    fn final_banner_signals_completion() {
+        // The checklist is no longer reprinted under the banner —
+        // `print_step_complete(5)` immediately above already showed the
+        // same state with Step 6 as ☐. Just the headline survives.
         let source = include_str!("setup.rs");
         let body_start = source
             .find("pub fn print_final_banner")
@@ -6200,9 +6286,10 @@ owner = "aimx-catchall"
             "final banner missing completion title. Window:\n{window}"
         );
         assert!(
-            window.contains("print_step_list"),
-            "final banner must reuse print_step_list so per-step glyphs render. \
-             Window:\n{window}"
+            !window.contains("print_step_list"),
+            "final banner must NOT reprint the checklist — \
+             `print_step_complete(5)` already showed the running checklist \
+             immediately above. Window:\n{window}"
         );
     }
 

--- a/tests/install_sh.sh
+++ b/tests/install_sh.sh
@@ -151,6 +151,7 @@ _out="$(
         type ui_warn >/dev/null 2>&1 && echo "HAS ui_warn"
         type ui_error >/dev/null 2>&1 && echo "HAS ui_error"
         type ui_success >/dev/null 2>&1 && echo "HAS ui_success"
+        type setup_completed >/dev/null 2>&1 && echo "HAS setup_completed"
     ' 2>&1
 )"
 assert_contains "INSTALL_SH_TEST=1 suppresses main" "${_out}" "SOURCED_OK"
@@ -163,6 +164,7 @@ assert_contains "helper: ui_info"                  "${_out}" "HAS ui_info"
 assert_contains "helper: ui_warn"                  "${_out}" "HAS ui_warn"
 assert_contains "helper: ui_error"                 "${_out}" "HAS ui_error"
 assert_contains "helper: ui_success"               "${_out}" "HAS ui_success"
+assert_contains "helper: setup_completed"          "${_out}" "HAS setup_completed"
 
 # Removed-helper regression: the binary owns the six-step UI now.
 # `has_tty` was removed when the post-install handoff was rewritten to
@@ -282,6 +284,91 @@ else
     FAIL=$((FAIL + 1))
     FAILED_NAMES="${FAILED_NAMES} sudo-v-redirect-missing"
     printf '  FAIL no sudo -v </dev/tty line found at all\n' >&2
+fi
+
+# ---------------------------------------------------------------------------
+# 3c. setup_completed gate (interrupted-setup regression)
+#
+# Re-running install.sh after Ctrl+C'ing out of `aimx setup` must NOT
+# bail with "Unit aimx.service not found". The fix gates the upgrade
+# decision on `setup_completed`: a service unit on disk is the durable
+# signal that the wizard previously finished. When the gate is missing,
+# the upgrade branch swaps the binary then runs `systemctl start aimx`
+# on a unit that doesn't exist and rolls back fatally.
+# ---------------------------------------------------------------------------
+
+echo "# setup_completed gate"
+
+# install.sh sets `set -eu` at its top, so sourcing it into a subshell
+# inherits errexit. Wrap each probe in an `if ... fi` so the returned
+# nonzero from setup_completed doesn't tear down the subshell before
+# the `printf` captures the result.
+
+# (a) Functional: no unit files → returns 1 (treat as fresh install).
+_out="$(
+    INSTALL_SH_TEST=1 sh -c '
+        . "'"${INSTALL_SH}"'"
+        if AIMX_SETUP_COMPLETED_SYSTEMD="/nonexistent/aimx.service" \
+           AIMX_SETUP_COMPLETED_OPENRC="/nonexistent/aimx" \
+                setup_completed
+        then
+            printf "RC=0"
+        else
+            printf "RC=%d" $?
+        fi
+    '
+)"
+assert_contains "setup_completed: no unit → rc 1" "${_out}" "RC=1"
+
+# (b) Functional: systemd unit present → returns 0 (treat as upgrade).
+_unit_tmp="$(mktemp -d 2>/dev/null || mktemp -d -t aimxsc)"
+: > "${_unit_tmp}/aimx.service"
+_out="$(
+    INSTALL_SH_TEST=1 sh -c '
+        . "'"${INSTALL_SH}"'"
+        if AIMX_SETUP_COMPLETED_SYSTEMD="'"${_unit_tmp}/aimx.service"'" \
+           AIMX_SETUP_COMPLETED_OPENRC="/nonexistent/aimx" \
+                setup_completed
+        then
+            printf "RC=0"
+        else
+            printf "RC=%d" $?
+        fi
+    '
+)"
+assert_contains "setup_completed: systemd unit present → rc 0" "${_out}" "RC=0"
+
+# (c) Functional: OpenRC script present → returns 0.
+: > "${_unit_tmp}/openrc-aimx"
+_out="$(
+    INSTALL_SH_TEST=1 sh -c '
+        . "'"${INSTALL_SH}"'"
+        if AIMX_SETUP_COMPLETED_SYSTEMD="/nonexistent/aimx.service" \
+           AIMX_SETUP_COMPLETED_OPENRC="'"${_unit_tmp}/openrc-aimx"'" \
+                setup_completed
+        then
+            printf "RC=0"
+        else
+            printf "RC=%d" $?
+        fi
+    '
+)"
+assert_contains "setup_completed: openrc script present → rc 0" "${_out}" "RC=0"
+
+rm -rf "${_unit_tmp}"
+
+# (d) Source-grep regression: the upgrade-decision block must call
+#     `setup_completed` before the version-comparison case statement.
+#     Without this gate, a binary present + no unit installed routes
+#     to the fatal `systemctl start aimx` path on re-run.
+_gate_count="$(grep -c 'if ! setup_completed' "${INSTALL_SH}" || true)"
+if [ "${_gate_count:-0}" -ge 1 ]; then
+    PASS=$((PASS + 1))
+    printf '  ok  upgrade decision gated on setup_completed (count=%s)\n' "${_gate_count}"
+else
+    FAIL=$((FAIL + 1))
+    FAILED_NAMES="${FAILED_NAMES} setup-completed-gate-missing"
+    printf '  FAIL `if ! setup_completed` gate missing from install.sh\n' >&2
 fi
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two related fixes to the `aimx setup` first-run experience.

### 1. `install.sh`: don't halt re-runs after interrupted setup

When a user Ctrl+Cs out of `aimx setup` before its final step, `/usr/local/bin/aimx` is on disk but no systemd unit / OpenRC init script was written. Re-running `curl -fsSL https://aimx.email/install.sh | sh` then hit the upgrade branch and bailed fatally on `systemctl start aimx` ("Unit aimx.service not found"), trapping the operator — every re-run rolled itself back.

A new `setup_completed` helper probes `/etc/systemd/system/aimx.service` and `/etc/init.d/aimx` (overridable via `AIMX_SETUP_COMPLETED_SYSTEMD` / `AIMX_SETUP_COMPLETED_OPENRC` for tests). The upgrade-vs-fresh decision is gated on it: if neither unit is on disk the script falls through to the existing fresh-install path, which re-lays the binary at the target tag and `exec`s `aimx setup` cleanly. Genuine upgrades (unit installed, version diff) are unchanged.

Before:
```
install: starting aimx.service (systemd)
Failed to start aimx.service: Unit aimx.service not found.
install: ✗ service start failed; rolling back
install: error: upgrade failed at start step; service restored if possible
```

After:
```
install: binary present but aimx setup did not complete (no service unit); continuing setup
install: dry-run: would exec 'sudo aimx setup' (binary owns wizard)
```

### 2. `aimx setup` closing handoff is clearer

- Promotes the `🐦‍⬛ AIMX setup — complete` banner so it sits between Step 5 and the Step 6 handoff, and drops the second checklist underneath it (the post-Step-5 checklist already shows the same state).
- Replaces the single-line `→ aimx agents setup` callout with a boxed callout under a sentence telling the operator to run the agents guided setup as a regular user (not root). Box geometry is locked in by an equal-width assertion across top border / body row / bottom border, and the body row hard-codes `→` so the borders stay aligned under `NO_COLOR` / non-TTY where `prompt_mark` would otherwise widen to `[>]`.
- Rewrites the closing capability line. Previously it claimed agents had access to email; at this point the daemon is up but no agent is wired yet. New wording: "AIMX is now running at @&lt;domain&gt; and ready to send and receive email." followed by "Once you've wired your MCP to your LLM, try asking your agent, e.g.".
- Prefixes "AIMX has been set up successfully." with the same green ☑ glyph the checklist uses, so it reads as the final box checked.

Rendered (TTY, `sg.aimx.click` example domain):

```
✓ Step 5 complete.

  ☑ Preflight checks on port 25
  ☑ Set up domain and DNS
  ☑ Set up TLS certificate
  ☑ Set up trust policy
  ☑ Install AIMX
  ☐ Set up MCP for agent(s)


🐦‍⬛ AIMX setup — complete


Step 6: Set up MCP for agent(s)

AIMX bundles MCP and skill files for the following AI agents & harnesses:

  • Claude Code
  • Codex CLI
  • OpenCode
  • Gemini CLI
  • Goose
  • OpenClaw
  • Hermes
  • NanoClaw

To wire AIMX into the harness you have installed, run the agents guided setup as a regular user (not root):

  ┌─────────────────────────────┐
  │  → aimx agents setup        │
  └─────────────────────────────┘


☑ AIMX has been set up successfully.

AIMX is now running at @sg.aimx.click and ready to send and receive email.

Once you've wired your MCP to your LLM, try asking your agent, e.g.
  claude -p "Set up agent@sg.aimx.click and respond to me via email the moment you receive my instructions via email."
```

## Test plan

### `install.sh`
- [x] `sh -n install.sh`
- [x] `shellcheck install.sh`
- [x] `shellcheck -s sh tests/install_sh.sh`
- [x] `sh tests/install_sh.sh` — 114/114 pass (4 new assertions in the `# setup_completed gate` section).
- [x] Dry-run smoke: `AIMX_DRY_RUN=1 AIMX_SETUP_COMPLETED_SYSTEMD=/nonexistent AIMX_SETUP_COMPLETED_OPENRC=/nonexistent sh install.sh --tag 0.0.9.1` prints "continuing setup" + fresh-install dry-run lines.
- [x] Dry-run smoke (regression): with the systemd unit file present, `sh install.sh --tag 99.99.99` still prints `upgrading X -> 99.99.99` / `would stop aimx.service, swap binary, restart (upgrade)`.
- [ ] End-to-end on a throwaway VPS: fresh box → install → Ctrl+C at "domain" prompt → re-run installer and confirm wizard re-enters without a `systemctl start` failure.

### `aimx setup` closing handoff
- [x] `cargo test` — 1149 unit + 116 integration tests pass.
- [x] `cargo clippy -- -D warnings` clean.
- [x] `cargo fmt -- --check` clean.
- [x] Targeted tests: `mcp_section_lines_are_in_documented_order`, `mcp_section_recommends_running_aimx_agents_setup`, `mcp_section_lists_every_registered_agent`, `final_banner_signals_completion`, `closing_message_carries_required_phrasing`, `closing_message_does_not_overclaim_agent_capability`, `run_setup_step_six_uses_handoff_state`, `run_setup_emits_section_headers_in_spec_order`.
- [ ] Visual smoke on a TTY: confirm the banner sits between Step 5 and Step 6, the box renders, and the closing block reads as accurate (daemon running, agents still need wiring).
- [ ] `NO_COLOR=1` smoke: confirm the box borders stay aligned (the body row uses literal `→`, not `prompt_mark`'s `[>]` fallback).
