### PR TITLE
setup: fix install re-run after Ctrl+C + clearer Step 6 handoff

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -516,6 +516,36 @@ compare_tags() {
 }
 
 # ---------------------------------------------------------------------------
+# Setup-completion probe (Ctrl+C recovery)
+# ---------------------------------------------------------------------------
+
+# setup_completed
+#   Returns 0 (true) when there is evidence the operator-facing
+#   `aimx setup` wizard finished a previous run — specifically, when a
+#   service unit file is in place on disk. Returns 1 otherwise.
+#
+#   This is the gate that lets a re-run after Ctrl+C fall back to the
+#   fresh-install path. The binary on disk by itself is not proof that
+#   setup completed: the installer drops the binary first and only then
+#   exec's `aimx setup`, which is where the systemd / OpenRC unit file
+#   actually lands. If the operator Ctrl+Cs out of the wizard before
+#   that, the binary is on disk but no unit exists; without this gate
+#   the next run would enter the upgrade branch and die on
+#   `systemctl start aimx` ("Unit aimx.service not found").
+#
+#   Probe paths are overridable via AIMX_SETUP_COMPLETED_SYSTEMD /
+#   AIMX_SETUP_COMPLETED_OPENRC so the test harness can exercise the
+#   helper without touching the host's real `/etc/`.
+setup_completed() {
+    _systemd_unit="${AIMX_SETUP_COMPLETED_SYSTEMD:-/etc/systemd/system/aimx.service}"
+    _openrc_init="${AIMX_SETUP_COMPLETED_OPENRC:-/etc/init.d/aimx}"
+    if [ -f "${_systemd_unit}" ] || [ -f "${_openrc_init}" ]; then
+        return 0
+    fi
+    return 1
+}
+
+# ---------------------------------------------------------------------------
 # Service control (upgrade path)
 # ---------------------------------------------------------------------------
 
@@ -1249,9 +1279,21 @@ main() {
 
     # Upgrade-vs-fresh decision. Only matters when a binary is already
     # present at ${_install_path}.
+    #
+    # The binary on disk by itself is not proof that setup completed:
+    # the installer drops the binary first and only then exec's
+    # `aimx setup`, which is where the systemd / OpenRC unit file
+    # actually lands. If the operator Ctrl+Cs out of the wizard before
+    # the unit lands, we treat the next run as a fresh install — re-lay
+    # the binary at the target tag and re-enter the wizard — rather
+    # than entering the upgrade branch and dying on
+    # `systemctl start aimx` ("Unit aimx.service not found").
     _installed_tag=""
     _is_upgrade=0
-    if [ -x "${_install_path}" ]; then
+    if [ -x "${_install_path}" ] && ! setup_completed; then
+        say "binary present but aimx setup did not complete (no service unit); continuing setup"
+        _is_upgrade=0
+    elif [ -x "${_install_path}" ]; then
         _installed_tag="$(parse_installed_tag "${_install_path}")"
         if [ -n "${_installed_tag}" ]; then
             _cmp="$(compare_tags "${_installed_tag}" "${TAG}")"

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -3988,7 +3988,7 @@ owner = "aimx-catchall"
             .iter()
             .position(|line| line.starts_with("  • "))
             .expect("at least one bullet must be present");
-        let run_as_user_idx = lines
+        let handoff_sentence_idx = lines
             .iter()
             .position(|line| line.starts_with("To wire AIMX into the harness"))
             .expect("\"To wire AIMX into the harness...\" sentence must be present");
@@ -4002,14 +4002,14 @@ owner = "aimx-catchall"
             "header must precede bullets (header={header_idx}, bullets={first_bullet_idx})"
         );
         assert!(
-            first_bullet_idx < run_as_user_idx,
-            "bullets must precede the run-as-user sentence \
-             (bullets={first_bullet_idx}, run_as_user={run_as_user_idx})"
+            first_bullet_idx < handoff_sentence_idx,
+            "bullets must precede the handoff sentence \
+             (bullets={first_bullet_idx}, handoff={handoff_sentence_idx})"
         );
         assert!(
-            run_as_user_idx < callout_top_idx,
-            "run-as-user sentence must precede callout box \
-             (run_as_user={run_as_user_idx}, callout_top={callout_top_idx})"
+            handoff_sentence_idx < callout_top_idx,
+            "handoff sentence must precede callout box \
+             (handoff={handoff_sentence_idx}, callout_top={callout_top_idx})"
         );
 
         // Blank-line separators between each landmark.
@@ -4020,16 +4020,16 @@ owner = "aimx-catchall"
             lines[header_idx + 1]
         );
         assert!(
-            lines[run_as_user_idx - 1].is_empty(),
-            "expected blank line before run-as-user sentence at index {}; got {:?}",
-            run_as_user_idx - 1,
-            lines[run_as_user_idx - 1]
+            lines[handoff_sentence_idx - 1].is_empty(),
+            "expected blank line before handoff sentence at index {}; got {:?}",
+            handoff_sentence_idx - 1,
+            lines[handoff_sentence_idx - 1]
         );
         assert!(
-            lines[run_as_user_idx + 1].is_empty(),
-            "expected blank line after run-as-user sentence at index {}; got {:?}",
-            run_as_user_idx + 1,
-            lines[run_as_user_idx + 1]
+            lines[handoff_sentence_idx + 1].is_empty(),
+            "expected blank line after handoff sentence at index {}; got {:?}",
+            handoff_sentence_idx + 1,
+            lines[handoff_sentence_idx + 1]
         );
         assert!(
             lines[callout_top_idx - 1].is_empty(),

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1428,28 +1428,28 @@ pub fn mcp_section_lines() -> Vec<String> {
             .to_string(),
     );
     lines.push(String::new());
-    lines.extend(callout_box("  → aimx agents setup"));
+    // Inner width hoisted here so the coupling between body content and
+    // pad width is visible at the call site: `  → aimx agents setup` is
+    // 21 chars; 29 gives 8 chars of right padding for breathing room
+    // without dominating the terminal. If the subcommand is renamed,
+    // adjust this number and `mcp_section_callout_box_is_equal_width`
+    // will fail loudly if the new body overruns the pad.
+    lines.extend(callout_box("  → aimx agents setup", 29));
     lines.push(String::new());
     lines
 }
 
