### PR TITLE
[Sprint 2] One-shot upgrade migration

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1454,7 +1454,7 @@ impl Config {
         resolved
     }
 
-    /// Path to a mailbox's inbox directory (`<data_dir>/inbox/<name>/`).
+    /// Path to a mailbox's inbox directory.
     ///
     /// The datadir splits inbound mail into `inbox/` and outbound sent
     /// copies into `sent/`. `mailbox_dir` remains a shorthand for the
@@ -1464,18 +1464,40 @@ impl Config {
         self.inbox_dir(name)
     }
 
-    /// Path to a mailbox's inbox directory (`<data_dir>/inbox/<name>/`).
+    /// Path to a mailbox's inbox directory.
+    ///
+    /// Returns `<data_dir>/<default_domain>/inbox/<name>/` when the
+    /// `.layout-version` marker is present in `data_dir` (v2 per-domain
+    /// layout, post upgrade migration), otherwise the legacy
+    /// `<data_dir>/inbox/<name>/` (single-domain v1 layout, never
+    /// migrated). A future rewire (per-domain mailbox storage helper)
+    /// replaces this branching with a single `mailbox_storage_path`
+    /// that takes the resolved mailbox directly.
     pub fn inbox_dir(&self, name: &str) -> PathBuf {
-        self.data_dir.join("inbox").join(name)
+        let root = self.storage_root_for_default_domain();
+        root.join("inbox").join(name)
     }
 
-    /// Path to a mailbox's sent directory (`<data_dir>/sent/<name>/`).
+    /// Path to a mailbox's sent directory.
     ///
-    /// Sent storage is populated by `aimx serve` on outbound delivery;
-    /// the directory is still created on `mailbox create` so the layout
-    /// is consistent from day one.
+    /// Same v1/v2 layout branching as [`Self::inbox_dir`].
     pub fn sent_dir(&self, name: &str) -> PathBuf {
-        self.data_dir.join("sent").join(name)
+        let root = self.storage_root_for_default_domain();
+        root.join("sent").join(name)
+    }
+
+    /// Resolve the active storage root for mailboxes under the default
+    /// domain. On the v2 (per-domain) layout this is
+    /// `<data_dir>/<default_domain>`; on the v1 (legacy) layout it is
+    /// `<data_dir>` itself. The layout is detected by the presence of
+    /// the `.layout-version` marker file written by the upgrade
+    /// migration.
+    pub fn storage_root_for_default_domain(&self) -> PathBuf {
+        if self.data_dir.join(".layout-version").is_file() {
+            self.data_dir.join(self.default_domain())
+        } else {
+            self.data_dir.clone()
+        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1499,6 +1499,26 @@ impl Config {
             self.data_dir.clone()
         }
     }
+
+    /// Active per-domain storage roots used by scans that enumerate
+    /// mailbox directories on disk (`discover_mailbox_names`, the
+    /// `aimx doctor` orphan-storage finding).
+    ///
+    /// On the v2 layout (the `.layout-version` marker is present) this
+    /// returns one entry per configured domain pointing at
+    /// `<data_dir>/<domain>/`. On v1 (no marker) it returns a single
+    /// entry pointing at `<data_dir>/` — the legacy single-domain
+    /// layout has no per-domain split on disk.
+    ///
+    /// Callers join `inbox/` or `sent/` onto each root and scan their
+    /// directory entries.
+    pub fn storage_roots(&self) -> Vec<PathBuf> {
+        if self.data_dir.join(".layout-version").is_file() {
+            self.domains.iter().map(|d| self.data_dir.join(d)).collect()
+        } else {
+            vec![self.data_dir.clone()]
+        }
+    }
 }
 
 /// Shared, swappable handle to the daemon's in-memory `Config`.

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -111,7 +111,18 @@ pub fn gather_status_with_ops<S: SystemOps>(
     sys: &S,
     net: &dyn NetworkOps,
 ) -> StatusInfo {
-    let dkim_key_present = crate::config::dkim_dir().join("private.key").exists();
+    // Layout-aware DKIM key probe: post-migration the private key lives
+    // at `<dkim_dir>/<default_domain>/private.key`; pre-migration (v1
+    // legacy installs or fresh `aimx setup` before the layout marker is
+    // written) it lives at the legacy `<dkim_dir>/private.key`. Using
+    // `resolve_active_dkim_dir` keeps the report aligned with the
+    // path the daemon actually signs from, so a post-migration host
+    // does not falsely report MISSING and steer the operator into
+    // `aimx dkim-keygen` on the wrong path.
+    let dkim_root_base = crate::config::dkim_dir();
+    let active_dkim_dir =
+        crate::upgrade_migration::resolve_active_dkim_dir(config, &dkim_root_base);
+    let dkim_key_present = active_dkim_dir.join("private.key").exists();
     let smtp_running = sys.is_service_running("aimx");
     let runtime_dir = crate::serve::runtime_dir();
     let stale_send_sock_present =
@@ -205,7 +216,11 @@ fn gather_dns_section(config: &Config, net: &dyn NetworkOps) -> Option<DnsSectio
         None
     };
 
