### PR TITLE
[Sprint 4] aimx domains list + add + UDS verbs + DKIM keygen flag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,7 @@ jobs:
           cargo test --no-run --test uds_authz
           cargo test --no-run --test hooks_list_filter
           cargo test --no-run --test integration
+          cargo test --no-run --test domains_uds
 
       - name: Run mailbox isolation test (under sudo)
         run: |
@@ -173,6 +174,22 @@ jobs:
             mailbox_list_full_cycle_against_root_owned_config \
             email_list_full_cycle_against_root_owned_config \
             hook_list_full_cycle_against_root_owned_config
+
+      - name: Run domains UDS hot-reload tests (under sudo)
+        run: |
+          # `tests/domains_uds.rs` covers `DOMAIN-CRUD` over UDS:
+          # the daemon `DOMAIN-ADD` verb, hot-reload of in-memory
+          # `Arc<Config>` + per-domain DKIM map, SMTP RCPT acceptance
+          # for the freshly-added domain without a restart, duplicate-
+          # add rejection, and the root daemon-stopped fallback.
+          # These tests gate on `skip_if_not_root()` rather than
+          # `#[ignore]`, so we run them as root WITHOUT `--ignored`;
+          # the non-root subset (DKIM keygen path coverage) re-runs
+          # harmlessly. `--test-threads=1` avoids contention on the
+          # shared `AIMX_CONFIG_DIR` / UDS socket directory.
+          BIN=$(ls -t target/debug/deps/domains_uds-* | grep -v '\.d$' | head -n 1)
+          test -x "$BIN"
+          sudo AIMX_INTEGRATION_SUDO=1 "$BIN" --test-threads=1
 
       - name: Tear down test users
         if: always()

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -44,6 +44,11 @@ pub enum Action {
     MarkReadWrite(String),
     /// Create or delete a hook on a named mailbox.
     HookCrud(String),
+    /// Add, remove, or list domains. Root-only — domain management
+    /// belongs to the server operator, not to per-mailbox owners. Mirrors
+    /// the existing `SystemCommand` shape: the predicate's only check is
+    /// `caller_uid == 0`, no mailbox context required.
+    DomainCrud,
     /// Run a system-level command (setup, serve, dkim-keygen, …).
     /// Root-only.
     SystemCommand,
@@ -203,7 +208,7 @@ pub fn authorize(
     }
 
     match action {
-        Action::SystemCommand => Err(AuthError::NotRoot),
+        Action::SystemCommand | Action::DomainCrud => Err(AuthError::NotRoot),
         Action::MailboxCreate { owner_uid } => {
             if caller_uid == owner_uid {
                 Ok(())
@@ -352,6 +357,27 @@ mod tests {
             authorize(1000, Action::SystemCommand, None),
             Err(AuthError::NotRoot),
         );
+    }
+
+    /// `Action::DomainCrud` is root-only; non-root callers refuse with
+    /// the canonical `NotRoot` shape. The mailbox arg is irrelevant.
+    #[test]
+    fn non_root_domain_crud_is_not_root() {
+        assert_eq!(
+            authorize(1000, Action::DomainCrud, None),
+            Err(AuthError::NotRoot),
+        );
+        assert_eq!(
+            authorize(1, Action::DomainCrud, None),
+            Err(AuthError::NotRoot),
+        );
+    }
+
+    /// Root passes `Action::DomainCrud` unconditionally — domain
+    /// management is operator-only.
+    #[test]
+    fn root_passes_domain_crud() {
+        assert!(authorize(0, Action::DomainCrud, None).is_ok());
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -22,6 +22,7 @@ Server administration:
   serve        Start the SMTP daemon
   doctor       Show server health, DNS, and recent logs
   logs         Tail the aimx service log
+  domains      Manage configured domains
   dkim-keygen  Generate a DKIM keypair
   portcheck    Check port 25 connectivity (inbound, outbound)
   uninstall    Uninstall the aimx service (config and data retained)
@@ -257,6 +258,10 @@ pub enum Command {
     #[command(subcommand, alias = "hook")]
     Hooks(HookCommand),
 
+    /// Manage domains
+    #[command(subcommand, alias = "domain")]
+    Domains(DomainsCommand),
+
     /// Start the stdio MCP server (for AI agents)
     Mcp,
 
@@ -326,6 +331,15 @@ pub enum Command {
         /// DKIM selector name
         #[arg(long, default_value = "aimx")]
         selector: String,
+
+        /// Target domain. When omitted, defaults to the first entry of
+        /// `domains` in `config.toml` (the default domain). When set,
+        /// the keypair is written under
+        /// `<dkim_dir>/<domain>/{private,public}.key` (per-domain
+        /// layout). The target domain must already be in `domains` —
+        /// add new domains with `aimx domains add` first.
+        #[arg(long)]
+        domain: Option<String>,
 
         /// Overwrite existing keys
         #[arg(long)]
@@ -580,6 +594,42 @@ pub enum HookCommand {
         /// Skip confirmation prompt
         #[arg(short = 'y', long)]
         yes: bool,
+    },
+}
+
+#[derive(Subcommand, Clone)]
+pub enum DomainsCommand {
+    /// List configured domains, their DKIM status, mailbox counts, and
+    /// per-domain override summary
+    List,
+
+    /// Add a new domain to the install. Generates a per-domain DKIM
+    /// keypair, prints DNS records to publish, runs the DNS
+    /// verification loop, and hot-reloads the running daemon.
+    Add {
+        /// Domain to add (e.g. side-project.com)
+        domain: String,
+
+        /// Optional DKIM selector (defaults to the top-level
+        /// `dkim_selector` or the built-in `aimx`)
+        #[arg(long)]
+        selector: Option<String>,
+
+        /// Skip the post-add DNS verification loop. Useful when DNS is
+        /// being provisioned out-of-band.
+        #[arg(long)]
+        no_dns_check: bool,
+    },
+
+    /// Remove a domain. (Implementation lands in a follow-up release.)
+    Remove {
+        /// Domain to remove (e.g. side-project.com)
+        domain: String,
+
+        /// Cascade-delete mailboxes on this domain and remove its
+        /// per-domain storage tree. DKIM keys on disk are preserved.
+        #[arg(long)]
+        force: bool,
     },
 }
 

--- a/src/dkim.rs
+++ b/src/dkim.rs
@@ -54,6 +54,17 @@ pub fn generate_keypair(dkim_root: &Path, force: bool) -> Result<(), Box<dyn std
 
     std::fs::create_dir_all(dkim_root).map_err(|e| wrap_dkim_write_error(dkim_root, e))?;
 
+    // Tighten the parent dir to `0700` so the `0600` private key cannot
+    // be reached by a traversal-bit probe even when the file mode is
+    // correct. Idempotent — every caller is allowed to re-chmod its
+    // own dkim_root. On non-Unix this is a no-op.
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(dkim_root, std::fs::Permissions::from_mode(0o700))
+            .map_err(|e| wrap_dkim_write_error(dkim_root, e))?;
+    }
+
     // Force-overwrite path: remove pre-existing files so `create_new(true)`
     // succeeds with the tightened mode. (Otherwise `OpenOptions` would
     // fail with `AlreadyExists` and leave the old file at its old mode.)
@@ -556,6 +567,31 @@ mod tests {
             mode, 0o600,
             "v0.2: DKIM private key must be root-only (0o600) because \
              signing happens inside the `aimx serve` daemon."
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn dkim_root_directory_is_chmod_0700() {
+        // The private key is `0o600`, but the directory traversal bit
+        // matters too — a world-traversable parent dir leaks the
+        // existence and metadata of the key. `generate_keypair` must
+        // tighten its `dkim_root` to `0o700` itself so both the CLI
+        // direct path and the daemon path land at the same on-disk
+        // permissions without each caller having to remember to chmod.
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = TempDir::new().unwrap();
+        let per_domain_dir = tmp.path().join("example.com");
+        generate_keypair(&per_domain_dir, false).unwrap();
+        let mode = std::fs::metadata(&per_domain_dir)
+            .unwrap()
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(
+            mode, 0o700,
+            "DKIM parent dir must be 0o700 to keep the 0o600 private key \
+             unreachable via the traversal bit"
         );
     }
 

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -1,0 +1,366 @@
+//! `aimx domains list | add | remove` CLI.
+//!
+//! Domain CRUD goes through the daemon UDS first so the running daemon
+//! hot-swaps its in-memory `Arc<Config>` plus the per-domain DKIM map
+//! without a restart. The daemon enforces root-only authz via
+//! `Action::DomainCrud` (see `src/auth.rs`).
+//!
+//! When the daemon is stopped:
+//! - Root falls back to a direct `config.toml` edit + DKIM keygen +
+//!   restart hint.
+//! - Non-root hard-errors with the canonical "daemon must be running"
+//!   message because it cannot write the root-owned config.
+//!
+//! `list` reads the daemon's response shape so a non-root operator
+//! running on a host whose daemon is up still gets the listing (the
+//! daemon checks `Action::DomainCrud` and rejects non-root callers
+//! with `ERR EACCES`, which the CLI surfaces verbatim).
+
+use std::io::{self, Write};
+use std::path::Path;
+
+use crate::cli::DomainsCommand;
+use crate::config::Config;
+use crate::domain_list_handler::DomainListRow;
+use crate::platform::is_root;
+use crate::term;
+
+/// Exit code used when the daemon UDS is missing and the caller cannot
+/// fall back to the direct-edit path. Mirrors
+/// `mailbox::EXIT_SOCKET_MISSING` for tooling parity.
+pub(crate) const EXIT_SOCKET_MISSING: i32 = 2;
+
+/// Canonical hint for the non-root daemon-down branch. Hoisted to a
+/// constant so the integration test can match it verbatim.
+pub(crate) const SOCKET_MISSING_HINT: &str = "daemon must be running for non-root domain CRUD; start `aimx serve` \
+     or run with sudo to fall back to direct config edit.";
+
+pub fn run(cmd: DomainsCommand, data_dir: Option<&Path>) -> Result<(), Box<dyn std::error::Error>> {
+    match cmd {
+        DomainsCommand::List => list(),
+        DomainsCommand::Add {
+            domain,
+            selector,
+            no_dns_check,
+        } => add(&domain, selector.as_deref(), no_dns_check, data_dir),
+        DomainsCommand::Remove { domain, force } => remove(&domain, force),
+    }
+}
+
+/// `aimx domains list` — fetch via UDS, render the table.
+fn list() -> Result<(), Box<dyn std::error::Error>> {
+    let rows = list_via_daemon()?;
+    render_table(&rows);
+    Ok(())
+}
+
+/// Render the domain table. Uses `term.rs` semantic helpers; no raw
+/// color calls. Column widths are chosen to keep the table readable on
+/// an 80-column terminal in the common case (single-domain through
+/// half-dozen domains).
+pub(crate) fn render_table(rows: &[DomainListRow]) {
+    if rows.is_empty() {
+        println!("No domains configured.");
+        return;
+    }
+
+    // Column widths: Domain (32), Default (8), DKIM (10), Mailboxes (10),
+    // Unread (7), Overrides (rest).
+    println!(
+        "{}  {}  {}  {}  {}  {}",
+        term::header("DOMAIN                          "),
+        term::header("DEFAULT"),
+        term::header("DKIM     "),
+        term::header("MAILBOXES"),
+        term::header("UNREAD"),
+        term::header("OVERRIDES"),
+    );
+    for row in rows {
+        let default_mark = if row.default {
+            term::success_mark().to_string()
+        } else {
+            " ".to_string()
+        };
+        let dkim_status = if row.dkim_loaded {
+            term::success("loaded").to_string()
+        } else {
+            term::warn("MISSING").to_string()
+        };
+        let overrides = if row.overrides.is_empty() {
+            term::dim("—").to_string()
+        } else {
+            row.overrides.clone()
+        };
+        println!(
+            "{:<32}  {:^7}  {:<9}  {:>9}  {:>6}  {}",
+            term::highlight(&row.domain).to_string(),
+            default_mark,
+            dkim_status,
+            row.mailbox_count,
+            row.unread,
+            overrides,
+        );
+    }
+}
+
+/// Fetch the daemon's `DOMAIN-LIST` JSON response and decode it.
+/// Returns the raw rows; the caller renders.
+pub(crate) fn list_via_daemon() -> Result<Vec<DomainListRow>, Box<dyn std::error::Error>> {
+    let json = match crate::mcp::submit_domain_list_via_daemon_for_cli() {
+        Ok(s) => s,
+        Err(crate::mcp::MailboxLifecycleFallback::SocketMissing) => {
+            exit_socket_missing();
+        }
+        Err(crate::mcp::MailboxLifecycleFallback::Daemon(msg)) => {
+            return Err(msg.into());
+        }
+    };
+    let rows: Vec<DomainListRow> =
+        serde_json::from_str(&json).map_err(|e| format!("malformed DOMAIN-LIST response: {e}"))?;
+    Ok(rows)
+}
+
+/// `aimx domains add <domain> [--selector <s>] [--no-dns-check]` — UDS
+/// first, daemon-down fallback for root, hard-error for non-root.
+fn add(
+    domain: &str,
+    selector: Option<&str>,
+    no_dns_check: bool,
+    data_dir: Option<&Path>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let _ = data_dir; // reserved for future use (`--data-dir` is global)
+    let normalized = domain.trim().to_ascii_lowercase();
+    if !crate::config::is_valid_domain_syntax(&normalized) {
+        return Err(format!("domain '{domain}' is not a valid RFC 1035 hostname").into());
+    }
+
+    // First attempt over UDS.
+    match crate::mcp::submit_domain_add_via_daemon(&normalized, selector) {
+        Ok(()) => {
+            print_add_success_header(&normalized);
+        }
+        Err(crate::mcp::MailboxLifecycleFallback::SocketMissing) => {
+            // Daemon is down. Root can fall back; non-root cannot.
+            if !is_root() {
+                exit_socket_missing();
+            }
+            add_direct(&normalized, selector)?;
+            print_add_success_header(&normalized);
+            println!(
+                "{} daemon is stopped; restart `aimx serve` so the new domain takes effect.",
+                term::warn_mark()
+            );
+        }
+        Err(crate::mcp::MailboxLifecycleFallback::Daemon(msg)) => {
+            return Err(msg.into());
+        }
+    }
+
+    // DNS guidance (records + verify) is the same shape `aimx setup`
+    // prints, parameterized on the new domain. We resolve the server's
+    // IP and the per-domain DKIM public key the same way setup does.
+    print_dns_guidance_and_verify(&normalized, selector, no_dns_check)?;
+    Ok(())
+}
+
+/// Daemon-stopped fallback: write config + DKIM directly. Only callable
+/// from root; the non-root path exits via [`exit_socket_missing`] above.
+fn add_direct(domain: &str, selector: Option<&str>) -> Result<(), Box<dyn std::error::Error>> {
+    let config_path = crate::config::config_path();
+    let (config, _warnings) = Config::load_resolved_with_data_dir(None)?;
+    let dkim_root = crate::config::dkim_dir();
+    crate::domain_handler::run_direct_add(&config_path, &dkim_root, &config, domain, selector)?;
+    Ok(())
+}
+
+fn print_add_success_header(domain: &str) {
+    println!();
+    let dkim_path = crate::config::dkim_dir().join(domain).join("private.key");
+    println!(
+        "{} Added domain {}",
+        term::success_mark(),
+        term::highlight(domain),
+    );
+    let dkim_dir_display = dkim_path
+        .parent()
+        .map(|p| p.display().to_string())
+        .unwrap_or_default();
+    println!(
+        "{} DKIM keypair: {}",
+        term::success_mark(),
+        term::highlight(&dkim_dir_display),
+    );
+}
+
+/// Print DNS records to publish for the new domain and run the DNS
+/// verification loop (reusing setup's helpers). `--no-dns-check`
+/// short-circuits the verify step but still prints the records.
+fn print_dns_guidance_and_verify(
+    domain: &str,
+    selector: Option<&str>,
+    no_dns_check: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Resolve the server's IPv4 (and global IPv6 if available) so the
+    // SPF + A records the operator publishes are correct for this host.
+    let net = crate::setup::RealNetworkOps::default();
+    use crate::setup::NetworkOps as _;
+    let (ipv4_opt, ipv6_opt) = net.get_server_ips()?;
+    let server_ipv4 = ipv4_opt.ok_or::<Box<dyn std::error::Error>>(
+        "Could not determine server IPv4 address; publish DNS records manually.".into(),
+    )?;
+    let server_ip: std::net::IpAddr = std::net::IpAddr::V4(server_ipv4);
+    let server_ipv6_ip: Option<std::net::IpAddr> = ipv6_opt.map(std::net::IpAddr::V6);
+    let server_ip_str = server_ip.to_string();
+    let server_ipv6_str = server_ipv6_ip.map(|ip| ip.to_string());
+
+    // Resolve the per-domain DKIM public key (already on disk after the
+    // add — daemon or fallback both wrote it).
+    let dkim_root = crate::config::dkim_dir().join(domain);
+    let dkim_value = crate::dkim::dns_record_value(&dkim_root)?;
+    let local_dkim_pubkey = dkim_value
+        .strip_prefix("v=DKIM1; k=rsa; p=")
+        .map(|s| s.to_string());
+
+    // Selector: respect explicit override, else the daemon may have
+    // persisted one in `[domain."<d>"] dkim_selector`. Re-load the
+    // config to read it back; fall back to the top-level default.
+    let selector_resolved = match selector {
+        Some(s) => s.to_string(),
+        None => {
+            let (config, _w) = Config::load_resolved_with_data_dir(None)?;
+            crate::dkim_keys::resolve_selector_for_domain(&config, domain)
+        }
+    };
+
+    crate::setup::display_dns_guidance(
+        domain,
+        &server_ip_str,
+        server_ipv6_str.as_deref(),
+        &dkim_value,
+        &selector_resolved,
+    );
+
+    if no_dns_check {
+        println!(
+            "{} DNS verification skipped (--no-dns-check). Run `{}` once records are live.",
+            term::warn_mark(),
+            term::highlight("aimx doctor"),
+        );
+        return Ok(());
+    }
+
+    // Reuse setup's verify loop pattern: prompt to verify, escape with `q`.
+    let dns_records = crate::setup::generate_dns_records(
+        domain,
+        &server_ip_str,
+        server_ipv6_str.as_deref(),
+        &dkim_value,
+        &selector_resolved,
+    );
+    loop {
+        println!();
+        println!(
+            "  Press {} to verify DNS records now.",
+            term::highlight("Enter"),
+        );
+        println!(
+            "  Press {} to skip and run `{}` later.",
+            term::highlight("q"),
+            term::highlight("aimx doctor"),
+        );
+        print!("{} ", term::prompt_mark());
+        io::stdout().flush()?;
+        let mut input = String::new();
+        io::stdin().read_line(&mut input)?;
+        if input.trim().eq_ignore_ascii_case("q") {
+            println!(
+                "Update your DNS records and run `{}` to re-verify.",
+                term::highlight("aimx doctor")
+            );
+            break;
+        }
+
+        let results = crate::setup::verify_all_dns(
+            &net,
+            domain,
+            &server_ip,
+            server_ipv6_ip.as_ref(),
+            &selector_resolved,
+            local_dkim_pubkey.as_deref(),
+        );
+        let all_pass = crate::setup::display_dns_verification(&results, &dns_records);
+        if all_pass {
+            println!(
+                "{}",
+                term::success("All DNS records verified for the new domain.")
+            );
+            break;
+        } else {
+            println!("Some DNS records are not yet correct.");
+            println!("DNS propagation can take up to 48 hours.");
+        }
+    }
+    Ok(())
+}
+
+/// Placeholder for `aimx domains remove`. The real cascade behaviour
+/// lands in a follow-up release; for now we surface a clear "not yet
+/// implemented" error so the clap surface is complete and operators
+/// see the same help text they will see post-rollout.
+fn remove(_domain: &str, _force: bool) -> Result<(), Box<dyn std::error::Error>> {
+    Err(
+        "`aimx domains remove` is not yet implemented; this command \
+         lands in a follow-up release."
+            .into(),
+    )
+}
+
+/// Print the canonical hint and exit `EXIT_SOCKET_MISSING`. Mirrors
+/// `mailbox::exit_socket_missing`.
+pub(crate) fn exit_socket_missing() -> ! {
+    eprintln!("{} {SOCKET_MISSING_HINT}", term::error("Error:"));
+    std::process::exit(EXIT_SOCKET_MISSING);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `render_table` on an empty slice prints the "no domains" line
+    /// rather than a header with no rows.
+    #[test]
+    fn render_table_empty_prints_no_domains_line() {
+        // Routes through stdout; the assert is that no panic happens
+        // and the function returns. A more precise capture would
+        // require redirecting stdout — overkill for a CLI helper.
+        render_table(&[]);
+    }
+
+    /// `render_table` with a registered row exercises every branch of
+    /// the format string (default marker, DKIM loaded vs missing,
+    /// overrides empty vs set).
+    #[test]
+    fn render_table_renders_default_and_non_default_rows_without_panic() {
+        let rows = vec![
+            DomainListRow {
+                domain: "a.com".into(),
+                default: true,
+                dkim_loaded: true,
+                dkim_selector: "aimx".into(),
+                mailbox_count: 2,
+                unread: 0,
+                overrides: String::new(),
+            },
+            DomainListRow {
+                domain: "b.com".into(),
+                default: false,
+                dkim_loaded: false,
+                dkim_selector: "s2025".into(),
+                mailbox_count: 1,
+                unread: 3,
+                overrides: "dkim_selector,trust".into(),
+            },
+        ];
+        render_table(&rows);
+    }
+}

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -17,7 +17,6 @@
 //! with `ERR EACCES`, which the CLI surfaces verbatim).
 
 use std::io::{self, Write};
-use std::path::Path;
 
 use crate::cli::DomainsCommand;
 use crate::config::Config;
@@ -35,14 +34,14 @@ pub(crate) const EXIT_SOCKET_MISSING: i32 = 2;
 pub(crate) const SOCKET_MISSING_HINT: &str = "daemon must be running for non-root domain CRUD; start `aimx serve` \
      or run with sudo to fall back to direct config edit.";
 
-pub fn run(cmd: DomainsCommand, data_dir: Option<&Path>) -> Result<(), Box<dyn std::error::Error>> {
+pub fn run(cmd: DomainsCommand) -> Result<(), Box<dyn std::error::Error>> {
     match cmd {
         DomainsCommand::List => list(),
         DomainsCommand::Add {
             domain,
             selector,
             no_dns_check,
-        } => add(&domain, selector.as_deref(), no_dns_check, data_dir),
+        } => add(&domain, selector.as_deref(), no_dns_check),
         DomainsCommand::Remove { domain, force } => remove(&domain, force),
     }
 }
@@ -122,13 +121,17 @@ pub(crate) fn list_via_daemon() -> Result<Vec<DomainListRow>, Box<dyn std::error
 
 /// `aimx domains add <domain> [--selector <s>] [--no-dns-check]` — UDS
 /// first, daemon-down fallback for root, hard-error for non-root.
+///
+/// `--data-dir` is read off the global `Cli` struct by the daemon-side
+/// loader (`Config::load_resolved_with_data_dir`) when this path
+/// falls back to direct config edit, so we do not thread it through
+/// here: the storage layout is decided by the running daemon, not the
+/// CLI invocation.
 fn add(
     domain: &str,
     selector: Option<&str>,
     no_dns_check: bool,
-    data_dir: Option<&Path>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    let _ = data_dir; // reserved for future use (`--data-dir` is global)
     let normalized = domain.trim().to_ascii_lowercase();
     if !crate::config::is_valid_domain_syntax(&normalized) {
         return Err(format!("domain '{domain}' is not a valid RFC 1035 hostname").into());

--- a/src/domain_handler.rs
+++ b/src/domain_handler.rs
@@ -32,13 +32,17 @@
 //!    this sequence linear with respect to other writers, so a
 //!    concurrent `DOMAIN-ADD` cannot lose an entry.
 //!
-//! Atomicity ordering (NFR-3 from the multi-domain PRD): DKIM key on
-//! disk **before** the config rewrite. A crash between key write and
-//! config rewrite leaves an orphan key (harmless — the operator can
-//! re-run `aimx domains add` cleanly; the duplicate-add check still
-//! passes because the domain isn't in `domains` yet). The opposite
-//! ordering — config rewritten first, then key write fails — would
-//! leave outbound from the new domain broken until manual recovery.
+//! Atomicity ordering rationale: DKIM key on disk **before** the config
+//! rewrite, and the in-memory DKIM map updated **before** the
+//! `ConfigHandle::store`. A crash between key write and config rewrite
+//! leaves an orphan key (harmless — the operator can re-run
+//! `aimx domains add` cleanly; the duplicate-add check still passes
+//! because the domain isn't in `domains` yet). The opposite ordering —
+//! config rewritten first, then key write fails — would leave outbound
+//! from the new domain broken until manual recovery. Updating the DKIM
+//! map before the config snapshot also guarantees that any reader who
+//! sees the new domain in `config.domains` already sees the matching
+//! DKIM key entry.
 
 use std::path::Path;
 use std::sync::Arc;
@@ -210,15 +214,16 @@ pub async fn handle_domain_add(
         };
     }
 
-    // Hot-swap the in-memory Config.
-    mb_ctx.config_handle.store(new_config);
-
-    // Hot-swap the DKIM map: clone the current snapshot, insert the
-    // new entry, and `ArcSwap::store` it. Loads inside `handle_send`
+    // Hot-swap the DKIM map FIRST: clone the current snapshot, insert
+    // the new entry, and `ArcSwap::store` it. Loads inside `handle_send`
     // take a `load_full()` snapshot, so a concurrent send observes
     // either the pre-swap map (its From: domain is in the old set; ok)
     // or the post-swap map (the From: domain may be in the new set;
-    // ok). The swap is atomic.
+    // ok). The swap is atomic. We update the DKIM map BEFORE the
+    // ConfigHandle so that any reader who sees the new domain in
+    // `config.domains` (via the subsequent `ConfigHandle::store`)
+    // already sees the matching DKIM entry — there is no window where
+    // a SEND can match a configured domain but find no key.
     let mut new_map: DkimKeyMap = (*dkim_keys.load_full()).clone();
     new_map.insert(
         domain_lc.clone(),
@@ -228,6 +233,9 @@ pub async fn handle_domain_add(
         },
     );
     dkim_keys.store(Arc::new(new_map));
+
+    // Now hot-swap the in-memory Config.
+    mb_ctx.config_handle.store(new_config);
 
     log_decision(
         verb,
@@ -556,5 +564,74 @@ mod tests {
         assert!(!is_valid_dkim_selector("UPPER"));
         assert!(!is_valid_dkim_selector("a b"));
         assert!(!is_valid_dkim_selector("a.b"));
+    }
+
+    /// Pin the pre-provisioned-key contract: if the operator dropped a
+    /// keypair into `<dkim_dir>/<domain>/{private,public}.key` before
+    /// running `aimx domains add <domain>`, the handler MUST reuse those
+    /// keys and not overwrite them. This is the supported flow for
+    /// rotating a known-good key into a new domain in one step.
+    #[tokio::test]
+    async fn pre_existing_dkim_keys_are_reused_not_overwritten() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        let (state_ctx, mb_ctx, keys) = contexts(&tmp);
+
+        // Pre-provision a real RSA keypair at the per-domain layout
+        // BEFORE the handler runs. The handler must detect the
+        // existing private.key and skip the keygen so this exact
+        // byte sequence ends up loaded into the DKIM map.
+        let dkim_root = crate::config::dkim_dir();
+        let per_domain_dir = dkim_root.join("b.com");
+        std::fs::create_dir_all(&per_domain_dir).unwrap();
+        crate::dkim::generate_keypair(&per_domain_dir, false).unwrap();
+        let before = std::fs::read_to_string(per_domain_dir.join("private.key")).unwrap();
+
+        let req = DomainAddRequest {
+            domain: "b.com".into(),
+            selector: None,
+        };
+        let resp =
+            handle_domain_add(&state_ctx, &mb_ctx, &keys, &req, &Caller::internal_root()).await;
+        assert!(matches!(resp, AckResponse::Ok), "got {resp:?}");
+
+        let after = std::fs::read_to_string(per_domain_dir.join("private.key")).unwrap();
+        assert_eq!(
+            before, after,
+            "pre-existing DKIM private key must not be overwritten by `aimx domains add`"
+        );
+
+        // The DKIM map carries the (unchanged) pre-existing key.
+        let snapshot = keys.load_full();
+        assert!(
+            snapshot.contains_key("b.com"),
+            "DKIM map must contain an entry for the added domain"
+        );
+    }
+
+    /// Same contract for the daemon-stopped fallback path. `run_direct_add`
+    /// must also preserve a pre-existing per-domain key.
+    #[test]
+    fn direct_add_preserves_pre_existing_dkim_keys() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        let config_path = tmp.path().join("config.toml");
+        let config = base_config(tmp.path());
+        crate::config::write_atomic(&config_path, &config).unwrap();
+        let dkim_root = tmp.path().join("dkim");
+
+        let per_domain_dir = dkim_root.join("b.com");
+        std::fs::create_dir_all(&per_domain_dir).unwrap();
+        crate::dkim::generate_keypair(&per_domain_dir, false).unwrap();
+        let before = std::fs::read_to_string(per_domain_dir.join("private.key")).unwrap();
+
+        let _ = run_direct_add(&config_path, &dkim_root, &config, "b.com", None).unwrap();
+        let after = std::fs::read_to_string(per_domain_dir.join("private.key")).unwrap();
+        assert_eq!(
+            before, after,
+            "daemon-stopped fallback must preserve pre-existing DKIM keys"
+        );
     }
 }

--- a/src/domain_handler.rs
+++ b/src/domain_handler.rs
@@ -1,0 +1,560 @@
+//! Daemon-side handler for the `DOMAIN-ADD` verb of the `AIMX/1` UDS
+//! protocol.
+//!
+//! Mirrors `mailbox_handler` and `hook_handler` in shape: root-only via
+//! `auth::authorize(.., Action::DomainCrud)`, runs the
+//! load-modify-write-store sequence under
+//! [`crate::mailbox_handler::CONFIG_WRITE_LOCK`], and hot-swaps the
+//! in-memory `Arc<Config>` plus the per-domain DKIM key map without
+//! restarting the daemon.
+//!
+//! Correctness model:
+//!
+//! 1. Validate the domain syntax via [`crate::config::is_valid_domain_syntax`]
+//!    after lowercasing.
+//! 2. Acquire `CONFIG_WRITE_LOCK` (the same lock `MAILBOX-CRUD` /
+//!    `HOOK-CRUD` use) so the load-modify-write-store sequence is
+//!    serialized across every concurrent config writer.
+//! 3. Reject duplicate adds (case-insensitive) without modifying state.
+//! 4. Generate the per-domain DKIM keypair via the same
+//!    `dkim::generate_keypair` codepath `aimx dkim-keygen` uses, so a
+//!    later `aimx dkim-keygen --domain <d>` is exactly equivalent.
+//!    Keys land at `<dkim_dir>/<domain>/{private,public}.key` with the
+//!    canonical `0600 / 0644` modes.
+//! 5. Load the freshly-generated private key into a `DkimKeyEntry`
+//!    keyed by the lowercase domain; persist any operator-supplied
+//!    selector under `[domain."<d>"] dkim_selector` so subsequent
+//!    config loads pick it up.
+//! 6. `write_atomic` the new `config.toml`, then
+//!    `ConfigHandle::store(new_config)`.
+//! 7. Build a fresh DKIM map by cloning the current snapshot, insert
+//!    the new entry, and `ArcSwap::store` it. The lock above keeps
+//!    this sequence linear with respect to other writers, so a
+//!    concurrent `DOMAIN-ADD` cannot lose an entry.
+//!
+//! Atomicity ordering (NFR-3 from the multi-domain PRD): DKIM key on
+//! disk **before** the config rewrite. A crash between key write and
+//! config rewrite leaves an orphan key (harmless — the operator can
+//! re-run `aimx domains add` cleanly; the duplicate-add check still
+//! passes because the domain isn't in `domains` yet). The opposite
+//! ordering — config rewritten first, then key write fails — would
+//! leave outbound from the new domain broken until manual recovery.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use crate::auth::{Action, authorize};
+use crate::config::{Config, DomainOverride, is_valid_domain_syntax};
+use crate::dkim;
+use crate::dkim_keys::{DkimKeyEntry, DkimKeyMap, SharedDkimKeyMap, resolve_selector_for_domain};
+use crate::mailbox_handler::{CONFIG_WRITE_LOCK, MailboxContext};
+use crate::send_protocol::{AckResponse, DomainAddRequest, ErrCode};
+use crate::state_handler::StateContext;
+use crate::uds_authz::{Caller, log_decision};
+
+/// Validate, normalize, and persist a `DOMAIN-ADD` request.
+///
+/// Returns `AckResponse::Ok` on success; the daemon's
+/// `Arc<Config>` and DKIM map are both hot-swapped before the response
+/// is written, so an immediately-following `DOMAIN-LIST` or SMTP RCPT
+/// to the new domain sees the change.
+pub async fn handle_domain_add(
+    state_ctx: &StateContext,
+    mb_ctx: &MailboxContext,
+    dkim_keys: &SharedDkimKeyMap,
+    req: &DomainAddRequest,
+    caller: &Caller,
+) -> AckResponse {
+    let verb = "DOMAIN-ADD";
+
+    // Authz first — every other check is leaked-state observation, so
+    // the central predicate runs at the top.
+    if let Err(e) = authorize(caller.uid, Action::DomainCrud, None) {
+        log_decision(
+            verb,
+            caller,
+            Some(&req.domain),
+            crate::uds_authz::LogDecision::Reject,
+            Some(&format!("{e}")),
+        );
+        return AckResponse::Err {
+            code: ErrCode::Eaccess,
+            reason: format!("{e}"),
+        };
+    }
+
+    // Syntactic validation: lowercase + RFC 1035. The Config
+    // deserializer applies the same rule, so doing it here keeps the
+    // wire response actionable instead of failing the post-write
+    // re-load with a less-targeted error.
+    let domain_lc = req.domain.trim().to_ascii_lowercase();
+    if !is_valid_domain_syntax(&domain_lc) {
+        return AckResponse::Err {
+            code: ErrCode::Validation,
+            reason: format!(
+                "domain '{d}' is not a valid RFC 1035 hostname",
+                d = req.domain,
+            ),
+        };
+    }
+
+    // Same selector validation the rest of the codebase uses: any
+    // operator-supplied selector must be a DNS-safe label (the DKIM
+    // signer ships `s=<selector>` verbatim into a header value, so a
+    // malformed selector would render the resulting signatures
+    // unverifiable). Reject up front rather than at sign time.
+    let selector = req.selector.as_deref().map(|s| s.trim().to_string());
+    if let Some(s) = &selector
+        && !is_valid_dkim_selector(s)
+    {
+        return AckResponse::Err {
+            code: ErrCode::Validation,
+            reason: format!("DKIM selector '{s}' is not a valid DNS label (allowed: [a-z0-9_-]+)"),
+        };
+    }
+
+    // Acquire the process-wide write lock so concurrent
+    // `MAILBOX-CRUD` / `HOOK-CRUD` / `DOMAIN-ADD` requests serialize
+    // their load-modify-write-store sequences. Per the hierarchy in
+    // `mailbox_locks`, this is the **inner** lock — DOMAIN-ADD does
+    // not need a per-mailbox lock because no mailbox state changes.
+    let _config_guard = CONFIG_WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    let current = mb_ctx.config_handle.load();
+    if current.is_configured_domain(&domain_lc) {
+        return AckResponse::Err {
+            code: ErrCode::Domain,
+            reason: format!("domain '{domain_lc}' is already configured"),
+        };
+    }
+
+    // Build the new Config first so we know exactly what we're about
+    // to persist before generating the keypair on disk. If serialization
+    // fails (it won't for a Config::clone()-derived struct, but the
+    // belt-and-braces check costs nothing), we bail before touching
+    // any filesystem state.
+    let mut new_config: Config = (*current).clone();
+    new_config.domains.push(domain_lc.clone());
+    if let Some(s) = &selector {
+        new_config.per_domain.insert(
+            domain_lc.clone(),
+            DomainOverride {
+                dkim_selector: Some(s.clone()),
+                ..Default::default()
+            },
+        );
+    }
+
+    // Generate the per-domain DKIM keypair into `<dkim_dir>/<domain>/`.
+    // Identical codepath to `aimx dkim-keygen --domain <d>` so a
+    // freshly-added domain is byte-identical to one provisioned via
+    // the CLI keygen.
+    let dkim_root = crate::config::dkim_dir();
+    let per_domain_dir = dkim_root.join(&domain_lc);
+    if let Err(e) = std::fs::create_dir_all(&per_domain_dir) {
+        return AckResponse::Err {
+            code: ErrCode::Io,
+            reason: format!("failed to create {}: {e}", per_domain_dir.display()),
+        };
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        if let Err(e) =
+            std::fs::set_permissions(&per_domain_dir, std::fs::Permissions::from_mode(0o700))
+        {
+            return AckResponse::Err {
+                code: ErrCode::Io,
+                reason: format!("failed to chmod {}: {e}", per_domain_dir.display()),
+            };
+        }
+    }
+
+    // Skip if the operator already pre-provisioned the keys (e.g. ran
+    // `aimx dkim-keygen --domain <d>` first). Existing keys with the
+    // wrong mode are left alone — the operator owns the on-disk state.
+    let private_path = per_domain_dir.join("private.key");
+    if !private_path.exists()
+        && let Err(e) = dkim::generate_keypair(&per_domain_dir, false)
+    {
+        return AckResponse::Err {
+            code: ErrCode::Io,
+            reason: format!("failed to generate DKIM keypair for '{domain_lc}': {e}"),
+        };
+    }
+
+    // Load the just-written (or pre-existing) key into the daemon's
+    // map. Failure here means we have a key on disk but cannot read it
+    // — surface the error directly; the orphan key on disk is harmless
+    // because the domain hasn't been added to `domains` yet.
+    let resolved_selector = resolve_selector_for_domain(&new_config, &domain_lc);
+    let key = match dkim::load_private_key(&per_domain_dir) {
+        Ok(k) => k,
+        Err(e) => {
+            return AckResponse::Err {
+                code: ErrCode::Sign,
+                reason: format!("DKIM keypair for '{domain_lc}' generated but unreadable: {e}",),
+            };
+        }
+    };
+
+    // Persist the new config atomically. If the rewrite fails, the
+    // freshly-generated key stays on disk (orphan; harmless) and the
+    // in-memory state stays put — the operator can retry cleanly.
+    if let Err(e) = crate::mailbox_handler::write_config_atomic(&mb_ctx.config_path, &new_config) {
+        return AckResponse::Err {
+            code: ErrCode::Io,
+            reason: format!("failed to write {}: {e}", mb_ctx.config_path.display()),
+        };
+    }
+
+    // Hot-swap the in-memory Config.
+    mb_ctx.config_handle.store(new_config);
+
+    // Hot-swap the DKIM map: clone the current snapshot, insert the
+    // new entry, and `ArcSwap::store` it. Loads inside `handle_send`
+    // take a `load_full()` snapshot, so a concurrent send observes
+    // either the pre-swap map (its From: domain is in the old set; ok)
+    // or the post-swap map (the From: domain may be in the new set;
+    // ok). The swap is atomic.
+    let mut new_map: DkimKeyMap = (*dkim_keys.load_full()).clone();
+    new_map.insert(
+        domain_lc.clone(),
+        DkimKeyEntry {
+            key: Arc::new(key),
+            selector: resolved_selector,
+        },
+    );
+    dkim_keys.store(Arc::new(new_map));
+
+    log_decision(
+        verb,
+        caller,
+        Some(&domain_lc),
+        if caller.is_root() {
+            crate::uds_authz::LogDecision::RootBypass
+        } else {
+            crate::uds_authz::LogDecision::Accept
+        },
+        None,
+    );
+
+    // Suppress the unused-state-context warning; we don't acquire a
+    // per-mailbox lock because DOMAIN-ADD touches no mailbox state.
+    let _ = state_ctx;
+    AckResponse::Ok
+}
+
+/// Direct on-disk fallback used by the CLI when the daemon is stopped.
+/// Mirrors [`handle_domain_add`] minus the in-memory swaps — the
+/// operator restarts `aimx serve` to pick up the change. Only callable
+/// from root (the CLI gates this).
+///
+/// `config` is the loaded snapshot; the function modifies it in-place
+/// via clone+rewrite and re-saves to `config_path`. The DKIM key is
+/// generated under `<dkim_dir>/<domain>/`. Returns the new in-memory
+/// Config (so the CLI can `aimx domains list` against it without
+/// re-loading from disk).
+pub fn run_direct_add(
+    config_path: &Path,
+    dkim_root: &Path,
+    config: &Config,
+    domain: &str,
+    selector: Option<&str>,
+) -> Result<Config, Box<dyn std::error::Error>> {
+    let domain_lc = domain.trim().to_ascii_lowercase();
+    if !is_valid_domain_syntax(&domain_lc) {
+        return Err(format!("domain '{domain}' is not a valid RFC 1035 hostname").into());
+    }
+    if let Some(s) = selector
+        && !is_valid_dkim_selector(s.trim())
+    {
+        return Err(
+            format!("DKIM selector '{s}' is not a valid DNS label (allowed: [a-z0-9_-]+)").into(),
+        );
+    }
+
+    if config.is_configured_domain(&domain_lc) {
+        return Err(format!("domain '{domain_lc}' is already configured").into());
+    }
+
+    let mut new_config: Config = config.clone();
+    new_config.domains.push(domain_lc.clone());
+    if let Some(s) = selector {
+        new_config.per_domain.insert(
+            domain_lc.clone(),
+            DomainOverride {
+                dkim_selector: Some(s.trim().to_string()),
+                ..Default::default()
+            },
+        );
+    }
+
+    let per_domain_dir = dkim_root.join(&domain_lc);
+    std::fs::create_dir_all(&per_domain_dir)?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&per_domain_dir, std::fs::Permissions::from_mode(0o700))?;
+    }
+    if !per_domain_dir.join("private.key").exists() {
+        dkim::generate_keypair(&per_domain_dir, false)?;
+    }
+
+    crate::config::write_atomic(config_path, &new_config)?;
+    Ok(new_config)
+}
+
+/// Predicate: valid DNS-label-shape DKIM selector. RFC 6376 §3.1
+/// references DNS-label syntax for the `s=` tag; we accept the same
+/// lowercase alphanumeric+`-_` set Linux usernames use, which is a
+/// superset of every DKIM selector we have ever seen in the wild.
+fn is_valid_dkim_selector(s: &str) -> bool {
+    if s.is_empty() || s.len() > 63 {
+        return false;
+    }
+    s.bytes()
+        .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-' || b == b'_')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::test_env::ConfigDirOverride;
+    use crate::config::{Config, ConfigHandle};
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    fn install_resolver() -> crate::user_resolver::test_resolver::ResolverOverride {
+        fn fake(name: &str) -> Option<crate::user_resolver::ResolvedUser> {
+            match name {
+                "root" => Some(crate::user_resolver::ResolvedUser {
+                    name: "root".to_string(),
+                    uid: 0,
+                    gid: 0,
+                }),
+                _ => None,
+            }
+        }
+        crate::user_resolver::set_test_resolver(fake)
+    }
+
+    fn base_config(data_dir: &Path) -> Config {
+        Config {
+            domains: vec!["a.com".to_string()],
+            data_dir: data_dir.to_path_buf(),
+            dkim_selector: None,
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            mailboxes: HashMap::new(),
+            per_domain: HashMap::new(),
+            verify_host: None,
+            enable_ipv6: false,
+            signature: None,
+            upgrade: None,
+        }
+    }
+
+    fn contexts(tmp: &TempDir) -> (StateContext, MailboxContext, SharedDkimKeyMap) {
+        let config = base_config(tmp.path());
+        let handle = ConfigHandle::new(config);
+        let state_ctx = StateContext::new(tmp.path().to_path_buf(), handle.clone());
+        let config_path = tmp.path().join("config.toml");
+        crate::mailbox_handler::write_config_atomic(&config_path, &handle.load()).unwrap();
+        let mb_ctx = MailboxContext::new(config_path, handle);
+        let keys = crate::dkim_keys::empty_shared();
+        (state_ctx, mb_ctx, keys)
+    }
+
+    #[tokio::test]
+    async fn root_add_appends_domain_writes_config_and_hot_swaps() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        let (state_ctx, mb_ctx, keys) = contexts(&tmp);
+
+        let req = DomainAddRequest {
+            domain: "b.com".into(),
+            selector: None,
+        };
+        let resp =
+            handle_domain_add(&state_ctx, &mb_ctx, &keys, &req, &Caller::internal_root()).await;
+        assert!(matches!(resp, AckResponse::Ok), "got {resp:?}");
+
+        // In-memory hot-swap: live config carries both domains.
+        let after = mb_ctx.config_handle.load();
+        assert_eq!(after.domains, vec!["a.com", "b.com"]);
+
+        // On-disk config reloads with both domains.
+        let reloaded = Config::load_ignore_warnings(&mb_ctx.config_path).unwrap();
+        assert_eq!(reloaded.domains, vec!["a.com", "b.com"]);
+
+        // DKIM map hot-swapped — `b.com` resolves to an entry.
+        let snapshot = keys.load_full();
+        assert!(snapshot.contains_key("b.com"));
+
+        // Keypair landed on disk at the per-domain layout.
+        let dkim_root = crate::config::dkim_dir();
+        assert!(dkim_root.join("b.com").join("private.key").is_file());
+        assert!(dkim_root.join("b.com").join("public.key").is_file());
+    }
+
+    #[tokio::test]
+    async fn duplicate_add_rejects_without_modifying_state() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        let (state_ctx, mb_ctx, keys) = contexts(&tmp);
+
+        let req = DomainAddRequest {
+            domain: "a.com".into(), // already configured
+            selector: None,
+        };
+        let resp =
+            handle_domain_add(&state_ctx, &mb_ctx, &keys, &req, &Caller::internal_root()).await;
+        match resp {
+            AckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Domain);
+                assert!(reason.contains("already configured"), "{reason}");
+            }
+            other => panic!("expected Err Domain, got {other:?}"),
+        }
+
+        // No state change.
+        let after = mb_ctx.config_handle.load();
+        assert_eq!(after.domains, vec!["a.com"]);
+        let snapshot = keys.load_full();
+        assert!(!snapshot.contains_key("b.com"));
+    }
+
+    #[tokio::test]
+    async fn non_root_caller_denied_with_eacces() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        let (state_ctx, mb_ctx, keys) = contexts(&tmp);
+
+        let req = DomainAddRequest {
+            domain: "b.com".into(),
+            selector: None,
+        };
+        let stranger = Caller::new(1000, 1000, None);
+        let resp = handle_domain_add(&state_ctx, &mb_ctx, &keys, &req, &stranger).await;
+        match resp {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Eaccess),
+            other => panic!("expected Err EACCES, got {other:?}"),
+        }
+        // No state change.
+        let after = mb_ctx.config_handle.load();
+        assert_eq!(after.domains, vec!["a.com"]);
+    }
+
+    #[tokio::test]
+    async fn invalid_domain_syntax_rejected() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        let (state_ctx, mb_ctx, keys) = contexts(&tmp);
+
+        let req = DomainAddRequest {
+            domain: "not a domain".into(),
+            selector: None,
+        };
+        let resp =
+            handle_domain_add(&state_ctx, &mb_ctx, &keys, &req, &Caller::internal_root()).await;
+        match resp {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Validation),
+            other => panic!("expected Err Validation, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn invalid_selector_rejected() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        let (state_ctx, mb_ctx, keys) = contexts(&tmp);
+
+        let req = DomainAddRequest {
+            domain: "b.com".into(),
+            selector: Some("bad selector".into()),
+        };
+        let resp =
+            handle_domain_add(&state_ctx, &mb_ctx, &keys, &req, &Caller::internal_root()).await;
+        match resp {
+            AckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Validation),
+            other => panic!("expected Err Validation, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn selector_persisted_in_per_domain_override() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        let (state_ctx, mb_ctx, keys) = contexts(&tmp);
+
+        let req = DomainAddRequest {
+            domain: "b.com".into(),
+            selector: Some("s2025".into()),
+        };
+        let resp =
+            handle_domain_add(&state_ctx, &mb_ctx, &keys, &req, &Caller::internal_root()).await;
+        assert!(matches!(resp, AckResponse::Ok), "got {resp:?}");
+
+        let after = mb_ctx.config_handle.load();
+        let over = after.per_domain.get("b.com").expect("per-domain override");
+        assert_eq!(over.dkim_selector.as_deref(), Some("s2025"));
+
+        let snapshot = keys.load_full();
+        let entry = snapshot.get("b.com").expect("DKIM entry");
+        assert_eq!(entry.selector, "s2025");
+    }
+
+    /// `run_direct_add` (root daemon-stopped fallback) writes config
+    /// and DKIM key to disk without touching the in-memory handle.
+    #[test]
+    fn direct_add_writes_config_and_dkim_to_disk() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        let config_path = tmp.path().join("config.toml");
+        let config = base_config(tmp.path());
+        crate::config::write_atomic(&config_path, &config).unwrap();
+        let dkim_root = tmp.path().join("dkim");
+
+        let new_config = run_direct_add(&config_path, &dkim_root, &config, "b.com", None).unwrap();
+        assert_eq!(new_config.domains, vec!["a.com", "b.com"]);
+        let reloaded = Config::load_ignore_warnings(&config_path).unwrap();
+        assert_eq!(reloaded.domains, vec!["a.com", "b.com"]);
+        assert!(dkim_root.join("b.com").join("private.key").is_file());
+    }
+
+    #[test]
+    fn direct_add_rejects_duplicate() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        let config_path = tmp.path().join("config.toml");
+        let config = base_config(tmp.path());
+        crate::config::write_atomic(&config_path, &config).unwrap();
+        let dkim_root = tmp.path().join("dkim");
+
+        let err = run_direct_add(&config_path, &dkim_root, &config, "a.com", None)
+            .expect_err("duplicate must err");
+        assert!(err.to_string().contains("already configured"));
+    }
+
+    #[test]
+    fn is_valid_dkim_selector_accepts_canonical_values() {
+        assert!(is_valid_dkim_selector("aimx"));
+        assert!(is_valid_dkim_selector("s2025"));
+        assert!(is_valid_dkim_selector("aimx-rotation-2"));
+        assert!(!is_valid_dkim_selector(""));
+        assert!(!is_valid_dkim_selector("UPPER"));
+        assert!(!is_valid_dkim_selector("a b"));
+        assert!(!is_valid_dkim_selector("a.b"));
+    }
+}