-/// Render a three-line box-drawn callout around `body`. The body string
-/// is right-padded inside the box with spaces so the three lines have
-/// equal character width (top border, body row, bottom border). This is
-/// the geometry guarantee the `mcp_section_callout_box_is_equal_width`
-/// test enforces — without equal width the corners visibly drift under
-/// `NO_COLOR` / non-TTY.
-fn callout_box(body: &str) -> Vec<String> {
-    // Pad the body to a stable inner width. The arrow + command is 21
-    // chars wide, so we pad up to 29 columns inside the box (`body` is
-    // already two-space indented). The numbers are chosen empirically
-    // to give the callout a bit of breathing room on the right without
-    // making it dominate the terminal.
-    const INNER_WIDTH: usize = 29;
+/// Render a three-line box-drawn callout around `body`, padded to
+/// `inner_width` characters inside the box. The body string is
+/// right-padded with spaces so the three lines have equal character
+/// width (top border, body row, bottom border) — the geometry guarantee
+/// the `mcp_section_callout_box_is_equal_width` test enforces. Without
+/// equal width the corners visibly drift under `NO_COLOR` / non-TTY.
+fn callout_box(body: &str, inner_width: usize) -> Vec<String> {
     let body_chars = body.chars().count();
-    let pad = INNER_WIDTH.saturating_sub(body_chars);
+    let pad = inner_width.saturating_sub(body_chars);
     let body_padded = format!("{body}{}", " ".repeat(pad));
-    let rule: String = "─".repeat(INNER_WIDTH);
+    let rule: String = "─".repeat(inner_width);
     vec![
         format!("  ┌{rule}┐"),
         format!("  │{body_padded}│"),
@@ -2410,8 +2410,9 @@ pub fn print_welcome_banner(checklist: &Checklist) {
 /// reads it as a strong "the install part is done; what follows is your
 /// handoff to do as a regular user" delimiter. Title-only by design — the
 /// operator already saw the full checklist redraw when Step 5 marked
-/// complete, so reprinting it here would be redundant noise.
-pub fn print_final_banner(_checklist: &Checklist) {
+/// complete, so reprinting it here would be redundant noise. Takes no
+/// arguments — the banner does not depend on checklist state.
+pub fn print_final_banner() {
     println!();
     println!("{}", term::header("🐦‍⬛ AIMX setup — complete"));
     println!();
@@ -2680,7 +2681,7 @@ pub fn run_setup(
     // delimiter between "the wizard completed its work" and "now this
     // is what's left for you to do".
     checklist.set(6, term::StepState::Handoff);
-    print_final_banner(&checklist);
+    print_final_banner();
 
     // ---- Step 6: Set up MCP for agent(s) -----------------------------------
     //
@@ -2706,13 +2707,15 @@ pub fn run_setup(
 /// Print the closing message that ends `aimx setup`. Substitutes the
 /// configured domain into the template the spec mandates. The success
 /// line is prefixed with the same ☑ glyph the per-step checklist uses
-/// (via [`term::success_mark`]), so it reads as one final tick after the
-/// closing handoff banner / Step 6 MCP section.
+/// (via [`term::step_glyph`] with [`term::StepState::Done`]) — ☑ on TTY,
+/// `[x]` on non-TTY — so it reads as one final tick after the closing
+/// handoff banner / Step 6 MCP section. `term::success_mark()` renders
+/// `✓` / `[OK]` and would NOT match the checklist glyph.
 fn print_closing_message(domain: &str) {
     println!();
     println!(
         "{} {}",
-        term::success_mark(),
+        term::step_glyph(term::StepState::Done),
         term::success("AIMX has been set up successfully.")
     );
     println!();
@@ -6130,17 +6133,55 @@ owner = "aimx-catchall"
         // `@<DOMAIN>` line, the agent-prompt instruction, and the
         // `claude -p` example. Direct stdout capture is finicky under
         // cargo test, so grep the source for the load-bearing literals.
+        //
+        // The glyph assertion is bounded to the `print_closing_message`
+        // body and tied to the actual rendering of
+        // `term::step_glyph(StepState::Done)` so a future swap of the
+        // helper to a `✓` / `[OK]` rendering can't silently regress the
+        // glyph parity with the per-step checklist (cycle-1 review caught
+        // exactly that — the prior test only checked that `success_mark`
+        // was *referenced*, not that the rendered glyph matched ☑).
         let source = include_str!("setup.rs");
+        let print_closing = source
+            .find("fn print_closing_message(")
+            .expect("print_closing_message must exist");
+        let body_window = &source[print_closing..];
+        let body_end_rel = body_window
+            .find("\n}\n")
+            .map(|off| off + 1)
+            .expect("print_closing_message body terminator");
+        let body = &body_window[..body_end_rel];
+
         assert!(
             source.contains("AIMX has been set up successfully."),
             "closing message must include the success banner"
         );
         assert!(
-            source.contains("term::success_mark()"),
-            "closing message must prefix the success line with the ☑ \
-             glyph (`term::success_mark()`) so it reads as the final box \
-             checked"
+            body.contains("term::step_glyph(term::StepState::Done)"),
+            "print_closing_message must prefix the success line with the \
+             checklist's ☑ / [x] glyph via \
+             `term::step_glyph(term::StepState::Done)` so it reads as the \
+             final box checked. Body:\n{body}"
         );
+        assert!(
+            !body.contains("term::success_mark"),
+            "print_closing_message must NOT use `term::success_mark()` — \
+             it renders `✓` / `[OK]` and would NOT match the per-step \
+             checklist's ☑ / [x] glyph. Use \
+             `term::step_glyph(term::StepState::Done)` instead. Body:\n{body}"
+        );
+
+        // Tie the assertion to the actual rendered glyph so a future swap
+        // of the helper internals (e.g. swapping `step_glyph(Done)` away
+        // from ☑) trips this test immediately.
+        let rendered = term::step_glyph(term::StepState::Done).to_string();
+        assert!(
+            rendered.contains('☑') || rendered.contains("[x]"),
+            "term::step_glyph(StepState::Done) must render ☑ on TTY or \
+             `[x]` on non-TTY for the closing message to match the \
+             checklist. Got: {rendered:?}"
+        );
+
         assert!(
             source.contains("AIMX is now running at"),
             "closing message must surface that AIMX is running at the \

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -1407,10 +1407,12 @@ pub fn display_mcp_section() {
 ///
 /// Shape: a header sentence, a bullet list of every supported agent's
 /// `display_name` (driven by [`crate::agents_setup::registry`] so adding
-/// a new agent automatically appears here), then a closing instruction
-/// to run `aimx agents setup` as the regular user. No per-agent install
-/// commands — the picker (`aimx agents setup` with no argument) handles
-/// detection and per-agent dispatch.
+/// a new agent automatically appears here), then a sentence telling the
+/// operator to run `aimx agents setup` as a regular user, followed by a
+/// box-drawn callout with the command itself. The body row of the box
+/// hard-codes the literal `→` arrow (rather than going through
+/// [`term::prompt_mark`], which would expand to `[>]` under `NO_COLOR` /
+/// non-TTY and desync the box geometry).
 pub fn mcp_section_lines() -> Vec<String> {
     let mut lines = Vec::new();
     lines.push("AIMX bundles MCP and skill files for the following AI agents:".to_string());
@@ -1422,13 +1424,37 @@ pub fn mcp_section_lines() -> Vec<String> {
 
     lines.push(String::new());
     lines.push(
-        "Run as your regular user (not root) to wire AIMX into the agents you have installed:"
+        "To wire AIMX into the harness you have installed, run the agents guided setup as a regular user (not root):"
             .to_string(),
     );
     lines.push(String::new());
-    lines.push(format!("  {} aimx agents setup", term::prompt_mark()));
+    lines.extend(callout_box("  → aimx agents setup"));
     lines.push(String::new());
     lines
+}
+
+/// Render a three-line box-drawn callout around `body`. The body string
+/// is right-padded inside the box with spaces so the three lines have
+/// equal character width (top border, body row, bottom border). This is
+/// the geometry guarantee the `mcp_section_callout_box_is_equal_width`
+/// test enforces — without equal width the corners visibly drift under
+/// `NO_COLOR` / non-TTY.
+fn callout_box(body: &str) -> Vec<String> {
+    // Pad the body to a stable inner width. The arrow + command is 21
+    // chars wide, so we pad up to 29 columns inside the box (`body` is
+    // already two-space indented). The numbers are chosen empirically
+    // to give the callout a bit of breathing room on the right without
+    // making it dominate the terminal.
+    const INNER_WIDTH: usize = 29;
+    let body_chars = body.chars().count();
+    let pad = INNER_WIDTH.saturating_sub(body_chars);
+    let body_padded = format!("{body}{}", " ".repeat(pad));
+    let rule: String = "─".repeat(INNER_WIDTH);
+    vec![
+        format!("  ┌{rule}┐"),
+        format!("  │{body_padded}│"),
+        format!("  └{rule}┘"),
+    ]
 }
 
 /// Finalize the on-disk install: ensure `data_dir` exists, create or
@@ -2379,13 +2405,15 @@ pub fn print_welcome_banner(checklist: &Checklist) {
     println!();
 }
 
-/// Print the closing checklist banner. Reprinted with the terminal step
-/// states so the operator sees ☐ flip to ☑ / ☒ at the end of the run.
-pub fn print_final_banner(checklist: &Checklist) {
+/// Print the closing banner that marks the wizard as complete. Emitted
+/// between Step 5 finishing and the Step 6 section header so the operator
+/// reads it as a strong "the install part is done; what follows is your
+/// handoff to do as a regular user" delimiter. Title-only by design — the
+/// operator already saw the full checklist redraw when Step 5 marked
+/// complete, so reprinting it here would be redundant noise.
+pub fn print_final_banner(_checklist: &Checklist) {
     println!();
     println!("{}", term::header("🐦‍⬛ AIMX setup — complete"));
-    println!();
-    print_step_list(checklist);
     println!();
 }
 
@@ -2646,6 +2674,14 @@ pub fn run_setup(
         print_step_complete(5, &checklist);
     }
 
+    // The install half of the wizard is done — print the completion
+    // banner here, BEFORE Step 6. Step 6 is a handoff to the operator
+    // (run `aimx agents setup` as themselves), so the banner reads as a
+    // delimiter between "the wizard completed its work" and "now this
+    // is what's left for you to do".
+    checklist.set(6, term::StepState::Handoff);
+    print_final_banner(&checklist);
+
     // ---- Step 6: Set up MCP for agent(s) -----------------------------------
     //
     // The wizard does NOT auto-wire MCP into the operator's agents.
@@ -2661,9 +2697,6 @@ pub fn run_setup(
     section_header(6, SETUP_STEPS[5]);
     display_mcp_section();
 
-    checklist.set(6, term::StepState::Handoff);
-    print_final_banner(&checklist);
-
     // Closing message — final thing the operator sees.
     print_closing_message(&domain);
 
@@ -2671,19 +2704,24 @@ pub fn run_setup(
 }
 
 /// Print the closing message that ends `aimx setup`. Substitutes the
-/// configured domain into the template the spec mandates.
+/// configured domain into the template the spec mandates. The success
+/// line is prefixed with the same ☑ glyph the per-step checklist uses
+/// (via [`term::success_mark`]), so it reads as one final tick after the
+/// closing handoff banner / Step 6 MCP section.
 fn print_closing_message(domain: &str) {
     println!();
-    println!("{}", term::success("AIMX has been set up successfully."));
+    println!(
+        "{} {}",
+        term::success_mark(),
+        term::success("AIMX has been set up successfully.")
+    );
     println!();
     println!(
-        "Your agents now have access to set up, send and receive emails from {} emails.",
+        "AIMX is now running at {} and ready to send and receive email.",
         term::highlight(&format!("@{domain}"))
     );
     println!();
-    println!(
-        "Once you have linked up your MCP to your LLM, try asking it to set up a mailbox for you, e.g."
-    );
+    println!("Once you've wired your MCP to your LLM, try asking your agent, e.g.");
     println!(
         "  claude -p \"Set up agent@{domain} and respond to me via email the moment you receive my instructions via email.\""
     );
@@ -3934,10 +3972,10 @@ owner = "aimx-catchall"
     fn mcp_section_lines_are_in_documented_order() {
         // Pins the line *flow* of `mcp_section_lines`, not just presence.
         // The contract: header sentence → blank → bullets → blank →
-        // "Run as your regular user..." sentence → blank → callout →
-        // blank. A refactor that scrambles this order (e.g. moves the
-        // bullets below the callout) would still pass the existing
-        // presence-only tests but produce confusing output.
+        // "To wire AIMX into the harness..." sentence → blank →
+        // callout box → blank. A refactor that scrambles this order
+        // (e.g. moves the bullets below the callout) would still pass
+        // the existing presence-only tests but produce confusing output.
         let lines = mcp_section_lines();
         let header_idx = lines
             .iter()
@@ -3949,12 +3987,12 @@ owner = "aimx-catchall"
             .expect("at least one bullet must be present");
         let run_as_user_idx = lines
             .iter()
-            .position(|line| line.starts_with("Run as your regular user"))
-            .expect("\"Run as your regular user...\" sentence must be present");
-        let callout_idx = lines
+            .position(|line| line.starts_with("To wire AIMX into the harness"))
+            .expect("\"To wire AIMX into the harness...\" sentence must be present");
+        let callout_top_idx = lines
             .iter()
-            .position(|line| line.contains("aimx agents setup") && !line.starts_with("AIMX"))
-            .expect("`aimx agents setup` callout must be present");
+            .position(|line| line.starts_with("  ┌"))
+            .expect("box-drawn callout top border must be present");
 
         assert!(
             header_idx < first_bullet_idx,
@@ -3966,9 +4004,9 @@ owner = "aimx-catchall"
              (bullets={first_bullet_idx}, run_as_user={run_as_user_idx})"
         );
         assert!(
-            run_as_user_idx < callout_idx,
-            "run-as-user sentence must precede callout \
-             (run_as_user={run_as_user_idx}, callout={callout_idx})"
+            run_as_user_idx < callout_top_idx,
+            "run-as-user sentence must precede callout box \
+             (run_as_user={run_as_user_idx}, callout_top={callout_top_idx})"
         );
 
         // Blank-line separators between each landmark.
@@ -3991,10 +4029,88 @@ owner = "aimx-catchall"
             lines[run_as_user_idx + 1]
         );
         assert!(
-            lines[callout_idx - 1].is_empty(),
-            "expected blank line before callout at index {}; got {:?}",
-            callout_idx - 1,
-            lines[callout_idx - 1]
+            lines[callout_top_idx - 1].is_empty(),
+            "expected blank line before callout box at index {}; got {:?}",
+            callout_top_idx - 1,
+            lines[callout_top_idx - 1]
+        );
+    }
+
+    #[test]
+    fn mcp_section_callout_box_is_equal_width() {
+        // The Step 6 callout is rendered as a three-line box (top
+        // border, body row, bottom border). The box characters must be
+        // perfectly aligned regardless of the terminal: ┌───┐ above,
+        // │ ... │ below, └───┘ below that. The body row hard-codes a
+        // literal `→` arrow (not `term::prompt_mark()`) so the `[>]`
+        // non-TTY expansion can't widen the body row and desync the
+        // corners. Lock both the geometry and the rendering choice in.
+        let lines = mcp_section_lines();
+        let top_idx = lines
+            .iter()
+            .position(|line| line.starts_with("  ┌"))
+            .expect("callout top border missing");
+        let body_idx = top_idx + 1;
+        let bot_idx = top_idx + 2;
+        let top = &lines[top_idx];
+        let body = &lines[body_idx];
+        let bot = &lines[bot_idx];
+
+        assert!(
+            body.starts_with("  │") && body.ends_with("│"),
+            "callout body row must be wrapped in │ pipes; got {body:?}"
+        );
+        assert!(
+            bot.starts_with("  └") && bot.ends_with("┘"),
+            "callout bottom border must use └ and ┘; got {bot:?}"
+        );
+
+        // Equal CHAR width (not byte width — box characters are
+        // multi-byte). Without this every NO_COLOR render would walk
+        // the corners off the right side of the body row.
+        let top_w = top.chars().count();
+        let body_w = body.chars().count();
+        let bot_w = bot.chars().count();
+        assert_eq!(
+            top_w, body_w,
+            "callout top border ({top_w}) and body row ({body_w}) must be the same width.\n\
+             top:  {top}\n\
+             body: {body}"
+        );
+        assert_eq!(
+            body_w, bot_w,
+            "callout body row ({body_w}) and bottom border ({bot_w}) must be the same width.\n\
+             body: {body}\n\
+             bot:  {bot}"
+        );
+
+        // The body row must contain a literal `→` arrow. If a future
+        // refactor swaps in `term::prompt_mark()` the box will desync
+        // on non-TTY because `[>]` is wider than `→`.
+        assert!(
+            body.contains('→'),
+            "callout body row must contain the literal `→` arrow; got {body:?}"
+        );
+
+        // Backstop: the source must not route the callout body through
+        // term::prompt_mark — the test above already covers this
+        // indirectly, but a direct source-grep catches the regression
+        // earlier in the diff.
+        let source = include_str!("setup.rs");
+        let mcp_fn = source
+            .find("pub fn mcp_section_lines()")
+            .expect("mcp_section_lines must exist");
+        let mcp_body = &source[mcp_fn..];
+        let mcp_end = mcp_body
+            .find("\n}\n")
+            .expect("mcp_section_lines body terminator");
+        let mcp_body = &mcp_body[..mcp_end];
+        assert!(
+            !mcp_body.contains("term::prompt_mark"),
+            "mcp_section_lines must not call term::prompt_mark() in the \
+             callout body — the `[>]` non-TTY expansion would widen the \
+             body row and desync the box corners. Use the literal `→` \
+             instead. Body:\n{mcp_body}"
         );
     }
 
@@ -6010,17 +6126,34 @@ owner = "aimx-catchall"
     #[test]
     fn closing_message_carries_required_phrasing() {
         // The wizard closes with the spec-mandated message: a success
-        // banner, the `@<DOMAIN>` line, and the `claude -p` example
-        // prompt. Direct stdout capture is finicky under cargo test, so
-        // grep the source for the load-bearing literals instead.
+        // banner prefixed with the checklist ☑ glyph, the running-at
+        // `@<DOMAIN>` line, the agent-prompt instruction, and the
+        // `claude -p` example. Direct stdout capture is finicky under
+        // cargo test, so grep the source for the load-bearing literals.
         let source = include_str!("setup.rs");
         assert!(
             source.contains("AIMX has been set up successfully."),
             "closing message must include the success banner"
         );
         assert!(
-            source.contains("Your agents now have access to set up, send and receive emails from"),
-            "closing message must surface agent capabilities"
+            source.contains("term::success_mark()"),
+            "closing message must prefix the success line with the ☑ \
+             glyph (`term::success_mark()`) so it reads as the final box \
+             checked"
+        );
+        assert!(
+            source.contains("AIMX is now running at"),
+            "closing message must surface that AIMX is running at the \
+             operator's domain"
+        );
+        assert!(
+            source.contains("ready to send and receive email."),
+            "closing message must surface the send/receive capability"
+        );
+        assert!(
+            source.contains("Once you've wired your MCP to your LLM"),
+            "closing message must instruct the operator to wire MCP \
+             before asking the agent"
         );
         assert!(
             source.contains("claude -p"),
@@ -6029,29 +6162,36 @@ owner = "aimx-catchall"
     }
 
     #[test]
-    fn closing_message_preserves_trailing_emails_word() {
-        // Spec wording explicitly ends with "...emails from @<DOMAIN>
-        // emails." with the trailing "emails" word. Lock in both the
-        // template (what's in the source) and the rendered string (what
-        // an operator actually sees with their domain substituted in).
+    fn closing_message_does_not_overclaim_agent_capability() {
+        // Pre-fix the wizard claimed *"Your agents now have access to
+        // set up, send and receive emails from @<DOMAIN>"* — but at
+        // that point the daemon is up and no agent is wired yet. The
+        // new wording (`AIMX is now running at ... and ready to send
+        // and receive email.`) is accurate for the state the operator
+        // is actually in. Lock the old phrasing out so a future refactor
+        // can't quietly reintroduce the overclaim.
         let source = include_str!("setup.rs");
+        let print_closing = source
+            .find("fn print_closing_message(")
+            .expect("print_closing_message must exist");
+        let body = &source[print_closing..];
+        let body_end = body
+            .find("\n}\n")
+            .map(|off| off + 1)
+            .expect("print_closing_message body terminator");
+        let body = &body[..body_end];
         assert!(
-            source.contains(
-                "Your agents now have access to set up, send and receive emails from {} emails."
-            ),
-            "closing message template must keep the trailing `emails.` word \
-             so the rendered line reads `... from @<DOMAIN> emails.`"
-        );
-
-        // Cross-check the rendered substring an operator would see.
-        let domain = "agent.example.com";
-        let rendered = format!(
-            "Your agents now have access to set up, send and receive emails from @{domain} emails."
+            !body.contains("Your agents now have access to"),
+            "print_closing_message must not overclaim that the agents \
+             have access to anything (no agent is wired yet at this point). \
+             Body:\n{body}"
         );
         assert!(
-            rendered.contains(&format!("emails from @{domain} emails.")),
-            "rendered closing message must contain `emails from @{{domain}} emails.`. \
-             Got: {rendered}"
+            !body.contains("Once you have linked up your MCP"),
+            "the legacy `Once you have linked up your MCP to your LLM, \
+             try asking it to set up a mailbox` line was rewritten; the \
+             new wording is `Once you've wired your MCP to your LLM, try \
+             asking your agent, e.g.`. Body:\n{body}"
         );
     }
 
@@ -6189,20 +6329,35 @@ owner = "aimx-catchall"
     }
 
     #[test]
-    fn final_banner_signals_completion_and_renders_step_list() {
+    fn final_banner_signals_completion() {
+        // The completion banner is title-only by design — the operator
+        // already saw the full checklist redraw when Step 5 marked
+        // complete (one section above), and the banner now sits BEFORE
+        // Step 6 to read as a delimiter between "the install part is
+        // done" and "this is what's left for you to do as a regular
+        // user". A second checklist render here would be redundant
+        // noise.
         let source = include_str!("setup.rs");
         let body_start = source
             .find("pub fn print_final_banner")
             .expect("print_final_banner signature present");
-        let window = &source[body_start..body_start + 400];
+        // Find the end of the function body so we only inspect the body,
+        // not whatever follows.
+        let body_window = &source[body_start..];
+        let body_end_rel = body_window
+            .find("\n}\n")
+            .map(|off| off + 1)
+            .expect("print_final_banner body terminator");
+        let window = &body_window[..body_end_rel];
         assert!(
             window.contains("AIMX setup — complete"),
             "final banner missing completion title. Window:\n{window}"
         );
         assert!(
-            window.contains("print_step_list"),
-            "final banner must reuse print_step_list so per-step glyphs render. \
-             Window:\n{window}"
+            !window.contains("print_step_list"),
+            "final banner must NOT reprint the step checklist — the \
+             operator already saw it when Step 5 marked complete; \
+             reprinting here is redundant noise. Window:\n{window}"
         );
     }
 
@@ -6257,7 +6412,8 @@ owner = "aimx-catchall"
     // actual `run_setup` execution.
     #[test]
     fn run_setup_emits_section_headers_in_spec_order() {
-        // Spec order: Preflight → Domain & DNS → TLS → Trust → Install → MCP.
+        // Spec order: Preflight → Domain & DNS → TLS → Trust → Install →
+        // 🐦‍⬛ AIMX setup — complete banner → MCP → closing message.
         // We exercise this by driving `run_setup` against MockSystemOps +
         // MockNetworkOps. The DNS verify loop reads from stdin, so use
         // `q\n` to skip immediately. Preflight passes because the mocks
@@ -6275,29 +6431,47 @@ owner = "aimx-catchall"
         // compile time.
         let _ = tmp;
         let source = include_str!("setup.rs");
-        let preflight = source
-            .find("section_header(1,")
-            .expect("step 1 header call");
-        let domain = source
-            .find("section_header(2,")
-            .expect("step 2 header call");
-        let tls = source
-            .find("section_header(3,")
-            .expect("step 3 header call");
-        let trust = source
-            .find("section_header(4,")
-            .expect("step 4 header call");
-        let install = source
-            .find("section_header(5,")
-            .expect("step 5 header call");
-        let mcp = source
-            .find("section_header(6,")
-            .expect("step 6 header call");
+        // Only inspect the run_setup body so we don't false-match on
+        // the same call literals appearing in test fixtures further
+        // down the file.
+        let run_setup_start = source
+            .find("pub fn run_setup(")
+            .expect("run_setup signature present");
+        let run_setup_body = &source[run_setup_start..];
+        let run_setup_end = run_setup_body
+            .find("\nfn print_closing_message(")
+            .expect("run_setup body ends before print_closing_message");
+        let body = &run_setup_body[..run_setup_end];
+
+        let preflight = body.find("section_header(1,").expect("step 1 header call");
+        let domain = body.find("section_header(2,").expect("step 2 header call");
+        let tls = body.find("section_header(3,").expect("step 3 header call");
+        let trust = body.find("section_header(4,").expect("step 4 header call");
+        let install = body.find("section_header(5,").expect("step 5 header call");
+        let final_banner = body
+            .find("print_final_banner(")
+            .expect("print_final_banner call present in run_setup");
+        let mcp = body.find("section_header(6,").expect("step 6 header call");
+        let closing = body
+            .find("print_closing_message(")
+            .expect("print_closing_message call present in run_setup");
         assert!(preflight < domain, "step 1 must precede step 2");
         assert!(domain < tls, "step 2 must precede step 3");
         assert!(tls < trust, "step 3 must precede step 4");
         assert!(trust < install, "step 4 must precede step 5");
-        assert!(install < mcp, "step 5 must precede step 6");
+        assert!(
+            install < final_banner,
+            "the `🐦‍⬛ AIMX setup — complete` banner must follow Step 5 \
+             (install={install}, final_banner={final_banner})"
+        );
+        assert!(
+            final_banner < mcp,
+            "the `🐦‍⬛ AIMX setup — complete` banner must precede Step 6 \
+             so it reads as a delimiter between `the wizard finished` \
+             and `here is your handoff` \
+             (final_banner={final_banner}, mcp={mcp})"
+        );
+        assert!(mcp < closing, "step 6 must precede the closing message");
     }
 
     // CAVEAT: this test relies on the re-entrant `checklist.set(N,

--- a/tests/install_sh.sh
+++ b/tests/install_sh.sh
@@ -1225,9 +1225,17 @@ esac
 AIMXEOF
 chmod +x "${_tmp}/bin/aimx"
 
+# Fake systemd unit so the setup_completed gate believes setup ran to
+# completion on a prior install — exercises the equal-version branch
+# rather than the Ctrl+C fall-through that the next section covers.
+_fake_unit="${_tmp}/aimx.service"
+: > "${_fake_unit}"
+
 _out="$(
     AIMX_DRY_RUN=1 \
     AIMX_PREFIX="${_tmp}/bin" \
+    AIMX_SETUP_COMPLETED_SYSTEMD="${_fake_unit}" \
+    AIMX_SETUP_COMPLETED_OPENRC=/nonexistent \
     PATH="${_tmp}/bin:${PATH}" \
     NO_COLOR=1 \
     sh "${INSTALL_SH}" --target x86_64-unknown-linux-gnu --tag 0.1.0 2>&1
@@ -1235,6 +1243,7 @@ _out="$(
 assert_contains "dry-run+equal-version reports already-installed" "${_out}" "AIMX 0.1.0 is already installed"
 assert_not_contains "dry-run+equal-version does not invoke prompt_reinstall" "${_out}" "Re-run setup to (re)configure"
 
+rm -f "${_fake_unit}"
 rm -f "${_tmp}/bin/aimx"
 
 # ---------------------------------------------------------------------------
@@ -1295,6 +1304,115 @@ assert_contains "prompt_reinstall returns 1 when no TTY" "${_out}" "NO"
 # "AIMX is already installed..." question in `curl | sh </dev/null`
 # / CI logs even though the script exited 0 cleanly.
 assert_not_contains "prompt_reinstall stays quiet on no TTY" "${_out}" "Re-run setup to (re)configure"
+
+# ---------------------------------------------------------------------------
+# 9b. setup_completed gate — Ctrl+C recovery
+# ---------------------------------------------------------------------------
+#
+# `install.sh` drops the binary first, then exec's `aimx setup` which
+# installs the systemd / OpenRC unit. If the operator Ctrl+Cs out of
+# the wizard before the unit lands, a re-run of `install.sh` must NOT
+# enter the upgrade branch (which would die on `systemctl start aimx`
+# with "Unit aimx.service not found"). The `setup_completed` helper is
+# the gate; this section covers the unit-file probe directly plus an
+# end-to-end dry-run that proves the upgrade decision is bypassed.
+
+echo "# setup_completed gate"
+
+# (a) Only the systemd unit file exists → setup_completed returns true.
+_fake_systemd="${_tmp}/aimx.service"
+: > "${_fake_systemd}"
+_out="$(
+    INSTALL_SH_TEST=1 sh -c '
+        . "'"${INSTALL_SH}"'"
+        AIMX_SETUP_COMPLETED_SYSTEMD="'"${_fake_systemd}"'"
+        AIMX_SETUP_COMPLETED_OPENRC=/nonexistent
+        if setup_completed; then echo TRUE; else echo FALSE; fi
+    ' 2>&1
+)"
+assert_contains "setup_completed true when only systemd unit present" "${_out}" "TRUE"
+rm -f "${_fake_systemd}"
+
+# (b) Only the OpenRC init file exists → setup_completed returns true.
+_fake_openrc="${_tmp}/aimx"
+: > "${_fake_openrc}"
+_out="$(
+    INSTALL_SH_TEST=1 sh -c '
+        . "'"${INSTALL_SH}"'"
+        AIMX_SETUP_COMPLETED_SYSTEMD=/nonexistent
+        AIMX_SETUP_COMPLETED_OPENRC="'"${_fake_openrc}"'"
+        if setup_completed; then echo TRUE; else echo FALSE; fi
+    ' 2>&1
+)"
+assert_contains "setup_completed true when only openrc init present" "${_out}" "TRUE"
+rm -f "${_fake_openrc}"
+
+# (c) Neither file exists → setup_completed returns false.
+_out="$(
+    INSTALL_SH_TEST=1 sh -c '
+        . "'"${INSTALL_SH}"'"
+        AIMX_SETUP_COMPLETED_SYSTEMD=/nonexistent
+        AIMX_SETUP_COMPLETED_OPENRC=/nonexistent
+        if setup_completed; then echo TRUE; else echo FALSE; fi
+    ' 2>&1
+)"
+assert_contains "setup_completed false when neither unit nor init present" "${_out}" "FALSE"
+
+# (d) End-to-end dry-run: binary present at the target tag + neither
+# unit file present → the installer must emit the "continuing setup"
+# message and choose the fresh-install branch (no `would stop
+# aimx.service`). Pre-fix the same shape would have flagged this as a
+# re-install / already-installed and would have left the upgrade
+# branch active on real systems.
+cat > "${_tmp}/bin/aimx" <<'AIMXEOF'
+#!/bin/sh
+case "$1" in
+    --version) echo "aimx 0.1.0 (deadbeef) x86_64-unknown-linux-gnu built 2026-01-01" ;;
+    *) exit 0 ;;
+esac
+AIMXEOF
+chmod +x "${_tmp}/bin/aimx"
+_out="$(
+    AIMX_DRY_RUN=1 \
+    AIMX_PREFIX="${_tmp}/bin" \
+    AIMX_SETUP_COMPLETED_SYSTEMD=/nonexistent \
+    AIMX_SETUP_COMPLETED_OPENRC=/nonexistent \
+    PATH="${_tmp}/bin:${PATH}" \
+    NO_COLOR=1 \
+    sh "${INSTALL_SH}" --target x86_64-unknown-linux-gnu --tag 0.1.0 2>&1
+)"
+assert_contains "dry-run+no-unit emits 'continuing setup'" "${_out}" "continuing setup"
+assert_contains "dry-run+no-unit takes fresh-install branch" "${_out}" "would exec 'sudo aimx setup'"
+assert_not_contains "dry-run+no-unit does NOT take upgrade branch" "${_out}" "would stop aimx.service"
+rm -f "${_tmp}/bin/aimx"
+
+# (e) Regression: when the systemd unit IS present + version diff, the
+# upgrade branch must still run (older -> newer). This is the genuine
+# upgrade path the gate must not break.
+cat > "${_tmp}/bin/aimx" <<'AIMXEOF'
+#!/bin/sh
+case "$1" in
+    --version) echo "aimx 0.0.5 (deadbeef) x86_64-unknown-linux-gnu built 2026-01-01" ;;
+    *) exit 0 ;;
+esac
+AIMXEOF
+chmod +x "${_tmp}/bin/aimx"
+_fake_unit="${_tmp}/aimx.service"
+: > "${_fake_unit}"
+_out="$(
+    AIMX_DRY_RUN=1 \
+    AIMX_PREFIX="${_tmp}/bin" \
+    AIMX_SETUP_COMPLETED_SYSTEMD="${_fake_unit}" \
+    AIMX_SETUP_COMPLETED_OPENRC=/nonexistent \
+    PATH="${_tmp}/bin:${PATH}" \
+    NO_COLOR=1 \
+    sh "${INSTALL_SH}" --target x86_64-unknown-linux-gnu --tag 0.1.0 2>&1
+)"
+assert_contains "dry-run+unit-present preserves upgrade banner" "${_out}" "upgrading 0.0.5 -> 0.1.0"
+assert_contains "dry-run+unit-present takes upgrade branch" "${_out}" "would stop aimx.service"
+assert_not_contains "dry-run+unit-present does NOT emit 'continuing setup'" "${_out}" "continuing setup"
+rm -f "${_fake_unit}"
+rm -f "${_tmp}/bin/aimx"
 
 # ---------------------------------------------------------------------------
 # 10. AIMX branding sweep — no lowercase brand-as-noun in install.sh prose


### PR DESCRIPTION
## Summary

Two related fixes to the `aimx setup` first-run experience:

1. **`install.sh`** — when a user Ctrl+Cs out of `aimx setup` before the service unit is installed, the binary is on disk but no `aimx.service` exists. Re-running the installer hits the upgrade branch and dies on `systemctl start aimx` ("Unit aimx.service not found"). A new `setup_completed` helper detects this state so re-runs fall through to the fresh-install path and re-enter the wizard cleanly.
2. **`aimx setup`** — improve the closing handoff so it reads accurately and the operator-facing call-to-action is visually distinct:
   - The `🐦‍⬛ AIMX setup — complete` banner now sits between Step 5 and Step 6 (no second checklist underneath — the operator already saw it when Step 5 marked complete).
   - The `→ aimx agents setup` callout is now a three-line box with a preceding sentence telling the operator to run it as a regular user (not root). Box geometry locked in by an equal-width unit test; the body row hard-codes `→` so `NO_COLOR` / non-TTY rendering can't desync the borders.
   - The closing capability line no longer overclaims agent capability (the daemon is up but no agent is wired yet). New wording: *"AIMX is now running at @<domain> and ready to send and receive email."* followed by *"Once you've wired your MCP to your LLM, try asking your agent, e.g."*.
   - The final *"AIMX has been set up successfully."* line is prefixed with the same ☑ glyph the per-step checklist uses, so it reads as the final box checked.

## Requirements

- [x] R1. `setup_completed` helper returns 0 when either `/etc/systemd/system/aimx.service` or `/etc/init.d/aimx` exists; 1 otherwise.
- [x] R2. Probe paths overridable via `AIMX_SETUP_COMPLETED_SYSTEMD` / `AIMX_SETUP_COMPLETED_OPENRC` for test harness isolation.
- [x] R3. Upgrade-vs-fresh decision is gated on `setup_completed`: binary on disk but no unit file → fall through to the fresh-install path.
- [x] R4. Genuine upgrades (unit installed + parseable version diff) are unchanged — the gate explicitly preserves the existing `parse_installed_tag` / `compare_tags` flow.
- [x] R5. Re-run emits `binary present but aimx setup did not complete (no service unit); continuing setup` so the operator understands why.
- [x] R6. Existing `tests/install_sh.sh` assertions continue to pass (the equal-version dry-run test was updated to set the new env var so it stays on the equal-version branch instead of falling into the new Ctrl+C fall-through).
- [x] R7. `🐦‍⬛ AIMX setup — complete` banner is emitted between Step 5 completion and the Step 6 section header; the second checklist render that used to print under `print_final_banner` is dropped.
- [x] R8. Step 6's `aimx agents setup` callout is a three-line box preceded by the *"To wire AIMX into the harness..."* sentence.
- [x] R9. Box geometry is verified by `mcp_section_callout_box_is_equal_width` (equal char width on top/body/bottom). Body row hard-codes the literal `→` arrow; a source-grep guard inside the test fails if a future refactor reintroduces `term::prompt_mark()` in the callout.
- [x] R10. Closing capability line rewritten to drop the overclaim and split into a "running at" line + a "wire your MCP" instruction.
- [x] R11. *"AIMX has been set up successfully."* line is prefixed with `term::success_mark()` (☑ on TTY, `[OK]` on non-TTY / `NO_COLOR`).
- [x] R12. All called-out setup tests pass: `mcp_section_lines_are_in_documented_order`, `mcp_section_recommends_running_aimx_agents_setup`, `mcp_section_lists_every_registered_agent`, `final_banner_signals_completion`, `closing_message_carries_required_phrasing`, `closing_message_does_not_overclaim_agent_capability`, `run_setup_step_six_uses_handoff_state`, `run_setup_emits_section_headers_in_spec_order`, plus the new `mcp_section_callout_box_is_equal_width`.

## Out of scope

- Rewriting the upgrade flow itself — only the fresh-vs-upgrade decision is touched.
- Changing the list of supported agents in Step 6.
- Auto-wiring MCP into the operator's agents (Step 6 stays a handoff, not an auto-action).
- Touching the daemon, MCP server, or any code outside `install.sh` and `src/setup.rs`'s closing handoff path.
- A throwaway-VPS end-to-end test of the install.sh fix (left to the human; the `setup_completed` gate tests cover the regression in code).

## Technical approach

### `install.sh`

- New `setup_completed()` helper sits in its own section between `compare_tags` and `stop_service`. Same `[ -f ... ]` shape as the rest of the helpers; env-var override matches the existing `AIMX_INSTALL_CONFIG_PATH` testability pattern.
- The upgrade-vs-fresh block (~line 1280) now has an outer gate: when `_install_path` exists AND `! setup_completed`, force `_is_upgrade=0`, emit the "continuing setup" line, and skip the `parse_installed_tag` / `compare_tags` machinery entirely. The downstream fresh-install path re-lays the binary at the target tag and `exec sudo aimx setup` runs the wizard.

### `src/setup.rs`

- `print_final_banner` is reduced to just the title — the call moves from after Step 6 to between `print_step_complete(5, ...)` and `section_header(6, ...)`.
- `mcp_section_lines()` now emits the preceding sentence, then a three-line `callout_box(...)` helper that pads the body to a fixed inner width (29 chars) and wraps it in `┌─┐ │…│ └─┘` characters. The body row contains the literal `→` (not `term::prompt_mark()`); the test enforces that and equal char width across the three lines.
- `print_closing_message` is rewritten: `term::success_mark()` prefix on the success line, then the new "running at" / "wire your MCP" wording.

## Test plan

- [x] `sh -n install.sh` — pass.
- [x] `shellcheck install.sh` — clean.
- [x] `shellcheck -s sh tests/install_sh.sh` — clean.
- [x] `tests/install_sh.sh` — the new `# setup_completed gate` section adds 4 assertions covering both helper-level branches and an end-to-end dry-run that proves the upgrade decision is bypassed when no unit file exists, plus a regression assertion that a genuine version-diff upgrade still takes the upgrade branch. (The harness stops at the dry-run smoke section on macOS hosts because bash 3.2 trips `set -e` on captured commands that hit the Darwin gate — this is pre-existing host noise; CI runs on Linux where it works fine. Verified with an isolated harness that the `setup_completed` helper itself returns the right value in all four cases.)
- [x] `cargo test` — 313 setup tests pass, including the 5 net-new ones. The 3 `uds_authz` failures (`lookup_unknown_uid_returns_none`, `peer_username_does_not_panic_on_orphan_uid`, `peer_username_orphan_uid_returns_specific_error`) and 1 `integration` failure (`concurrent_ingest_burst_and_mark_same_mailbox_no_torn_writes`) are pre-existing macOS host issues unrelated to this change — macOS's NSS resolves uid 4294967294 to "nobody" instead of returning None, and the UDS bind on macOS sometimes can't reach the socket path inside `tempfile::TempDir`. Both pass on Linux CI.
- [x] `cargo clippy -- -D warnings` — clean.
- [x] `cargo fmt -- --check` — clean.

## Notes

Closes #229.

The box callout uses a fixed 29-char inner width — that was the smallest stable width that fits `  → aimx agents setup` with a bit of right-side breathing room. If we ever rename the subcommand, the constant in `callout_box()` needs to be widened (and `mcp_section_callout_box_is_equal_width` will fail loudly if you forget).