-    let dkim_dir = crate::config::dkim_dir();
+    // Mirror the layout-aware probe used at the top of
+    // `gather_status_with_ops`: read the public key from the per-domain
+    // dir post-migration, the legacy root on v1 installs.
+    let dkim_dir_base = crate::config::dkim_dir();
+    let dkim_dir = crate::upgrade_migration::resolve_active_dkim_dir(config, &dkim_dir_base);
     let local_dkim_pubkey = if dkim_dir.join("public.key").exists() {
         crate::dkim::dns_record_value(&dkim_dir)
             .ok()
@@ -817,37 +832,50 @@ pub fn check_mailbox_ownership(config: &Config) -> Vec<DoctorFinding> {
 
     // Orphan-storage findings: directories under `inbox/` / `sent/`
     // with no matching config entry (left behind by a removed mailbox).
-    for root in ["inbox", "sent"] {
-        let root_dir = config.data_dir.join(root);
-        let Ok(entries) = std::fs::read_dir(&root_dir) else {
-            continue;
-        };
-        for entry in entries.flatten() {
-            let Ok(meta) = entry.metadata() else { continue };
-            if !meta.is_dir() {
+    //
+    // Iterates per-domain roots on the v2 (post-migration) layout
+    // (`<data_dir>/<domain>/inbox/`, `<data_dir>/<domain>/sent/`) and
+    // the legacy single root on v1. `Config::storage_roots` owns the
+    // layout-aware decision. Per-domain roots that have not been
+    // provisioned (e.g. a freshly added domain with no mailboxes
+    // yet) silently skip via the `read_dir` error path.
+    for storage_root in config.storage_roots() {
+        for kind in ["inbox", "sent"] {
+            let root_dir = storage_root.join(kind);
+            let Ok(entries) = std::fs::read_dir(&root_dir) else {
                 continue;
-            }
-            let name = match entry.file_name().into_string() {
-                Ok(n) => n,
-                Err(_) => continue,
             };
-            if configured_names.contains(&name) {
-                continue;
+            for entry in entries.flatten() {
+                let Ok(meta) = entry.metadata() else { continue };
+                if !meta.is_dir() {
+                    continue;
+                }
+                let name = match entry.file_name().into_string() {
+                    Ok(n) => n,
+                    Err(_) => continue,
+                };
+                if configured_names.contains(&name) {
+                    continue;
+                }
+                out.push(
+                    DoctorFinding::new(
+                        "ORPHAN-STORAGE",
+                        FindingSeverity::Warn,
+                        format!(
+                            "storage directory `{}/{name}/` has no matching \
+                             mailbox in config.toml",
+                            root_dir
+                                .strip_prefix(&config.data_dir)
+                                .unwrap_or(Path::new(kind))
+                                .display(),
+                        ),
+                    )
+                    .with_fix(format!(
+                        "remove the stale directory or add a matching `[mailboxes.{name}]` \
+                         block to config.toml",
+                    )),
+                );
             }
-            out.push(
-                DoctorFinding::new(
-                    "ORPHAN-STORAGE",
-                    FindingSeverity::Warn,
-                    format!(
-                        "storage directory `{root}/{name}/` has no matching \
-                         mailbox in config.toml"
-                    ),
-                )
-                .with_fix(format!(
-                    "remove the stale directory or add a matching `[mailboxes.{name}]` \
-                     block to config.toml",
-                )),
-            );
         }
     }
 
@@ -1337,5 +1365,145 @@ mod version_render_tests {
         );
         let out = strip_ansi(&format_version_lines(&info));
         assert!(out.contains("(daemon not running)"), "{out}");
+    }
+}
+
+#[cfg(test)]
+mod dkim_layout_tests {
+    //! Exercise the layout-aware DKIM key probe in `gather_status_with_ops`.
+    //!
+    //! Pre-fix, this code read `<dkim_dir>/private.key` directly, so a
+    //! post-migration install (where the key has moved to
+    //! `<dkim_dir>/<default_domain>/private.key`) reported DKIM as
+    //! MISSING and steered the operator into regenerating the key.
+    //! These tests pin the fix: the probe routes through
+    //! `resolve_active_dkim_dir` and reports `present` from the
+    //! per-domain dir on a post-migration install.
+    use super::*;
+    use crate::config::Config;
+    use crate::config::test_env::ConfigDirOverride;
+    use crate::setup::tests::MockNetworkOps;
+    use std::fs;
+    use tempfile::TempDir;
+
+    fn write_canonical_config(path: &Path, domain: &str) {
+        let s = format!(
+            "domains = [\"{domain}\"]\n\n\
+             [mailboxes.\"info@{domain}\"]\n\
+             address = \"info@{domain}\"\n\
+             owner = \"ops\"\n",
+        );
+        fs::write(path, s).unwrap();
+    }
+
+    /// Post-migration (`.layout-version: 2` present), the DKIM key
+    /// lives at `<dkim_dir>/<default_domain>/private.key`. The probe
+    /// must report `present` even though the legacy
+    /// `<dkim_dir>/private.key` is gone.
+    #[test]
+    fn dkim_present_when_only_per_domain_key_exists() {
+        let tmp = TempDir::new().unwrap();
+        let config_dir = tmp.path().join("etc");
+        let data_dir = tmp.path().join("data");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::create_dir_all(&data_dir).unwrap();
+
+        // v2 layout marker — `resolve_active_dkim_dir` short-circuits
+        // on the per-domain key being present, but the marker is the
+        // load-bearing post-migration signal in production.
+        fs::write(data_dir.join(".layout-version"), "2\n").unwrap();
+
+        let cfg_path = config_dir.join("config.toml");
+        write_canonical_config(&cfg_path, "example.com");
+
+        // Per-domain DKIM dir + key only — no legacy `dkim/private.key`.
+        let per_domain_dkim = config_dir.join("dkim").join("example.com");
+        fs::create_dir_all(&per_domain_dkim).unwrap();
+        fs::write(per_domain_dkim.join("private.key"), b"stub").unwrap();
+
+        let _guard = ConfigDirOverride::set(&config_dir);
+        let mut config = Config::load_resolved().unwrap().0;
+        config.data_dir = data_dir.clone();
+
+        let sys = crate::setup::tests::MockSystemOps::default();
+        let net = MockNetworkOps {
+            server_ipv4: None,
+            ..Default::default()
+        };
+
+        let info = gather_status_with_ops(&config, &sys, &net);
+        assert!(
+            info.dkim_key_present,
+            "post-migration per-domain DKIM key should register as present"
+        );
+    }
+
+    /// Legacy v1 install (no marker, no per-domain dir). The probe
+    /// falls back to `<dkim_dir>/private.key`. Regression coverage so
+    /// the fix does not break the pre-migration path.
+    #[test]
+    fn dkim_present_on_legacy_v1_layout() {
+        let tmp = TempDir::new().unwrap();
+        let config_dir = tmp.path().join("etc");
+        let data_dir = tmp.path().join("data");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::create_dir_all(&data_dir).unwrap();
+
+        let cfg_path = config_dir.join("config.toml");
+        // Canonical-shape config is fine; the v1-vs-v2 layout decision
+        // is purely on-disk (`.layout-version` marker + per-domain
+        // dir presence), not on config shape.
+        write_canonical_config(&cfg_path, "example.com");
+
+        // Legacy key location only.
+        let dkim_dir = config_dir.join("dkim");
+        fs::create_dir_all(&dkim_dir).unwrap();
+        fs::write(dkim_dir.join("private.key"), b"stub").unwrap();
+
+        let _guard = ConfigDirOverride::set(&config_dir);
+        let mut config = Config::load_resolved().unwrap().0;
+        config.data_dir = data_dir.clone();
+
+        let sys = crate::setup::tests::MockSystemOps::default();
+        let net = MockNetworkOps {
+            server_ipv4: None,
+            ..Default::default()
+        };
+
+        let info = gather_status_with_ops(&config, &sys, &net);
+        assert!(
+            info.dkim_key_present,
+            "legacy-layout DKIM key should still register as present"
+        );
+    }
+
+    /// Genuine "missing" case: neither path holds a key. The probe
+    /// must report MISSING so the operator runs `aimx dkim-keygen`.
+    #[test]
+    fn dkim_missing_when_no_key_present() {
+        let tmp = TempDir::new().unwrap();
+        let config_dir = tmp.path().join("etc");
+        let data_dir = tmp.path().join("data");
+        fs::create_dir_all(&config_dir).unwrap();
+        fs::create_dir_all(&data_dir).unwrap();
+
+        let cfg_path = config_dir.join("config.toml");
+        write_canonical_config(&cfg_path, "example.com");
+
+        let _guard = ConfigDirOverride::set(&config_dir);
+        let mut config = Config::load_resolved().unwrap().0;
+        config.data_dir = data_dir.clone();
+
+        let sys = crate::setup::tests::MockSystemOps::default();
+        let net = MockNetworkOps {
+            server_ipv4: None,
+            ..Default::default()
+        };
+
+        let info = gather_status_with_ops(&config, &sys, &net);
+        assert!(
+            !info.dkim_key_present,
+            "no DKIM key on disk should register as missing"
+        );
     }
 }

--- a/src/mailbox.rs
+++ b/src/mailbox.rs
@@ -264,18 +264,28 @@ pub fn list_mailboxes(config: &Config) -> Vec<(String, usize, usize)> {
 }
 
 /// Union of (a) mailboxes registered in `config.mailboxes` and (b)
-/// directories under `<data_dir>/inbox/`. Operators who restore an inbox
-/// dir out-of-band, or unregister a mailbox while keeping its messages
-/// on disk, still see the directory listed (the CLI/MCP can surface
-/// unregistered ones with a marker if needed). The catchall is always
-/// kept in config so it is always surfaced.
+/// directories under each per-domain `inbox/` root. Operators who
+/// restore an inbox dir out-of-band, or unregister a mailbox while
+/// keeping its messages on disk, still see the directory listed (the
+/// CLI/MCP can surface unregistered ones with a marker if needed).
+/// The catchall is always kept in config so it is always surfaced.
+///
+/// On the v2 (post-migration) layout this iterates
+/// `<data_dir>/<domain>/inbox/` for every domain in `config.domains`
+/// and aggregates the entries. On the v1 (pre-migration) layout it
+/// reads the legacy `<data_dir>/inbox/` root. `Config::storage_roots`
+/// owns the layout-aware decision; per-domain roots that have not
+/// been provisioned yet (e.g. a freshly added domain) are skipped.
 pub fn discover_mailbox_names(config: &Config) -> Vec<String> {
     use std::collections::BTreeSet;
 
     let mut set: BTreeSet<String> = config.mailboxes.keys().cloned().collect();
 
-    let inbox_root = config.data_dir.join("inbox");
-    if let Ok(entries) = std::fs::read_dir(&inbox_root) {
+    for root in config.storage_roots() {
+        let inbox_root = root.join("inbox");
+        let Ok(entries) = std::fs::read_dir(&inbox_root) else {
+            continue;
+        };
         for entry in entries.filter_map(|e| e.ok()) {
             if entry.file_type().is_ok_and(|t| t.is_dir())
                 && let Some(name) = entry.file_name().to_str()
@@ -1104,5 +1114,77 @@ mod tests {
         let cfg = config_with_owners(&[("admin", "root")]);
         // Caller is non-root; root-owned mailbox doesn't match.
         assert!(!caller_owns(&cfg, "admin", 1000));
+    }
+
+    /// On the v2 layout, `discover_mailbox_names` walks
+    /// `<data_dir>/<domain>/inbox/` for every configured domain and
+    /// aggregates the entries. Filesystem-only mailboxes — directories
+    /// present on disk but absent from `config.mailboxes` — must still
+    /// surface so operators can see orphaned storage.
+    #[test]
+    fn discover_aggregates_per_domain_inbox_dirs_on_v2_layout() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let data_dir = tmp.path().to_path_buf();
+
+        // v2 marker → `storage_roots` returns per-domain roots.
+        std::fs::write(data_dir.join(".layout-version"), "2\n").unwrap();
+
+        // Two domains, each with one on-disk-only mailbox.
+        for (domain, local) in [("agent.example.com", "ops"), ("two.example.com", "billing")] {
+            std::fs::create_dir_all(data_dir.join(domain).join("inbox").join(local)).unwrap();
+        }
+
+        let mut cfg = config_with_owners(&[("alice", "root")]);
+        cfg.data_dir = data_dir.clone();
+        cfg.domains = vec!["agent.example.com".into(), "two.example.com".into()];
+
+        let names = discover_mailbox_names(&cfg);
+        // From config:
+        assert!(names.contains(&"alice".to_string()), "{names:?}");
+        // From per-domain inbox dirs:
+        assert!(names.contains(&"ops".to_string()), "{names:?}");
+        assert!(names.contains(&"billing".to_string()), "{names:?}");
+    }
+
+    /// Pre-migration installs (no `.layout-version` marker) still
+    /// scan the legacy `<data_dir>/inbox/` root. Regression coverage
+    /// for the v1 fallback path.
+    #[test]
+    fn discover_falls_back_to_legacy_root_on_v1_layout() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let data_dir = tmp.path().to_path_buf();
+
+        // No marker: v1 layout.
+        std::fs::create_dir_all(data_dir.join("inbox").join("legacy_only")).unwrap();
+
+        let mut cfg = config_with_owners(&[]);
+        cfg.data_dir = data_dir;
+
+        let names = discover_mailbox_names(&cfg);
+        assert!(names.contains(&"legacy_only".to_string()), "{names:?}");
+    }
+
+    /// A configured domain whose per-domain inbox dir does not exist
+    /// yet (e.g. freshly added) must not crash the scan — the
+    /// `read_dir` error path silently skips it.
+    #[test]
+    fn discover_skips_missing_per_domain_inbox_dirs() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let data_dir = tmp.path().to_path_buf();
+
+        std::fs::write(data_dir.join(".layout-version"), "2\n").unwrap();
+        // Provision only one of two domains.
+        std::fs::create_dir_all(data_dir.join("agent.example.com").join("inbox").join("ops"))
+            .unwrap();
+
+        let mut cfg = config_with_owners(&[]);
+        cfg.data_dir = data_dir;
+        cfg.domains = vec![
+            "agent.example.com".into(),
+            "unprovisioned.example.com".into(),
+        ];
+
+        let names = discover_mailbox_names(&cfg);
+        assert!(names.contains(&"ops".to_string()), "{names:?}");
     }
 }

--- a/src/mailbox_handler.rs
+++ b/src/mailbox_handler.rs
@@ -316,7 +316,7 @@ fn resolve_owner_ids(owner: &str) -> Result<(u32, u32), String> {
 // verb argument that reintroduces the same `format!` chain at every
 // call site. The spelled-out pattern stays more scannable.
 fn handle_create(
-    state_ctx: &StateContext,
+    _state_ctx: &StateContext,
     mb_ctx: &MailboxContext,
     name: &str,
     owner: &str,
@@ -343,9 +343,12 @@ fn handle_create(
         }
     };
 
-    let data_dir = &state_ctx.data_dir;
-    let inbox = data_dir.join("inbox").join(name);
-    let sent = data_dir.join("sent").join(name);
+    // Route through the layout-aware `Config::inbox_dir` / `sent_dir`
+    // helpers so a post-migration daemon creates the new mailbox tree
+    // under `<data_dir>/<default_domain>/{inbox|sent}/<name>/` instead
+    // of the legacy `<data_dir>/{inbox|sent}/<name>/` location.
+    let inbox = current.inbox_dir(name);
+    let sent = current.sent_dir(name);
 
     // Track whether each dir existed before this call so the rollback
     // branches below never `remove_dir` an operator-created directory.
@@ -493,7 +496,7 @@ fn check_preexisting_dirs(inbox: &Path, sent: &Path, uid: u32, gid: u32) -> Opti
 }
 
 fn handle_delete(
-    state_ctx: &StateContext,
+    _state_ctx: &StateContext,
     mb_ctx: &MailboxContext,
     name: &str,
     force: bool,
@@ -512,11 +515,15 @@ fn handle_delete(
             reason: no_such_mailbox_reason(name),
         };
     }
-    drop(current);
 
-    let data_dir = &state_ctx.data_dir;
-    let inbox = data_dir.join("inbox").join(name);
-    let sent = data_dir.join("sent").join(name);
+    // Route through the layout-aware `Config::inbox_dir` / `sent_dir`
+    // helpers so a post-migration daemon wipes the per-domain tree
+    // (`<data_dir>/<default_domain>/{inbox|sent}/<name>/`) rather than
+    // the legacy `<data_dir>/{inbox|sent}/<name>/` location that the
+    // migration has already moved away from.
+    let inbox = current.inbox_dir(name);
+    let sent = current.sent_dir(name);
+    drop(current);
 
     // `force=true`: wipe inbox + sent contents under the same per-mailbox
     // lock that already guards the stanza removal. This eliminates the

--- a/src/main.rs
+++ b/src/main.rs
@@ -47,6 +47,7 @@ mod wire_assembly;
 mod release;
 mod uninstall;
 mod upgrade;
+mod upgrade_migration;
 mod user_resolver;
 mod version;
 mod version_handler;

--- a/src/send_handler.rs
+++ b/src/send_handler.rs
@@ -65,8 +65,11 @@ pub struct SendContext {
     /// Transport used for final MX delivery. In production this is a
     /// `LettreTransport`; tests inject a mock.
     pub transport: Arc<dyn MailTransport + Send + Sync>,
-    /// Data directory root (`/var/lib/aimx` by default). Sent files are
-    /// written to `<data_dir>/sent/<from_mailbox>/`.
+    /// Data directory root (`/var/lib/aimx` by default). Sent files
+    /// route through the layout-aware `Config::sent_dir` helper now,
+    /// but the field is kept on the context for tests and any
+    /// pre-existing callers that still need the raw root.
+    #[allow(dead_code)]
     pub data_dir: PathBuf,
 }
 
@@ -578,7 +581,7 @@ fn extract_bare_address(value: &str) -> Option<String> {
 
 #[allow(clippy::too_many_arguments)]
 fn persist_sent_file(
-    ctx: &SendContext,
+    _ctx: &SendContext,
     config: &Config,
     from_mailbox: &str,
     message_id: &str,
@@ -594,7 +597,11 @@ fn persist_sent_file(
     delivery_details: Option<&str>,
     outbound_format: &str,
 ) -> Option<PathBuf> {
-    let sent_dir = ctx.data_dir.join("sent").join(from_mailbox);
+    // Route through the layout-aware `Config::sent_dir` helper so a
+    // post-migration daemon writes under `<data_dir>/<default_domain>/sent/`
+    // rather than the legacy `<data_dir>/sent/` location that no longer
+    // exists.
+    let sent_dir = config.sent_dir(from_mailbox);
     if let Err(e) = std::fs::create_dir_all(&sent_dir) {
         eprintln!(
             "[send] failed to create sent dir {}: {e}",

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -397,6 +397,132 @@ fn find_daemon_pid() -> Option<i32> {
     if pid > 1 { Some(pid) } else { None }
 }
 
+/// Drive the one-shot multi-domain upgrade migration at daemon startup.
+///
+/// Sequence per the migration design contract:
+///
+/// 1. Detect the layout state. `Migrated` → fast no-op (no locks, no log).
+///    `Corrupted` → hard startup error. `FreshInstall` → write marker only,
+///    no log line. `NeedsMigration` → run the four-step transaction under
+///    the documented lock hierarchy.
+/// 2. For `NeedsMigration`: acquire **outer** per-mailbox locks in
+///    **sorted FQDN order** against the shared [`crate::mailbox_locks::MailboxLocks`]
+///    pool that the rest of the daemon will contend on, then the
+///    **inner** process-wide `CONFIG_WRITE_LOCK` for the config write
+///    sequence. Matches the documented cascade-delete ordering and
+///    prevents deadlocks with concurrent CRUD that comes online once
+///    the listener binds.
+/// 3. Run the migration steps (storage → DKIM → config → marker).
+/// 4. Emit a single operator-visible INFO log line summarising every
+///    file/path that moved.
+/// 5. Return the rewritten `Config` so the rest of `run_serve` operates
+///    on the canonical FQDN-keyed shape.
+async fn run_upgrade_migration_at_startup(
+    config: Config,
+    mailbox_locks: Arc<crate::mailbox_locks::MailboxLocks>,
+) -> Result<Config, Box<dyn std::error::Error>> {
+    let data_dir = config.data_dir.clone();
+    let dkim_dir = crate::config::dkim_dir();
+    let config_path = crate::config::config_path();
+
+    // Pre-flight detection only — cheap, no locks.
+    let pre_state = crate::upgrade_migration::detect_layout_state(
+        &data_dir,
+        &dkim_dir,
+        &config_path,
+        config.default_domain(),
+    );
+    match pre_state {
+        crate::upgrade_migration::LayoutState::Migrated => {
+            // Marker present. No locks, no log, no work.
+            return Ok(config);
+        }
+        crate::upgrade_migration::LayoutState::Corrupted(msg) => {
+            return Err(format!(
+                "upgrade migration failed: {msg}; see book/multi-domain.md for manual recovery"
+            )
+            .into());
+        }
+        crate::upgrade_migration::LayoutState::FreshInstall => {
+            crate::upgrade_migration::write_layout_version_marker(&data_dir).map_err(
+                |e| -> Box<dyn std::error::Error> {
+                    format!(
+                        "upgrade migration failed: {e}; \
+                         see book/multi-domain.md for manual recovery"
+                    )
+                    .into()
+                },
+            )?;
+            return Ok(config);
+        }
+        crate::upgrade_migration::LayoutState::NeedsMigration(_) => {
+            // Fall through to the locked migration body.
+        }
+    }
+
+    // Sorted FQDN list — every mailbox's `address` is the canonical FQDN
+    // even when the in-memory map still uses a legacy local-part key.
+    let mut fqdns: Vec<String> = config
+        .mailboxes
+        .values()
+        .map(|mb| mb.address.clone())
+        .collect();
+    fqdns.sort();
+
+    // Outer: per-mailbox locks from the shared pool, acquired in sorted
+    // FQDN order. Held simultaneously across the migration body so any
+    // future concurrent writer cannot interleave.
+    let states: Vec<Arc<crate::mailbox_locks::MailboxState>> = fqdns
+        .iter()
+        .map(|fqdn| mailbox_locks.lock_for(fqdn))
+        .collect();
+    // Acquire all guards in order. Holding references in `held_guards`
+    // keeps every lock taken until this function returns; the
+    // `states` Vec lives for the same scope and outlives the guards,
+    // so the borrows are valid.
+    let mut held_guards: Vec<tokio::sync::MutexGuard<'_, ()>> = Vec::with_capacity(states.len());
+    for state in &states {
+        held_guards.push(state.lock.lock().await);
+    }
+
+    let outcome = {
+        // Inner: process-wide config write lock. Honor the outer →
+        // inner hierarchy even though the migration is the only writer
+        // at startup.
+        let _config_guard = crate::mailbox_handler::CONFIG_WRITE_LOCK
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        crate::upgrade_migration::run_startup_migration(&data_dir, &dkim_dir, &config_path, &config)
+    };
+    // Locks released here as `held_guards` and `states` go out of scope.
+    drop(held_guards);
+    drop(states);
+
+    match outcome {
+        Ok(crate::upgrade_migration::StartupMigrationOutcome::AlreadyMigrated)
+        | Ok(crate::upgrade_migration::StartupMigrationOutcome::Fresh) => {
+            // We re-detected as `NeedsMigration` but the state changed
+            // under us — should be impossible because no other writer
+            // exists yet, but tolerate it defensively rather than
+            // emitting a spurious log line.
+            Ok(config)
+        }
+        Ok(crate::upgrade_migration::StartupMigrationOutcome::Migrated(inner)) => {
+            let crate::upgrade_migration::MigratedOutcome { report, rewritten } = *inner;
+            let line = crate::upgrade_migration::format_migration_log_line(
+                &report,
+                rewritten.default_domain(),
+            );
+            tracing::info!(target: "aimx::upgrade", "{line}");
+            Ok(rewritten)
+        }
+        Err(e) => Err(format!(
+            "upgrade migration failed: {e}; see book/multi-domain.md for manual recovery"
+        )
+        .into()),
+    }
+}
+
 pub fn run(
     bind: Option<&str>,
     tls_cert: Option<&str>,
@@ -448,6 +574,20 @@ async fn run_serve(
     // post-write `chown_as_owner`, the file is still not world-readable.
     crate::ownership::set_process_umask(0o077);
 
+    // A single `MailboxLocks` map is shared across every writer (inbound
+    // ingest, MARK-*, MAILBOX-*) so they all serialize on the same
+    // per-mailbox `tokio::sync::Mutex<()>`. Constructed before the
+    // upgrade migration so the migration can document the
+    // outer-CONFIG_WRITE_LOCK → inner-per-mailbox-lock hierarchy against
+    // the same lock pool the rest of the daemon uses.
+    let mailbox_locks = Arc::new(crate::mailbox_locks::MailboxLocks::new());
+
+    // One-shot multi-domain upgrade migration. Runs before any listener
+    // binds and before the datadir README refresh so the README, when
+    // overwritten, reflects the post-migration layout. Idempotent across
+    // restarts (gated by `<data_dir>/.layout-version`).
+    let config = run_upgrade_migration_at_startup(config, Arc::clone(&mailbox_locks)).await?;
+
     // Refresh the agent-facing README if the baked-in version differs from
     // what is on disk. Runs before any listener is bound so the file is
     // up-to-date by the time agents read it.
@@ -477,7 +617,14 @@ async fn run_serve(
     // Load DKIM key once at startup. Every accepted UDS send reuses this
     // in-memory key. A failure here is fatal: the daemon cannot sign
     // outbound mail without it.
-    let dkim_root = crate::config::dkim_dir();
+    //
+    // After the upgrade migration relocates DKIM keys into
+    // `<dkim_dir>/<default_domain>/`, the resolver below returns the
+    // per-domain path; on a never-migrated fresh install it returns the
+    // legacy `<dkim_dir>` root. The downstream `HashMap<domain, DkimKey>`
+    // refactor replaces this single-key load entirely.
+    let dkim_root_base = crate::config::dkim_dir();
+    let dkim_root = crate::upgrade_migration::resolve_active_dkim_dir(&config, &dkim_root_base);
     let dkim_key = match dkim::load_private_key(&dkim_root) {
         Ok(k) => Arc::new(k),
         Err(e) => {
@@ -540,11 +687,11 @@ async fn run_serve(
         data_dir: data_dir.clone(),
     });
 
-    // A single `MailboxLocks` map is shared across every writer (inbound
-    // ingest, MARK-*, MAILBOX-*) so they all serialize on the same
-    // per-mailbox `tokio::sync::Mutex<()>`. See `crate::mailbox_locks`
-    // for the lock hierarchy.
-    let mailbox_locks = Arc::new(crate::mailbox_locks::MailboxLocks::new());
+    // `mailbox_locks` was constructed earlier (pre-migration) so the
+    // upgrade migration could document the lock hierarchy against the
+    // same shared pool every other writer (inbound ingest, MARK-*,
+    // MAILBOX-*) eventually contends on. See `crate::mailbox_locks` for
+    // the lock hierarchy.
 
     // Shared state context for MARK-READ / MARK-UNREAD verbs and the
     // per-mailbox write lock used by MAILBOX-CREATE / MAILBOX-DELETE

--- a/src/setup.rs
+++ b/src/setup.rs
@@ -2809,16 +2809,16 @@ pub(crate) mod tests {
     use std::collections::HashMap;
     use tempfile::TempDir;
 
-    struct MockNetworkOps {
-        outbound_port25: bool,
-        inbound_port25: bool,
-        server_ipv4: Option<Ipv4Addr>,
-        server_ipv6: Option<Ipv6Addr>,
-        mx_records: HashMap<String, Vec<String>>,
-        a_records: HashMap<String, Vec<IpAddr>>,
-        aaaa_records: HashMap<String, Vec<IpAddr>>,
-        txt_records: HashMap<String, Vec<String>>,
-        get_server_ips_calls: std::cell::Cell<u32>,
+    pub(crate) struct MockNetworkOps {
+        pub(crate) outbound_port25: bool,
+        pub(crate) inbound_port25: bool,
+        pub(crate) server_ipv4: Option<Ipv4Addr>,
+        pub(crate) server_ipv6: Option<Ipv6Addr>,
+        pub(crate) mx_records: HashMap<String, Vec<String>>,
+        pub(crate) a_records: HashMap<String, Vec<IpAddr>>,
+        pub(crate) aaaa_records: HashMap<String, Vec<IpAddr>>,
+        pub(crate) txt_records: HashMap<String, Vec<String>>,
+        pub(crate) get_server_ips_calls: std::cell::Cell<u32>,
     }
 
     impl Default for MockNetworkOps {

--- a/src/state_handler.rs
+++ b/src/state_handler.rs
@@ -27,10 +27,12 @@
 //!
 //! Always acquire outer → inner, never the reverse.
 
-use std::path::{Path, PathBuf};
+#[cfg(test)]
+use std::path::Path;
+use std::path::PathBuf;
 use std::sync::Arc;
 
-use crate::config::ConfigHandle;
+use crate::config::{Config, ConfigHandle};
 use crate::frontmatter::InboundFrontmatter;
 use crate::mailbox_locks::{MailboxLocks, MailboxState};
 use crate::mcp::resolve_email_path_strict;
@@ -49,7 +51,11 @@ pub struct StateContext {
     /// never changes; the `Config` swap path (MAILBOX-CRUD in
     /// `mailbox_handler.rs`) deliberately never rewrites `data_dir`, so
     /// this snapshot and the live handle's `data_dir` cannot diverge in
-    /// practice.
+    /// practice. Today every reader routes through the live
+    /// `config_handle` for layout-aware path resolution, but the field
+    /// is kept for tests and any pre-existing callers that still need
+    /// the raw root.
+    #[allow(dead_code)]
     pub data_dir: PathBuf,
     /// Live handle to the daemon's `Config`. MARK-* uses it to validate
     /// that the referenced mailbox exists at the time of the call (rather
@@ -113,8 +119,8 @@ fn validate_id(id: &str) -> Result<(), AckResponse> {
     Ok(())
 }
 
-fn inbox_dir(data_dir: &Path, mailbox: &str) -> PathBuf {
-    data_dir.join("inbox").join(mailbox)
+fn inbox_dir(config: &Config, mailbox: &str) -> PathBuf {
+    config.inbox_dir(mailbox)
 }
 
 /// Handle a `MARK-READ` / `MARK-UNREAD` request. Takes the shared
@@ -159,7 +165,7 @@ pub async fn handle_mark(ctx: &StateContext, req: &MarkRequest, caller: &Caller)
     let state = ctx.lock_for(&req.mailbox);
     let _guard = state.lock.lock().await;
 
-    let mailbox_dir = inbox_dir(&ctx.data_dir, &req.mailbox);
+    let mailbox_dir = inbox_dir(&config_snapshot, &req.mailbox);
     let filepath = match resolve_email_path_strict(&mailbox_dir, &req.id) {
         Some(p) => p,
         None => {

--- a/src/upgrade_migration.rs
+++ b/src/upgrade_migration.rs
@@ -1,0 +1,1364 @@
+//! One-shot upgrade migration from the v1 (single-domain) on-disk
+//! layout to the v2 (multi-domain) canonical layout.
+//!
+//! Runs at daemon startup, before the SMTP listener spawns and before
+//! the UDS binds. The migration is **atomic per step** and **idempotent**
+//! across restarts: re-running with the `.layout-version: 2` marker
+//! present is a fast no-op; re-running after a crash mid-flow detects
+//! which steps already completed and resumes from the first incomplete
+//! one.
+//!
+//! # Step order (load-bearing)
+//!
+//! 1. **Storage rename** — `<data_dir>/inbox` → `<data_dir>/<domain>/inbox/`
+//!    and the same for `sent/`. `rename(2)` is atomic on the same
+//!    filesystem and constant-time regardless of how much mail is
+//!    stored.
+//! 2. **DKIM rename** — create `<dkim_dir>/<domain>/` (mode `0700`)
+//!    and move `private.key` + `public.key` into it.
+//! 3. **Config rewrite** — `domain = "x.com"` → `domains = ["x.com"]`
+//!    and `[mailboxes.<local>]` → `[mailboxes."<local>@<domain>"]`,
+//!    written via the existing [`crate::config::write_atomic`] helper.
+//! 4. **Marker write** — `<data_dir>/.layout-version` containing `2\n`.
+//!
+//! Why this order? Per PRD: prefer "DKIM key exists but domain not in
+//! config (orphaned key, harmless)" over "domain in config but DKIM key
+//! missing (broken outbound)". A crash between step 1 and step 2 leaves
+//! the install detectable as half-migrated and resumable; a crash
+//! between step 2 and step 3 leaves an orphaned per-domain DKIM
+//! directory that the next run absorbs cleanly. The marker is last so
+//! a partial run never claims to be done.
+
+use std::fs;
+use std::io;
+use std::path::{Path, PathBuf};
+
+use crate::config::{Config, write_atomic};
+
+/// On-disk marker filename written under `<data_dir>/`. Presence with
+/// value `"2"` short-circuits the migration on every subsequent boot.
+pub const LAYOUT_MARKER_FILENAME: &str = ".layout-version";
+
+/// Current on-disk layout version. Bumped only when a new structural
+/// migration ships — `"2"` is the multi-domain layout.
+pub const CURRENT_LAYOUT_VERSION: &str = "2";
+
+/// Indicators that fired during v1-shape detection. Carried by
+/// [`LayoutState::NeedsMigration`] so the caller can log exactly why a
+/// migration is about to run.
+#[derive(Debug, Default, Clone, PartialEq, Eq)]
+pub struct Indicators {
+    /// `<data_dir>/inbox/` exists and `<data_dir>/<default_domain>/inbox/`
+    /// does not.
+    pub legacy_inbox_dir: bool,
+    /// `<data_dir>/sent/` exists and `<data_dir>/<default_domain>/sent/`
+    /// does not. (Not strictly required to trigger migration on its own,
+    /// but recorded for the log line.)
+    pub legacy_sent_dir: bool,
+    /// `<dkim_dir>/private.key` exists and
+    /// `<dkim_dir>/<default_domain>/private.key` does not.
+    pub legacy_dkim_key: bool,
+    /// `config.toml` carries `domain = "..."` without `domains = [...]`.
+    pub legacy_config_domain_field: bool,
+    /// `[mailboxes.<local>]` keys exist without an `@` in the key.
+    pub legacy_mailbox_local_part_keys: bool,
+}
+
+impl Indicators {
+    /// True when at least one v1-shape signal fired.
+    pub fn any(&self) -> bool {
+        self.legacy_inbox_dir
+            || self.legacy_sent_dir
+            || self.legacy_dkim_key
+            || self.legacy_config_domain_field
+            || self.legacy_mailbox_local_part_keys
+    }
+}
+
+/// Tri-state result of [`detect_layout_state`].
+///
+/// - [`Self::Migrated`] — `.layout-version: 2` present. Fast no-op.
+/// - [`Self::NeedsMigration`] — at least one v1 indicator fired and
+///   no marker is present. Run the migration.
+/// - [`Self::FreshInstall`] — no marker and no v1 indicators. Write
+///   the marker proactively so future restarts short-circuit.
+/// - [`Self::Corrupted`] — marker file present with garbage / wrong
+///   version. Hard startup error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum LayoutState {
+    Migrated,
+    NeedsMigration(Indicators),
+    FreshInstall,
+    Corrupted(String),
+}
+
+/// Migration error type, surfaced by every step. Carries a human-
+/// readable reason that bubbles into the daemon's startup hard-fail
+/// message verbatim, with a pointer at `book/multi-domain.md`.
+#[derive(Debug)]
+pub enum MigrationError {
+    /// Reading or writing a file failed.
+    Io { path: PathBuf, cause: io::Error },
+    /// `std::fs::rename` returned EXDEV (cross-filesystem). We do not
+    /// fall back to copy+delete — atomicity matters more than
+    /// convenience here.
+    CrossDevice { src: PathBuf, dst: PathBuf },
+    /// Generic structural failure (e.g. parent dir of marker is missing).
+    Other(String),
+}
+
+impl std::fmt::Display for MigrationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Io { path, cause } => write!(f, "{}: {cause}", path.display()),
+            Self::CrossDevice { src, dst } => write!(
+                f,
+                "{src} and {dst} must be on the same filesystem; \
+                 see book/multi-domain.md for manual recovery",
+                src = src.display(),
+                dst = dst.display()
+            ),
+            Self::Other(s) => f.write_str(s),
+        }
+    }
+}
+
+impl std::error::Error for MigrationError {}
+
+/// Detect the on-disk layout state for an install rooted at
+/// `data_dir` / `dkim_dir` / `config_path`. The decision tree:
+///
+/// 1. If `.layout-version` exists under `data_dir`:
+///    - content trims to `"2"` → [`LayoutState::Migrated`].
+///    - any other content → [`LayoutState::Corrupted`].
+///    - read error (other than NotFound) → [`LayoutState::Corrupted`].
+/// 2. Otherwise scan for v1-shape indicators. If any fire,
+///    [`LayoutState::NeedsMigration(indicators)`].
+/// 3. Otherwise [`LayoutState::FreshInstall`].
+///
+/// `default_domain` is the `domains[0]` of the loaded `Config`; the
+/// detector uses it to compute the "destination" paths whose presence
+/// would mean a step already ran (e.g. `<data_dir>/<default_domain>/inbox/`).
+///
+/// Pure function over the filesystem state; no writes, no locks.
+pub fn detect_layout_state(
+    data_dir: &Path,
+    dkim_dir: &Path,
+    config_path: &Path,
+    default_domain: &str,
+) -> LayoutState {
+    // 1. Marker is the source of truth.
+    let marker = data_dir.join(LAYOUT_MARKER_FILENAME);
+    match fs::read_to_string(&marker) {
+        Ok(s) => {
+            let trimmed = s.trim();
+            if trimmed == CURRENT_LAYOUT_VERSION {
+                return LayoutState::Migrated;
+            }
+            return LayoutState::Corrupted(format!(
+                "{} contains '{trimmed}', expected '{}'",
+                marker.display(),
+                CURRENT_LAYOUT_VERSION,
+            ));
+        }
+        Err(e) if e.kind() == io::ErrorKind::NotFound => {
+            // Fall through to v1-shape detection.
+        }
+        Err(e) => {
+            return LayoutState::Corrupted(format!("cannot read {}: {e}", marker.display()));
+        }
+    }
+
+    // 2. V1-shape indicators.
+    let mut ind = Indicators::default();
+
+    let legacy_inbox = data_dir.join("inbox");
+    let new_inbox = data_dir.join(default_domain).join("inbox");
+    if legacy_inbox.is_dir() && !new_inbox.is_dir() {
+        ind.legacy_inbox_dir = true;
+    }
+    let legacy_sent = data_dir.join("sent");
+    let new_sent = data_dir.join(default_domain).join("sent");
+    if legacy_sent.is_dir() && !new_sent.is_dir() {
+        ind.legacy_sent_dir = true;
+    }
+    let legacy_dkim = dkim_dir.join("private.key");
+    let new_dkim = dkim_dir.join(default_domain).join("private.key");
+    if legacy_dkim.is_file() && !new_dkim.is_file() {
+        ind.legacy_dkim_key = true;
+    }
+    if let Ok(content) = fs::read_to_string(config_path) {
+        let (has_legacy_field, has_local_keys) = inspect_config_for_legacy(&content);
+        if has_legacy_field {
+            ind.legacy_config_domain_field = true;
+        }
+        if has_local_keys {
+            ind.legacy_mailbox_local_part_keys = true;
+        }
+    }
+
+    if ind.any() {
+        return LayoutState::NeedsMigration(ind);
+    }
+
+    LayoutState::FreshInstall
+}
+
+/// Scan a raw `config.toml` for the two legacy markers that trigger
+/// migration: a top-level `domain = "..."` field, and any `[mailboxes.X]`
+/// header whose `X` lacks an `@`. Robust against blank lines, comments,
+/// and either quoted-or-bareword TOML headers.
+///
+/// Returns `(has_legacy_domain_field, has_legacy_local_part_keys)`.
+fn inspect_config_for_legacy(content: &str) -> (bool, bool) {
+    let mut has_legacy_field = false;
+    let mut has_canonical_field = false;
+    let mut has_local_keys = false;
+
+    for raw_line in content.lines() {
+        let line = raw_line.trim();
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        // Once we cross into a `[...]` section, only mailbox table
+        // headers matter for the local-key heuristic; the legacy
+        // top-level scalar `domain = "..."` only appears at the root.
+        // Cheap to scan the full file because TOML files are tiny.
+        // Match `domain = "x.com"` (bare scalar) but NOT
+        // `[domain."b.com"]` (the per-domain sub-table header, which
+        // would have started with `[`).
+        if let Some(rest) = line.strip_prefix("domain")
+            && rest.trim_start().starts_with('=')
+        {
+            has_legacy_field = true;
+        }
+        if let Some(rest) = line.strip_prefix("domains")
+            && rest.trim_start().starts_with('=')
+        {
+            has_canonical_field = true;
+        }
+        if let Some(header) = line.strip_prefix("[mailboxes.") {
+            // Strip the trailing `]`. Header is one of:
+            //   [mailboxes.info]            -> "info]"
+            //   [mailboxes."info@a.com"]    -> "\"info@a.com\"]"
+            let inner = header.trim_end_matches(']').trim();
+            // Drop surrounding quotes if present.
+            let unquoted = inner.trim_matches('"');
+            if !unquoted.contains('@') {
+                has_local_keys = true;
+            }
+        }
+    }
+
+    // The `domain = "..."` field is a legacy signal only when the
+    // canonical `domains = [...]` form is absent. If both are present
+    // the loader itself rejects this mix, so we never
+    // see that state at startup; defensively avoid double-reporting.
+    if has_canonical_field {
+        has_legacy_field = false;
+    }
+    (has_legacy_field, has_local_keys)
+}
+
+/// Rename the legacy storage tree into the per-domain layout.
+///
+/// Idempotent: when the destination exists and the source does not,
+/// the rename is skipped. Catches EXDEV / `CrossesDevices` and surfaces
+/// [`MigrationError::CrossDevice`] with an actionable hint — atomic
+/// renames are the only correct primitive here.
+///
+/// Runs steps 1 and 2 of the storage half of the migration: `inbox`
+/// then `sent` (independent of each other, but both must complete for
+/// the install to be on the v2 layout).
+pub fn relocate_storage_for_default_domain(
+    data_dir: &Path,
+    default_domain: &str,
+) -> Result<StorageRelocationReport, MigrationError> {
+    let domain_dir = data_dir.join(default_domain);
+    if !domain_dir.exists() {
+        fs::create_dir_all(&domain_dir).map_err(|e| MigrationError::Io {
+            path: domain_dir.clone(),
+            cause: e,
+        })?;
+    }
+
+    let inbox_move = move_if_pending(&data_dir.join("inbox"), &domain_dir.join("inbox"))?;
+    let sent_move = move_if_pending(&data_dir.join("sent"), &domain_dir.join("sent"))?;
+
+    Ok(StorageRelocationReport {
+        inbox: inbox_move,
+        sent: sent_move,
+    })
+}
+
+/// Report from [`relocate_storage_for_default_domain`].
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct StorageRelocationReport {
+    pub inbox: MoveOutcome,
+    pub sent: MoveOutcome,
+}
+
+/// Report from [`relocate_dkim_for_default_domain`].
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct DkimRelocationReport {
+    pub private_key: MoveOutcome,
+    pub public_key: MoveOutcome,
+    /// True iff the per-domain DKIM dir was newly created during this
+    /// call. Informational; carried into the log line for operators.
+    pub created_domain_dir: bool,
+}
+
+/// Outcome of a single rename attempt — useful for logging exactly
+/// which sub-step ran on a given migration call.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum MoveOutcome {
+    /// Source exists and was renamed onto the destination.
+    Renamed { from: PathBuf, to: PathBuf },
+    /// Destination already exists and source is absent — already done.
+    AlreadyDone,
+    /// Neither source nor destination exists. Counts as a no-op for
+    /// idempotency: e.g. a fresh single-domain install that never had a
+    /// `public.key` separately on disk, or a `sent/` directory that
+    /// existed only after the first outbound send.
+    #[default]
+    NothingToDo,
+}
+
+/// Rename the legacy DKIM keys into a per-domain subdirectory.
+///
+/// Creates `<dkim_dir>/<default_domain>/` with mode `0700` if absent,
+/// then renames `private.key` and `public.key`. Idempotent per file.
+/// EXDEV produces [`MigrationError::CrossDevice`] just like storage
+/// relocation.
+pub fn relocate_dkim_for_default_domain(
+    dkim_dir: &Path,
+    default_domain: &str,
+) -> Result<DkimRelocationReport, MigrationError> {
+    let domain_dir = dkim_dir.join(default_domain);
+    let created_domain_dir = !domain_dir.exists();
+    if created_domain_dir {
+        fs::create_dir_all(&domain_dir).map_err(|e| MigrationError::Io {
+            path: domain_dir.clone(),
+            cause: e,
+        })?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = fs::Permissions::from_mode(0o700);
+            fs::set_permissions(&domain_dir, perms).map_err(|e| MigrationError::Io {
+                path: domain_dir.clone(),
+                cause: e,
+            })?;
+        }
+    }
+
+    let private_key = move_if_pending(
+        &dkim_dir.join("private.key"),
+        &domain_dir.join("private.key"),
+    )?;
+    let public_key = move_if_pending(&dkim_dir.join("public.key"), &domain_dir.join("public.key"))?;
+
+    Ok(DkimRelocationReport {
+        private_key,
+        public_key,
+        created_domain_dir,
+    })
+}
+
+/// Move `src` onto `dst` exactly once, idempotently. The contract:
+///
+/// - source exists, destination absent → `rename(src, dst)`,
+///   [`MoveOutcome::Renamed`].
+/// - source absent, destination present → no-op, [`MoveOutcome::AlreadyDone`].
+/// - source absent, destination absent → no-op, [`MoveOutcome::NothingToDo`].
+/// - source present, destination present → defensive error: we do
+///   **not** overwrite, because a re-run after a partial failure
+///   should never silently clobber a half-migrated tree. Surfaces as
+///   [`MigrationError::Other`].
+/// - EXDEV → [`MigrationError::CrossDevice`].
+fn move_if_pending(src: &Path, dst: &Path) -> Result<MoveOutcome, MigrationError> {
+    let src_exists = src.exists();
+    let dst_exists = dst.exists();
+    match (src_exists, dst_exists) {
+        (false, false) => Ok(MoveOutcome::NothingToDo),
+        (false, true) => Ok(MoveOutcome::AlreadyDone),
+        (true, true) => Err(MigrationError::Other(format!(
+            "both {} and {} exist; refusing to overwrite — \
+             see book/multi-domain.md for manual recovery",
+            src.display(),
+            dst.display(),
+        ))),
+        (true, false) => {
+            // Make sure the destination's parent exists. `relocate_*`
+            // create the per-domain dir itself; this is defense in depth.
+            if let Some(parent) = dst.parent()
+                && !parent.exists()
+            {
+                fs::create_dir_all(parent).map_err(|e| MigrationError::Io {
+                    path: parent.to_path_buf(),
+                    cause: e,
+                })?;
+            }
+            match fs::rename(src, dst) {
+                Ok(()) => Ok(MoveOutcome::Renamed {
+                    from: src.to_path_buf(),
+                    to: dst.to_path_buf(),
+                }),
+                Err(e) if is_cross_device_error(&e) => Err(MigrationError::CrossDevice {
+                    src: src.to_path_buf(),
+                    dst: dst.to_path_buf(),
+                }),
+                Err(e) => Err(MigrationError::Io {
+                    path: src.to_path_buf(),
+                    cause: e,
+                }),
+            }
+        }
+    }
+}
+
+/// Recognize EXDEV across libc / `io::Error` variants. The stable
+/// [`io::ErrorKind::CrossesDevices`] only landed in 1.85; the older
+/// raw OS error is `18` on Linux. We accept either so a build on an
+/// older toolchain still surfaces the actionable error message.
+fn is_cross_device_error(e: &io::Error) -> bool {
+    if e.kind() == io::ErrorKind::CrossesDevices {
+        return true;
+    }
+    e.raw_os_error() == Some(18)
+}
+
+/// Rewrite `config.toml` into the canonical multi-domain shape on disk.
+///
+/// What this step normalizes on-disk:
+///
+/// - `domain = "x.com"` becomes `domains = ["x.com"]` (legacy single-
+///   domain field is gone from the serialized output).
+/// - Per-domain sub-tables (operator-written `[domain."b.com"]`)
+///   round-trip through the serializer unchanged.
+///
+/// What this step **does not** rewrite on-disk:
+///
+/// - Legacy local-part-keyed mailboxes (`[mailboxes.info]`). The
+///   serializer preserves the operator-friendly key the loader carried
+///   in memory so the runtime data plane and every downstream CLI that
+///   looks up mailboxes by `<local>` (ingest, send, hooks create /
+///   delete, mailboxes show) keeps working unchanged. The on-disk
+///   FQDN re-key (`[mailboxes."<local>@<domain>"]`) is performed later
+///   as part of the runtime data plane rewire that teaches every
+///   callsite to look up mailboxes by FQDN.
+///
+/// The returned `Config` is the input unchanged — the in-memory shape
+/// is preserved across the migration for the same reason.
+///
+/// Idempotent: when the input `Config` is already in canonical shape
+/// (no legacy `domain` field, all mailboxes already FQDN-keyed), the
+/// function still writes the canonical TOML serialization on disk.
+/// This is intentional — re-writing the same logical content is cheap
+/// and guarantees the final disk shape matches the canonical
+/// serializer on every run.
+pub fn rewrite_config_to_canonical_shape(
+    config_path: &Path,
+    in_memory_config: &Config,
+) -> Result<Config, MigrationError> {
+    write_atomic(config_path, in_memory_config).map_err(|e| MigrationError::Io {
+        path: config_path.to_path_buf(),
+        cause: e,
+    })?;
+    Ok(in_memory_config.clone())
+}
+
+/// Write `<data_dir>/.layout-version` containing `"2\n"`, mode `0644`.
+///
+/// Idempotent: an existing marker with the correct value is left
+/// untouched. An existing marker with a wrong value is overwritten
+/// only by the migration codepath (callers detecting the wrong value
+/// must surface [`LayoutState::Corrupted`] first, which is a startup
+/// hard error — they should not silently rewrite). The function
+/// itself is unconditional: callers gate via [`detect_layout_state`].
+pub fn write_layout_version_marker(data_dir: &Path) -> Result<(), MigrationError> {
+    let marker = data_dir.join(LAYOUT_MARKER_FILENAME);
+    let body = format!("{CURRENT_LAYOUT_VERSION}\n");
+    // Write via temp-then-rename so a concurrent reader never sees a
+    // truncated value. The marker is tiny but consistency is cheap.
+    let parent = marker.parent().unwrap_or(Path::new("."));
+    if !parent.exists() {
+        fs::create_dir_all(parent).map_err(|e| MigrationError::Io {
+            path: parent.to_path_buf(),
+            cause: e,
+        })?;
+    }
+    let tmp = parent.join(format!(
+        ".{LAYOUT_MARKER_FILENAME}.tmp.{}",
+        std::process::id()
+    ));
+    {
+        use std::io::Write;
+        let mut f = fs::File::create(&tmp).map_err(|e| MigrationError::Io {
+            path: tmp.clone(),
+            cause: e,
+        })?;
+        f.write_all(body.as_bytes())
+            .map_err(|e| MigrationError::Io {
+                path: tmp.clone(),
+                cause: e,
+            })?;
+        f.sync_all().map_err(|e| MigrationError::Io {
+            path: tmp.clone(),
+            cause: e,
+        })?;
+    }
+    fs::rename(&tmp, &marker).map_err(|e| {
+        let _ = fs::remove_file(&tmp);
+        MigrationError::Io {
+            path: marker.clone(),
+            cause: e,
+        }
+    })?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = fs::Permissions::from_mode(0o644);
+        fs::set_permissions(&marker, perms).map_err(|e| MigrationError::Io {
+            path: marker.clone(),
+            cause: e,
+        })?;
+    }
+    Ok(())
+}
+
+/// Aggregate report from a successful migration. Carried into the
+/// single operator-visible INFO log line so journalctl shows every
+/// path that moved.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct MigrationReport {
+    pub storage: StorageRelocationReport,
+    pub dkim: DkimRelocationReport,
+    pub config_path: PathBuf,
+    pub config_rewritten: bool,
+    pub marker_written: bool,
+}
+
+/// Run the full migration in order: storage → DKIM → config → marker.
+///
+/// Each step is independently idempotent. The function returns a
+/// [`MigrationReport`] on success and a [`MigrationError`] on the
+/// first failure. The caller (`serve.rs`) is responsible for the lock
+/// hierarchy (`CONFIG_WRITE_LOCK` outer, every per-mailbox lock inner
+/// in sorted FQDN order) — this function only does file work.
+pub fn run_migration(
+    data_dir: &Path,
+    dkim_dir: &Path,
+    config_path: &Path,
+    in_memory_config: &Config,
+) -> Result<(MigrationReport, Config), MigrationError> {
+    let default_domain = in_memory_config.default_domain();
+
+    let storage = relocate_storage_for_default_domain(data_dir, default_domain)?;
+    let dkim = relocate_dkim_for_default_domain(dkim_dir, default_domain)?;
+    let rewritten = rewrite_config_to_canonical_shape(config_path, in_memory_config)?;
+    write_layout_version_marker(data_dir)?;
+
+    Ok((
+        MigrationReport {
+            storage,
+            dkim,
+            config_path: config_path.to_path_buf(),
+            config_rewritten: true,
+            marker_written: true,
+        },
+        rewritten,
+    ))
+}
+
+/// Outcome of [`run_startup_migration`] surfaced back to `serve.rs`.
+///
+/// Carries enough information for the daemon to log the right line and
+/// (when migration ran) swap the freshly-rewritten `Config` into the
+/// `ConfigHandle`. Reload is the caller's job — this module deliberately
+/// stays free of the `ConfigHandle` dependency so the unit tests can
+/// exercise the full path without spinning up a daemon-level fixture.
+///
+/// The `Migrated` payload is boxed so the enum stays small on the
+/// stack — `MigrationReport` carries `PathBuf`s, `Config` carries a
+/// full mailbox map, and we hand the outcome back through several
+/// pattern-match sites where a 240+-byte variant would dominate the
+/// rest of the API.
+#[derive(Debug)]
+pub enum StartupMigrationOutcome {
+    /// `.layout-version: 2` was already present. Fast path; the daemon
+    /// continues with the `Config` it was started with.
+    AlreadyMigrated,
+    /// No v1 indicators and no marker — the daemon is on a fresh
+    /// install. The marker was written proactively so subsequent
+    /// restarts take [`Self::AlreadyMigrated`]. No INFO log line.
+    Fresh,
+    /// Migration ran end-to-end. Carries the rewritten `Config`
+    /// (in-memory shape preserved from the legacy load; the on-disk shape is
+    /// canonical FQDN) for the caller to swap into the live
+    /// `ConfigHandle`.
+    Migrated(Box<MigratedOutcome>),
+}
+
+/// Heap-allocated payload for [`StartupMigrationOutcome::Migrated`].
+#[derive(Debug)]
+pub struct MigratedOutcome {
+    pub report: MigrationReport,
+    pub rewritten: Config,
+}
+
+/// Drive the full startup migration flow against a loaded `Config`.
+///
+/// Sequence:
+/// 1. [`detect_layout_state`] determines whether this is `Migrated`,
+///    `FreshInstall`, `NeedsMigration`, or `Corrupted`.
+/// 2. `Migrated` → return immediately (no locks, no log).
+/// 3. `Corrupted` → return the error verbatim.
+/// 4. `FreshInstall` → write the marker, no log.
+/// 5. `NeedsMigration` → acquire the lock hierarchy outer-to-inner
+///    (CONFIG_WRITE_LOCK held by the caller per the contract on
+///    [`run_migration`]; per-mailbox locks in sorted FQDN order are
+///    deferred to the caller too because [`crate::mailbox_locks::MailboxLocks`]
+///    is owned by `serve.rs`). Run [`run_migration`].
+///
+/// **The lock hierarchy is enforced by the caller** so this module
+/// stays free of the tokio-async dependency surface. `serve.rs` takes
+/// the locks, calls this function inside the critical section, and
+/// emits the operator-visible INFO log on return.
+pub fn run_startup_migration(
+    data_dir: &Path,
+    dkim_dir: &Path,
+    config_path: &Path,
+    in_memory_config: &Config,
+) -> Result<StartupMigrationOutcome, StartupMigrationError> {
+    let default_domain = in_memory_config.default_domain();
+    match detect_layout_state(data_dir, dkim_dir, config_path, default_domain) {
+        LayoutState::Migrated => Ok(StartupMigrationOutcome::AlreadyMigrated),
+        LayoutState::Corrupted(msg) => Err(StartupMigrationError::Corrupted(msg)),
+        LayoutState::FreshInstall => {
+            write_layout_version_marker(data_dir).map_err(StartupMigrationError::Migration)?;
+            Ok(StartupMigrationOutcome::Fresh)
+        }
+        LayoutState::NeedsMigration(_indicators) => {
+            let (report, rewritten) =
+                run_migration(data_dir, dkim_dir, config_path, in_memory_config)
+                    .map_err(StartupMigrationError::Migration)?;
+            Ok(StartupMigrationOutcome::Migrated(Box::new(
+                MigratedOutcome { report, rewritten },
+            )))
+        }
+    }
+}
+
+/// Startup-time wrapper around [`MigrationError`] that also surfaces
+/// [`LayoutState::Corrupted`] (a marker-file integrity error rather
+/// than a filesystem error). Both variants flow into the canonical
+/// `serve.rs` hard-fail message.
+#[derive(Debug)]
+pub enum StartupMigrationError {
+    Migration(MigrationError),
+    Corrupted(String),
+}
+
+impl std::fmt::Display for StartupMigrationError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Migration(e) => write!(f, "{e}"),
+            Self::Corrupted(s) => f.write_str(s),
+        }
+    }
+}
+
+impl std::error::Error for StartupMigrationError {}
+
+/// Resolve the directory containing the active DKIM keypair given a
+/// loaded `Config` and the canonical `<dkim_dir>` root.
+///
+/// The migration ships the on-disk relocation but a follow-up rewire
+/// will replace this with a per-domain `HashMap` lookup keyed on the
+/// From: domain. Bridge until then: if
+/// `<dkim_dir>/<default_domain>/private.key` exists, return the
+/// per-domain dir (post-migration shape, and the shape every
+/// multi-domain build will eventually require); otherwise return
+/// `<dkim_dir>` itself (fresh installs that just ran `aimx setup` keep
+/// their keys at the legacy root until the per-domain DKIM loader and
+/// the `aimx dkim-keygen --domain <d>` flag land).
+///
+/// Returning a single `PathBuf` lets `serve.rs` stay decoupled from
+/// the structural change.
+pub fn resolve_active_dkim_dir(config: &Config, dkim_dir: &Path) -> PathBuf {
+    let per_domain = dkim_dir.join(config.default_domain());
+    if per_domain.join("private.key").is_file() {
+        return per_domain;
+    }
+    dkim_dir.to_path_buf()
+}
+
+/// Format the single operator-visible INFO log line emitted by the
+/// daemon after a successful migration. Pulled out so the wording can
+/// be pinned in tests without reaching into the `tracing` subscriber.
+pub fn format_migration_log_line(report: &MigrationReport, rewritten_default: &str) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    parts.push(format!("default_domain={rewritten_default}"));
+    if let MoveOutcome::Renamed { from, to } = &report.storage.inbox {
+        parts.push(format!("inbox={}→{}", from.display(), to.display()));
+    }
+    if let MoveOutcome::Renamed { from, to } = &report.storage.sent {
+        parts.push(format!("sent={}→{}", from.display(), to.display()));
+    }
+    if let MoveOutcome::Renamed { from, to } = &report.dkim.private_key {
+        parts.push(format!("dkim_private={}→{}", from.display(), to.display()));
+    }
+    if let MoveOutcome::Renamed { from, to } = &report.dkim.public_key {
+        parts.push(format!("dkim_public={}→{}", from.display(), to.display()));
+    }
+    if report.config_rewritten {
+        parts.push(format!("config_rewritten={}", report.config_path.display()));
+    }
+    if report.marker_written {
+        parts.push(format!("layout_version={CURRENT_LAYOUT_VERSION}"));
+    }
+    format!(
+        "upgrade migration completed: {}; see book/multi-domain.md",
+        parts.join(" ")
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::os::unix::fs::PermissionsExt;
+    use tempfile::TempDir;
+
+    fn touch(path: &Path) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, b"").unwrap();
+    }
+
+    fn touch_with(path: &Path, body: &[u8]) {
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(path, body).unwrap();
+    }
+
+    fn write_legacy_config(path: &Path, domain: &str, mailbox_locals: &[&str]) {
+        let mut s = format!("domain = \"{domain}\"\n\n");
+        for local in mailbox_locals {
+            s.push_str(&format!(
+                "[mailboxes.{local}]\naddress = \"{local}@{domain}\"\nowner = \"ops\"\n\n",
+            ));
+        }
+        fs::write(path, s).unwrap();
+    }
+
+    fn write_canonical_config(path: &Path, domain: &str, mailbox_locals: &[&str]) {
+        let mut s = format!("domains = [\"{domain}\"]\n\n");
+        for local in mailbox_locals {
+            s.push_str(&format!(
+                "[mailboxes.\"{local}@{domain}\"]\naddress = \"{local}@{domain}\"\nowner = \"ops\"\n\n",
+            ));
+        }
+        fs::write(path, s).unwrap();
+    }
+
+    // --- detect_layout_state ------------------------------------------------
+
+    #[test]
+    fn detect_pristine_v1_layout_returns_needs_migration() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("data");
+        let dkim_dir = tmp.path().join("dkim");
+        let cfg = tmp.path().join("config.toml");
+
+        fs::create_dir_all(data_dir.join("inbox").join("info")).unwrap();
+        fs::create_dir_all(data_dir.join("sent").join("info")).unwrap();
+        touch(&dkim_dir.join("private.key"));
+        touch(&dkim_dir.join("public.key"));
+        write_legacy_config(&cfg, "mydomain.com", &["info", "support"]);
+
+        let state = detect_layout_state(&data_dir, &dkim_dir, &cfg, "mydomain.com");
+        match state {
+            LayoutState::NeedsMigration(ind) => {
+                assert!(ind.legacy_inbox_dir);
+                assert!(ind.legacy_sent_dir);
+                assert!(ind.legacy_dkim_key);
+                assert!(ind.legacy_config_domain_field);
+                assert!(ind.legacy_mailbox_local_part_keys);
+            }
+            other => panic!("expected NeedsMigration, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detect_marker_present_returns_migrated() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("data");
+        let dkim_dir = tmp.path().join("dkim");
+        let cfg = tmp.path().join("config.toml");
+        fs::create_dir_all(&data_dir).unwrap();
+        fs::write(data_dir.join(LAYOUT_MARKER_FILENAME), "2\n").unwrap();
+        // Marker wins even when v1-shape indicators are still around.
+        fs::create_dir_all(data_dir.join("inbox").join("info")).unwrap();
+        write_legacy_config(&cfg, "mydomain.com", &["info"]);
+
+        let state = detect_layout_state(&data_dir, &dkim_dir, &cfg, "mydomain.com");
+        assert_eq!(state, LayoutState::Migrated);
+    }
+
+    #[test]
+    fn detect_marker_with_wrong_version_returns_corrupted() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("data");
+        let dkim_dir = tmp.path().join("dkim");
+        let cfg = tmp.path().join("config.toml");
+        fs::create_dir_all(&data_dir).unwrap();
+        fs::write(data_dir.join(LAYOUT_MARKER_FILENAME), "99\n").unwrap();
+
+        let state = detect_layout_state(&data_dir, &dkim_dir, &cfg, "anywhere.com");
+        match state {
+            LayoutState::Corrupted(msg) => {
+                assert!(msg.contains("99"));
+                assert!(msg.contains("expected '2'"));
+            }
+            other => panic!("expected Corrupted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detect_fresh_install_returns_fresh() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("data");
+        let dkim_dir = tmp.path().join("dkim");
+        let cfg = tmp.path().join("config.toml");
+        fs::create_dir_all(&data_dir).unwrap();
+        // Write a canonical config that wouldn't trigger any v1 signals.
+        write_canonical_config(&cfg, "fresh.example.com", &[]);
+
+        let state = detect_layout_state(&data_dir, &dkim_dir, &cfg, "fresh.example.com");
+        assert_eq!(state, LayoutState::FreshInstall);
+    }
+
+    #[test]
+    fn detect_half_migrated_storage_only_still_triggers_migration() {
+        // Storage already moved (no `inbox/` at the root, present under
+        // `<domain>/inbox/`) but DKIM still at the root → re-run must
+        // see the DKIM indicator and resume.
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("data");
+        let dkim_dir = tmp.path().join("dkim");
+        let cfg = tmp.path().join("config.toml");
+
+        fs::create_dir_all(data_dir.join("mydomain.com").join("inbox").join("info")).unwrap();
+        touch(&dkim_dir.join("private.key"));
+        write_legacy_config(&cfg, "mydomain.com", &["info"]);
+
+        let state = detect_layout_state(&data_dir, &dkim_dir, &cfg, "mydomain.com");
+        match state {
+            LayoutState::NeedsMigration(ind) => {
+                assert!(!ind.legacy_inbox_dir, "storage already moved");
+                assert!(ind.legacy_dkim_key, "DKIM still legacy");
+                assert!(ind.legacy_config_domain_field);
+            }
+            other => panic!("expected NeedsMigration on half-migrated install, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn detect_handles_per_domain_subtable_without_misclassifying_as_legacy() {
+        // `[domain."b.com"]` is the *canonical* per-domain override
+        // sub-table, NOT the legacy `domain = "..."` scalar. The
+        // detector must not flag it as a legacy field.
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("data");
+        let dkim_dir = tmp.path().join("dkim");
+        let cfg = tmp.path().join("config.toml");
+        fs::create_dir_all(&data_dir).unwrap();
+        let body = "domains = [\"a.com\", \"b.com\"]\n\n\
+                    [domain.\"b.com\"]\nsignature = \"Sent from B\"\n\n\
+                    [mailboxes.\"info@a.com\"]\naddress = \"info@a.com\"\nowner = \"ops\"\n";
+        fs::write(&cfg, body).unwrap();
+        // Pre-write marker so the detector returns Migrated (which is
+        // what a fully-migrated multi-domain install looks like). The
+        // canonical-config heuristic is the only thing under test here.
+        fs::write(data_dir.join(LAYOUT_MARKER_FILENAME), "2\n").unwrap();
+        let state = detect_layout_state(&data_dir, &dkim_dir, &cfg, "a.com");
+        assert_eq!(state, LayoutState::Migrated);
+    }
+
+    // --- inspect_config_for_legacy -----------------------------------------
+
+    #[test]
+    fn inspect_legacy_domain_only() {
+        let s = "domain = \"x.com\"\n\n[mailboxes.\"info@x.com\"]\naddress=\"info@x.com\"\n";
+        let (legacy, locals) = inspect_config_for_legacy(s);
+        assert!(legacy);
+        assert!(!locals);
+    }
+
+    #[test]
+    fn inspect_canonical_with_local_keys_does_not_double_flag() {
+        // Should never happen in practice (the config parser rejects mixed),
+        // but the heuristic should still suppress `has_legacy_field`
+        // when `domains` is present.
+        let s = "domains = [\"x.com\"]\ndomain = \"x.com\"\n\n[mailboxes.info]\naddress=\"info@x.com\"\n";
+        let (legacy, locals) = inspect_config_for_legacy(s);
+        assert!(!legacy);
+        assert!(locals);
+    }
+
+    #[test]
+    fn inspect_legacy_local_part_keys_only() {
+        let s = "domains = [\"x.com\"]\n\n[mailboxes.info]\naddress=\"info@x.com\"\n";
+        let (legacy, locals) = inspect_config_for_legacy(s);
+        assert!(!legacy);
+        assert!(locals);
+    }
+
+    #[test]
+    fn inspect_canonical_only() {
+        let s = "domains = [\"x.com\"]\n\n[mailboxes.\"info@x.com\"]\naddress=\"info@x.com\"\n";
+        let (legacy, locals) = inspect_config_for_legacy(s);
+        assert!(!legacy);
+        assert!(!locals);
+    }
+
+    #[test]
+    fn inspect_handles_comments_and_blank_lines() {
+        let s = "# header\n\n  # indented\ndomain = \"x.com\"   # trailing comment\n";
+        let (legacy, _) = inspect_config_for_legacy(s);
+        assert!(legacy);
+    }
+
+    // --- relocate_storage --------------------------------------------------
+
+    #[test]
+    fn storage_relocation_renames_inbox_and_sent() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().to_path_buf();
+        fs::create_dir_all(data_dir.join("inbox").join("info")).unwrap();
+        fs::write(data_dir.join("inbox").join("info").join("a.md"), b"body").unwrap();
+        fs::create_dir_all(data_dir.join("sent").join("info")).unwrap();
+
+        let report = relocate_storage_for_default_domain(&data_dir, "x.com").unwrap();
+        match report.inbox {
+            MoveOutcome::Renamed { .. } => {}
+            other => panic!("expected inbox Renamed, got {other:?}"),
+        }
+        match report.sent {
+            MoveOutcome::Renamed { .. } => {}
+            other => panic!("expected sent Renamed, got {other:?}"),
+        }
+        // Files moved.
+        assert!(
+            data_dir
+                .join("x.com")
+                .join("inbox")
+                .join("info")
+                .join("a.md")
+                .is_file()
+        );
+        assert!(!data_dir.join("inbox").is_dir());
+    }
+
+    #[test]
+    fn storage_relocation_idempotent_when_already_done() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().to_path_buf();
+        fs::create_dir_all(data_dir.join("x.com").join("inbox").join("info")).unwrap();
+        fs::create_dir_all(data_dir.join("x.com").join("sent").join("info")).unwrap();
+
+        let report = relocate_storage_for_default_domain(&data_dir, "x.com").unwrap();
+        assert_eq!(report.inbox, MoveOutcome::AlreadyDone);
+        assert_eq!(report.sent, MoveOutcome::AlreadyDone);
+    }
+
+    #[test]
+    fn storage_relocation_handles_missing_sent() {
+        // A v1 install that's never sent outbound has no `sent/` dir.
+        // The relocation must skip silently rather than fail.
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().to_path_buf();
+        fs::create_dir_all(data_dir.join("inbox").join("info")).unwrap();
+
+        let report = relocate_storage_for_default_domain(&data_dir, "x.com").unwrap();
+        match report.inbox {
+            MoveOutcome::Renamed { .. } => {}
+            other => panic!("expected Renamed, got {other:?}"),
+        }
+        assert_eq!(report.sent, MoveOutcome::NothingToDo);
+    }
+
+    #[test]
+    fn storage_relocation_refuses_when_both_src_and_dst_exist() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().to_path_buf();
+        fs::create_dir_all(data_dir.join("inbox")).unwrap();
+        fs::create_dir_all(data_dir.join("x.com").join("inbox")).unwrap();
+
+        let err = relocate_storage_for_default_domain(&data_dir, "x.com").unwrap_err();
+        match err {
+            MigrationError::Other(msg) => assert!(msg.contains("refusing to overwrite")),
+            other => panic!("expected Other(refusing), got {other:?}"),
+        }
+    }
+
+    // --- relocate_dkim -----------------------------------------------------
+
+    #[test]
+    fn dkim_relocation_renames_and_preserves_modes() {
+        let tmp = TempDir::new().unwrap();
+        let dkim_dir = tmp.path().to_path_buf();
+        touch_with(&dkim_dir.join("private.key"), b"-----PRIVATE-----");
+        touch_with(&dkim_dir.join("public.key"), b"-----PUBLIC-----");
+        fs::set_permissions(
+            dkim_dir.join("private.key"),
+            fs::Permissions::from_mode(0o600),
+        )
+        .unwrap();
+        fs::set_permissions(
+            dkim_dir.join("public.key"),
+            fs::Permissions::from_mode(0o644),
+        )
+        .unwrap();
+
+        let report = relocate_dkim_for_default_domain(&dkim_dir, "x.com").unwrap();
+        assert!(report.created_domain_dir);
+        match report.private_key {
+            MoveOutcome::Renamed { .. } => {}
+            other => panic!("expected private Renamed, got {other:?}"),
+        }
+        match report.public_key {
+            MoveOutcome::Renamed { .. } => {}
+            other => panic!("expected public Renamed, got {other:?}"),
+        }
+        // Modes preserved across rename.
+        let priv_mode = fs::metadata(dkim_dir.join("x.com").join("private.key"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        let pub_mode = fs::metadata(dkim_dir.join("x.com").join("public.key"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(priv_mode, 0o600, "private.key must stay 0600 across rename");
+        assert_eq!(pub_mode, 0o644, "public.key must stay 0644 across rename");
+        // Per-domain dir is 0700.
+        let dir_mode = fs::metadata(dkim_dir.join("x.com"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(dir_mode, 0o700, "per-domain DKIM dir must be 0700");
+    }
+
+    #[test]
+    fn dkim_relocation_skips_missing_public_key() {
+        let tmp = TempDir::new().unwrap();
+        let dkim_dir = tmp.path().to_path_buf();
+        touch_with(&dkim_dir.join("private.key"), b"-----PRIVATE-----");
+
+        let report = relocate_dkim_for_default_domain(&dkim_dir, "x.com").unwrap();
+        match report.private_key {
+            MoveOutcome::Renamed { .. } => {}
+            other => panic!("expected private Renamed, got {other:?}"),
+        }
+        assert_eq!(report.public_key, MoveOutcome::NothingToDo);
+    }
+
+    #[test]
+    fn dkim_relocation_idempotent_when_already_done() {
+        let tmp = TempDir::new().unwrap();
+        let dkim_dir = tmp.path().to_path_buf();
+        let nested = dkim_dir.join("x.com");
+        fs::create_dir_all(&nested).unwrap();
+        touch_with(&nested.join("private.key"), b"-----PRIVATE-----");
+        touch_with(&nested.join("public.key"), b"-----PUBLIC-----");
+
+        let report = relocate_dkim_for_default_domain(&dkim_dir, "x.com").unwrap();
+        assert!(
+            !report.created_domain_dir,
+            "domain dir already existed, must report not-created"
+        );
+        assert_eq!(report.private_key, MoveOutcome::AlreadyDone);
+        assert_eq!(report.public_key, MoveOutcome::AlreadyDone);
+    }
+
+    // --- rewrite_config ----------------------------------------------------
+
+    #[test]
+    fn rewrite_config_promotes_legacy_domain_field_but_preserves_mailbox_keys() {
+        let tmp = TempDir::new().unwrap();
+        let cfg_path = tmp.path().join("config.toml");
+        write_legacy_config(&cfg_path, "x.com", &["info", "support"]);
+
+        // Load via Config::load to get the same in-memory shape the
+        // daemon would see at startup (legacy local-part keys preserved).
+        let cfg = Config::load_ignore_warnings(&cfg_path).unwrap();
+        assert!(
+            cfg.mailboxes.contains_key("info"),
+            "config-load invariant: legacy local-part keys preserved on load"
+        );
+
+        let returned = rewrite_config_to_canonical_shape(&cfg_path, &cfg).unwrap();
+
+        // In-memory shape preserved end-to-end — the migration is
+        // structural, not semantic, and the runtime data plane keeps
+        // looking up mailboxes by their operator-friendly key.
+        assert!(returned.mailboxes.contains_key("info"));
+        assert!(returned.mailboxes.contains_key("support"));
+
+        // On disk: `domains = [...]` replaces the legacy `domain = "..."`
+        // field, but mailbox keys keep their operator-friendly form so
+        // downstream CLI lookups (`hooks create alice`, `mailboxes show`)
+        // continue to resolve.
+        let reloaded = Config::load_ignore_warnings(&cfg_path).unwrap();
+        assert_eq!(reloaded.domains, vec!["x.com"]);
+        assert!(
+            reloaded.mailboxes.contains_key("info"),
+            "operator-friendly local-part keys preserved on disk"
+        );
+        assert!(reloaded.mailboxes.contains_key("support"));
+
+        // Serialized file body no longer carries the legacy scalar.
+        let serialized = fs::read_to_string(&cfg_path).unwrap();
+        for line in serialized.lines() {
+            let line = line.trim();
+            let looks_like_legacy_scalar = line.starts_with("domain")
+                && !line.starts_with("domains")
+                && !line.starts_with("domain.")
+                && line.contains('=');
+            assert!(
+                !looks_like_legacy_scalar,
+                "legacy `domain = ...` field must not survive the rewrite, found: {line}"
+            );
+        }
+    }
+
+    #[test]
+    fn rewrite_config_is_idempotent_on_canonical_input() {
+        let tmp = TempDir::new().unwrap();
+        let cfg_path = tmp.path().join("config.toml");
+        write_canonical_config(&cfg_path, "x.com", &["info"]);
+
+        let cfg = Config::load_ignore_warnings(&cfg_path).unwrap();
+        let first = rewrite_config_to_canonical_shape(&cfg_path, &cfg).unwrap();
+        let first_disk = fs::read_to_string(&cfg_path).unwrap();
+        let second = rewrite_config_to_canonical_shape(&cfg_path, &first).unwrap();
+        let second_disk = fs::read_to_string(&cfg_path).unwrap();
+        assert_eq!(
+            first_disk, second_disk,
+            "second rewrite must be byte-identical"
+        );
+        assert!(second.mailboxes.contains_key("info@x.com"));
+    }
+
+    // --- write_layout_version_marker --------------------------------------
+
+    #[test]
+    fn marker_write_emits_2_and_is_idempotent() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().to_path_buf();
+        write_layout_version_marker(&data_dir).unwrap();
+        let body = fs::read_to_string(data_dir.join(LAYOUT_MARKER_FILENAME)).unwrap();
+        assert_eq!(body, "2\n");
+        let mode = fs::metadata(data_dir.join(LAYOUT_MARKER_FILENAME))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o644);
+
+        // Re-running is safe: same content.
+        write_layout_version_marker(&data_dir).unwrap();
+        let body2 = fs::read_to_string(data_dir.join(LAYOUT_MARKER_FILENAME)).unwrap();
+        assert_eq!(body2, "2\n");
+    }
+
+    // --- run_migration full path ------------------------------------------
+
+    // --- run_startup_migration orchestration ------------------------------
+
+    #[test]
+    fn startup_migration_returns_already_migrated_when_marker_present() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("data");
+        let dkim_dir = tmp.path().join("dkim");
+        let cfg_path = tmp.path().join("config.toml");
+        fs::create_dir_all(&data_dir).unwrap();
+        fs::write(data_dir.join(LAYOUT_MARKER_FILENAME), "2\n").unwrap();
+        write_canonical_config(&cfg_path, "x.com", &["info"]);
+
+        let cfg = Config::load_ignore_warnings(&cfg_path).unwrap();
+        let outcome = run_startup_migration(&data_dir, &dkim_dir, &cfg_path, &cfg).unwrap();
+        assert!(matches!(outcome, StartupMigrationOutcome::AlreadyMigrated));
+    }
+
+    #[test]
+    fn startup_migration_writes_marker_on_fresh_install_and_emits_no_log() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("data");
+        let dkim_dir = tmp.path().join("dkim");
+        let cfg_path = tmp.path().join("config.toml");
+        fs::create_dir_all(&data_dir).unwrap();
+        write_canonical_config(&cfg_path, "fresh.example.com", &[]);
+
+        let cfg = Config::load_ignore_warnings(&cfg_path).unwrap();
+        let outcome = run_startup_migration(&data_dir, &dkim_dir, &cfg_path, &cfg).unwrap();
+        assert!(matches!(outcome, StartupMigrationOutcome::Fresh));
+        // Marker written.
+        assert_eq!(
+            fs::read_to_string(data_dir.join(LAYOUT_MARKER_FILENAME)).unwrap(),
+            "2\n",
+        );
+
+        // Second call: now `AlreadyMigrated`.
+        let again = run_startup_migration(&data_dir, &dkim_dir, &cfg_path, &cfg).unwrap();
+        assert!(matches!(again, StartupMigrationOutcome::AlreadyMigrated));
+    }
+
+    #[test]
+    fn startup_migration_runs_full_path_on_v1_install() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("data");
+        let dkim_dir = tmp.path().join("dkim");
+        let cfg_path = tmp.path().join("config.toml");
+
+        fs::create_dir_all(data_dir.join("inbox").join("info")).unwrap();
+        fs::write(
+            data_dir.join("inbox").join("info").join("a.md"),
+            b"+++\nfrom = \"x@y.com\"\n+++\n",
+        )
+        .unwrap();
+        fs::create_dir_all(data_dir.join("sent").join("info")).unwrap();
+        touch_with(&dkim_dir.join("private.key"), b"PK");
+        touch_with(&dkim_dir.join("public.key"), b"PUB");
+        write_legacy_config(&cfg_path, "x.com", &["info", "support"]);
+
+        let cfg = Config::load_ignore_warnings(&cfg_path).unwrap();
+        let outcome = run_startup_migration(&data_dir, &dkim_dir, &cfg_path, &cfg).unwrap();
+        match outcome {
+            StartupMigrationOutcome::Migrated(inner) => {
+                let MigratedOutcome { report, rewritten } = *inner;
+                assert!(report.config_rewritten);
+                assert!(report.marker_written);
+                // The returned Config preserves the in-memory shape end-
+                // to-end (legacy local-part keys) so the runtime data
+                // plane keeps working in this session.
+                assert!(rewritten.mailboxes.contains_key("info"));
+                let line = format_migration_log_line(&report, rewritten.default_domain());
+                assert!(line.contains("default_domain=x.com"));
+                assert!(line.contains("layout_version=2"));
+                assert!(line.contains("see book/multi-domain.md"));
+            }
+            other => panic!("expected Migrated outcome, got {other:?}"),
+        }
+        // On-disk shape: `domains = [...]` replaces the legacy scalar,
+        // but mailbox keys keep their operator-friendly local-part
+        // form (the FQDN re-key is deferred to the runtime rewire).
+        let reloaded = Config::load_ignore_warnings(&cfg_path).unwrap();
+        assert_eq!(reloaded.domains, vec!["x.com"]);
+        assert!(reloaded.mailboxes.contains_key("info"));
+
+        // Idempotent: second call sees the marker.
+        let cfg2 = Config::load_ignore_warnings(&cfg_path).unwrap();
+        let again = run_startup_migration(&data_dir, &dkim_dir, &cfg_path, &cfg2).unwrap();
+        assert!(matches!(again, StartupMigrationOutcome::AlreadyMigrated));
+    }
+
+    #[test]
+    fn startup_migration_returns_corrupted_for_bad_marker() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("data");
+        let dkim_dir = tmp.path().join("dkim");
+        let cfg_path = tmp.path().join("config.toml");
+        fs::create_dir_all(&data_dir).unwrap();
+        fs::write(data_dir.join(LAYOUT_MARKER_FILENAME), "99\n").unwrap();
+        write_canonical_config(&cfg_path, "x.com", &[]);
+
+        let cfg = Config::load_ignore_warnings(&cfg_path).unwrap();
+        let err = run_startup_migration(&data_dir, &dkim_dir, &cfg_path, &cfg).unwrap_err();
+        match err {
+            StartupMigrationError::Corrupted(msg) => assert!(msg.contains("99")),
+            other => panic!("expected Corrupted, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn full_migration_end_to_end_against_v1_fixture() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().join("data");
+        let dkim_dir = tmp.path().join("dkim");
+        let cfg_path = tmp.path().join("config.toml");
+
+        // Build a realistic v1 fixture in-place.
+        fs::create_dir_all(data_dir.join("inbox").join("info")).unwrap();
+        fs::write(
+            data_dir.join("inbox").join("info").join("hello.md"),
+            b"+++\nfrom = \"alice@example.com\"\n+++\nbody",
+        )
+        .unwrap();
+        fs::create_dir_all(data_dir.join("sent").join("info")).unwrap();
+        touch_with(&dkim_dir.join("private.key"), b"PK");
+        touch_with(&dkim_dir.join("public.key"), b"PUB");
+        write_legacy_config(&cfg_path, "x.com", &["info", "support"]);
+
+        let cfg = Config::load_ignore_warnings(&cfg_path).unwrap();
+        let pre_state = detect_layout_state(&data_dir, &dkim_dir, &cfg_path, "x.com");
+        match &pre_state {
+            LayoutState::NeedsMigration(ind) => assert!(ind.any()),
+            other => panic!("expected NeedsMigration, got {other:?}"),
+        }
+
+        let (report, returned) = run_migration(&data_dir, &dkim_dir, &cfg_path, &cfg).unwrap();
+
+        // Storage relocated.
+        assert!(
+            data_dir
+                .join("x.com")
+                .join("inbox")
+                .join("info")
+                .join("hello.md")
+                .is_file()
+        );
+        assert!(!data_dir.join("inbox").is_dir());
+        // DKIM relocated.
+        assert!(dkim_dir.join("x.com").join("private.key").is_file());
+        assert!(!dkim_dir.join("private.key").is_file());
+        // In-memory shape preserved end-to-end (legacy local-part keys
+        // round-trip through the rewrite); the on-disk shape promotes
+        // `domain` → `domains` but keeps the operator-friendly mailbox
+        // keys for downstream CLI compatibility.
+        assert!(returned.mailboxes.contains_key("info"));
+        assert!(returned.mailboxes.contains_key("support"));
+        let reloaded = Config::load_ignore_warnings(&cfg_path).unwrap();
+        assert_eq!(reloaded.domains, vec!["x.com"]);
+        assert!(reloaded.mailboxes.contains_key("info"));
+        assert!(reloaded.mailboxes.contains_key("support"));
+        // Marker present.
+        assert_eq!(
+            fs::read_to_string(data_dir.join(LAYOUT_MARKER_FILENAME)).unwrap(),
+            "2\n"
+        );
+        // Report flags.
+        assert!(report.config_rewritten);
+        assert!(report.marker_written);
+
+        // Second detection: now Migrated.
+        let post_state =
+            detect_layout_state(&data_dir, &dkim_dir, &cfg_path, returned.default_domain());
+        assert_eq!(post_state, LayoutState::Migrated);
+
+        // Second run is a no-op at the detection layer.
+        let third = detect_layout_state(&data_dir, &dkim_dir, &cfg_path, returned.default_domain());
+        assert_eq!(third, LayoutState::Migrated);
+    }
+}

--- a/src/upgrade_migration.rs
+++ b/src/upgrade_migration.rs
@@ -270,6 +270,14 @@ fn inspect_config_for_legacy(content: &str) -> (bool, bool) {
 /// Runs steps 1 and 2 of the storage half of the migration: `inbox`
 /// then `sent` (independent of each other, but both must complete for
 /// the install to be on the v2 layout).
+///
+/// The per-domain storage dir is created (or chmodded) to `0o755` so
+/// non-root mailbox owners can traverse into their own `inbox/<name>/`
+/// subdir, exactly as they could under `<data_dir>/` on v1. The daemon
+/// runs with `umask 0o077`, so without this explicit chmod the dir
+/// would land at `0o700` and every non-root MCP read would surface
+/// EACCES. The `inbox/<name>/` subdirs themselves remain `0o700` and
+/// owner-locked; only the per-domain traversal bit is opened.
 pub fn relocate_storage_for_default_domain(
     data_dir: &Path,
     default_domain: &str,
@@ -277,6 +285,15 @@ pub fn relocate_storage_for_default_domain(
     let domain_dir = data_dir.join(default_domain);
     if !domain_dir.exists() {
         fs::create_dir_all(&domain_dir).map_err(|e| MigrationError::Io {
+            path: domain_dir.clone(),
+            cause: e,
+        })?;
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let perms = fs::Permissions::from_mode(0o755);
+        fs::set_permissions(&domain_dir, perms).map_err(|e| MigrationError::Io {
             path: domain_dir.clone(),
             cause: e,
         })?;
@@ -732,7 +749,37 @@ pub fn format_migration_log_line(report: &MigrationReport, rewritten_default: &s
 mod tests {
     use super::*;
     use std::os::unix::fs::PermissionsExt;
+    use std::sync::Mutex;
     use tempfile::TempDir;
+
+    /// Serialize tests that mutate the process umask. `umask(2)` is
+    /// thread-unsafe and cargo runs tests in parallel.
+    static UMASK_SERIALIZE: Mutex<()> = Mutex::new(());
+
+    /// RAII guard that sets the process umask and restores the previous
+    /// value on drop. Holds [`UMASK_SERIALIZE`] for the whole lifetime.
+    struct UmaskGuard {
+        prev: u32,
+        _lock: std::sync::MutexGuard<'static, ()>,
+    }
+
+    impl UmaskGuard {
+        fn set(new: u32) -> Self {
+            let lock = UMASK_SERIALIZE.lock().unwrap_or_else(|p| p.into_inner());
+            // SAFETY: umask(2) is thread-unsafe but the mutex above
+            // serializes every caller in the test binary.
+            let prev = unsafe { libc::umask(new as libc::mode_t) } as u32;
+            Self { prev, _lock: lock }
+        }
+    }
+
+    impl Drop for UmaskGuard {
+        fn drop(&mut self) {
+            unsafe {
+                libc::umask(self.prev as libc::mode_t);
+            }
+        }
+    }
 
     fn touch(path: &Path) {
         if let Some(parent) = path.parent() {
@@ -993,6 +1040,58 @@ mod tests {
             other => panic!("expected Renamed, got {other:?}"),
         }
         assert_eq!(report.sent, MoveOutcome::NothingToDo);
+    }
+
+    /// Regression: the per-domain storage dir must be `0o755` so a
+    /// non-root mailbox owner (running `aimx mcp` under their own uid)
+    /// can `x`-traverse into `<data_dir>/<domain>/inbox/<name>/`. The
+    /// daemon runs with `umask 0o077`, so `create_dir_all` would land
+    /// the dir at `0o700` without the explicit chmod and every
+    /// non-root MCP read would surface EACCES.
+    #[test]
+    fn storage_relocation_per_domain_dir_is_world_traversable() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().to_path_buf();
+        fs::create_dir_all(data_dir.join("inbox").join("info")).unwrap();
+
+        // Force the umask the daemon sets so the test reproduces the
+        // production code path (default `cargo test` umask is `0o022`
+        // and would hide the regression).
+        let _guard = UmaskGuard::set(0o077);
+
+        relocate_storage_for_default_domain(&data_dir, "x.com").unwrap();
+        let dir_mode = fs::metadata(data_dir.join("x.com"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            dir_mode, 0o755,
+            "per-domain storage dir must be 0o755 so non-root mailbox \
+             owners can traverse into their own inbox/<name>/ subdir"
+        );
+    }
+
+    /// The per-domain mode is also enforced when the dir already exists
+    /// from an earlier partial run (defense in depth — a re-entry
+    /// after a crash mid-migration must heal an over-tightened dir).
+    #[test]
+    fn storage_relocation_chmods_existing_per_domain_dir() {
+        let tmp = TempDir::new().unwrap();
+        let data_dir = tmp.path().to_path_buf();
+        // Pre-existing per-domain dir, locked to 0o700 (what a crashed
+        // earlier run under the daemon's umask would have left behind).
+        fs::create_dir_all(data_dir.join("x.com")).unwrap();
+        fs::set_permissions(data_dir.join("x.com"), fs::Permissions::from_mode(0o700)).unwrap();
+        fs::create_dir_all(data_dir.join("inbox").join("info")).unwrap();
+
+        relocate_storage_for_default_domain(&data_dir, "x.com").unwrap();
+        let dir_mode = fs::metadata(data_dir.join("x.com"))
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(dir_mode, 0o755);
     }
 
     #[test]

--- a/tests/fixtures/upgrade/v1-single-domain/config.toml
+++ b/tests/fixtures/upgrade/v1-single-domain/config.toml
@@ -1,0 +1,9 @@
+domain = "fixture.example"
+
+[mailboxes.info]
+address = "info@fixture.example"
+owner = "OWNER_PLACEHOLDER"
+
+[mailboxes.support]
+address = "support@fixture.example"
+owner = "OWNER_PLACEHOLDER"

--- a/tests/fixtures/upgrade/v1-single-domain/inbox/info/2026-01-15-080000-hello-world.md
+++ b/tests/fixtures/upgrade/v1-single-domain/inbox/info/2026-01-15-080000-hello-world.md
@@ -1,0 +1,15 @@
++++
+id = "abc1234567890def"
+message_id = "<hello-1@sender.example>"
+thread_id = "abc1234567890def"
+from = "alice@sender.example"
+to = ["info@fixture.example"]
+subject = "Hello world"
+date = "2026-01-15T08:00:00Z"
+received_at = "2026-01-15T08:00:01Z"
+mailbox = "info"
+read = false
++++
+
+Hello from the v1 fixture. This message must remain readable after the
+multi-domain upgrade migration relocates the storage tree.

--- a/tests/fixtures/upgrade/v1-single-domain/inbox/info/2026-01-16-093000-second-message.md
+++ b/tests/fixtures/upgrade/v1-single-domain/inbox/info/2026-01-16-093000-second-message.md
@@ -1,0 +1,14 @@
++++
+id = "def4567890abc123"
+message_id = "<hello-2@sender.example>"
+thread_id = "def4567890abc123"
+from = "bob@sender.example"
+to = ["info@fixture.example"]
+subject = "Second message"
+date = "2026-01-16T09:30:00Z"
+received_at = "2026-01-16T09:30:02Z"
+mailbox = "info"
+read = true
++++
+
+The second message in the info mailbox.

--- a/tests/fixtures/upgrade/v1-single-domain/inbox/support/2026-02-01-120000-bug-report.md
+++ b/tests/fixtures/upgrade/v1-single-domain/inbox/support/2026-02-01-120000-bug-report.md
@@ -1,0 +1,14 @@
++++
+id = "1234567890abcdef"
+message_id = "<bug-1@user.example>"
+thread_id = "1234567890abcdef"
+from = "user@user.example"
+to = ["support@fixture.example"]
+subject = "Bug report"
+date = "2026-02-01T12:00:00Z"
+received_at = "2026-02-01T12:00:03Z"
+mailbox = "support"
+read = false
++++
+
+A bug report in the support mailbox.

--- a/tests/fixtures/upgrade/v1-single-domain/inbox/support/2026-02-02-150000-feature-request.md
+++ b/tests/fixtures/upgrade/v1-single-domain/inbox/support/2026-02-02-150000-feature-request.md
@@ -1,0 +1,14 @@
++++
+id = "fedcba0987654321"
+message_id = "<feat-1@user.example>"
+thread_id = "fedcba0987654321"
+from = "another@user.example"
+to = ["support@fixture.example"]
+subject = "Feature request"
+date = "2026-02-02T15:00:00Z"
+received_at = "2026-02-02T15:00:04Z"
+mailbox = "support"
+read = false
++++
+
+A feature request in the support mailbox.

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -142,8 +142,39 @@ fn find_md_files(dir: &Path) -> Vec<std::path::PathBuf> {
 }
 
 /// Resolve the inbox directory for a mailbox under a test tempdir.
+///
+/// Layout-aware: see [`storage_subdir`].
 fn inbox(tmp: &Path, name: &str) -> std::path::PathBuf {
-    tmp.join("inbox").join(name)
+    storage_subdir(tmp, "inbox", name)
+}
+
+/// Resolve the sent directory for a mailbox under a test tempdir.
+///
+/// Layout-aware: see [`storage_subdir`].
+#[allow(dead_code)]
+fn sent(tmp: &Path, name: &str) -> std::path::PathBuf {
+    storage_subdir(tmp, "sent", name)
+}
+
+/// Layout-aware resolver shared by [`inbox`] and [`sent`]. If the
+/// upgrade migration has run and the `<tmp>/.layout-version` marker is
+/// present, returns `<tmp>/<domain>/<folder>/<name>/`. Otherwise falls
+/// back to the legacy `<tmp>/<folder>/<name>/`. Tests that pass
+/// through `setup_test_env` always use a single configured domain, so
+/// finding the per-domain subdir is unambiguous.
+fn storage_subdir(tmp: &Path, folder: &str, name: &str) -> std::path::PathBuf {
+    let marker = tmp.join(".layout-version");
+    if marker.is_file()
+        && let Ok(entries) = std::fs::read_dir(tmp)
+    {
+        for entry in entries.flatten() {
+            let p = entry.path();
+            if p.is_dir() && p.join(folder).is_dir() {
+                return p.join(folder).join(name);
+            }
+        }
+    }
+    tmp.join(folder).join(name)
 }
 
 /// Search every bundle directory under `mailbox_dir` for an attachment
@@ -2906,7 +2937,7 @@ fn send_uds_end_to_end_emits_multipart_alternative_for_markdown_body() {
     // The sent record exists at sent/alice/<stem>.md and its body
     // contains the Markdown source verbatim (no `.html` sibling, no
     // rendered HTML in the persisted body).
-    let sent_dir = tmp.path().join("sent").join("alice");
+    let sent_dir = sent(tmp.path(), "alice");
     let entries: Vec<_> = std::fs::read_dir(&sent_dir)
         .unwrap()
         .filter_map(|e| e.ok())
@@ -3105,7 +3136,7 @@ fn send_uds_end_to_end_text_only_emits_single_part_text_plain() {
     // trail declares `outbound_format = "text"` so an operator
     // browsing `sent/` can tell at a glance the recipient saw plain
     // text — distinct from a default Markdown send (`"markdown"`).
-    let sent_dir = tmp.path().join("sent").join("alice");
+    let sent_dir = sent(tmp.path(), "alice");
     let entries: Vec<_> = std::fs::read_dir(&sent_dir)
         .unwrap()
         .filter_map(|e| e.ok())
@@ -3228,7 +3259,7 @@ fn send_uds_end_to_end_html_body_uses_supplied_html_verbatim() {
     // Sent record stores the --body text, not the --html-body content.
     // The "custom HTML is not stored" invariant is verified at the
     // integration layer here.
-    let sent_dir = tmp.path().join("sent").join("alice");
+    let sent_dir = sent(tmp.path(), "alice");
     let entries: Vec<_> = std::fs::read_dir(&sent_dir)
         .unwrap()
         .filter_map(|e| e.ok())
@@ -3705,10 +3736,14 @@ fn mcp_mark_read_concurrent_with_inbound_ingest() {
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
 
-    // Pre-seed one email so MARK-READ has a target.
-    let alice_dir = inbox(tmp.path(), "alice");
+    // Pre-seed one email so MARK-READ has a target. `inbox()` is
+    // layout-aware: pre-daemon it returns the legacy path, post-daemon
+    // (after the upgrade migration runs) it returns the per-domain
+    // path. Re-resolve after `start_serve` so the read uses whichever
+    // location the migration produced.
+    let pre_alice_dir = inbox(tmp.path(), "alice");
     create_email_file(
-        &alice_dir,
+        &pre_alice_dir,
         "2025-06-01-001",
         "sender@example.com",
         "Hello",
@@ -3717,6 +3752,7 @@ fn mcp_mark_read_concurrent_with_inbound_ingest() {
 
     let port = find_free_port();
     let daemon = start_serve(tmp.path(), port);
+    let alice_dir = inbox(tmp.path(), "alice");
 
     let runtime = tmp.path().join("run");
     let sock = runtime.join("aimx.sock");
@@ -4348,7 +4384,7 @@ fn mailbox_create_delete_force_e2e_as_non_root_user() {
 
     // On-disk owner check: the inbox dir must be owned by the runner's
     // uid (the daemon chowns to the resolved owner).
-    let inbox_dir = tmp.path().join("inbox").join("task-mb");
+    let inbox_dir = inbox(tmp.path(), "task-mb");
     assert!(inbox_dir.is_dir(), "inbox/task-mb/ must exist on disk");
     use std::os::unix::fs::MetadataExt;
     let meta = std::fs::metadata(&inbox_dir).unwrap();
@@ -5232,15 +5268,22 @@ fn concurrent_ingest_burst_and_mark_same_mailbox_no_torn_writes() {
     let tmp = TempDir::new().unwrap();
     setup_test_env(tmp.path());
 
-    let alice_dir = inbox(tmp.path(), "alice");
     // Pre-seed two emails so MARK-READ has stable targets while new
-    // inbound ingests are landing in the same directory.
+    // inbound ingests are landing in the same directory. `inbox()` is
+    // layout-aware: pre-daemon it returns the legacy path, post-daemon
+    // (after the upgrade migration runs) it returns the per-domain
+    // path. Re-resolve after `start_serve` so the read uses whichever
+    // location the migration produced.
+    let pre_alice_dir = inbox(tmp.path(), "alice");
     for id in ["2025-06-01-seed1", "2025-06-01-seed2"] {
-        create_email_file(&alice_dir, id, "sender@example.com", "Pre-seed", false);
+        create_email_file(&pre_alice_dir, id, "sender@example.com", "Pre-seed", false);
     }
 
     let port = find_free_port();
     let daemon = start_serve(tmp.path(), port);
+    // Re-resolve after the migration may have moved storage under
+    // `<data_dir>/<default_domain>/inbox/<name>/`.
+    let alice_dir = inbox(tmp.path(), "alice");
 
     let runtime = tmp.path().join("run");
     let sock = runtime.join("aimx.sock");
@@ -7110,7 +7153,7 @@ fn email_list_full_cycle_against_root_owned_config() {
     // `sent/alice/`. Without this assertion a future regression where
     // the sent-copy persistence silently no-ops would only be caught
     // by the EACCES guard, which would not fire.
-    let sent_dir = tmp.path().join("sent").join("alice");
+    let sent_dir = sent(tmp.path(), "alice");
     let sent_md_count = std::fs::read_dir(&sent_dir)
         .expect("sent/alice/ must exist")
         .filter_map(|e| e.ok())

--- a/tests/uds_authz.rs
+++ b/tests/uds_authz.rs
@@ -40,6 +40,34 @@ use std::time::{Duration, Instant};
 const ALICE: &str = "aimx-test-alice";
 const BOB: &str = "aimx-test-bob";
 
+/// The default domain baked into the test config (see `spin_up_serve`).
+/// After the daemon's first-start upgrade migration runs, mailbox
+/// storage lives at `<data_dir>/<DEFAULT_DOMAIN>/{inbox,sent}/<name>/`
+/// instead of the legacy `<data_dir>/{inbox,sent}/<name>/`. Tests that
+/// stat mailbox dirs on disk must route through the helpers below so
+/// they pick up the post-migration layout.
+const DEFAULT_DOMAIN: &str = "it.example.com";
+
+/// Path to a mailbox's inbox directory in the post-migration per-domain
+/// layout: `<tmp_root>/data/<DEFAULT_DOMAIN>/inbox/<name>/`.
+fn mailbox_inbox_path(tmp_root: &Path, mailbox: &str) -> PathBuf {
+    tmp_root
+        .join("data")
+        .join(DEFAULT_DOMAIN)
+        .join("inbox")
+        .join(mailbox)
+}
+
+/// Path to a mailbox's sent directory in the post-migration per-domain
+/// layout: `<tmp_root>/data/<DEFAULT_DOMAIN>/sent/<name>/`.
+fn mailbox_sent_path(tmp_root: &Path, mailbox: &str) -> PathBuf {
+    tmp_root
+        .join("data")
+        .join(DEFAULT_DOMAIN)
+        .join("sent")
+        .join(mailbox)
+}
+
 /// RAII guard: kill the serve subprocess and remove the test users on
 /// drop. Drop runs on assertion failure too, so the CI step stays
 /// hermetic.
@@ -373,18 +401,19 @@ fn spin_up_serve() -> Fixture {
     }
 
     let config_content = format!(
-        "domain = \"it.example.com\"\n\
+        "domain = \"{domain}\"\n\
          data_dir = \"{data_dir}\"\n\
          dkim_selector = \"aimx\"\n\n\
          [mailboxes.catchall]\n\
-         address = \"*@it.example.com\"\n\
+         address = \"*@{domain}\"\n\
          owner = \"aimx-catchall\"\n\n\
          [mailboxes.{alice}]\n\
-         address = \"{alice}@it.example.com\"\n\
+         address = \"{alice}@{domain}\"\n\
          owner = \"{alice}\"\n\n\
          [mailboxes.{bob}]\n\
-         address = \"{bob}@it.example.com\"\n\
+         address = \"{bob}@{domain}\"\n\
          owner = \"{bob}\"\n",
+        domain = DEFAULT_DOMAIN,
         data_dir = data_dir.display(),
         alice = ALICE,
         bob = BOB,
@@ -802,14 +831,14 @@ fn mailbox_create_non_root_owner_synthesized_from_peercred() {
 
     // On-disk owner must be alice (the SO_PEERCRED caller), never bob
     // (the wire `Owner:` header). NFR1 in one assertion.
-    let inbox = fx.tmp_root.join("data").join("inbox").join("alicemade");
+    let inbox = mailbox_inbox_path(&fx.tmp_root, "alicemade");
     let on_disk = stat_owner_username(&inbox);
     assert_eq!(
         on_disk, ALICE,
         "expected on-disk owner to equal SO_PEERCRED caller {ALICE}, got {on_disk} \
          (wire Owner:{BOB} must NOT be honored for non-root callers)"
     );
-    let sent = fx.tmp_root.join("data").join("sent").join("alicemade");
+    let sent = mailbox_sent_path(&fx.tmp_root, "alicemade");
     let on_disk_sent = stat_owner_username(&sent);
     assert_eq!(on_disk_sent, ALICE, "sent dir owner must match inbox dir");
 
@@ -834,7 +863,7 @@ fn mailbox_create_non_root_owner_ok() {
         raw_mailbox_create_frame("aliceowned", ALICE).as_bytes(),
     );
     assert_response_contains(&resp, "AIMX/1 OK");
-    let inbox = fx.tmp_root.join("data").join("inbox").join("aliceowned");
+    let inbox = mailbox_inbox_path(&fx.tmp_root, "aliceowned");
     assert_eq!(stat_owner_username(&inbox), ALICE);
     drop(fx);
 }
@@ -940,7 +969,7 @@ fn mailbox_delete_non_root_cross_uid_returns_no_such_mailbox() {
 
     // Defense in depth: bob's mailbox still exists on disk after the
     // failed cross-uid delete attempt.
-    let bob_inbox = fx.tmp_root.join("data").join("inbox").join(BOB);
+    let bob_inbox = mailbox_inbox_path(&fx.tmp_root, BOB);
     assert!(
         bob_inbox.exists(),
         "bob's inbox must still exist after alice's failed cross-uid delete"

--- a/tests/upgrade.rs
+++ b/tests/upgrade.rs
@@ -1,0 +1,508 @@
+//! Integration tests for the one-shot multi-domain upgrade migration.
+//!
+//! Spawns the real `aimx serve` binary against a v1 fixture install in
+//! a `TempDir`, asserts the migration ran, post-migration layout is
+//! correct, the original messages are still readable, an SMTP RCPT to
+//! the (now-relocated) mailbox lands in the right place, the second
+//! restart is a no-op, and a corrupted `.layout-version` causes a hard
+//! startup failure.
+
+use assert_cmd::cargo::cargo_bin;
+use std::fs;
+use std::io::Read as _;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command as StdCommand, Stdio};
+use std::sync::LazyLock;
+use tempfile::TempDir;
+use wait_timeout::ChildExt as _;
+
+/// Process-scoped cache of a pre-generated 2048-bit RSA DKIM keypair.
+/// Generating 2048-bit RSA on every test is multi-hundred-millisecond
+/// work; the cache fronts that one-time cost for the whole upgrade
+/// test module. Mirrors the pattern used in `tests/integration.rs`.
+static DKIM_CACHE: LazyLock<TempDir> = LazyLock::new(|| {
+    let cache = TempDir::new().expect("create DKIM cache tempdir");
+    // dkim-keygen needs a parseable config.toml (it loads Config at startup).
+    let config_content = format!(
+        "domain = \"cache.example.com\"\ndata_dir = \"{}\"\n\n\
+         [mailboxes.catchall]\naddress = \"*@cache.example.com\"\nowner = \"aimx-catchall\"\n",
+        cache.path().display()
+    );
+    fs::write(cache.path().join("config.toml"), config_content).expect("write cache config.toml");
+    let status = StdCommand::new(cargo_bin("aimx"))
+        .env("AIMX_CONFIG_DIR", cache.path())
+        .arg("dkim-keygen")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("Failed to run aimx dkim-keygen for DKIM cache");
+    assert!(
+        status.success(),
+        "aimx dkim-keygen exited non-zero when populating DKIM cache"
+    );
+    cache
+});
+
+fn cached_dkim_private() -> PathBuf {
+    DKIM_CACHE.path().join("dkim").join("private.key")
+}
+fn cached_dkim_public() -> PathBuf {
+    DKIM_CACHE.path().join("dkim").join("public.key")
+}
+
+fn current_username() -> String {
+    // The fixture's `owner = "OWNER_PLACEHOLDER"` is rewritten to the
+    // calling user at test runtime so the daemon can chown the mailbox
+    // dirs to a real, present uid (`getpwnam` resolves locally).
+    let uid = unsafe { libc::geteuid() };
+    if uid == 0 {
+        if let Some(sudo_user) = std::env::var_os("SUDO_USER") {
+            let name = sudo_user.to_string_lossy().into_owned();
+            if !name.is_empty() && name != "root" {
+                return name;
+            }
+        }
+        return "nobody".to_string();
+    }
+    let pw = unsafe { libc::getpwuid(uid) };
+    if pw.is_null() {
+        return "nobody".to_string();
+    }
+    let cstr = unsafe { std::ffi::CStr::from_ptr((*pw).pw_name) };
+    cstr.to_string_lossy().into_owned()
+}
+
+fn find_free_port() -> u16 {
+    std::net::TcpListener::bind("127.0.0.1:0")
+        .unwrap()
+        .local_addr()
+        .unwrap()
+        .port()
+}
+
+/// Copy the v1 fixture into a fresh `TempDir`, rewriting the owner
+/// placeholder, and seed a cached DKIM keypair so the daemon's startup
+/// DKIM load (and any post-migration outbound) finds real keys.
+fn install_v1_fixture(tmp: &Path) -> PathBuf {
+    let fixture =
+        PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/upgrade/v1-single-domain");
+    copy_dir_recursive(&fixture, tmp);
+
+    // Replace the OWNER_PLACEHOLDER with a real local username so
+    // `getpwnam` resolves and the daemon doesn't refuse to chown.
+    let cfg_path = tmp.join("config.toml");
+    let mut body = fs::read_to_string(&cfg_path).unwrap();
+    body = body.replace("OWNER_PLACEHOLDER", &current_username());
+    fs::write(&cfg_path, &body).unwrap();
+
+    // Seed the legacy DKIM keypair at `<cfg>/dkim/{private,public}.key`.
+    let dkim_dir = tmp.join("dkim");
+    fs::create_dir_all(&dkim_dir).unwrap();
+    fs::copy(cached_dkim_private(), dkim_dir.join("private.key")).unwrap();
+    fs::copy(cached_dkim_public(), dkim_dir.join("public.key")).unwrap();
+
+    cfg_path
+}
+
+fn copy_dir_recursive(src: &Path, dst: &Path) {
+    fs::create_dir_all(dst).unwrap();
+    for entry in fs::read_dir(src).unwrap() {
+        let entry = entry.unwrap();
+        let name = entry.file_name();
+        let from = entry.path();
+        let to = dst.join(&name);
+        // Skip `.gitkeep` placeholders that exist only to keep empty
+        // directories under version control.
+        if name == ".gitkeep" {
+            // Still ensure the parent (the empty dir) exists.
+            continue;
+        }
+        if from.is_dir() {
+            copy_dir_recursive(&from, &to);
+        } else {
+            fs::copy(&from, &to).unwrap();
+        }
+    }
+}
+
+/// Spawn `aimx serve` against `tmp` and wait for the SMTP port to bind.
+/// Returns the child process; the caller is responsible for `stop_serve`.
+fn start_serve(tmp: &Path, port: u16) -> Child {
+    let runtime = tmp.join("run");
+    fs::create_dir_all(&runtime).unwrap();
+    let mut child = StdCommand::new(cargo_bin("aimx"))
+        .env("AIMX_CONFIG_DIR", tmp)
+        .env("AIMX_RUNTIME_DIR", &runtime)
+        // The sandbox-fallback knob keeps test runs free of systemd-run
+        // dependencies that aren't in the harness's environment.
+        .env("AIMX_SANDBOX_FORCE_FALLBACK", "1")
+        .arg("--data-dir")
+        .arg(tmp)
+        .arg("serve")
+        .arg("--bind")
+        .arg(format!("127.0.0.1:{port}"))
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn aimx serve");
+
+    let started = std::time::Instant::now();
+    loop {
+        if started.elapsed() > std::time::Duration::from_secs(30) {
+            let _ = child.kill();
+            let mut stderr_buf = String::new();
+            if let Some(mut err) = child.stderr.take() {
+                let _ = err.read_to_string(&mut stderr_buf);
+            }
+            panic!(
+                "aimx serve did not start within 30s on port {port}; stderr:\n{}",
+                stderr_buf.trim()
+            );
+        }
+        if std::net::TcpStream::connect(format!("127.0.0.1:{port}")).is_ok() {
+            break;
+        }
+        if let Ok(Some(status)) = child.try_wait() {
+            let mut stderr_buf = String::new();
+            if let Some(mut err) = child.stderr.take() {
+                let _ = err.read_to_string(&mut stderr_buf);
+            }
+            panic!(
+                "aimx serve exited early with {status:?} before binding port {port}; stderr:\n{}",
+                stderr_buf.trim()
+            );
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+    child
+}
+
+fn stop_serve(mut child: Child) {
+    unsafe {
+        libc::kill(child.id() as libc::pid_t, libc::SIGTERM);
+    }
+    let _ = child.wait_timeout(std::time::Duration::from_secs(10));
+}
+
+/// Run `aimx serve` to completion, returning its exit status + stderr.
+/// Used by tests that expect a hard-fail at startup (e.g. corrupted
+/// `.layout-version`): the daemon never binds, so the test cannot
+/// rely on `start_serve` returning successfully.
+fn run_serve_expecting_exit(tmp: &Path, port: u16) -> (std::process::ExitStatus, String) {
+    let runtime = tmp.join("run");
+    fs::create_dir_all(&runtime).unwrap();
+    let mut child = StdCommand::new(cargo_bin("aimx"))
+        .env("AIMX_CONFIG_DIR", tmp)
+        .env("AIMX_RUNTIME_DIR", &runtime)
+        .env("AIMX_SANDBOX_FORCE_FALLBACK", "1")
+        .arg("--data-dir")
+        .arg(tmp)
+        .arg("serve")
+        .arg("--bind")
+        .arg(format!("127.0.0.1:{port}"))
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn aimx serve");
+
+    // Give the daemon a fair window to detect the corrupted marker and
+    // refuse to start. 10s is generous; the actual path is microsecond
+    // work.
+    let outcome = child
+        .wait_timeout(std::time::Duration::from_secs(15))
+        .expect("wait_timeout");
+    let status = match outcome {
+        Some(s) => s,
+        None => {
+            // Daemon did not exit; kill it so the test can fail cleanly.
+            let _ = child.kill();
+            let _ = child.wait();
+            panic!("aimx serve unexpectedly stayed alive after 15s when a hard fail was expected");
+        }
+    };
+    let mut stderr_buf = String::new();
+    if let Some(mut err) = child.stderr.take() {
+        let _ = err.read_to_string(&mut stderr_buf);
+    }
+    (status, stderr_buf)
+}
+
+fn smtp_send(port: u16, from: &str, rcpt: &str, body_lines: &[&str]) {
+    use std::io::{BufRead as _, Write as _};
+    let stream = std::net::TcpStream::connect(format!("127.0.0.1:{port}")).unwrap();
+    stream
+        .set_read_timeout(Some(std::time::Duration::from_secs(10)))
+        .unwrap();
+    let mut reader = std::io::BufReader::new(stream.try_clone().unwrap());
+    let mut writer = stream;
+
+    let mut buf = String::new();
+    reader.read_line(&mut buf).unwrap();
+    assert!(buf.starts_with("220"), "expected SMTP banner, got: {buf}");
+
+    buf.clear();
+    write!(writer, "EHLO test.local\r\n").unwrap();
+    loop {
+        reader.read_line(&mut buf).unwrap();
+        if buf.contains("250 ") {
+            break;
+        }
+    }
+
+    buf.clear();
+    write!(writer, "MAIL FROM:<{from}>\r\n").unwrap();
+    reader.read_line(&mut buf).unwrap();
+    assert!(buf.starts_with("250"), "MAIL FROM failed: {buf}");
+
+    buf.clear();
+    write!(writer, "RCPT TO:<{rcpt}>\r\n").unwrap();
+    reader.read_line(&mut buf).unwrap();
+    assert!(buf.starts_with("250"), "RCPT TO failed: {buf}");
+
+    buf.clear();
+    write!(writer, "DATA\r\n").unwrap();
+    reader.read_line(&mut buf).unwrap();
+    assert!(buf.starts_with("354"), "DATA prompt failed: {buf}");
+
+    for line in body_lines {
+        write!(writer, "{line}\r\n").unwrap();
+    }
+    write!(writer, ".\r\n").unwrap();
+    buf.clear();
+    reader.read_line(&mut buf).unwrap();
+    assert!(buf.starts_with("250"), "DATA end failed: {buf}");
+
+    write!(writer, "QUIT\r\n").unwrap();
+    let _ = reader.read_line(&mut buf);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[test]
+fn upgrade_migrates_v1_fixture_end_to_end() {
+    let tmp = TempDir::new().unwrap();
+    install_v1_fixture(tmp.path());
+
+    // Sanity: fixture is shaped like v1 before the daemon starts.
+    assert!(tmp.path().join("inbox").join("info").is_dir());
+    assert!(tmp.path().join("inbox").join("support").is_dir());
+    assert!(tmp.path().join("dkim").join("private.key").is_file());
+    let cfg_before = fs::read_to_string(tmp.path().join("config.toml")).unwrap();
+    assert!(
+        cfg_before.contains("domain = \"fixture.example\""),
+        "fixture must start with legacy `domain = ...`",
+    );
+    assert!(
+        cfg_before.contains("[mailboxes.info]"),
+        "fixture must start with legacy local-part mailbox keys",
+    );
+
+    let port = find_free_port();
+    let child = start_serve(tmp.path(), port);
+    stop_serve(child);
+
+    // Post-migration layout.
+    let domain = "fixture.example";
+    assert!(
+        tmp.path()
+            .join(domain)
+            .join("inbox")
+            .join("info")
+            .join("2026-01-15-080000-hello-world.md")
+            .is_file(),
+        "v1 inbox/info/<msg>.md must be readable from new per-domain path",
+    );
+    assert!(
+        tmp.path()
+            .join(domain)
+            .join("inbox")
+            .join("support")
+            .join("2026-02-01-120000-bug-report.md")
+            .is_file(),
+        "v1 inbox/support/<msg>.md must be readable from new per-domain path",
+    );
+    assert!(
+        !tmp.path().join("inbox").exists(),
+        "legacy <data_dir>/inbox/ must be gone after migration",
+    );
+    assert!(
+        !tmp.path().join("sent").exists(),
+        "legacy <data_dir>/sent/ must be gone after migration",
+    );
+    assert!(
+        tmp.path().join(domain).join("inbox").join("info").is_dir(),
+        "per-domain inbox must be in place",
+    );
+
+    // DKIM relocated to per-domain dir.
+    assert!(
+        tmp.path()
+            .join("dkim")
+            .join(domain)
+            .join("private.key")
+            .is_file(),
+        "private.key must be at <dkim_dir>/<default_domain>/ post-migration",
+    );
+    assert!(
+        !tmp.path().join("dkim").join("private.key").is_file(),
+        "legacy <dkim_dir>/private.key must be gone after migration",
+    );
+
+    // Config normalized.
+    let cfg_after = fs::read_to_string(tmp.path().join("config.toml")).unwrap();
+    assert!(
+        cfg_after.contains("domains = ["),
+        "config must carry `domains = [...]` post-migration; got:\n{cfg_after}"
+    );
+    assert!(
+        !cfg_after
+            .lines()
+            .any(|l| l.trim_start().starts_with("domain =")),
+        "legacy `domain = ...` scalar must be gone; got:\n{cfg_after}"
+    );
+    // Mailbox keys stay operator-friendly on disk so every downstream
+    // CLI lookup that targets a mailbox by its local-part name keeps
+    // working without a runtime rewrite. The on-disk FQDN re-key is
+    // deferred to the runtime data plane rewire that lands separately.
+    assert!(
+        cfg_after.contains("[mailboxes.info]"),
+        "operator-friendly mailbox key must be preserved on disk; got:\n{cfg_after}"
+    );
+    assert!(
+        cfg_after.contains("[mailboxes.support]"),
+        "operator-friendly mailbox key must be preserved on disk; got:\n{cfg_after}"
+    );
+
+    // Marker present.
+    let marker = tmp.path().join(".layout-version");
+    let marker_body = fs::read_to_string(&marker).unwrap();
+    assert_eq!(marker_body, "2\n", "layout marker must contain `2\\n`");
+}
+
+#[test]
+fn upgrade_is_idempotent_on_second_start() {
+    let tmp = TempDir::new().unwrap();
+    install_v1_fixture(tmp.path());
+
+    // First start runs the migration.
+    let port1 = find_free_port();
+    let c1 = start_serve(tmp.path(), port1);
+    stop_serve(c1);
+
+    let cfg_after_first = fs::read_to_string(tmp.path().join("config.toml")).unwrap();
+    let marker_after_first = fs::read_to_string(tmp.path().join(".layout-version")).unwrap();
+
+    // Second start is a no-op at the migration layer. We can't observe
+    // "no log line" directly from outside the daemon, but we can pin
+    // that the on-disk config + marker are byte-identical to after
+    // the first start (which proves no rewrite happened).
+    let port2 = find_free_port();
+    let c2 = start_serve(tmp.path(), port2);
+    stop_serve(c2);
+
+    let cfg_after_second = fs::read_to_string(tmp.path().join("config.toml")).unwrap();
+    let marker_after_second = fs::read_to_string(tmp.path().join(".layout-version")).unwrap();
+
+    assert_eq!(
+        cfg_after_first, cfg_after_second,
+        "second start must not rewrite config.toml",
+    );
+    assert_eq!(
+        marker_after_first, marker_after_second,
+        "second start must not rewrite the layout marker",
+    );
+}
+
+#[test]
+fn upgrade_hard_fails_on_corrupted_marker() {
+    let tmp = TempDir::new().unwrap();
+    install_v1_fixture(tmp.path());
+    // Plant a bogus marker before first start. Per the design: the
+    // marker is the source of truth, and a wrong-version marker is a
+    // hard startup error rather than a "ignore + remigrate" path.
+    fs::write(tmp.path().join(".layout-version"), "99\n").unwrap();
+
+    let port = find_free_port();
+    let (status, stderr) = run_serve_expecting_exit(tmp.path(), port);
+    assert!(
+        !status.success(),
+        "expected non-zero exit on corrupted marker; got {status:?}",
+    );
+    assert!(
+        stderr.contains("upgrade migration failed"),
+        "stderr must carry the canonical migration-failure prefix; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("book/multi-domain.md"),
+        "stderr must point at book/multi-domain.md; got:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("99") || stderr.contains("expected '2'"),
+        "stderr must reference the corrupted marker value; got:\n{stderr}"
+    );
+}
+
+/// Post-migration SMTP RCPT TO must land in the new FQDN-keyed mailbox
+/// storage path. The migration deliberately preserves the legacy
+/// in-memory friendly-key shape for the current daemon session and
+/// teaches `Config::inbox_dir` / `Config::sent_dir` to route to the
+/// per-domain layout once the marker is on disk, so RCPT to a v1
+/// local-part keeps working post-migration and the file lands under
+/// `<data_dir>/<default_domain>/inbox/<local-part>/`.
+#[test]
+fn upgrade_smtp_rcpt_lands_in_new_fqdn_keyed_path() {
+    let tmp = TempDir::new().unwrap();
+    install_v1_fixture(tmp.path());
+    let port = find_free_port();
+    let child = start_serve(tmp.path(), port);
+
+    let body_lines = &[
+        "From: smoke@sender.example",
+        "To: info@fixture.example",
+        "Subject: post-migration smoke",
+        "Date: Tue, 03 Feb 2026 10:00:00 +0000",
+        "Message-ID: <smoke-1@sender.example>",
+        "",
+        "Body of the smoke test.",
+    ];
+    smtp_send(
+        port,
+        "smoke@sender.example",
+        "info@fixture.example",
+        body_lines,
+    );
+
+    let started = std::time::Instant::now();
+    let new_inbox = tmp
+        .path()
+        .join("fixture.example")
+        .join("inbox")
+        .join("info");
+    loop {
+        if started.elapsed() > std::time::Duration::from_secs(10) {
+            stop_serve(child);
+            let snapshot: Vec<String> = fs::read_dir(&new_inbox)
+                .unwrap()
+                .filter_map(|e| e.ok())
+                .map(|e| e.file_name().to_string_lossy().into_owned())
+                .collect();
+            panic!(
+                "post-migration ingest never landed under {}; current contents: {snapshot:?}",
+                new_inbox.display()
+            );
+        }
+        let landed = fs::read_dir(&new_inbox)
+            .unwrap()
+            .filter_map(|e| e.ok())
+            .any(|e| {
+                let n = e.file_name().to_string_lossy().into_owned();
+                n.contains("smoke") || n.contains("post-migration")
+            });
+        if landed {
+            break;
+        }
+        std::thread::sleep(std::time::Duration::from_millis(100));
+    }
+
+    stop_serve(child);
+}


### PR DESCRIPTION
## Sprint Goal

Implement the atomic on-disk migration that brings legacy single-domain installs onto the canonical multi-domain layout on first `aimx serve` startup under the new binary. Idempotent across restarts, hard-fail on partial completion, single INFO log line on success.

## Stories Implemented

### [S2-1] Detection logic + `.layout-version` marker semantics
- [x] New module `src/upgrade_migration.rs` exposes `pub enum LayoutState { Migrated, NeedsMigration(Indicators), FreshInstall, Corrupted(String) }` and `pub fn detect_layout_state(...)`.
- [x] `Indicators` carries which v1-shape signals fired, for logging at migration time.
- [x] `LayoutState::Corrupted` returned on wrong/garbage `.layout-version` content; `serve.rs` translates to a startup hard error.
- [x] `LayoutState::FreshInstall` triggers a one-shot `.layout-version: 2` write before the daemon starts accepting traffic.
- [x] Unit tests cover: pristine v1 layout, half-migrated layout, fully migrated, fresh install, corrupted marker.
- [x] Module is named `src/upgrade_migration.rs` rather than the originally-spec'd `src/upgrade.rs` because the binary self-update flow already owns the `upgrade` name. Called out below in Technical Decisions.

### [S2-2] Storage + DKIM atomic relocation via `rename(2)`
- [x] `relocate_storage_for_default_domain(data_dir, default_domain)` renames `<data_dir>/inbox` → `<data_dir>/<default_domain>/inbox/` and `<data_dir>/sent` → `<data_dir>/<default_domain>/sent/`.
- [x] `relocate_dkim_for_default_domain(dkim_dir, default_domain)` creates `<dkim_dir>/<default_domain>/` mode `0700 root:root`, then renames `private.key` and `public.key` into it (modes `0600` / `0644` preserved across rename).
- [x] Idempotency per-file: when the destination exists and the source doesn't, the rename is skipped.
- [x] EXDEV detection: cross-filesystem rename caught and reported as `"<src> and <dst> must be on the same filesystem; see book/multi-domain.md for manual recovery"`.
- [x] Unit tests with `TempDir`: clean v1 → v2, half-relocated storage (skips rename), missing DKIM file (proceeds), refuses to overwrite when both source and destination exist.

### [S2-3] Config rewrite via `write_atomic` + `.layout-version` write
- [x] `rewrite_config_to_canonical_shape(config_path, in_memory_config)` serializes via the existing `write_atomic` helper.
- [x] `write_layout_version_marker(data_dir)` writes `<data_dir>/.layout-version` containing `2\n`, mode `0644 root:root`.
- [x] Idempotency: re-running on an already-canonical config writes the same bytes.
- [x] Unit tests cover legacy → canonical rewrite, already-canonical no-op, marker write idempotent across repeated calls.
- [ ] **Deferred**: the on-disk legacy local-part → FQDN re-key (`[mailboxes.info]` → `[mailboxes.\"info@<domains[0]>\"]`). Doing it here would break every downstream `config.mailboxes.get(<local>)` callsite (ingest, send, hooks, CLI `mailboxes show` / `hooks create`) until the runtime data plane is rewired. The structural `domain` → `domains` promotion still ships in this PR. See Technical Decisions / Deferred Items below.

### [S2-4] Wire the migration into `serve.rs` startup under the lock hierarchy
- [x] `serve.rs` startup sequence: load config → detect layout state → if `NeedsMigration`, acquire locks + run migration steps in order (storage → DKIM → config → marker) → continue to listener bind.
- [x] If `LayoutState::FreshInstall`, write `.layout-version: 2` before continuing.
- [x] On migration error, `serve.rs` returns the canonical `\"upgrade migration failed: <reason>; see book/multi-domain.md for manual recovery\"` error which surfaces to the operator on stderr and exits with code 1.
- [x] On migration success, emit a single `tracing::info!(target: \"aimx::upgrade\", \"upgrade migration completed: ...\")` line summarising every file/path that moved.
- [x] Subsequent restarts with `.layout-version: 2` present: `detect_layout_state` short-circuits with `Migrated`, no locks acquired, no log line.
- [x] Per-mailbox locks acquired in sorted FQDN order against the shared `MailboxLocks` pool, then `CONFIG_WRITE_LOCK`. Matches the documented cascade-delete ordering.

### [S2-5] Upgrade-fixture integration test
- [x] Fixture v1 install at `tests/fixtures/upgrade/v1-single-domain/` with 2 mailboxes (`info`, `support`) and 2 messages per mailbox.
- [x] New integration test `tests/upgrade.rs` exercises the full upgrade path end-to-end against the fixture.
- [x] Post-migration assertions: storage relocated, DKIM relocated, config normalized (`domains = [\"fixture.example\"]`), `.layout-version: 2` present, original messages still readable from the per-domain path.
- [x] Post-migration SMTP RCPT to a v1 mailbox local-part lands in the new per-domain inbox.
- [x] Idempotency: second `aimx serve` start against the same `TempDir` is a no-op (config + marker byte-identical to after first start).
- [x] Hard-fail: a fixture with a corrupted `.layout-version` (`99`) causes the daemon to exit with the canonical hard error.

## Technical Decisions

- **Mailbox-key re-key deferred.** The S2-3 acceptance criteria call for both `domain → domains` AND `[mailboxes.<local>]` → `[mailboxes.\"<local>@<domain>\"]` to land in the config rewrite. Doing the latter in this sprint breaks every downstream `config.mailboxes.get(<local>)` callsite (`ingest::resolve_recipient_mailbox`, `send_handler` lookups, CLI `aimx hooks create --mailbox alice`, `aimx mailboxes show <name>`) because the runtime data plane is not yet FQDN-aware. The result is a daemon that migrates on first start and then can't deliver mail to its own configured mailboxes — every existing integration test that uses `setup_test_env` (~120 tests) fails. The pragmatic call: ship the structural `domain → domains` promotion now, defer the mailbox-key FQDN re-key to the runtime data-plane rewire (next sprint) where it lands alongside `resolve_mailbox_for_rcpt` and the per-domain DKIM map. On-disk shape after this PR: canonical `domains = [\"x.com\"]` with operator-friendly mailbox keys preserved. The marker is still bumped to `2` because the **storage + DKIM** layout fully converts to the per-domain shape.
- **Layout-aware path shim in `Config::inbox_dir` / `sent_dir`.** Sprint 2's storage relocation physically moves mailbox directories to `<data_dir>/<default_domain>/{inbox|sent}/<name>/`. The runtime data plane (ingest, send_handler, state_handler, mailbox_handler, doctor, CLI) needs to find them. Rather than refactor every callsite to the new per-domain storage helper (that's the next sprint's S3-5 deliverable), `Config::inbox_dir` / `sent_dir` / `mailbox_dir` consult `<data_dir>/.layout-version` and route to the per-domain location post-migration. Same-process callers see v2 paths immediately after the marker lands. One `stat` per call, microsecond cost.
- **DKIM key load resolves per-domain post-migration.** `serve.rs` calls into `crate::upgrade_migration::resolve_active_dkim_dir(&config, &dkim_dir)` to find the key dir. If `<dkim_dir>/<default_domain>/private.key` exists (post-migration), uses the per-domain path; otherwise falls back to `<dkim_dir>/` (fresh single-domain installs). The follow-up `HashMap<domain, DkimKeyEntry>` lookup replaces this single-key load entirely.
- **`send_handler` + `state_handler` + `mailbox_handler` now route storage paths through the layout-aware `Config` helpers.** Previously these built `data_dir.join(\"inbox\").join(name)` directly, bypassing `Config::inbox_dir`. Updated to go through the layout-aware helpers so a post-migration daemon writes/reads under the per-domain tree.
- **New module is `src/upgrade_migration.rs`, not `src/upgrade.rs`.** The sprint spec called for `src/upgrade.rs`, but the existing self-update CLI (`aimx upgrade`) already owns that module name and is widely referenced. Renaming the existing module would have been a much larger and unrelated diff. The new module's docstring and the commit message both explain the naming.
- **`MigratedOutcome` boxed inside `StartupMigrationOutcome::Migrated`.** Clippy's `large_enum_variant` lint flagged the inline form. Boxing keeps the enum tiny on the stack at every pattern-match site, with no observable runtime cost (one heap allocation per migration run, and the migration runs at most once per install).

## Deferred Items

- **On-disk legacy local-part → FQDN mailbox key re-key.** Deferred from the S2-3 AC because the runtime data plane is not yet FQDN-aware. Lands in the runtime data-plane rewire that introduces `resolve_mailbox_for_rcpt` and the per-domain DKIM map.
- **Per-domain DKIM `HashMap` load.** The current `serve.rs` still loads a single DKIM key for the default domain. The per-domain `HashMap<String, DkimKeyEntry>` keyed on the From: domain (with hot-reload via `ArcSwap`) lands in the next sprint's S3-2.

## Review Focus Areas

- **`src/upgrade_migration.rs`** — the heart of the sprint. The detection tree (`detect_layout_state`), the rename helpers (`relocate_storage_for_default_domain`, `relocate_dkim_for_default_domain`, `move_if_pending`), the config rewrite, the marker write, the orchestration (`run_startup_migration`), and the layout-aware DKIM resolver (`resolve_active_dkim_dir`). Cross-device EXDEV handling deserves attention — we hard-fail rather than copy+delete because atomicity matters more than convenience here.
- **`src/serve.rs::run_upgrade_migration_at_startup`** — the lock-hierarchy gymnastics. Outer per-mailbox locks acquired in sorted FQDN order against the shared `MailboxLocks` pool, then inner `CONFIG_WRITE_LOCK`. The lock acquisition is technically unnecessary at startup (no concurrent writer exists), but the discipline is in place so any future refactor that moves the migration later in startup inherits it.
- **`src/config.rs::Config::inbox_dir` / `sent_dir` / `storage_root_for_default_domain`** — the layout-aware path resolution shim. The marker check on every call is the part most likely to deserve a cached field; the next sprint's storage helper will replace it entirely.
- **`tests/upgrade.rs`** — the end-to-end integration coverage. The fixture under `tests/fixtures/upgrade/v1-single-domain/` is realistic (legacy `domain = \"fixture.example\"` config + 2 mailboxes + 2 messages each + a v1 DKIM keypair sourced from the test-scoped cache). The four test functions exercise the full happy path, the idempotency invariant, the corrupted-marker hard-fail, and the post-migration SMTP RCPT.
- **`tests/integration.rs::storage_subdir`** — the layout-aware test helper that lets the existing integration suite keep finding mailbox files after the migration relocates them. Two existing tests (`mcp_mark_read_concurrent_with_inbound_ingest`, `concurrent_ingest_burst_and_mark_same_mailbox_no_torn_writes`) now re-resolve `alice_dir` after `start_serve` so the pre-seed and post-daemon-read use the right path.

## Test Coverage

- 1207 unit tests pass (`cargo test --bin aimx`).
- 116 integration tests pass (`cargo test --test integration`); 8 ignored as before.
- 4 upgrade-fixture integration tests pass (`cargo test --test upgrade`).
- `cargo clippy --all-targets -- -D warnings` clean.
- `cargo fmt -- --check` clean.
- Verifier crate (`services/verifier/`) builds clean (no changes there).