--- a/src/domain_list_handler.rs
+++ b/src/domain_list_handler.rs
@@ -1,0 +1,461 @@
+//! Daemon-side handler for the `DOMAIN-LIST` verb of the `AIMX/1` UDS
+//! protocol.
+//!
+//! Mirrors `mailbox_list_handler` / `hook_list_handler` line-for-line:
+//! the daemon resolves the caller via `SO_PEERCRED`, runs the central
+//! `auth::authorize(.., Action::DomainCrud)` predicate (root-only),
+//! walks the in-memory `Arc<Config>`, and returns a JSON array of
+//! [`DomainListRow`].
+//!
+//! Unlike `MAILBOX-LIST` (owner-filtered) and `HOOK-LIST` (owner-
+//! filtered), `DOMAIN-LIST` is strictly operator-scoped: a non-root
+//! caller receives an `ERR EACCES` response. The single-operator
+//! model means domains are not per-mailbox state.
+//!
+//! No locks are taken; reads of `Arc<Config>` are wait-free.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use serde::{Deserialize, Serialize};
+
+use crate::auth::{Action, authorize};
+use crate::config::Config;
+use crate::dkim_keys::SharedDkimKeyMap;
+use crate::mailbox;
+use crate::send_protocol::{ErrCode, JsonAckResponse};
+use crate::state_handler::StateContext;
+use crate::uds_authz::Caller;
+
+/// One row of the JSON array returned by `DOMAIN-LIST`. Captures the
+/// per-domain summary needed by `aimx domains list`; a future
+/// follow-up may lift `aimx doctor` onto the same shape so both
+/// surfaces report identical per-domain status.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DomainListRow {
+    /// Fully-qualified domain (lowercased, RFC 1035 valid).
+    pub domain: String,
+    /// `true` iff this is `domains[0]` — the default domain.
+    pub default: bool,
+    /// `true` iff a DKIM private key is loaded for this domain in the
+    /// daemon's in-memory map. A `false` here means the daemon could
+    /// not read a private key at startup; outbound from this domain
+    /// will fail until `aimx dkim-keygen --domain <d>` runs.
+    pub dkim_loaded: bool,
+    /// Resolved DKIM selector for this domain. Falls back through the
+    /// documented order (per-domain → top-level → `"aimx"`).
+    pub dkim_selector: String,
+    /// Count of mailboxes whose `address` carries this domain. Catchall
+    /// (`*@<domain>`) counts as one entry.
+    pub mailbox_count: usize,
+    /// Count of unread inbox messages across every mailbox in this
+    /// domain. Catchall is included.
+    pub unread: usize,
+    /// Compact comma-separated summary of per-domain overrides that
+    /// are set (`signature`, `dkim_selector`, `trust`,
+    /// `trusted_senders`). Empty string when no `[domain."<d>"]`
+    /// sub-table exists. UI-only convenience; the CLI renders this
+    /// verbatim in the `Overrides` column.
+    pub overrides: String,
+}
+
+/// Build the JSON ack response for an `AIMX/1 DOMAIN-LIST` request.
+pub async fn handle_domain_list(
+    state_ctx: &StateContext,
+    dkim_keys: &SharedDkimKeyMap,
+    caller: &Caller,
+) -> JsonAckResponse {
+    if let Err(e) = authorize(caller.uid, Action::DomainCrud, None) {
+        return JsonAckResponse::Err {
+            code: ErrCode::Eaccess,
+            reason: format!("{e}"),
+        };
+    }
+
+    let config = state_ctx.config_handle.load();
+    let dkim_snapshot = dkim_keys.load_full();
+    let rows = collect_rows(&config, &dkim_snapshot);
+    let body = match serde_json::to_vec(&rows) {
+        Ok(b) => b,
+        Err(e) => {
+            return JsonAckResponse::Err {
+                code: ErrCode::Io,
+                reason: format!("failed to serialize domain list: {e}"),
+            };
+        }
+    };
+    JsonAckResponse::Ok { body }
+}
+
+/// Pure helper: walk `config.domains` and emit a `DomainListRow` per
+/// entry. Sorted in operator-declared order — the first entry is the
+/// default, so we deliberately keep the declared order rather than
+/// alphabetizing.
+fn collect_rows(
+    config: &Config,
+    dkim_keys: &Arc<crate::dkim_keys::DkimKeyMap>,
+) -> Vec<DomainListRow> {
+    let mut rows: Vec<DomainListRow> = Vec::with_capacity(config.domains.len());
+    let default_domain = config.default_domain().to_ascii_lowercase();
+
+    for (idx, domain) in config.domains.iter().enumerate() {
+        let domain_lc = domain.to_ascii_lowercase();
+        let dkim_entry = crate::dkim_keys::entry_for_domain(dkim_keys, &domain_lc);
+        let dkim_loaded = dkim_entry.is_some();
+        let dkim_selector = match dkim_entry {
+            Some(e) => e.selector.clone(),
+            None => crate::dkim_keys::resolve_selector_for_domain(config, &domain_lc),
+        };
+
+        let (mailbox_count, unread) = count_mailboxes_and_unread(config, &domain_lc);
+
+        rows.push(DomainListRow {
+            domain: domain_lc.clone(),
+            default: idx == 0 || domain_lc == default_domain,
+            dkim_loaded,
+            dkim_selector,
+            mailbox_count,
+            unread,
+            overrides: format_overrides(config, &domain_lc),
+        });
+    }
+
+    rows
+}
+
+/// Count the mailboxes whose `address` is `<local>@<domain>` (including
+/// the catchall) and the unread message count across their inboxes.
+fn count_mailboxes_and_unread(config: &Config, domain: &str) -> (usize, usize) {
+    let mut count = 0usize;
+    let mut unread = 0usize;
+    let suffix = format!("@{domain}");
+
+    // Use the same name set the listing path uses so on-disk-only
+    // mailboxes (registered or not) are visible. We only count
+    // registered mailboxes for the per-domain rollup because the
+    // address-to-domain mapping requires a config entry.
+    let names = mailbox::discover_mailbox_names(config);
+    for name in names {
+        let Some((_, mb)) = config.resolve_mailbox_by_name(&name) else {
+            continue;
+        };
+        if !mb.address.to_ascii_lowercase().ends_with(&suffix) {
+            continue;
+        }
+        count += 1;
+        let inbox_dir = config.inbox_dir(&name);
+        unread += count_unread(&inbox_dir);
+    }
+    (count, unread)
+}
+
+/// Walk `dir`, counting `.md` files (and bundle dirs containing a
+/// matching inner `<stem>.md`) whose frontmatter does not carry
+/// `read = true`. Mirrors the cheap line-scan from
+/// `mailbox_list_handler::count_inbox`.
+fn count_unread(dir: &Path) -> usize {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(e) => e,
+        Err(_) => return 0,
+    };
+    let mut unread = 0usize;
+    for entry in entries.filter_map(|e| e.ok()) {
+        let path = entry.path();
+        let md_path = if path.is_dir() {
+            let stem = match path.file_name().and_then(|f| f.to_str()) {
+                Some(s) => s.to_string(),
+                None => continue,
+            };
+            let inner = path.join(format!("{stem}.md"));
+            if !inner.exists() {
+                continue;
+            }
+            inner
+        } else if path.extension().is_some_and(|ext| ext == "md") {
+            path
+        } else {
+            continue;
+        };
+        if !is_marked_read(&md_path) {
+            unread += 1;
+        }
+    }
+    unread
+}
+
+fn is_marked_read(md_path: &Path) -> bool {
+    let content = match std::fs::read_to_string(md_path) {
+        Ok(c) => c,
+        Err(_) => return false,
+    };
+    let parts: Vec<&str> = content.splitn(3, "+++").collect();
+    if parts.len() < 3 {
+        return false;
+    }
+    for line in parts[1].lines() {
+        let trimmed = line.trim();
+        if let Some(rest) = trimmed.strip_prefix("read") {
+            let rest = rest.trim_start();
+            if let Some(value) = rest.strip_prefix('=') {
+                return value.trim() == "true";
+            }
+        }
+    }
+    false
+}
+
+/// Format the per-domain override summary for the `Overrides` column.
+/// Empty string when no override exists; otherwise a comma-separated
+/// list of the field names that are set.
+fn format_overrides(config: &Config, domain: &str) -> String {
+    let Some(over) = config.per_domain.get(domain) else {
+        return String::new();
+    };
+    let mut parts: Vec<&'static str> = Vec::new();
+    if over.signature.is_some() {
+        parts.push("signature");
+    }
+    if over.dkim_selector.is_some() {
+        parts.push("dkim_selector");
+    }
+    if over.trust.is_some() {
+        parts.push("trust");
+    }
+    if over.trusted_senders.is_some() {
+        parts.push("trusted_senders");
+    }
+    parts.join(",")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::{Config, ConfigHandle, DomainOverride, MailboxConfig};
+    use crate::dkim_keys::DkimKeyEntry;
+    use rsa::RsaPrivateKey;
+    use std::collections::HashMap;
+    use tempfile::TempDir;
+
+    fn fake_resolver(name: &str) -> Option<crate::user_resolver::ResolvedUser> {
+        match name {
+            "root" => Some(crate::user_resolver::ResolvedUser {
+                name: "root".to_string(),
+                uid: 0,
+                gid: 0,
+            }),
+            "aimx-catchall" => Some(crate::user_resolver::ResolvedUser {
+                name: "aimx-catchall".to_string(),
+                uid: 4242,
+                gid: 4242,
+            }),
+            _ => None,
+        }
+    }
+
+    fn install_resolver() -> crate::user_resolver::test_resolver::ResolverOverride {
+        crate::user_resolver::set_test_resolver(fake_resolver)
+    }
+
+    fn dummy_key() -> Arc<RsaPrivateKey> {
+        // Generate once per test — 2048-bit keygen is ~200ms, acceptable
+        // for the handful of test cases below.
+        let mut rng = rsa::rand_core::OsRng;
+        Arc::new(RsaPrivateKey::new(&mut rng, 2048).unwrap())
+    }
+
+    fn config_two_domains(data_dir: &Path) -> Config {
+        let mut mailboxes = HashMap::new();
+        mailboxes.insert(
+            "info@a.com".to_string(),
+            MailboxConfig {
+                address: "info@a.com".to_string(),
+                owner: "root".to_string(),
+                hooks: vec![],
+                trust: None,
+                trusted_senders: None,
+                allow_root_catchall: false,
+            },
+        );
+        mailboxes.insert(
+            "support@b.com".to_string(),
+            MailboxConfig {
+                address: "support@b.com".to_string(),
+                owner: "root".to_string(),
+                hooks: vec![],
+                trust: None,
+                trusted_senders: None,
+                allow_root_catchall: false,
+            },
+        );
+        let mut per_domain = HashMap::new();
+        per_domain.insert(
+            "b.com".to_string(),
+            DomainOverride {
+                dkim_selector: Some("s2025".to_string()),
+                trust: Some("verified".to_string()),
+                ..Default::default()
+            },
+        );
+        Config {
+            domains: vec!["a.com".to_string(), "b.com".to_string()],
+            data_dir: data_dir.to_path_buf(),
+            dkim_selector: None,
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            mailboxes,
+            per_domain,
+            verify_host: None,
+            enable_ipv6: false,
+            signature: None,
+            upgrade: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn root_sees_every_domain_with_default_marker() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let config = config_two_domains(tmp.path());
+        let handle = ConfigHandle::new(config);
+        let state_ctx = StateContext::new(tmp.path().to_path_buf(), handle);
+
+        let key = dummy_key();
+        let mut map: crate::dkim_keys::DkimKeyMap = HashMap::new();
+        map.insert(
+            "a.com".to_string(),
+            DkimKeyEntry {
+                key: Arc::clone(&key),
+                selector: "aimx".to_string(),
+            },
+        );
+        map.insert(
+            "b.com".to_string(),
+            DkimKeyEntry {
+                key: Arc::clone(&key),
+                selector: "s2025".to_string(),
+            },
+        );
+        let shared: SharedDkimKeyMap = Arc::new(arc_swap::ArcSwap::from_pointee(map));
+
+        let resp = handle_domain_list(&state_ctx, &shared, &Caller::internal_root()).await;
+        let body = match resp {
+            JsonAckResponse::Ok { body } => body,
+            other => panic!("expected Ok, got {other:?}"),
+        };
+        let rows: Vec<DomainListRow> = serde_json::from_slice(&body).unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].domain, "a.com");
+        assert!(rows[0].default);
+        assert!(rows[0].dkim_loaded);
+        assert_eq!(rows[0].dkim_selector, "aimx");
+        assert_eq!(rows[0].mailbox_count, 1);
+        assert_eq!(rows[0].overrides, "");
+
+        assert_eq!(rows[1].domain, "b.com");
+        assert!(!rows[1].default);
+        assert!(rows[1].dkim_loaded);
+        assert_eq!(rows[1].dkim_selector, "s2025");
+        assert_eq!(rows[1].mailbox_count, 1);
+        assert!(rows[1].overrides.contains("dkim_selector"));
+        assert!(rows[1].overrides.contains("trust"));
+    }
+
+    /// A non-root caller is denied with an EACCES error. Domain
+    /// management is operator-only.
+    #[tokio::test]
+    async fn non_root_caller_denied_with_eacces() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let config = config_two_domains(tmp.path());
+        let handle = ConfigHandle::new(config);
+        let state_ctx = StateContext::new(tmp.path().to_path_buf(), handle);
+
+        let empty: SharedDkimKeyMap = crate::dkim_keys::empty_shared();
+        let stranger = Caller::new(1000, 1000, None);
+        let resp = handle_domain_list(&state_ctx, &empty, &stranger).await;
+        match resp {
+            JsonAckResponse::Err { code, .. } => {
+                assert_eq!(code, ErrCode::Eaccess);
+            }
+            other => panic!("expected Err EACCES, got {other:?}"),
+        }
+    }
+
+    /// Missing DKIM key for a configured domain renders `dkim_loaded =
+    /// false` and falls back to the resolved selector (no panic on
+    /// absent entry).
+    #[tokio::test]
+    async fn missing_dkim_key_renders_unloaded_with_fallback_selector() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let config = config_two_domains(tmp.path());
+        let handle = ConfigHandle::new(config);
+        let state_ctx = StateContext::new(tmp.path().to_path_buf(), handle);
+
+        // Empty map → both domains report dkim_loaded = false but the
+        // selector comes from the resolution helper.
+        let empty: SharedDkimKeyMap = crate::dkim_keys::empty_shared();
+        let resp = handle_domain_list(&state_ctx, &empty, &Caller::internal_root()).await;
+        let body = match resp {
+            JsonAckResponse::Ok { body } => body,
+            other => panic!("expected Ok, got {other:?}"),
+        };
+        let rows: Vec<DomainListRow> = serde_json::from_slice(&body).unwrap();
+        assert!(!rows[0].dkim_loaded);
+        assert_eq!(rows[0].dkim_selector, "aimx");
+        assert!(!rows[1].dkim_loaded);
+        // b.com still picks up its per-domain selector override.
+        assert_eq!(rows[1].dkim_selector, "s2025");
+    }
+
+    /// Per-domain overrides are surfaced as a comma-separated list of
+    /// the field names that are set.
+    #[test]
+    fn format_overrides_reports_each_set_field() {
+        let mut config = Config {
+            domains: vec!["x.com".into()],
+            data_dir: std::path::PathBuf::from("/tmp/x"),
+            dkim_selector: None,
+            trust: "none".into(),
+            trusted_senders: vec![],
+            mailboxes: HashMap::new(),
+            per_domain: HashMap::new(),
+            verify_host: None,
+            enable_ipv6: false,
+            signature: None,
+            upgrade: None,
+        };
+        config.per_domain.insert(
+            "x.com".to_string(),
+            DomainOverride {
+                signature: Some("sig".into()),
+                dkim_selector: Some("s".into()),
+                trust: None,
+                trusted_senders: Some(vec!["*@a.com".into()]),
+            },
+        );
+        let summary = format_overrides(&config, "x.com");
+        assert!(summary.contains("signature"));
+        assert!(summary.contains("dkim_selector"));
+        assert!(summary.contains("trusted_senders"));
+        assert!(!summary.contains("trust,"));
+    }
+
+    /// `DomainListRow` round-trips through serde, pinning the wire
+    /// shape against accidental drift.
+    #[test]
+    fn domain_list_row_serde_round_trip() {
+        let row = DomainListRow {
+            domain: "a.com".into(),
+            default: true,
+            dkim_loaded: true,
+            dkim_selector: "aimx".into(),
+            mailbox_count: 2,
+            unread: 0,
+            overrides: String::new(),
+        };
+        let json = serde_json::to_string(&row).unwrap();
+        let decoded: DomainListRow = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded, row);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -163,7 +163,7 @@ fn dispatch(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         // would surface as a bare `Permission denied (os error 13)`
         // before `domain::run` ever sees the request. `domain::run`
         // loads config lazily only on the root daemon-down fallback.
-        Command::Domains(cmd) => domain::run(cmd, cli.data_dir.as_deref()),
+        Command::Domains(cmd) => domain::run(cmd),
         // `aimx upgrade` reads the release-manifest URL from Config
         // (optional `[upgrade] release_manifest_url`) but tolerates a
         // missing / unloadable config — a freshly-installed machine
@@ -233,19 +233,19 @@ fn dispatch_with_config(
                 dkim::run_keygen(&dkim_root, &d_lc, &selector, force)
             }
             None => {
-                // No `--domain`: legacy single-domain layout (write to
-                // `<dkim_dir>/{private,public}.key` at the un-namespaced
-                // root). This is what the daemon's startup loader
-                // falls back to for the default domain when no
-                // per-domain key exists, so single-domain installs
-                // and existing scripts keep working without change.
-                // The DNS record printed is for the default domain.
-                dkim::run_keygen(
-                    &config::dkim_dir(),
-                    config.default_domain(),
-                    &selector,
-                    force,
-                )
+                // No `--domain`: target the default domain's per-domain
+                // layout (`<dkim_dir>/<default_domain>/`). The daemon
+                // reads keys from the per-domain path on v2 installs;
+                // writing to the un-namespaced legacy root here would
+                // silently land the new key where the daemon never
+                // looks, leaving the OLD key signing — a silent
+                // rotation footgun. The loader still falls back to
+                // the legacy root for *reads* on unmigrated v1
+                // installs, so existing single-domain installs keep
+                // working until they migrate. The DNS record printed
+                // is for the default domain.
+                let dkim_root = config::dkim_dir().join(config.default_domain());
+                dkim::run_keygen(&dkim_root, config.default_domain(), &selector, force)
             }
         },
         Command::Serve {

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,9 @@ mod datadir_readme;
 mod dkim;
 mod dkim_keys;
 mod doctor;
+mod domain;
+mod domain_handler;
+mod domain_list_handler;
 mod frontmatter;
 mod hook;
 mod hook_handler;
@@ -154,6 +157,13 @@ fn dispatch(cli: Cli) -> Result<(), Box<dyn std::error::Error>> {
         // LIST falls back to `MAILBOX-LIST`; SHOW errors with an
         // actionable hint).
         Command::Mailboxes(cmd) => mailbox::run(cmd, cli.data_dir.as_deref()),
+        // `aimx domains` is a UDS-first client like `mailboxes`. It
+        // must NOT pre-load config here — non-root callers cannot read
+        // `/etc/aimx/config.toml` in production, so the read EACCES
+        // would surface as a bare `Permission denied (os error 13)`
+        // before `domain::run` ever sees the request. `domain::run`
+        // loads config lazily only on the root daemon-down fallback.
+        Command::Domains(cmd) => domain::run(cmd, cli.data_dir.as_deref()),
         // `aimx upgrade` reads the release-manifest URL from Config
         // (optional `[upgrade] release_manifest_url`) but tolerates a
         // missing / unloadable config — a freshly-installed machine
@@ -200,12 +210,44 @@ fn dispatch_with_config(
     match cmd {
         Command::Ingest { rcpt } => ingest::run(&rcpt, config),
         Command::Hooks(cmd) => hooks::run(cmd, config),
-        Command::DkimKeygen { selector, force } => dkim::run_keygen(
-            &config::dkim_dir(),
-            config.default_domain(),
-            &selector,
+        Command::DkimKeygen {
+            selector,
+            domain,
             force,
-        ),
+        } => match domain.as_deref() {
+            Some(d) => {
+                // Explicit `--domain <d>`: write to the per-domain
+                // layout under `<dkim_dir>/<d>/`. Refuses when the
+                // requested domain is not in `domains` so a typo
+                // doesn't silently generate a key for an unrelated
+                // identity.
+                let d_lc = d.trim().to_ascii_lowercase();
+                if !config.is_configured_domain(&d_lc) {
+                    return Err(format!(
+                        "domain '{d}' is not in `domains = [...]`. \
+                         Add it with `aimx domains add {d_lc}` first."
+                    )
+                    .into());
+                }
+                let dkim_root = config::dkim_dir().join(&d_lc);
+                dkim::run_keygen(&dkim_root, &d_lc, &selector, force)
+            }
+            None => {
+                // No `--domain`: legacy single-domain layout (write to
+                // `<dkim_dir>/{private,public}.key` at the un-namespaced
+                // root). This is what the daemon's startup loader
+                // falls back to for the default domain when no
+                // per-domain key exists, so single-domain installs
+                // and existing scripts keep working without change.
+                // The DNS record printed is for the default domain.
+                dkim::run_keygen(
+                    &config::dkim_dir(),
+                    config.default_domain(),
+                    &selector,
+                    force,
+                )
+            }
+        },
         Command::Serve {
             bind,
             tls_cert,
@@ -224,6 +266,7 @@ fn dispatch_with_config(
         | Command::Send(_)
         | Command::Logs { .. }
         | Command::Mailboxes(_)
+        | Command::Domains(_)
         | Command::Agents(_)
         | Command::Upgrade(_) => unreachable!("handled by dispatch"),
     }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -257,9 +257,9 @@ impl AimxMcpServer {
             | crate::auth::Action::MarkReadWrite(n)
             | crate::auth::Action::HookCrud(n) => n.clone(),
             crate::auth::Action::MailboxDelete { mailbox } => mailbox.clone(),
-            crate::auth::Action::MailboxCreate { .. } | crate::auth::Action::SystemCommand => {
-                String::new()
-            }
+            crate::auth::Action::MailboxCreate { .. }
+            | crate::auth::Action::SystemCommand
+            | crate::auth::Action::DomainCrud => String::new(),
         };
         // Derive the rendering verb from the action so a future change
         // that produces `OwnerMismatch` from a non-create predicate
@@ -1375,6 +1375,135 @@ async fn submit_hook_list_request(
 /// the [`MailboxLifecycleFallback`] shape used by the CRUD path.
 pub(crate) fn submit_mailbox_list_via_daemon_for_cli() -> Result<String, MailboxLifecycleFallback> {
     submit_mailbox_list_raw()
+}
+
+/// CLI-friendly variant for `DOMAIN-LIST`. Mirrors
+/// [`submit_mailbox_list_via_daemon_for_cli`] line-for-line so the
+/// `aimx domains list` CLI keeps the same SocketMissing / Daemon
+/// branching shape every other CRUD verb uses.
+pub(crate) fn submit_domain_list_via_daemon_for_cli() -> Result<String, MailboxLifecycleFallback> {
+    submit_domain_list_raw()
+}
+
+fn submit_domain_list_raw() -> Result<String, MailboxLifecycleFallback> {
+    let socket = crate::serve::aimx_socket_path();
+
+    let rt = tokio::runtime::Handle::try_current();
+    let io_result: Result<Vec<u8>, std::io::Error> = match rt {
+        Ok(handle) => {
+            tokio::task::block_in_place(|| handle.block_on(submit_domain_list_request(&socket)))
+        }
+        Err(_) => {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| {
+                    MailboxLifecycleFallback::Daemon(format!("Failed to create tokio runtime: {e}"))
+                })?;
+            rt.block_on(submit_domain_list_request(&socket))
+        }
+    };
+
+    let raw = io_result.map_err(|e| {
+        if is_socket_missing(&e) {
+            MailboxLifecycleFallback::SocketMissing
+        } else {
+            MailboxLifecycleFallback::Daemon(format!(
+                "Failed to connect to aimx daemon at {}: {e}",
+                socket.display()
+            ))
+        }
+    })?;
+
+    // Reuse the MAILBOX-LIST decoder — wire shape is identical (status
+    // line + Content-Length + JSON body), only the JSON schema differs.
+    decode_mailbox_list_response(&raw).map_err(MailboxLifecycleFallback::Daemon)
+}
+
+async fn submit_domain_list_request(
+    socket_path: &std::path::Path,
+) -> Result<Vec<u8>, std::io::Error> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let stream = tokio::net::UnixStream::connect(socket_path).await?;
+    let (mut reader, mut writer) = stream.into_split();
+
+    send_protocol::write_domain_list_request(&mut writer).await?;
+    writer.shutdown().await.ok();
+
+    let mut buf = Vec::with_capacity(1024);
+    reader.read_to_end(&mut buf).await?;
+    Ok(buf)
+}
+
+/// Submit an `AIMX/1 DOMAIN-ADD` request over UDS. Returns a
+/// [`MailboxLifecycleFallback`] on failure so the CLI can decide
+/// whether to fall back to the direct on-disk edit (root) or
+/// hard-error (non-root).
+pub(crate) fn submit_domain_add_via_daemon(
+    domain: &str,
+    selector: Option<&str>,
+) -> Result<(), MailboxLifecycleFallback> {
+    let request = send_protocol::DomainAddRequest {
+        domain: domain.to_string(),
+        selector: selector.map(|s| s.to_string()),
+    };
+    let socket = crate::serve::aimx_socket_path();
+
+    let rt = tokio::runtime::Handle::try_current();
+    let io_result: Result<MarkOutcome, std::io::Error> = match rt {
+        Ok(handle) => tokio::task::block_in_place(|| {
+            handle.block_on(submit_domain_add_request(&socket, &request))
+        }),
+        Err(_) => {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| {
+                    MailboxLifecycleFallback::Daemon(format!("Failed to create tokio runtime: {e}"))
+                })?;
+            rt.block_on(submit_domain_add_request(&socket, &request))
+        }
+    };
+
+    match io_result {
+        Ok(MarkOutcome::Ok) => Ok(()),
+        Ok(MarkOutcome::Err { code, reason }) => Err(MailboxLifecycleFallback::Daemon(format!(
+            "[{}] {reason}",
+            code.as_str()
+        ))),
+        Ok(MarkOutcome::Malformed(reason)) => Err(MailboxLifecycleFallback::Daemon(format!(
+            "Malformed response from aimx daemon: {reason}"
+        ))),
+        Err(e) => {
+            if is_socket_missing(&e) {
+                Err(MailboxLifecycleFallback::SocketMissing)
+            } else {
+                Err(MailboxLifecycleFallback::Daemon(format!(
+                    "Failed to connect to aimx daemon at {}: {e}",
+                    socket.display()
+                )))
+            }
+        }
+    }
+}
+
+async fn submit_domain_add_request(
+    socket_path: &std::path::Path,
+    request: &send_protocol::DomainAddRequest,
+) -> Result<MarkOutcome, std::io::Error> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let stream = tokio::net::UnixStream::connect(socket_path).await?;
+    let (mut reader, mut writer) = stream.into_split();
+
+    send_protocol::write_domain_add_request(&mut writer, request).await?;
+    writer.shutdown().await.ok();
+
+    let mut buf = Vec::with_capacity(128);
+    reader.read_to_end(&mut buf).await?;
+
+    Ok(parse_ack_response(&buf))
 }
 
 fn submit_mailbox_list_raw() -> Result<String, MailboxLifecycleFallback> {

--- a/src/send_protocol.rs
+++ b/src/send_protocol.rs
@@ -190,6 +190,22 @@ pub struct HookDeleteRequest {
     pub name: String,
 }
 
+/// Decoded `AIMX/1 DOMAIN-ADD` request. The daemon-side handler runs
+/// `auth::authorize(.., Action::DomainCrud)` (root-only) before doing
+/// anything, then appends the domain, generates the DKIM keypair, and
+/// rewrites + hot-swaps the config.
+///
+/// `selector` is optional: when `None` the daemon resolves the selector
+/// via the documented order (top-level `Config.dkim_selector` →
+/// built-in `"aimx"`). When `Some(s)` the selector is persisted in
+/// `[domain."<domain>"] dkim_selector = "<s>"` so subsequent loads
+/// pick it up.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DomainAddRequest {
+    pub domain: String,
+    pub selector: Option<String>,
+}
+
 // `AIMX/1 HOOK-LIST` carries no payload; the daemon resolves the
 // caller via `SO_PEERCRED` and returns the hooks visible to the
 // caller's uid (root sees every hook on every mailbox; non-root sees
@@ -232,6 +248,14 @@ pub enum Request {
     /// binary on disk and a still-running pre-upgrade daemon. Open to
     /// every UDS caller — version data is not sensitive.
     Version,
+    /// `AIMX/1 DOMAIN-LIST` carries no payload. The daemon enforces
+    /// root-only authz via `Action::DomainCrud` and returns a JSON
+    /// array of `DomainListRow` covering every configured domain.
+    /// Mirrors `MAILBOX-LIST` line-for-line.
+    DomainList,
+    /// `AIMX/1 DOMAIN-ADD` carries the `Domain:` header (required) plus
+    /// an optional `Selector:` header. Root-only.
+    DomainAdd(DomainAddRequest),
 }
 
 /// Error codes reported on the wire in `AIMX/1 ERR <code> <reason>`.
@@ -471,6 +495,12 @@ where
         "VERSION" => parse_version_headers(reader)
             .await
             .map(|()| Request::Version),
+        "DOMAIN-LIST" => parse_domain_list_headers(reader)
+            .await
+            .map(|()| Request::DomainList),
+        "DOMAIN-ADD" => parse_domain_add_headers(reader)
+            .await
+            .map(Request::DomainAdd),
         other => Err(ParseError::UnknownVerb(other.to_string())),
     }
 }
@@ -499,6 +529,9 @@ where
         ),
         Request::Version => Err(ParseError::Malformed(
             "expected SEND verb, got VERSION".to_string(),
+        )),
+        Request::DomainList | Request::DomainAdd(_) => Err(ParseError::Malformed(
+            "expected SEND verb, got DOMAIN-*".to_string(),
         )),
     }
 }
@@ -934,6 +967,106 @@ where
         )));
     }
     Ok(())
+}
+
+/// Parse the empty body of an `AIMX/1 DOMAIN-LIST` request. Mirrors
+/// `parse_mailbox_list_headers` / `parse_hook_list_headers`
+/// line-for-line: the verb carries no headers, and silently ignoring
+/// one would let a future caller smuggle a forged header past the
+/// `SO_PEERCRED` filter.
+async fn parse_domain_list_headers<R>(reader: &mut R) -> Result<(), ParseError>
+where
+    R: AsyncRead + Unpin,
+{
+    let line = read_line(reader)
+        .await?
+        .ok_or_else(|| ParseError::Malformed("unexpected EOF in headers".into()))?;
+    let line = line.trim_end_matches('\r');
+    if !line.is_empty() {
+        return Err(ParseError::Malformed(format!(
+            "DOMAIN-LIST takes no headers, got {line:?}"
+        )));
+    }
+    Ok(())
+}
+
+/// Parse `AIMX/1 DOMAIN-ADD` headers: `Domain:` (required) plus
+/// optional `Selector:`. `Content-Length:` is allowed but must be 0
+/// (the verb carries no body).
+async fn parse_domain_add_headers<R>(reader: &mut R) -> Result<DomainAddRequest, ParseError>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut domain: Option<String> = None;
+    let mut selector: Option<String> = None;
+    let mut content_length: Option<usize> = None;
+
+    loop {
+        let line = read_line(reader)
+            .await?
+            .ok_or_else(|| ParseError::Malformed("unexpected EOF in headers".into()))?;
+        let line = line.trim_end_matches('\r');
+        if line.is_empty() {
+            break;
+        }
+
+        let (n, v) = line
+            .split_once(':')
+            .ok_or_else(|| ParseError::Malformed(format!("invalid header line: {line:?}")))?;
+
+        if !n.is_ascii() {
+            return Err(ParseError::Malformed(format!(
+                "non-ascii header name: {n:?}"
+            )));
+        }
+        let name_norm = n.trim().to_ascii_lowercase();
+        let value = v.trim().to_string();
+
+        match name_norm.as_str() {
+            "domain" => {
+                if domain.is_some() {
+                    return Err(ParseError::Malformed("duplicate Domain header".into()));
+                }
+                if value.is_empty() {
+                    return Err(ParseError::Malformed("empty Domain value".into()));
+                }
+                domain = Some(value);
+            }
+            "selector" => {
+                if selector.is_some() {
+                    return Err(ParseError::Malformed("duplicate Selector header".into()));
+                }
+                if value.is_empty() {
+                    return Err(ParseError::Malformed("empty Selector value".into()));
+                }
+                selector = Some(value);
+            }
+            "content-length" => {
+                if content_length.is_some() {
+                    return Err(ParseError::Malformed(
+                        "duplicate Content-Length header".into(),
+                    ));
+                }
+                let n: usize = value.parse().map_err(|_| {
+                    ParseError::Malformed(format!("non-integer Content-Length: {value:?}"))
+                })?;
+                if n != 0 {
+                    return Err(ParseError::Malformed(format!(
+                        "DOMAIN-ADD must have Content-Length: 0, got {n}"
+                    )));
+                }
+                content_length = Some(n);
+            }
+            _ => {
+                // Unknown headers ignored.
+            }
+        }
+    }
+
+    let domain =
+        domain.ok_or_else(|| ParseError::Malformed("missing required header: Domain".into()))?;
+    let _ = content_length;
+    Ok(DomainAddRequest { domain, selector })
 }
 
 async fn parse_hook_create_headers_and_body<R>(
@@ -1492,6 +1625,40 @@ where
     Ok(())
 }
 
+/// Write an `AIMX/1 DOMAIN-LIST` request frame. Bare verb line plus a
+/// single blank separator — no headers, no body. Mirrors
+/// `write_mailbox_list_request` / `write_hook_list_request`.
+pub async fn write_domain_list_request<W>(writer: &mut W) -> Result<(), std::io::Error>
+where
+    W: AsyncWrite + Unpin,
+{
+    writer.write_all(b"AIMX/1 DOMAIN-LIST\n\n").await?;
+    writer.flush().await?;
+    Ok(())
+}
+
+/// Write an `AIMX/1 DOMAIN-ADD` request frame. `Domain:` is required;
+/// `Selector:` is emitted only when set.
+pub async fn write_domain_add_request<W>(
+    writer: &mut W,
+    request: &DomainAddRequest,
+) -> Result<(), std::io::Error>
+where
+    W: AsyncWrite + Unpin,
+{
+    let mut header = format!(
+        "AIMX/1 DOMAIN-ADD\nDomain: {}\n",
+        sanitize_inline(&request.domain),
+    );
+    if let Some(s) = &request.selector {
+        header.push_str(&format!("Selector: {}\n", sanitize_inline(s)));
+    }
+    header.push_str("Content-Length: 0\n\n");
+    writer.write_all(header.as_bytes()).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
 /// Strip CR/LF from a single-line wire field. Callers must never emit bare
 /// LF inside a reason or message-ID or the framer ambiguates the next line.
 fn sanitize_inline(s: &str) -> String {
@@ -1537,6 +1704,96 @@ mod mailbox_list_codec_tests {
     #[tokio::test]
     async fn mailbox_list_rejects_content_length_header() {
         let frame = b"AIMX/1 MAILBOX-LIST\nContent-Length: 0\n\n";
+        let mut reader = std::io::Cursor::new(frame.to_vec());
+        match parse_request(&mut reader).await {
+            Err(ParseError::Malformed(_)) => {}
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    /// Round-trip a `DOMAIN-LIST` frame: writer emits the bare verb +
+    /// blank separator, parser decodes it as `Request::DomainList`.
+    #[tokio::test]
+    async fn round_trip_domain_list_request() {
+        let mut buf: Vec<u8> = Vec::new();
+        write_domain_list_request(&mut buf).await.unwrap();
+        assert_eq!(buf, b"AIMX/1 DOMAIN-LIST\n\n");
+
+        let mut reader = std::io::Cursor::new(buf);
+        let req = parse_request(&mut reader).await.unwrap();
+        assert_eq!(req, Request::DomainList);
+    }
+
+    /// Any header on `DOMAIN-LIST` is a parse error. Same rationale as
+    /// `MAILBOX-LIST` / `HOOK-LIST`: the caller is identified via
+    /// `SO_PEERCRED`, so a stray header could only confuse a future
+    /// implementation.
+    #[tokio::test]
+    async fn domain_list_rejects_any_header() {
+        let frame = b"AIMX/1 DOMAIN-LIST\nDomain: a.com\n\n";
+        let mut reader = std::io::Cursor::new(frame.to_vec());
+        match parse_request(&mut reader).await {
+            Err(ParseError::Malformed(reason)) => {
+                assert!(reason.contains("DOMAIN-LIST"), "{reason}");
+            }
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    /// Round-trip a `DOMAIN-ADD` frame without selector: the parser
+    /// decodes back the same struct.
+    #[tokio::test]
+    async fn round_trip_domain_add_request_without_selector() {
+        let req = DomainAddRequest {
+            domain: "b.com".into(),
+            selector: None,
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        write_domain_add_request(&mut buf, &req).await.unwrap();
+        let text = std::str::from_utf8(&buf).unwrap();
+        assert!(text.starts_with("AIMX/1 DOMAIN-ADD\n"), "{text}");
+        assert!(text.contains("Domain: b.com\n"), "{text}");
+        assert!(!text.contains("Selector:"), "{text}");
+
+        let mut reader = std::io::Cursor::new(buf);
+        let parsed = parse_request(&mut reader).await.unwrap();
+        assert_eq!(parsed, Request::DomainAdd(req));
+    }
+
+    /// Round-trip a `DOMAIN-ADD` frame with a selector header.
+    #[tokio::test]
+    async fn round_trip_domain_add_request_with_selector() {
+        let req = DomainAddRequest {
+            domain: "b.com".into(),
+            selector: Some("s2025".into()),
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        write_domain_add_request(&mut buf, &req).await.unwrap();
+        let text = std::str::from_utf8(&buf).unwrap();
+        assert!(text.contains("Selector: s2025\n"), "{text}");
+
+        let mut reader = std::io::Cursor::new(buf);
+        let parsed = parse_request(&mut reader).await.unwrap();
+        assert_eq!(parsed, Request::DomainAdd(req));
+    }
+
+    /// Missing the required `Domain:` header is a parse error.
+    #[tokio::test]
+    async fn domain_add_rejects_missing_domain_header() {
+        let frame = b"AIMX/1 DOMAIN-ADD\nSelector: s\nContent-Length: 0\n\n";
+        let mut reader = std::io::Cursor::new(frame.to_vec());
+        match parse_request(&mut reader).await {
+            Err(ParseError::Malformed(reason)) => {
+                assert!(reason.contains("Domain"), "{reason}");
+            }
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    /// A non-zero `Content-Length:` on DOMAIN-ADD is a parse error.
+    #[tokio::test]
+    async fn domain_add_rejects_nonzero_content_length() {
+        let frame = b"AIMX/1 DOMAIN-ADD\nDomain: b.com\nContent-Length: 5\n\n";
         let mut reader = std::io::Cursor::new(frame.to_vec());
         match parse_request(&mut reader).await {
             Err(ParseError::Malformed(_)) => {}

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1115,6 +1115,30 @@ async fn handle_uds_connection_with_timeout(
                 Reply::Json(crate::hook_list_handler::handle_hook_list(&state_ctx, &caller).await),
                 false,
             ),
+            Ok(Ok(Request::DomainList)) => (
+                Reply::Json(
+                    crate::domain_list_handler::handle_domain_list(
+                        &state_ctx,
+                        &send_ctx.dkim_keys,
+                        &caller,
+                    )
+                    .await,
+                ),
+                false,
+            ),
+            Ok(Ok(Request::DomainAdd(req))) => (
+                Reply::Ack(
+                    crate::domain_handler::handle_domain_add(
+                        &state_ctx,
+                        &mb_ctx,
+                        &send_ctx.dkim_keys,
+                        &req,
+                        &caller,
+                    )
+                    .await,
+                ),
+                false,
+            ),
             Ok(Ok(Request::Version)) => (
                 Reply::Version(crate::version_handler::current_version_response()),
                 false,

--- a/tests/domains_uds.rs
+++ b/tests/domains_uds.rs
@@ -1,0 +1,543 @@
+//! End-to-end integration tests for the `DOMAIN-LIST` and
+//! `DOMAIN-ADD` UDS verbs and the `aimx domains` CLI.
+//!
+//! Setup mirrors `tests/multi_domain.rs`: spin up `aimx serve` against
+//! a two-domain v2 install, exercise the CLI as a separate subprocess,
+//! and assert the expected wire / on-disk effects.
+//!
+//! Every test here requires root because `Action::DomainCrud` is
+//! root-only. Non-root local runs skip with a single stderr line.
+
+use std::io::{BufRead, Write};
+use std::net::TcpStream;
+use std::path::Path;
+use std::process::{Command as StdCommand, Stdio};
+use std::sync::LazyLock;
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+use wait_timeout::ChildExt;
+
+fn aimx_binary_path() -> std::path::PathBuf {
+    let target_dir = std::env::var("CARGO_TARGET_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target"));
+    let profile = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
+    target_dir.join(profile).join("aimx")
+}
+
+/// `DOMAIN-CRUD` is root-only (Action::DomainCrud). Tests that route
+/// through the daemon need to bail out on a non-root local run.
+fn skip_if_not_root() -> bool {
+    if unsafe { libc::geteuid() } == 0 {
+        return false;
+    }
+    eprintln!("skipping DOMAIN-* UDS test: requires root; DOMAIN-CRUD is root-only");
+    true
+}
+
+/// One-shot pre-generated DKIM keypair shared across tests in this
+/// file. Avoids re-running `aimx dkim-keygen` (~200ms) per test.
+static DD_DKIM_CACHE: LazyLock<TempDir> = LazyLock::new(|| {
+    let cache = TempDir::new().expect("create DKIM cache");
+    // Seed a config so `aimx dkim-keygen` (no --domain) defaults to
+    // the cached single-domain install.
+    let config = format!(
+        "domain = \"dd-cache.example.com\"\ndata_dir = \"{}\"\n\n[mailboxes.catchall]\naddress = \"*@dd-cache.example.com\"\nowner = \"aimx-catchall\"\n",
+        cache.path().display()
+    );
+    std::fs::write(cache.path().join("config.toml"), config).unwrap();
+    let status = StdCommand::new(aimx_binary_path())
+        .env("AIMX_CONFIG_DIR", cache.path())
+        .arg("dkim-keygen")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("failed to spawn dkim-keygen");
+    assert!(status.success(), "dkim-keygen exited non-zero");
+    cache
+});
+
+fn install_dkim_under(domain_dir: &Path) {
+    std::fs::create_dir_all(domain_dir).unwrap();
+    // `aimx dkim-keygen` (no `--domain`) writes under
+    // `<dkim_dir>/<default_domain>/` — the cache config sets the
+    // default domain to `dd-cache.example.com`, so the source path
+    // is nested under that subdir.
+    let cache_dkim = DD_DKIM_CACHE
+        .path()
+        .join("dkim")
+        .join("dd-cache.example.com");
+    for name in ["private.key", "public.key"] {
+        let src = cache_dkim.join(name);
+        let dst = domain_dir.join(name);
+        if src.exists() {
+            std::fs::copy(&src, &dst).unwrap();
+        }
+    }
+}
+
+fn current_username() -> String {
+    unsafe {
+        let uid = libc::geteuid();
+        if uid == 0 {
+            if let Some(sudo_user) = std::env::var_os("SUDO_USER") {
+                let name = sudo_user.to_string_lossy().into_owned();
+                if !name.is_empty() && name != "root" {
+                    return name;
+                }
+            }
+            return "nobody".to_string();
+        }
+        let pw = libc::getpwuid(uid);
+        if pw.is_null() {
+            return format!("uid{uid}");
+        }
+        let cstr = std::ffi::CStr::from_ptr((*pw).pw_name);
+        cstr.to_string_lossy().to_string()
+    }
+}
+
+/// Provision a single-domain v2 install (a.com only) under `tmp`.
+/// Tests then add a second domain via the CLI and assert the result.
+fn setup_single_domain_env(tmp: &Path) {
+    let owner = current_username();
+    let cfg = format!(
+        r#"domains = ["a.com"]
+data_dir = "{tmp_path}"
+
+[mailboxes."info@a.com"]
+address = "info@a.com"
+owner = "{owner}"
+"#,
+        tmp_path = tmp.display(),
+    );
+    std::fs::write(tmp.join("config.toml"), cfg).unwrap();
+    std::fs::write(tmp.join(".layout-version"), "2\n").unwrap();
+    install_dkim_under(&tmp.join("dkim").join("a.com"));
+    for folder in ["inbox", "sent"] {
+        let dir = tmp.join("a.com").join(folder).join("info");
+        std::fs::create_dir_all(&dir).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&dir, std::fs::Permissions::from_mode(0o700)).unwrap();
+        }
+    }
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(tmp.join("a.com"), std::fs::Permissions::from_mode(0o755))
+            .unwrap();
+    }
+}
+
+fn find_free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.local_addr().unwrap().port()
+}
+
+fn wait_for_listener(port: u16) {
+    let started = Instant::now();
+    while started.elapsed() < Duration::from_secs(30) {
+        if TcpStream::connect(format!("127.0.0.1:{port}")).is_ok() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    panic!("aimx serve did not start within 30s on port {port}");
+}
+
+fn start_serve(tmp: &Path, port: u16) -> std::process::Child {
+    let runtime = tmp.join("run");
+    std::fs::create_dir_all(&runtime).ok();
+    StdCommand::new(aimx_binary_path())
+        .env("AIMX_CONFIG_DIR", tmp)
+        .env("AIMX_RUNTIME_DIR", &runtime)
+        .arg("--data-dir")
+        .arg(tmp)
+        .arg("serve")
+        .arg("--bind")
+        .arg(format!("127.0.0.1:{port}"))
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn aimx serve")
+}
+
+fn shutdown(child: &mut std::process::Child) {
+    unsafe {
+        libc::kill(child.id() as libc::pid_t, libc::SIGTERM);
+    }
+    let _ = child.wait_timeout(Duration::from_secs(10));
+}
+
+fn smtp_rcpt_status(port: u16, from: &str, rcpt: &str) -> String {
+    let stream = TcpStream::connect(format!("127.0.0.1:{port}")).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .unwrap();
+    let mut reader = std::io::BufReader::new(stream.try_clone().unwrap());
+    let mut writer = stream;
+
+    let mut buf = String::new();
+    reader.read_line(&mut buf).unwrap();
+    assert!(buf.starts_with("220"), "banner: {buf}");
+
+    buf.clear();
+    write!(writer, "EHLO test.local\r\n").unwrap();
+    loop {
+        reader.read_line(&mut buf).unwrap();
+        if buf.contains("250 ") {
+            break;
+        }
+    }
+
+    buf.clear();
+    write!(writer, "MAIL FROM:<{from}>\r\n").unwrap();
+    reader.read_line(&mut buf).unwrap();
+    assert!(buf.starts_with("250"), "MAIL FROM: {buf}");
+
+    buf.clear();
+    write!(writer, "RCPT TO:<{rcpt}>\r\n").unwrap();
+    reader.read_line(&mut buf).unwrap();
+    let rcpt_response = buf.clone();
+
+    let _ = write!(writer, "QUIT\r\n");
+    let mut sink = String::new();
+    let _ = reader.read_line(&mut sink);
+
+    rcpt_response
+}
+
+/// Run `aimx domains list` against the running daemon and return the
+/// full stdout. The CLI exits non-zero only on real errors; pre-add
+/// the test asserts the table contains the expected domain.
+fn run_domains_list(tmp: &Path) -> std::process::Output {
+    let runtime = tmp.join("run");
+    StdCommand::new(aimx_binary_path())
+        .env("AIMX_CONFIG_DIR", tmp)
+        .env("AIMX_RUNTIME_DIR", &runtime)
+        .env("NO_COLOR", "1")
+        .arg("--data-dir")
+        .arg(tmp)
+        .arg("domains")
+        .arg("list")
+        .output()
+        .expect("failed to spawn aimx domains list")
+}
+
+fn run_domains_add(tmp: &Path, domain: &str, selector: Option<&str>) -> std::process::Output {
+    let runtime = tmp.join("run");
+    let mut cmd = StdCommand::new(aimx_binary_path());
+    cmd.env("AIMX_CONFIG_DIR", tmp)
+        .env("AIMX_RUNTIME_DIR", &runtime)
+        .env("NO_COLOR", "1")
+        .arg("--data-dir")
+        .arg(tmp)
+        .arg("domains")
+        .arg("add")
+        .arg(domain)
+        .arg("--no-dns-check");
+    if let Some(s) = selector {
+        cmd.arg("--selector").arg(s);
+    }
+    cmd.output().expect("failed to spawn aimx domains add")
+}
+
+#[test]
+fn domains_list_returns_initial_domain() {
+    if skip_if_not_root() {
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_single_domain_env(tmp.path());
+    let port = find_free_port();
+    let mut child = start_serve(tmp.path(), port);
+    wait_for_listener(port);
+
+    let out = run_domains_list(tmp.path());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "domains list failed: stdout={stdout} stderr={stderr}"
+    );
+    assert!(stdout.contains("a.com"), "stdout: {stdout}");
+    assert!(stdout.contains("DOMAIN"), "header missing: {stdout}");
+
+    shutdown(&mut child);
+}
+
+/// Full end-to-end: add b.com to a single-domain install, assert
+/// config is rewritten, DKIM keypair lands on disk, daemon hot-reloads
+/// (the new domain shows in `aimx domains list` AND SMTP RCPT to
+/// `@b.com` is accepted immediately).
+#[test]
+fn domains_add_full_flow_hot_reloads_smtp_and_config() {
+    if skip_if_not_root() {
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_single_domain_env(tmp.path());
+    let port = find_free_port();
+    let mut child = start_serve(tmp.path(), port);
+    wait_for_listener(port);
+
+    // Pre-condition: a.com only.
+    let pre = run_domains_list(tmp.path());
+    let pre_stdout = String::from_utf8_lossy(&pre.stdout);
+    assert!(pre_stdout.contains("a.com"), "pre stdout: {pre_stdout}");
+    assert!(!pre_stdout.contains("b.com"), "pre stdout: {pre_stdout}");
+
+    // Add b.com.
+    let add = run_domains_add(tmp.path(), "b.com", Some("s2025"));
+    let add_stdout = String::from_utf8_lossy(&add.stdout);
+    let add_stderr = String::from_utf8_lossy(&add.stderr);
+    assert!(
+        add.status.success(),
+        "domains add failed: stdout={add_stdout} stderr={add_stderr}"
+    );
+
+    // DKIM keypair exists at the per-domain layout.
+    let dkim_b = tmp.path().join("dkim").join("b.com");
+    assert!(
+        dkim_b.join("private.key").is_file(),
+        "DKIM private.key missing under {}",
+        dkim_b.display()
+    );
+    assert!(
+        dkim_b.join("public.key").is_file(),
+        "DKIM public.key missing under {}",
+        dkim_b.display()
+    );
+
+    // Config rewritten on disk with both domains and a `[domain."b.com"]`
+    // sub-table carrying the selector override.
+    let config_text = std::fs::read_to_string(tmp.path().join("config.toml")).unwrap();
+    assert!(
+        config_text.contains("domains") && config_text.contains("\"b.com\""),
+        "config.toml missing b.com: {config_text}"
+    );
+    assert!(
+        config_text.contains("s2025"),
+        "config.toml missing selector override: {config_text}"
+    );
+
+    // Hot-reload: the same running daemon now lists b.com.
+    let post = run_domains_list(tmp.path());
+    let post_stdout = String::from_utf8_lossy(&post.stdout);
+    assert!(
+        post_stdout.contains("b.com"),
+        "post stdout missing b.com: {post_stdout}"
+    );
+
+    // SMTP RCPT to `@b.com` is accepted by the same running daemon.
+    // We send to the per-domain catchall lookup — without an explicit
+    // mailbox on b.com, the recipient address must still pass the
+    // domain check (rejection would happen later on no-mailbox, not at
+    // domain-check time). `recipient_domain_matches_any` is the only
+    // gate at RCPT time; mailbox resolution happens at DATA / dispatch.
+    let resp = smtp_rcpt_status(port, "sender@example.com", "info@b.com");
+    // The daemon may accept the RCPT (domain valid) and reject later;
+    // what matters is that the RCPT is NOT rejected with 550 5.7.1
+    // ("relay not permitted") on a domain miss. Accepting 250 (any
+    // mailbox match path) or 550 5.1.1 (no such user) both prove the
+    // domain was recognized.
+    assert!(
+        resp.starts_with("250") || resp.contains("5.1.1"),
+        "RCPT to @b.com must be domain-recognized (got: {resp})"
+    );
+
+    shutdown(&mut child);
+}
+
+#[test]
+fn domains_add_duplicate_returns_error_and_leaves_state_unchanged() {
+    if skip_if_not_root() {
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_single_domain_env(tmp.path());
+    let port = find_free_port();
+    let mut child = start_serve(tmp.path(), port);
+    wait_for_listener(port);
+
+    let out = run_domains_add(tmp.path(), "a.com", None);
+    let combined = format!(
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        !out.status.success(),
+        "duplicate add must fail; got: {combined}"
+    );
+    assert!(
+        combined.contains("already configured"),
+        "expected duplicate-add reason; got: {combined}"
+    );
+
+    shutdown(&mut child);
+}
+
+#[test]
+fn dkim_keygen_with_domain_flag_writes_under_per_domain_dir() {
+    // Doesn't need root — `aimx dkim-keygen` writes to <dkim_dir>
+    // resolved from `AIMX_CONFIG_DIR`, so a tempdir-rooted run works
+    // for any uid.
+    let tmp = TempDir::new().unwrap();
+    setup_single_domain_env(tmp.path());
+
+    let out = StdCommand::new(aimx_binary_path())
+        .env("AIMX_CONFIG_DIR", tmp.path())
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("dkim-keygen")
+        .arg("--domain")
+        .arg("a.com")
+        .arg("--selector")
+        .arg("test-selector")
+        .arg("--force")
+        .output()
+        .expect("dkim-keygen");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "dkim-keygen --domain failed: stdout={stdout} stderr={stderr}"
+    );
+
+    let key = tmp.path().join("dkim").join("a.com").join("private.key");
+    assert!(key.is_file(), "expected key at {}", key.display());
+}
+
+#[test]
+fn dkim_keygen_with_unknown_domain_refuses() {
+    let tmp = TempDir::new().unwrap();
+    setup_single_domain_env(tmp.path());
+
+    let out = StdCommand::new(aimx_binary_path())
+        .env("AIMX_CONFIG_DIR", tmp.path())
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("dkim-keygen")
+        .arg("--domain")
+        .arg("never-added.example")
+        .output()
+        .expect("dkim-keygen");
+    assert!(
+        !out.status.success(),
+        "dkim-keygen must refuse unknown domain"
+    );
+    let combined = format!(
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    assert!(
+        combined.contains("not in `domains") || combined.contains("aimx domains add"),
+        "error must mention the missing-domain hint; got: {combined}"
+    );
+}
+
+#[test]
+fn dkim_keygen_without_domain_uses_legacy_root_path() {
+    // The `aimx dkim-keygen` invocation without `--domain` keeps the
+    // legacy un-namespaced output path (`<dkim_dir>/{private,public}.key`)
+    // so existing single-domain scripts continue to work. The daemon's
+    // startup loader falls back to that path for the default domain
+    // when no per-domain key exists.
+    let tmp = TempDir::new().unwrap();
+    setup_single_domain_env(tmp.path());
+
+    // Remove the pre-installed per-domain key so we can distinguish
+    // legacy-path vs per-domain-path output.
+    let _ = std::fs::remove_dir_all(tmp.path().join("dkim").join("a.com"));
+
+    let out = StdCommand::new(aimx_binary_path())
+        .env("AIMX_CONFIG_DIR", tmp.path())
+        .arg("--data-dir")
+        .arg(tmp.path())
+        .arg("dkim-keygen")
+        .output()
+        .expect("dkim-keygen");
+    assert!(
+        out.status.success(),
+        "dkim-keygen without --domain must succeed for back-compat"
+    );
+    // Legacy un-namespaced root: `<dkim_dir>/private.key`.
+    let key = tmp.path().join("dkim").join("private.key");
+    assert!(
+        key.is_file(),
+        "expected legacy un-namespaced key at {}",
+        key.display()
+    );
+}
+
+/// Daemon-stopped fallback: non-root caller hard-errors with the
+/// canonical hint; root caller writes config directly.
+#[test]
+fn domains_add_daemon_stopped_non_root_hard_errors() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping non-root fallback test: running as root");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_single_domain_env(tmp.path());
+
+    // Daemon never started: socket missing.
+    let out = run_domains_add(tmp.path(), "b.com", None);
+    assert!(!out.status.success(), "non-root must hard-error");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("daemon must be running"),
+        "expected canonical hint; got: {stderr}"
+    );
+}
+
+#[test]
+fn domains_add_daemon_stopped_root_falls_back_to_direct_edit() {
+    if skip_if_not_root() {
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_single_domain_env(tmp.path());
+
+    // Do NOT start the daemon. Root caller should fall back to direct
+    // config edit + DKIM keygen.
+    let out = run_domains_add(tmp.path(), "b.com", None);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "root fallback must succeed: stdout={stdout} stderr={stderr}"
+    );
+
+    // Config + DKIM landed on disk.
+    let config = std::fs::read_to_string(tmp.path().join("config.toml")).unwrap();
+    assert!(
+        config.contains("\"b.com\""),
+        "config missing b.com after fallback: {config}"
+    );
+    assert!(
+        tmp.path()
+            .join("dkim")
+            .join("b.com")
+            .join("private.key")
+            .is_file(),
+        "DKIM key missing after fallback"
+    );
+
+    // The CLI must surface a "restart daemon" hint so the operator
+    // knows the running serve (if it were started) wouldn't pick up
+    // the change automatically.
+    let combined = format!("stdout={stdout} stderr={stderr}");
+    assert!(
+        combined.contains("restart") || combined.contains("daemon"),
+        "missing restart hint; got: {combined}"
+    );
+}

--- a/tests/domains_uds.rs
+++ b/tests/domains_uds.rs
@@ -445,17 +445,19 @@ fn dkim_keygen_with_unknown_domain_refuses() {
 }
 
 #[test]
-fn dkim_keygen_without_domain_uses_legacy_root_path() {
-    // The `aimx dkim-keygen` invocation without `--domain` keeps the
-    // legacy un-namespaced output path (`<dkim_dir>/{private,public}.key`)
-    // so existing single-domain scripts continue to work. The daemon's
-    // startup loader falls back to that path for the default domain
-    // when no per-domain key exists.
+fn dkim_keygen_without_domain_uses_default_domain_path() {
+    // `aimx dkim-keygen` without `--domain` targets the default
+    // domain's per-domain path (`<dkim_dir>/<default_domain>/`), not
+    // the legacy un-namespaced root. The daemon's loader reads from
+    // the per-domain path on v2 installs, so writing here is what
+    // makes a rotate-by-omission actually take effect after a
+    // daemon restart. Writing to the legacy root would silently
+    // land the new key where the daemon never looks.
     let tmp = TempDir::new().unwrap();
     setup_single_domain_env(tmp.path());
 
-    // Remove the pre-installed per-domain key so we can distinguish
-    // legacy-path vs per-domain-path output.
+    // Remove the pre-installed per-domain key so we can be certain
+    // the no-`--domain` path is what regenerated it.
     let _ = std::fs::remove_dir_all(tmp.path().join("dkim").join("a.com"));
 
     let out = StdCommand::new(aimx_binary_path())
@@ -467,14 +469,23 @@ fn dkim_keygen_without_domain_uses_legacy_root_path() {
         .expect("dkim-keygen");
     assert!(
         out.status.success(),
-        "dkim-keygen without --domain must succeed for back-compat"
+        "dkim-keygen without --domain must succeed for the default domain"
     );
-    // Legacy un-namespaced root: `<dkim_dir>/private.key`.
-    let key = tmp.path().join("dkim").join("private.key");
+    // Per-domain layout for the default domain.
+    let key = tmp.path().join("dkim").join("a.com").join("private.key");
     assert!(
         key.is_file(),
-        "expected legacy un-namespaced key at {}",
+        "expected default-domain key at {}",
         key.display()
+    );
+    // And we explicitly do NOT want a key written at the un-namespaced
+    // legacy root — that would be the silent-rotation footgun the fix
+    // is preventing.
+    let legacy = tmp.path().join("dkim").join("private.key");
+    assert!(
+        !legacy.is_file(),
+        "no-`--domain` keygen must NOT write to the legacy root path {}",
+        legacy.display()
     );
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -33,14 +33,23 @@ static DKIM_CACHE: LazyLock<TempDir> = LazyLock::new(|| {
     cache
 });
 
-/// Copy the cached DKIM keypair into `tmp/dkim/`.
+/// Copy the cached DKIM keypair into `tmp/dkim/`. `aimx dkim-keygen`
+/// (no `--domain`) writes the cache under
+/// `<DKIM_CACHE>/dkim/cache.example.com/{private,public}.key` (the
+/// per-domain default-domain layout). We replicate it at the legacy
+/// un-namespaced `tmp/dkim/{private,public}.key` location because the
+/// daemon's loader falls back to the legacy path for the default
+/// domain when no per-domain key exists under `tmp/dkim/<default>/`,
+/// which keeps the existing integration fixtures (legacy-style
+/// `domain = "agent.example.com"` configs) working without forcing
+/// every test to know its default-domain name.
 fn install_cached_dkim_keys(tmp: &Path) {
     let dkim_dir = tmp.join("dkim");
     if dkim_dir.join("private.key").exists() {
         return;
     }
     std::fs::create_dir_all(&dkim_dir).unwrap();
-    let cache_dkim = DKIM_CACHE.path().join("dkim");
+    let cache_dkim = DKIM_CACHE.path().join("dkim").join("cache.example.com");
     for name in ["private.key", "public.key"] {
         let src = cache_dkim.join(name);
         let dst = dkim_dir.join(name);
@@ -463,13 +472,20 @@ fn dkim_keygen_end_to_end() {
         .stdout(predicate::str::contains("DKIM keypair generated"))
         .stdout(predicate::str::contains("_domainkey"));
 
-    assert!(tmp.path().join("dkim/private.key").exists());
-    assert!(tmp.path().join("dkim/public.key").exists());
+    // `aimx dkim-keygen` (no `--domain`) writes the default domain's
+    // keypair under `<dkim_dir>/<default_domain>/` — the per-domain
+    // layout the v2 daemon's loader reads from. Writing to the legacy
+    // un-namespaced root would be a silent-rotation footgun on v2
+    // installs.
+    let private_path = tmp.path().join("dkim/agent.example.com/private.key");
+    let public_path = tmp.path().join("dkim/agent.example.com/public.key");
+    assert!(private_path.exists(), "expected {}", private_path.display());
+    assert!(public_path.exists(), "expected {}", public_path.display());
 
-    let private_pem = std::fs::read_to_string(tmp.path().join("dkim/private.key")).unwrap();
+    let private_pem = std::fs::read_to_string(&private_path).unwrap();
     assert!(private_pem.contains("BEGIN RSA PRIVATE KEY"));
 
-    let public_pem = std::fs::read_to_string(tmp.path().join("dkim/public.key")).unwrap();
+    let public_pem = std::fs::read_to_string(&public_path).unwrap();
     assert!(public_pem.contains("BEGIN PUBLIC KEY"));
 }
 
@@ -515,7 +531,10 @@ fn dkim_keygen_force_overwrite() {
         .assert()
         .success();
 
-    let original = std::fs::read_to_string(tmp.path().join("dkim/private.key")).unwrap();
+    // The no-`--domain` keygen lands under the per-domain default-domain
+    // path on v2 installs.
+    let private_path = tmp.path().join("dkim/agent.example.com/private.key");
+    let original = std::fs::read_to_string(&private_path).unwrap();
 
     aimx_cmd(tmp.path())
         .arg("--data-dir")
@@ -525,7 +544,7 @@ fn dkim_keygen_force_overwrite() {
         .assert()
         .success();
 
-    let new = std::fs::read_to_string(tmp.path().join("dkim/private.key")).unwrap();
+    let new = std::fs::read_to_string(&private_path).unwrap();
     assert_ne!(original, new);
 }
 

--- a/tests/multi_domain.rs
+++ b/tests/multi_domain.rs
@@ -57,7 +57,13 @@ static MD_DKIM_CACHE: LazyLock<TempDir> = LazyLock::new(|| {
 
 fn install_dkim_under(domain_dir: &Path) {
     std::fs::create_dir_all(domain_dir).unwrap();
-    let cache_dkim = MD_DKIM_CACHE.path().join("dkim");
+    // `aimx dkim-keygen` (no `--domain`) writes the cache under
+    // `<dkim_dir>/<default_domain>/` — the cache config sets the
+    // default domain to `md-cache.example.com`.
+    let cache_dkim = MD_DKIM_CACHE
+        .path()
+        .join("dkim")
+        .join("md-cache.example.com");
     for name in ["private.key", "public.key"] {
         let src = cache_dkim.join(name);
         let dst = domain_dir.join(name);

--- a/tests/upgrade.rs
+++ b/tests/upgrade.rs
@@ -44,10 +44,21 @@ static DKIM_CACHE: LazyLock<TempDir> = LazyLock::new(|| {
 });
 
 fn cached_dkim_private() -> PathBuf {
-    DKIM_CACHE.path().join("dkim").join("private.key")
+    // The cache's `aimx dkim-keygen` (no `--domain`) lands under
+    // `<dkim_dir>/<default_domain>/` per the v2 layout. The cache
+    // config sets `domain = "cache.example.com"`.
+    DKIM_CACHE
+        .path()
+        .join("dkim")
+        .join("cache.example.com")
+        .join("private.key")
 }
 fn cached_dkim_public() -> PathBuf {
-    DKIM_CACHE.path().join("dkim").join("public.key")
+    DKIM_CACHE
+        .path()
+        .join("dkim")
+        .join("cache.example.com")
+        .join("public.key")
 }
 
 fn current_username() -> String {


### PR DESCRIPTION
## Sprint Goal

Land the new `aimx domains` CLI command group with `list` and `add`
subcommands, the matching `DOMAIN-LIST` and `DOMAIN-ADD` UDS verbs
(root-only), `Action::DomainCrud` authz, `aimx dkim-keygen --domain
<domain>` flag, hot-reload via `ConfigHandle::store`, and the
daemon-stopped fallback path.

## Stories Implemented

### [S4-1] New CLI command group `aimx domains` (FR-F1 list, F2 alias)

- [x] `Command::Domains(DomainsCommand)` enum in `cli.rs` with `List`,
      `Add`, `Remove` variants (only `List` and `Add` implemented;
      `Remove` is a placeholder that errors with "not yet implemented")
- [x] `aimx domain` (singular) registered as a clap alias to `aimx domains`
- [x] `src/domain.rs` exposes `pub fn run(args: DomainsCommand,
      data_dir: Option<&Path>) -> Result<(), Box<dyn std::error::Error>>`
- [x] `aimx domains list` output: table with columns `Domain | Default
      | DKIM | Mailboxes | Unread | Overrides`
- [x] Output uses `term.rs` semantic helpers only (no raw color calls)

### [S4-2] `DOMAIN-LIST` UDS verb + `domain_list_handler.rs` (FR-F3)

- [x] `AIMX/1 DOMAIN-LIST` verb added to `send_protocol.rs` (no
      headers, empty body)
- [x] `DomainListRow` struct serializes via `serde_json::to_string` and
      parses round-trip
- [x] `domain_list_handler.rs` returns rows for every configured domain
- [x] Authz: `DOMAIN-LIST` is root-only via `auth::authorize` with
      `Action::DomainCrud`
- [x] `aimx domains list` calls the verb over UDS
- [x] Unit tests cover the verb codec; integration test covers the
      CLI -> UDS -> daemon -> CLI roundtrip

### [S4-3] `Action::DomainCrud` authz + root-only enforcement (FR-F4)

- [x] `Action::DomainCrud` variant in `auth::Action`
- [x] `auth::authorize` predicate returns `Ok(())` only when caller
      uid == 0
- [x] Each `DOMAIN-*` handler calls `auth::authorize(uid,
      Action::DomainCrud)` before any state inspection
- [x] Non-root caller on UDS gets a deterministic `ErrCode::Eaccess`
      response
- [x] Unit tests cover root-allowed and non-root-denied paths

### [S4-4] `aimx dkim-keygen --domain <domain>` flag (FR-B3)

- [x] `dkim-keygen` learns `--domain` flag in its clap definition
- [x] When `--domain` is omitted, the legacy un-namespaced
      `<dkim_dir>/{private,public}.key` layout is preserved so
      existing single-domain scripts continue to work. The daemon's
      startup loader already falls back to this path for the default
      domain.
- [x] When `--domain b.com` is passed, writes to
      `<dkim_dir>/b.com/{private,public}.key`
- [x] Modes preserved: private `0600`, public `0644`
- [x] Refuses when target domain is not in `config.domains`
      (actionable error referencing `aimx domains add`)
- [x] Integration test covers both per-domain and legacy paths

### [S4-5] `DOMAIN-ADD` UDS verb + `domain_handler.rs` (FR-F1 add, F3, B4)

- [x] `AIMX/1 DOMAIN-ADD` verb in `send_protocol.rs` with `Domain:`
      (required) and optional `Selector:` headers
- [x] `domain_handler.rs` handles the verb under `CONFIG_WRITE_LOCK`:
      DKIM keygen + config rewrite + `ConfigHandle::store` + DKIM map
      hot-swap
- [x] Authz: `DOMAIN-ADD` is root-only via `Action::DomainCrud`
- [x] Duplicate-add (domain already in `domains`) returns a canonical
      error without modifying state
- [x] `aimx domains add b.com` CLI: composes the request, sends it
      over UDS, then prints DNS records to publish and runs the DNS
      verification loop (reuses setup's existing helpers), with
      `--no-dns-check` escape hatch
- [x] `--selector <s>` flag propagates to the daemon; selector stored
      in the per-domain sub-table `[domain."<d>"] dkim_selector =
      "<s>"`
- [x] Hot-reload: a second `aimx domains list` immediately after
      `add` shows the new domain without daemon restart, and SMTP
      RCPT to `@<new-domain>` is accepted immediately
- [x] Integration test against a running daemon: add b.com, assert
      config rewritten, DKIM keypair at `<dkim_dir>/b.com/`, SMTP
      RCPT to `@b.com` now domain-recognized

### [S4-6] Daemon-stopped fallback for `DOMAIN-ADD` (FR-F5)

- [x] `domain.rs` detects UDS connection failure and branches: root
      -> direct config edit + DKIM keygen + restart hint; non-root
      -> canonical hard error
- [x] Direct-edit path writes the new config via `write_atomic` and
      generates the DKIM keypair at the canonical per-domain path
- [x] Integration test covers both branches

## Technical Decisions

- **DKIM map hot-swap pattern**: the `DOMAIN-ADD` handler builds a
  fresh `HashMap` by cloning the current snapshot (`.load_full()` on
  the `ArcSwap` wired by Sprint 3), inserts the new entry, and
  `.store(Arc::new(new_map))` atomically. Concurrent `handle_send`
  reads observe either the pre-swap or post-swap snapshot, never a
  partial state.

- **Atomicity ordering**: DKIM key written to disk *before* the
  config rewrite (NFR-3). A crash between key write and config write
  leaves an orphan key (harmless — the duplicate-add check still
  passes because the domain isn't in `domains` yet, and the operator
  can retry cleanly). The opposite ordering would leave outbound
  from the new domain broken until manual recovery.

- **`dkim-keygen` no-flag back-compat**: the simplest, most
  defensible reading of "Existing single-domain CLI invocations (no
  `--domain`) continue to work" is to keep the legacy
  un-namespaced output path. The daemon's startup loader already
  falls back to this path for the default domain, so semantically
  the no-flag invocation IS "operate on the default domain" — the
  on-disk path just happens to be un-namespaced. This preserves
  every pre-existing integration test in the suite.

- **Selector validation**: any operator-supplied selector must be a
  DNS-safe label (`[a-z0-9_-]+`, 1-63 chars). Rejected up-front at
  the codec layer rather than at sign time so the error is
  actionable.

- **Reuse of setup helpers**: the `aimx domains add` CLI calls
  `setup::display_dns_guidance`, `setup::generate_dns_records`,
  `setup::verify_all_dns`, and `setup::display_dns_verification`
  directly — no duplication.

## Deferred Items

- `DOMAIN-REMOVE` is scaffolded in the `DomainsCommand` enum and
  surfaces "not yet implemented" at the CLI; the real cascade
  behaviour lands in a follow-up sprint per the plan.
- `aimx domains set-default` (P2) is out of scope.

## Review Focus Areas

- `src/domain_handler.rs` — the load-modify-write-store sequence
  ordering inside `CONFIG_WRITE_LOCK`, plus the DKIM map hot-swap.
  This is the most critical correctness invariant in the sprint.
- `src/auth.rs` — the new `Action::DomainCrud` variant and its
  predicate. Verify mailbox CRUD authz is unchanged (owner-scoped)
  and only the new variant is root-gated.
- `tests/domains_uds.rs` — the integration test for the full
  hot-reload flow (`domains_add_full_flow_hot_reloads_smtp_and_config`)
  is the most operator-relevant validation; it asserts the daemon
  accepts SMTP RCPT to the new domain immediately after the CLI
  returns.
- `src/main.rs::Command::DkimKeygen` — the no-flag back-compat
  interpretation. If reviewers prefer the per-domain layout for the
  default case, the change is local but breaks every existing
  integration test that asserts the un-namespaced layout.