### PR TITLE
[Sprint 5] aimx domains remove + --force cascade

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -125,6 +125,7 @@ jobs:
           cargo test --no-run --test hooks_list_filter
           cargo test --no-run --test integration
           cargo test --no-run --test domains_uds
+          cargo test --no-run --test domains_remove
 
       - name: Run mailbox isolation test (under sudo)
         run: |
@@ -188,6 +189,21 @@ jobs:
           # harmlessly. `--test-threads=1` avoids contention on the
           # shared `AIMX_CONFIG_DIR` / UDS socket directory.
           BIN=$(ls -t target/debug/deps/domains_uds-* | grep -v '\.d$' | head -n 1)
+          test -x "$BIN"
+          sudo AIMX_INTEGRATION_SUDO=1 "$BIN" --test-threads=1
+
+      - name: Run domains-remove cascade tests (under sudo)
+        run: |
+          # `tests/domains_remove.rs` covers `DOMAIN-REMOVE` over UDS:
+          # clean remove, blocked-by-mailboxes refusal, last-domain
+          # hard-block, --force cascade (mailbox wipe + per-domain
+          # storage rmdir + config rewrite + DKIM map hot-swap with
+          # the keypair preserved on disk), concurrent-ingest stress
+          # against the surviving domain, and the daemon-stopped
+          # fallback for root. Same skip_if_not_root() gate as
+          # domains_uds — run without --ignored under sudo, single
+          # thread to avoid socket contention.
+          BIN=$(ls -t target/debug/deps/domains_remove-* | grep -v '\.d$' | head -n 1)
           test -x "$BIN"
           sudo AIMX_INTEGRATION_SUDO=1 "$BIN" --test-threads=1
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,14 +86,15 @@ jobs:
             src/mailbox_list_handler.rs src/mailbox_handler.rs \
             src/send_handler.rs src/ingest.rs src/state_handler.rs \
             src/mcp.rs src/hook_handler.rs src/hooks.rs src/serve.rs \
-            src/setup.rs 2>/dev/null \
-            | grep -vE 'src/(storage|upgrade_migration|mailbox)\.rs' || true)
+            src/setup.rs src/domain_handler.rs 2>/dev/null \
+            | grep -vE 'src/(storage|upgrade_migration|mailbox|domain_handler)\.rs' || true)
           if [ -n "$HITS" ]; then
             echo "ERROR: raw .join(\"inbox\"|\"sent\") found in production code outside the storage helper."
             echo "Use crate::storage::mailbox_storage_path or storage_path_for instead."
             echo "Allowed exemptions: src/storage.rs (the helper itself),"
             echo "src/upgrade_migration.rs (owns the rename(2) of legacy roots),"
-            echo "src/mailbox.rs (discover_mailbox_names walks storage_roots() + inbox/)."
+            echo "src/mailbox.rs (discover_mailbox_names walks storage_roots() + inbox/),"
+            echo "src/domain_handler.rs (cascade rmdir of per-domain inbox/ and sent/ parents)."
             echo
             echo "$HITS"
             exit 1

--- a/src/domain.rs
+++ b/src/domain.rs
@@ -306,16 +306,120 @@ fn print_dns_guidance_and_verify(
     Ok(())
 }
 
-/// Placeholder for `aimx domains remove`. The real cascade behaviour
-/// lands in a follow-up release; for now we surface a clear "not yet
-/// implemented" error so the clap surface is complete and operators
-/// see the same help text they will see post-rollout.
-fn remove(_domain: &str, _force: bool) -> Result<(), Box<dyn std::error::Error>> {
-    Err(
-        "`aimx domains remove` is not yet implemented; this command \
-         lands in a follow-up release."
-            .into(),
-    )
+/// `aimx domains remove <domain> [--force]` — UDS first, daemon-down
+/// fallback for root, hard-error for non-root.
+///
+/// The CLI consumes the daemon's structured `DOMAIN-REMOVE` response
+/// (`DomainRemoveResponse`) and renders one of three outcomes:
+///
+/// 1. **Clean remove** (no force, no blockers): "removed domain X
+///    from config" plus the DKIM-preserved hint pointing at
+///    `<dkim_dir>/<domain>/`.
+/// 2. **Blocked by mailboxes** (no force, blockers exist): numbered
+///    list of blocking mailbox FQDNs plus the `--force` suggestion.
+///    Exits non-zero.
+/// 3. **Force cascade complete**: per-mailbox deletion summary plus
+///    the storage-tree-removed line plus the DKIM-preserved hint.
+///
+/// Daemon-side errors (last-domain hard-block, unknown domain, authz)
+/// are surfaced verbatim with the canonical reason string. The
+/// last-domain hard-block additionally points at `aimx uninstall`.
+fn remove(domain: &str, force: bool) -> Result<(), Box<dyn std::error::Error>> {
+    let normalized = domain.trim().to_ascii_lowercase();
+    if !crate::config::is_valid_domain_syntax(&normalized) {
+        return Err(format!("domain '{domain}' is not a valid RFC 1035 hostname").into());
+    }
+
+    match crate::mcp::submit_domain_remove_via_daemon(&normalized, force) {
+        Ok(body) => {
+            let response: crate::domain_handler::DomainRemoveResponse = serde_json::from_str(&body)
+                .map_err(|e| format!("malformed DOMAIN-REMOVE response: {e} (body: {body:?})"))?;
+            render_remove_response(&response)
+        }
+        Err(crate::mcp::MailboxLifecycleFallback::SocketMissing) => {
+            if !is_root() {
+                exit_socket_missing();
+            }
+            let response = remove_direct(&normalized, force)?;
+            render_remove_response(&response)?;
+            println!(
+                "{} daemon is stopped; restart `aimx serve` so the config change takes effect.",
+                term::warn_mark()
+            );
+            Ok(())
+        }
+        Err(crate::mcp::MailboxLifecycleFallback::Daemon(msg)) => Err(msg.into()),
+    }
+}
+
+/// Daemon-stopped fallback: edit config + wipe storage directly. Only
+/// callable from root; the non-root path exits via
+/// [`exit_socket_missing`].
+fn remove_direct(
+    domain: &str,
+    force: bool,
+) -> Result<crate::domain_handler::DomainRemoveResponse, Box<dyn std::error::Error>> {
+    let config_path = crate::config::config_path();
+    let (config, _warnings) = Config::load_resolved_with_data_dir(None)?;
+    crate::domain_handler::run_direct_remove(&config_path, &config, domain, force)
+}
+
+/// Pretty-print the daemon's `DomainRemoveResponse`. Routes through
+/// `term.rs` semantic helpers (no raw color calls). Exit semantics:
+///
+/// - `BlockedByMailboxes` → non-zero exit (`Err(...)`) so the caller
+///   shell sees a failed `aimx domains remove`. The CLI still prints
+///   the blocker list to stdout for operator inspection.
+/// - `Removed` → success.
+fn render_remove_response(
+    response: &crate::domain_handler::DomainRemoveResponse,
+) -> Result<(), Box<dyn std::error::Error>> {
+    use crate::domain_handler::DomainRemoveOutcome;
+
+    match response.outcome {
+        DomainRemoveOutcome::BlockedByMailboxes => {
+            println!(
+                "{} Domain has {} mailbox(es) — pass {} to cascade-delete them:",
+                term::warn_mark(),
+                response.blocking_mailboxes.len(),
+                term::highlight("--force"),
+            );
+            for (i, fqdn) in response.blocking_mailboxes.iter().enumerate() {
+                println!("  {:>2}. {}", i + 1, term::highlight(fqdn));
+            }
+            println!();
+            println!(
+                "{} DKIM keypair preserved at {}",
+                term::info("info:"),
+                term::highlight(&response.dkim_dir),
+            );
+            // Non-zero exit so scripts can branch on the refusal.
+            Err("refused: domain has mailboxes; rerun with --force to cascade".into())
+        }
+        DomainRemoveOutcome::Removed => {
+            if response.cascaded_mailboxes.is_empty() {
+                println!("{} Removed domain from config.", term::success_mark(),);
+            } else {
+                println!(
+                    "{} Removed domain (cascade) — {} mailbox(es) deleted:",
+                    term::success_mark(),
+                    response.cascaded_mailboxes.len(),
+                );
+                for fqdn in &response.cascaded_mailboxes {
+                    println!("    {} {}", term::dim("-"), term::highlight(fqdn));
+                }
+            }
+            if response.storage_tree_removed {
+                println!("{} Storage tree removed.", term::success_mark());
+            }
+            println!(
+                "{} DKIM keypair preserved at {}",
+                term::info("info:"),
+                term::highlight(&response.dkim_dir),
+            );
+            Ok(())
+        }
+    }
 }
 
 /// Print the canonical hint and exit `EXIT_SOCKET_MISSING`. Mirrors

--- a/src/domain_handler.rs
+++ b/src/domain_handler.rs
@@ -356,11 +356,22 @@ pub struct DomainRemoveResponse {
     /// `outcome == Removed` AND `--force` was set; empty otherwise.
     /// Sorted for stable output.
     pub cascaded_mailboxes: Vec<String>,
-    /// `true` when the per-domain storage tree (`<data_dir>/<domain>/`)
-    /// was rmdir'd as part of the cascade. `false` for the non-force
-    /// clean-remove path (the tree never existed there to begin with
-    /// — no mailboxes on the domain — but the `rmdir` is still
-    /// attempted best-effort so an empty leftover tree is cleaned up).
+    /// `true` iff this remove operation actually deleted a non-empty
+    /// per-domain storage tree from disk (`<data_dir>/<domain>/`). The
+    /// CLI uses this to decide whether to print the "Storage tree
+    /// removed." line. False for:
+    ///
+    /// * the soft-refused `blocked_by_mailboxes` path (no cascade
+    ///   ran),
+    /// * the clean-no-blockers path when no per-domain dir existed
+    ///   beforehand (typical — no mailboxes on the domain means no
+    ///   storage tree was ever provisioned),
+    /// * `--force` cascades where the per-domain dir was absent at
+    ///   entry (degenerate, but possible if storage was hand-cleaned
+    ///   before the remove).
+    ///
+    /// True only when the handler observed an on-disk per-domain tree
+    /// at entry and successfully `rmdir`'d it.
     pub storage_tree_removed: bool,
     /// Absolute path to `<dkim_dir>/<domain>/` — preserved on disk
     /// regardless of `--force` so the operator can re-add the domain
@@ -404,6 +415,30 @@ pub enum DomainRemoveOutcome {
 /// rewrite → `ConfigHandle::store` → DKIM map hot-swap) so any other
 /// handler observes either the pre-cascade or the post-cascade state,
 /// never a half-cascaded one.
+///
+/// **Re-run recovery contract (not strict atomicity).** The cascade
+/// is *re-runnable*, not atomic in the database-transaction sense. If
+/// a per-mailbox wipe or `rmdir` fails partway through, the early
+/// return surfaces the IO error and:
+///
+/// * the per-mailbox locks and `CONFIG_WRITE_LOCK` are released
+///   (RAII drop on the held guards),
+/// * the in-memory `Config` and DKIM map have NOT been swapped yet
+///   (both stores happen after the wipe/rmdir block), so external
+///   observers (SMTP RCPT, MCP, CLI list) still see the domain and
+///   its mailboxes as configured,
+/// * on-disk state may be partially wiped (some mailboxes' inbox /
+///   sent directories empty, others still populated).
+///
+/// Recovery is to re-run `aimx domains remove <domain> --force`. The
+/// second invocation re-acquires every per-mailbox lock, re-walks the
+/// (still-configured) mailbox set, and re-applies the wipes idempotently
+/// (`wipe_mailbox_contents` tolerates already-empty / already-missing
+/// directories; `rmdir` on a missing path is treated as success-and-
+/// no-op). Nothing observes intermediate state outside the lock — a
+/// concurrent reader either sees the pre-cascade view (locks held by
+/// the first attempt) or the post-cascade view (after the second
+/// attempt completes).
 ///
 /// DKIM key files at `<dkim_dir>/<domain>/` are **never** deleted by
 /// this handler. The path is echoed back in the response so the CLI
@@ -557,6 +592,15 @@ pub async fn handle_domain_remove(
         .lock()
         .unwrap_or_else(|poisoned| poisoned.into_inner());
 
+    // Test-only injection point: between lock acquisition and the
+    // under-lock re-snapshot. Used to pin the
+    // `live_blocker_fqdns != lock_keys` conflict-detection invariant
+    // by simulating a (hypothetically) racing mailbox-set mutation
+    // without actually racing another handler. No-op in release
+    // builds.
+    #[cfg(test)]
+    test_hooks::run_after_locks_hook(mb_ctx);
+
     // Re-snapshot under the lock so the rest of the critical section
     // runs against a coherent view. A concurrent writer that landed
     // between our pre-flight snapshot and the lock acquisition is
@@ -664,6 +708,12 @@ pub async fn handle_domain_remove(
     // mailbox wipe missed something or an unmanaged file leaked in.
     // Either way, surface the failure loudly rather than silently
     // recursing.
+    //
+    // `storage_tree_removed` is only set to `true` when we observed a
+    // per-domain directory at entry AND successfully removed it. The
+    // CLI uses this flag to decide whether to print "Storage tree
+    // removed." — printing it on the clean-no-blockers path when no
+    // tree ever existed is misleading.
     let domain_root = current.data_dir.join(&domain_lc);
     let storage_tree_removed = if domain_root.is_dir() {
         // The cascade wipes both `inbox/<local>/` and `sent/<local>/`
@@ -678,7 +728,11 @@ pub async fn handle_domain_remove(
         }
         match std::fs::remove_dir(&domain_root) {
             Ok(()) => true,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+            // Race against an external cleanup — the directory was
+            // there when we checked `is_dir()` but is gone now. Treat
+            // as "we did not actually do the removal" rather than
+            // claiming we did.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
             Err(e) => {
                 return JsonAckResponse::Err {
                     code: ErrCode::Io,
@@ -694,8 +748,8 @@ pub async fn handle_domain_remove(
     } else {
         // No on-disk tree to remove — typically the non-force clean
         // path or a domain whose mailboxes were all created but never
-        // received mail.
-        true
+        // received mail. We did not delete anything from disk.
+        false
     };
 
     // Build the new in-memory Config.
@@ -848,7 +902,10 @@ pub fn run_direct_remove(
         }
         match std::fs::remove_dir(&domain_root) {
             Ok(()) => true,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+            // Race against an external cleanup — the directory vanished
+            // between the `is_dir()` check and the `rmdir`. We did not
+            // remove it.
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => false,
             Err(e) => {
                 return Err(format!(
                     "failed to remove storage tree {}: {e}",
@@ -858,7 +915,8 @@ pub fn run_direct_remove(
             }
         }
     } else {
-        true
+        // No on-disk tree to remove.
+        false
     };
 
     let mut new_config = config.clone();
@@ -879,6 +937,50 @@ pub fn run_direct_remove(
         storage_tree_removed,
         dkim_dir,
     })
+}
+
+/// Test-only injection points used by the unit tests in this module to
+/// pin invariants that are unreachable via production codepaths today.
+#[cfg(test)]
+mod test_hooks {
+    use super::MailboxContext;
+    use std::sync::Mutex;
+
+    /// Hook executed after `handle_domain_remove` has taken the
+    /// per-mailbox locks + `CONFIG_WRITE_LOCK` but before it
+    /// re-snapshots the config. Mutates the in-memory config via the
+    /// supplied `MailboxContext` so the test can drive the
+    /// `live_blocker_fqdns != lock_keys` conflict-detection branch
+    /// deterministically.
+    type Hook = Box<dyn Fn(&MailboxContext) + Send + Sync + 'static>;
+
+    static HOOK: Mutex<Option<Hook>> = Mutex::new(None);
+
+    pub(super) fn run_after_locks_hook(mb_ctx: &MailboxContext) {
+        let guard = HOOK.lock().unwrap();
+        if let Some(h) = guard.as_ref() {
+            h(mb_ctx);
+        }
+    }
+
+    /// RAII handle that uninstalls the hook on drop so tests can run
+    /// in parallel without leaking the hook across other tests in the
+    /// module.
+    pub(super) struct HookGuard;
+
+    impl Drop for HookGuard {
+        fn drop(&mut self) {
+            *HOOK.lock().unwrap() = None;
+        }
+    }
+
+    pub(super) fn install<F>(f: F) -> HookGuard
+    where
+        F: Fn(&MailboxContext) + Send + Sync + 'static,
+    {
+        *HOOK.lock().unwrap() = Some(Box::new(f));
+        HookGuard
+    }
 }
 
 #[cfg(test)]
@@ -1335,6 +1437,15 @@ mod tests {
                 assert!(parsed.blocking_mailboxes.is_empty());
                 assert!(parsed.cascaded_mailboxes.is_empty());
                 assert!(parsed.dkim_dir.ends_with("/b.com"));
+                // The per-domain storage tree never existed (no
+                // mailboxes were ever provisioned on b.com), so the
+                // response must report `storage_tree_removed = false`
+                // — printing "Storage tree removed." in this case
+                // would be misleading.
+                assert!(
+                    !parsed.storage_tree_removed,
+                    "clean-no-blockers must NOT claim a storage tree was removed when none existed",
+                );
             }
             other => panic!("expected Ok, got {other:?}"),
         }
@@ -1707,5 +1818,91 @@ mod tests {
         // Config unchanged on disk.
         let reloaded = Config::load_ignore_warnings(&config_path).unwrap();
         assert_eq!(reloaded.domains, vec!["a.com", "b.com"]);
+    }
+
+    /// Pin the `live_blocker_fqdns != lock_keys` conflict-detection
+    /// invariant. The path is unreachable via production codepaths
+    /// today because every mailbox-set mutator (`MAILBOX-CREATE`,
+    /// `MAILBOX-DELETE`, `DOMAIN-REMOVE` itself) takes the same
+    /// per-mailbox locks + `CONFIG_WRITE_LOCK` we hold here — but a
+    /// future bug that introduces drift between the canonical
+    /// pre-cascade scan and the per-mailbox lock acquisition list
+    /// would silently leak (skipping or double-touching mailboxes).
+    /// This test installs a test-only after-locks hook that injects
+    /// a new b.com mailbox into the live config snapshot AFTER the
+    /// locks have been taken — simulating exactly that drift — and
+    /// asserts the handler detects the divergence and refuses with
+    /// `ErrCode::Conflict`. Uses a serial-test-style coarse mutex to
+    /// keep the global hook race-free with respect to other tests.
+    #[tokio::test]
+    async fn live_blocker_fqdns_not_equal_lock_keys_refused_with_conflict() {
+        // Module-local async mutex to serialize the global hook
+        // across any other test that decides to install it
+        // concurrently. Use tokio's Mutex so we can hold the guard
+        // across the `.await` on `handle_domain_remove`.
+        static SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+        let _serial = SERIAL.lock().await;
+
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        let (state_ctx, mb_ctx, keys) = contexts_with_config(
+            &tmp,
+            two_domain_config(tmp.path(), &["info"]), // single b.com mailbox
+        );
+
+        // Install the after-locks hook: once the handler has taken
+        // the per-mailbox locks (only `info@b.com` at this point) and
+        // the CONFIG_WRITE_LOCK, mutate the live config to insert a
+        // *new* b.com mailbox (`stranger@b.com`) that the lock-set
+        // pre-scan never saw. The under-lock re-scan must now produce
+        // a `live_blocker_fqdns` list that diverges from `lock_keys`,
+        // tripping the conflict-detection branch.
+        let _hook = test_hooks::install(move |mb_ctx| {
+            let snapshot = mb_ctx.config_handle.load();
+            let mut new_config = (*snapshot).clone();
+            new_config.mailboxes.insert(
+                "stranger@b.com".to_string(),
+                crate::config::MailboxConfig {
+                    address: "stranger@b.com".to_string(),
+                    owner: "testowner".to_string(),
+                    hooks: vec![],
+                    trust: None,
+                    trusted_senders: None,
+                    allow_root_catchall: false,
+                },
+            );
+            mb_ctx.config_handle.store(new_config);
+        });
+
+        let req = DomainRemoveRequest {
+            domain: "b.com".into(),
+            force: true,
+        };
+        let resp =
+            handle_domain_remove(&state_ctx, &mb_ctx, &keys, &req, &Caller::internal_root()).await;
+        match resp {
+            JsonAckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Conflict, "reason={reason}");
+                assert!(
+                    reason.contains("changed under the cascade lock"),
+                    "expected the cascade-lock conflict reason, got: {reason}",
+                );
+            }
+            other => panic!("expected Err Conflict, got {other:?}"),
+        }
+
+        // The handler refused before touching the in-memory config /
+        // DKIM map / on-disk state. The post-hook config still carries
+        // both b.com mailboxes; the on-disk config still has b.com in
+        // `domains`.
+        let after = mb_ctx.config_handle.load();
+        assert!(
+            after.domains.contains(&"b.com".to_string()),
+            "domain must not be dropped on conflict path: {:?}",
+            after.domains,
+        );
+        assert!(after.mailboxes.contains_key("info@b.com"));
+        assert!(after.mailboxes.contains_key("stranger@b.com"));
     }
 }

--- a/src/domain_handler.rs
+++ b/src/domain_handler.rs
@@ -47,12 +47,16 @@
 use std::path::Path;
 use std::sync::Arc;
 
+use serde::{Deserialize, Serialize};
+
 use crate::auth::{Action, authorize};
 use crate::config::{Config, DomainOverride, is_valid_domain_syntax};
 use crate::dkim;
 use crate::dkim_keys::{DkimKeyEntry, DkimKeyMap, SharedDkimKeyMap, resolve_selector_for_domain};
 use crate::mailbox_handler::{CONFIG_WRITE_LOCK, MailboxContext};
-use crate::send_protocol::{AckResponse, DomainAddRequest, ErrCode};
+use crate::send_protocol::{
+    AckResponse, DomainAddRequest, DomainRemoveRequest, ErrCode, JsonAckResponse,
+};
 use crate::state_handler::StateContext;
 use crate::uds_authz::{Caller, log_decision};
 
@@ -327,6 +331,556 @@ fn is_valid_dkim_selector(s: &str) -> bool {
         .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-' || b == b'_')
 }
 
+/// Structured body returned by `DOMAIN-REMOVE` on every non-error
+/// outcome. The CLI parses this directly so the operator-visible
+/// output stays consistent across clean removes, blocked-by-mailboxes
+/// refusals, and `--force` cascades.
+///
+/// The handler returns a `JsonAckResponse::Err` (with the canonical
+/// reason string) for authz, validation, last-domain hard-block,
+/// domain-not-configured, and IO failures. Every other outcome
+/// (including the soft "refused because mailboxes still exist"
+/// branch) returns a `JsonAckResponse::Ok` carrying this struct so
+/// the CLI can render the list of blocking mailboxes verbatim.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct DomainRemoveResponse {
+    /// `removed` — the domain was dropped from `config.domains`.
+    /// `blocked_by_mailboxes` — refused because mailboxes still
+    ///    reference this domain and `force = false`. The
+    ///    `blocking_mailboxes` field carries the list.
+    pub outcome: DomainRemoveOutcome,
+    /// FQDNs of mailboxes that still reference this domain. Populated
+    /// when `outcome == BlockedByMailboxes`. Sorted for stable output.
+    pub blocking_mailboxes: Vec<String>,
+    /// FQDNs of mailboxes the cascade deleted. Populated when
+    /// `outcome == Removed` AND `--force` was set; empty otherwise.
+    /// Sorted for stable output.
+    pub cascaded_mailboxes: Vec<String>,
+    /// `true` when the per-domain storage tree (`<data_dir>/<domain>/`)
+    /// was rmdir'd as part of the cascade. `false` for the non-force
+    /// clean-remove path (the tree never existed there to begin with
+    /// — no mailboxes on the domain — but the `rmdir` is still
+    /// attempted best-effort so an empty leftover tree is cleaned up).
+    pub storage_tree_removed: bool,
+    /// Absolute path to `<dkim_dir>/<domain>/` — preserved on disk
+    /// regardless of `--force` so the operator can re-add the domain
+    /// without re-generating a fresh keypair. The CLI prints this as
+    /// the "DKIM keypair preserved at …" hint.
+    pub dkim_dir: String,
+}
+
+/// Outcome tag for [`DomainRemoveResponse`]. Stringly-typed on the
+/// wire so adding a future outcome (e.g. `Deferred`) doesn't break a
+/// stale CLI that only branches on the variants it recognizes.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum DomainRemoveOutcome {
+    /// Domain dropped from `config.domains`. Cascade fields are
+    /// populated when `--force` was set.
+    Removed,
+    /// Domain still has mailboxes referencing it; the cascade was not
+    /// requested. The CLI prints the `blocking_mailboxes` list and
+    /// suggests `--force` to cascade.
+    BlockedByMailboxes,
+}
+
+/// Validate, lock, and persist a `DOMAIN-REMOVE` request.
+///
+/// Returns [`JsonAckResponse::Ok`] carrying a [`DomainRemoveResponse`]
+/// body on every non-error outcome (clean remove, soft-refused
+/// because blockers, `--force` cascade). Returns [`JsonAckResponse::Err`]
+/// for authz failures, validation failures, the last-domain hard-block,
+/// unknown-domain, and IO failures.
+///
+/// Lock hierarchy follows the daemon-wide convention documented in
+/// [`crate::mailbox_locks`]: per-mailbox locks (acquired in sorted
+/// FQDN order) are the **outer** layer; the process-wide
+/// [`CONFIG_WRITE_LOCK`] is the **inner** layer. Inverting the order
+/// would deadlock against a concurrent `MAILBOX-CREATE` /
+/// `MAILBOX-DELETE` / `HOOK-CREATE` / `HOOK-DELETE` request, every
+/// one of which takes the per-mailbox lock first then the config
+/// lock. Crash-safety: the per-mailbox locks are held across the
+/// entire critical section (per-mailbox wipe → `rmdir` → config
+/// rewrite → `ConfigHandle::store` → DKIM map hot-swap) so any other
+/// handler observes either the pre-cascade or the post-cascade state,
+/// never a half-cascaded one.
+///
+/// DKIM key files at `<dkim_dir>/<domain>/` are **never** deleted by
+/// this handler. The path is echoed back in the response so the CLI
+/// can print the "preserved on disk" hint. Rationale: avoid surprise
+/// key destruction; the operator can remove the directory by hand if
+/// they really want the keys gone.
+pub async fn handle_domain_remove(
+    state_ctx: &StateContext,
+    mb_ctx: &MailboxContext,
+    dkim_keys: &SharedDkimKeyMap,
+    req: &DomainRemoveRequest,
+    caller: &Caller,
+) -> JsonAckResponse {
+    let verb = "DOMAIN-REMOVE";
+
+    // Authz first — every other check below would leak observable
+    // state to an unauthorized caller.
+    if let Err(e) = authorize(caller.uid, Action::DomainCrud, None) {
+        log_decision(
+            verb,
+            caller,
+            Some(&req.domain),
+            crate::uds_authz::LogDecision::Reject,
+            Some(&format!("{e}")),
+        );
+        return JsonAckResponse::Err {
+            code: ErrCode::Eaccess,
+            reason: format!("{e}"),
+        };
+    }
+
+    // Lowercase + syntactic validation; the loader applies the same
+    // rule but doing it up-front means the wire response is actionable
+    // even before we touch the config snapshot.
+    let domain_lc = req.domain.trim().to_ascii_lowercase();
+    if !is_valid_domain_syntax(&domain_lc) {
+        return JsonAckResponse::Err {
+            code: ErrCode::Validation,
+            reason: format!(
+                "domain '{d}' is not a valid RFC 1035 hostname",
+                d = req.domain,
+            ),
+        };
+    }
+
+    // Snapshot the current config under the live handle so we can
+    // pre-compute the lock set and the blocking-mailbox list before
+    // taking any locks. The snapshot is an `Arc` clone — cheap.
+    let pre_current = mb_ctx.config_handle.load();
+
+    if !pre_current.is_configured_domain(&domain_lc) {
+        return JsonAckResponse::Err {
+            code: ErrCode::Domain,
+            reason: format!("domain '{domain_lc}' is not configured"),
+        };
+    }
+
+    // Last-domain hard-block. The check is independent of `force` —
+    // an AIMX install must have at least one domain to be functional.
+    // Operators wanting a full teardown should use `aimx uninstall`.
+    if pre_current.domains.len() == 1 {
+        return JsonAckResponse::Err {
+            code: ErrCode::Domain,
+            reason: format!(
+                "cannot remove '{domain_lc}': it is the last configured domain. \
+                 An AIMX install must have at least one domain. \
+                 Use `aimx uninstall` for a full teardown."
+            ),
+        };
+    }
+
+    // Compute the sorted FQDN list of mailboxes on the target domain.
+    // Used both for the blocker list (no-force refusal) and for the
+    // per-mailbox lock acquisition order (force cascade).
+    let mut blockers: Vec<String> = pre_current
+        .mailboxes
+        .values()
+        .filter(|mb| mailbox_address_in_domain(&mb.address, &domain_lc))
+        .map(|mb| mb.address.clone())
+        .collect();
+    blockers.sort();
+    blockers.dedup();
+
+    let dkim_dir_path = crate::config::dkim_dir().join(&domain_lc);
+    let dkim_dir_string = dkim_dir_path.display().to_string();
+
+    // Non-force soft refusal: report the blockers via Ok body so the
+    // CLI can pretty-print the list and suggest `--force`. Drop the
+    // snapshot before returning so the live handle isn't pinned.
+    if !req.force && !blockers.is_empty() {
+        drop(pre_current);
+        log_decision(
+            verb,
+            caller,
+            Some(&domain_lc),
+            crate::uds_authz::LogDecision::Accept,
+            Some("refused: mailboxes still reference this domain"),
+        );
+        return ok_response(DomainRemoveResponse {
+            outcome: DomainRemoveOutcome::BlockedByMailboxes,
+            blocking_mailboxes: blockers,
+            cascaded_mailboxes: vec![],
+            storage_tree_removed: false,
+            dkim_dir: dkim_dir_string,
+        });
+    }
+
+    // We're committing to either a clean remove (no mailboxes, no
+    // force needed) OR a `--force` cascade.
+    //
+    // Lock ordering rationale (see `mailbox_locks.rs` module docs):
+    //
+    // outer: per-mailbox locks from `state_ctx.locks` in **sorted FQDN
+    //        order**. Inbound ingest, MARK-*, MAILBOX-CRUD, and
+    //        HOOK-CRUD all take the per-mailbox lock FIRST, then the
+    //        config lock — inverting that order here would deadlock
+    //        against any of them.
+    // inner: CONFIG_WRITE_LOCK. Serializes the load-modify-write-store
+    //        sequence across every config writer.
+    //
+    // Sorting the FQDN list before acquiring the locks gives us a
+    // deterministic order — required so two concurrent cascades on
+    // overlapping mailbox sets (impossible today; future-proofing)
+    // cannot deadlock against each other.
+    //
+    // We hold the per-mailbox locks across the per-mailbox wipe, the
+    // storage-tree rmdir, the config rewrite, and the in-memory
+    // hot-swaps. Concurrent ingest into mailboxes on OTHER domains
+    // (e.g. `support@a.com` while we remove `b.com`) is unaffected
+    // because the per-mailbox lock map is keyed by mailbox, not by
+    // domain — locks on b.com mailboxes don't block locks on a.com
+    // mailboxes. This is what makes the cascade compatible with
+    // background ingest on the surviving domain.
+    let lock_keys = blockers.clone();
+    let lock_states: Vec<Arc<crate::mailbox_locks::MailboxState>> = lock_keys
+        .iter()
+        .map(|fqdn| state_ctx.locks.lock_for(fqdn))
+        .collect();
+    drop(pre_current);
+
+    // Acquire the per-mailbox guards in order. Held until the end of
+    // this function via `held_guards`.
+    let mut held_guards: Vec<tokio::sync::MutexGuard<'_, ()>> =
+        Vec::with_capacity(lock_states.len());
+    for state in &lock_states {
+        held_guards.push(state.lock.lock().await);
+    }
+
+    // Inner: process-wide config write lock.
+    let _config_guard = CONFIG_WRITE_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+    // Re-snapshot under the lock so the rest of the critical section
+    // runs against a coherent view. A concurrent writer that landed
+    // between our pre-flight snapshot and the lock acquisition is
+    // detected here.
+    let current = mb_ctx.config_handle.load();
+
+    // Re-check the last-domain invariant and the blocking-mailbox set
+    // under the lock — a concurrent `DOMAIN-REMOVE` or
+    // `MAILBOX-CREATE` may have changed them.
+    if current.domains.len() == 1 {
+        return JsonAckResponse::Err {
+            code: ErrCode::Domain,
+            reason: format!(
+                "cannot remove '{domain_lc}': it is the last configured domain. \
+                 An AIMX install must have at least one domain. \
+                 Use `aimx uninstall` for a full teardown."
+            ),
+        };
+    }
+    if !current.is_configured_domain(&domain_lc) {
+        return JsonAckResponse::Err {
+            code: ErrCode::Domain,
+            reason: format!("domain '{domain_lc}' is not configured"),
+        };
+    }
+
+    // Re-collect blockers under the lock. If the set grew since the
+    // pre-flight snapshot we did NOT take that mailbox's lock, so we
+    // must abort the cascade rather than silently skip the new mailbox
+    // (which could leak files on disk owned by a domain we then drop
+    // from config). Realistically this never fires — `MAILBOX-CREATE`
+    // takes its own per-mailbox lock and the config lock, and we hold
+    // the config lock — but the check is the cheap belt-and-braces.
+    let mut live_blockers: Vec<(String, crate::config::MailboxConfig)> = current
+        .mailboxes
+        .iter()
+        .filter(|(_, mb)| mailbox_address_in_domain(&mb.address, &domain_lc))
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    live_blockers.sort_by(|a, b| a.1.address.cmp(&b.1.address));
+
+    let live_blocker_fqdns: Vec<String> = live_blockers
+        .iter()
+        .map(|(_, mb)| mb.address.clone())
+        .collect();
+    if live_blocker_fqdns != lock_keys {
+        return JsonAckResponse::Err {
+            code: ErrCode::Conflict,
+            reason: format!(
+                "mailbox set for '{domain_lc}' changed under the cascade lock; retry the remove"
+            ),
+        };
+    }
+
+    if !req.force && !live_blockers.is_empty() {
+        // Should be unreachable — the pre-flight branch above returns
+        // before we ever take the locks for the non-force path. Keep
+        // the guard as belt-and-braces against a future refactor that
+        // drops the early return.
+        return JsonAckResponse::Err {
+            code: ErrCode::NonEmpty,
+            reason: format!(
+                "domain '{domain_lc}' still has {} mailbox(es); pass --force to cascade",
+                live_blockers.len()
+            ),
+        };
+    }
+
+    // Per-mailbox wipe (force cascade only). Each mailbox's
+    // `inbox/<local>/` and `sent/<local>/` directory contents are
+    // removed via the same helper `MAILBOX-DELETE --force` uses, so
+    // the wipe contract (dotfile preservation, symlink handling,
+    // missing-dir tolerance) is shared. The directories themselves
+    // are removed below via `rmdir` after the per-domain rmdir.
+    let mut cascaded: Vec<String> = Vec::with_capacity(live_blockers.len());
+    for (_key, mb) in &live_blockers {
+        let inbox =
+            crate::storage::mailbox_storage_path(&current, mb, crate::storage::Folder::Inbox);
+        let sent = crate::storage::mailbox_storage_path(&current, mb, crate::storage::Folder::Sent);
+        if let Err(e) = crate::mailbox::wipe_mailbox_contents(&inbox) {
+            return JsonAckResponse::Err {
+                code: ErrCode::Io,
+                reason: format!("failed to wipe inbox for '{}': {e}", mb.address),
+            };
+        }
+        if let Err(e) = crate::mailbox::wipe_mailbox_contents(&sent) {
+            return JsonAckResponse::Err {
+                code: ErrCode::Io,
+                reason: format!("failed to wipe sent for '{}': {e}", mb.address),
+            };
+        }
+        // After wiping contents, remove the per-mailbox directories
+        // themselves so the per-domain rmdir below sees an empty
+        // tree. Best-effort: a missing directory is fine (e.g.
+        // mailbox never received mail); a non-empty directory is a
+        // bug surfaced by the per-domain rmdir below.
+        let _ = std::fs::remove_dir(&inbox);
+        let _ = std::fs::remove_dir(&sent);
+        cascaded.push(mb.address.clone());
+    }
+
+    // Storage-tree rmdir: explicitly `rmdir`, never `remove_dir_all`.
+    // The mailbox wipes above are the only safe deletion path; if the
+    // per-domain dir still has children at this point it means a
+    // mailbox wipe missed something or an unmanaged file leaked in.
+    // Either way, surface the failure loudly rather than silently
+    // recursing.
+    let domain_root = current.data_dir.join(&domain_lc);
+    let storage_tree_removed = if domain_root.is_dir() {
+        // The cascade wipes both `inbox/<local>/` and `sent/<local>/`
+        // dirs out, leaving the `inbox/` and `sent/` parents behind.
+        // Walk through and rmdir those as well so the per-domain
+        // root is empty before the final rmdir. Best-effort on each
+        // — if either is missing (e.g. an install that never had any
+        // sent mail), `rmdir` returns NotFound which we ignore.
+        for folder in ["inbox", "sent"] {
+            let p = domain_root.join(folder);
+            let _ = std::fs::remove_dir(&p);
+        }
+        match std::fs::remove_dir(&domain_root) {
+            Ok(()) => true,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+            Err(e) => {
+                return JsonAckResponse::Err {
+                    code: ErrCode::Io,
+                    reason: format!(
+                        "failed to remove storage tree {}: {e} \
+                         (per-mailbox wipes left non-empty contents — \
+                         inspect manually)",
+                        domain_root.display()
+                    ),
+                };
+            }
+        }
+    } else {
+        // No on-disk tree to remove — typically the non-force clean
+        // path or a domain whose mailboxes were all created but never
+        // received mail.
+        true
+    };
+
+    // Build the new in-memory Config.
+    let mut new_config: Config = (*current).clone();
+    // Drop the per-domain sub-table.
+    new_config.per_domain.remove(&domain_lc);
+    // Drop every [mailboxes."<local>@<domain>"] entry.
+    new_config
+        .mailboxes
+        .retain(|_, mb| !mailbox_address_in_domain(&mb.address, &domain_lc));
+    // Drop the domain string.
+    new_config
+        .domains
+        .retain(|d| !d.eq_ignore_ascii_case(&domain_lc));
+
+    if let Err(e) = crate::mailbox_handler::write_config_atomic(&mb_ctx.config_path, &new_config) {
+        return JsonAckResponse::Err {
+            code: ErrCode::Io,
+            reason: format!("failed to write {}: {e}", mb_ctx.config_path.display()),
+        };
+    }
+
+    // Hot-swap the DKIM map FIRST: drop the per-domain entry. Order
+    // mirrors `handle_domain_add` — we keep readers consistent so any
+    // reader who sees the domain GONE from `config.domains` also sees
+    // the DKIM map entry gone.
+    let mut new_map: DkimKeyMap = (*dkim_keys.load_full()).clone();
+    new_map.remove(&domain_lc);
+    dkim_keys.store(Arc::new(new_map));
+
+    // Now hot-swap the in-memory Config.
+    mb_ctx.config_handle.store(new_config);
+    drop(current);
+
+    log_decision(
+        verb,
+        caller,
+        Some(&domain_lc),
+        if caller.is_root() {
+            crate::uds_authz::LogDecision::RootBypass
+        } else {
+            crate::uds_authz::LogDecision::Accept
+        },
+        None,
+    );
+
+    // Drop the per-mailbox guards explicitly so the lock scope ends
+    // before the response is written.
+    drop(held_guards);
+    drop(lock_states);
+
+    ok_response(DomainRemoveResponse {
+        outcome: DomainRemoveOutcome::Removed,
+        blocking_mailboxes: vec![],
+        cascaded_mailboxes: cascaded,
+        storage_tree_removed,
+        dkim_dir: dkim_dir_string,
+    })
+}
+
+/// Helper: serialize a `DomainRemoveResponse` into the wire body.
+fn ok_response(resp: DomainRemoveResponse) -> JsonAckResponse {
+    match serde_json::to_vec(&resp) {
+        Ok(body) => JsonAckResponse::Ok { body },
+        Err(e) => JsonAckResponse::Err {
+            code: ErrCode::Io,
+            reason: format!("failed to serialize DOMAIN-REMOVE response: {e}"),
+        },
+    }
+}
+
+/// True iff `address` belongs to `domain` (case-insensitive). Used to
+/// match both regular `<local>@<domain>` mailboxes and per-domain
+/// catchall (`*@<domain>`) entries against the target domain.
+fn mailbox_address_in_domain(address: &str, domain: &str) -> bool {
+    match address.rsplit_once('@') {
+        Some((_, d)) => d.eq_ignore_ascii_case(domain),
+        None => false,
+    }
+}
+
+/// Direct on-disk fallback used by the CLI when the daemon is stopped.
+/// Mirrors [`handle_domain_remove`] minus the in-memory swaps — the
+/// operator restarts `aimx serve` to pick up the change. Only callable
+/// from root (the CLI gates this).
+///
+/// Returns the in-memory [`DomainRemoveResponse`] for the CLI to
+/// render. Last-domain hard-block, unknown-domain, validation, and
+/// IO errors are surfaced as `Err`. DKIM keys are NEVER removed.
+pub fn run_direct_remove(
+    config_path: &Path,
+    config: &Config,
+    domain: &str,
+    force: bool,
+) -> Result<DomainRemoveResponse, Box<dyn std::error::Error>> {
+    let domain_lc = domain.trim().to_ascii_lowercase();
+    if !is_valid_domain_syntax(&domain_lc) {
+        return Err(format!("domain '{domain}' is not a valid RFC 1035 hostname").into());
+    }
+    if !config.is_configured_domain(&domain_lc) {
+        return Err(format!("domain '{domain_lc}' is not configured").into());
+    }
+    if config.domains.len() == 1 {
+        return Err(format!(
+            "cannot remove '{domain_lc}': it is the last configured domain. \
+             An AIMX install must have at least one domain. \
+             Use `aimx uninstall` for a full teardown."
+        )
+        .into());
+    }
+
+    let mut blockers: Vec<(String, crate::config::MailboxConfig)> = config
+        .mailboxes
+        .iter()
+        .filter(|(_, mb)| mailbox_address_in_domain(&mb.address, &domain_lc))
+        .map(|(k, v)| (k.clone(), v.clone()))
+        .collect();
+    blockers.sort_by(|a, b| a.1.address.cmp(&b.1.address));
+
+    let dkim_dir = crate::config::dkim_dir()
+        .join(&domain_lc)
+        .display()
+        .to_string();
+
+    if !force && !blockers.is_empty() {
+        return Ok(DomainRemoveResponse {
+            outcome: DomainRemoveOutcome::BlockedByMailboxes,
+            blocking_mailboxes: blockers.iter().map(|(_, mb)| mb.address.clone()).collect(),
+            cascaded_mailboxes: vec![],
+            storage_tree_removed: false,
+            dkim_dir,
+        });
+    }
+
+    let mut cascaded: Vec<String> = Vec::with_capacity(blockers.len());
+    for (_key, mb) in &blockers {
+        let inbox = crate::storage::mailbox_storage_path(config, mb, crate::storage::Folder::Inbox);
+        let sent = crate::storage::mailbox_storage_path(config, mb, crate::storage::Folder::Sent);
+        crate::mailbox::wipe_mailbox_contents(&inbox)?;
+        crate::mailbox::wipe_mailbox_contents(&sent)?;
+        let _ = std::fs::remove_dir(&inbox);
+        let _ = std::fs::remove_dir(&sent);
+        cascaded.push(mb.address.clone());
+    }
+
+    let domain_root = config.data_dir.join(&domain_lc);
+    let storage_tree_removed = if domain_root.is_dir() {
+        for folder in ["inbox", "sent"] {
+            let _ = std::fs::remove_dir(domain_root.join(folder));
+        }
+        match std::fs::remove_dir(&domain_root) {
+            Ok(()) => true,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => true,
+            Err(e) => {
+                return Err(format!(
+                    "failed to remove storage tree {}: {e}",
+                    domain_root.display()
+                )
+                .into());
+            }
+        }
+    } else {
+        true
+    };
+
+    let mut new_config = config.clone();
+    new_config.per_domain.remove(&domain_lc);
+    new_config
+        .mailboxes
+        .retain(|_, mb| !mailbox_address_in_domain(&mb.address, &domain_lc));
+    new_config
+        .domains
+        .retain(|d| !d.eq_ignore_ascii_case(&domain_lc));
+
+    crate::config::write_atomic(config_path, &new_config)?;
+
+    Ok(DomainRemoveResponse {
+        outcome: DomainRemoveOutcome::Removed,
+        blocking_mailboxes: vec![],
+        cascaded_mailboxes: cascaded,
+        storage_tree_removed,
+        dkim_dir,
+    })
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -342,6 +896,11 @@ mod tests {
                     name: "root".to_string(),
                     uid: 0,
                     gid: 0,
+                }),
+                "testowner" => Some(crate::user_resolver::ResolvedUser {
+                    name: "testowner".to_string(),
+                    uid: 1000,
+                    gid: 1000,
                 }),
                 _ => None,
             }
@@ -633,5 +1192,520 @@ mod tests {
             before, after,
             "daemon-stopped fallback must preserve pre-existing DKIM keys"
         );
+    }
+
+    // ----------------- DOMAIN-REMOVE tests --------------------------------
+
+    use crate::config::MailboxConfig;
+    use crate::send_protocol::{DomainRemoveRequest, JsonAckResponse};
+
+    /// Build a real but throwaway DKIM private key for tests. Uses a
+    /// fresh TempDir so the on-disk artifacts don't pollute the test
+    /// process and disappear at the end of the call.
+    fn make_test_dkim_key() -> rsa::RsaPrivateKey {
+        let tmp = TempDir::new().unwrap();
+        crate::dkim::generate_keypair(tmp.path(), false).unwrap();
+        crate::dkim::load_private_key(tmp.path()).unwrap()
+    }
+
+    /// Build a two-domain config with `a.com` + `b.com`. Optional
+    /// mailboxes can be added under `b.com` to exercise the cascade.
+    fn two_domain_config(data_dir: &Path, bcom_mailboxes: &[&str]) -> Config {
+        let mut mailboxes = HashMap::new();
+        // Always-on a.com mailbox so the a.com side isn't empty during
+        // tests that verify the cascade doesn't touch the surviving
+        // domain.
+        mailboxes.insert(
+            "info@a.com".to_string(),
+            MailboxConfig {
+                address: "info@a.com".to_string(),
+                owner: "testowner".to_string(),
+                hooks: vec![],
+                trust: None,
+                trusted_senders: None,
+                allow_root_catchall: false,
+            },
+        );
+        for name in bcom_mailboxes {
+            let addr = format!("{name}@b.com");
+            mailboxes.insert(
+                addr.clone(),
+                MailboxConfig {
+                    address: addr,
+                    owner: "testowner".to_string(),
+                    hooks: vec![],
+                    trust: None,
+                    trusted_senders: None,
+                    allow_root_catchall: false,
+                },
+            );
+        }
+        let mut per_domain = HashMap::new();
+        per_domain.insert(
+            "b.com".to_string(),
+            DomainOverride {
+                signature: None,
+                dkim_selector: Some("s2025".into()),
+                trust: None,
+                trusted_senders: None,
+            },
+        );
+        Config {
+            domains: vec!["a.com".to_string(), "b.com".to_string()],
+            data_dir: data_dir.to_path_buf(),
+            dkim_selector: None,
+            trust: "none".to_string(),
+            trusted_senders: vec![],
+            mailboxes,
+            per_domain,
+            verify_host: None,
+            enable_ipv6: false,
+            signature: None,
+            upgrade: None,
+        }
+    }
+
+    fn contexts_with_config(
+        tmp: &TempDir,
+        config: Config,
+    ) -> (StateContext, MailboxContext, SharedDkimKeyMap) {
+        // Seed the v2 marker so `mailbox_storage_path` resolves to the
+        // per-domain layout (`<data_dir>/<domain>/{inbox|sent}/<local>`).
+        std::fs::write(tmp.path().join(".layout-version"), "2\n").unwrap();
+        let handle = ConfigHandle::new(config);
+        let state_ctx = StateContext::new(tmp.path().to_path_buf(), handle.clone());
+        let config_path = tmp.path().join("config.toml");
+        crate::mailbox_handler::write_config_atomic(&config_path, &handle.load()).unwrap();
+        let mb_ctx = MailboxContext::new(config_path, handle);
+        let keys = crate::dkim_keys::empty_shared();
+        (state_ctx, mb_ctx, keys)
+    }
+
+    /// Provision the on-disk storage tree for a mailbox so the cascade
+    /// has something to wipe. Seeds one fake `.md` file inside the
+    /// inbox so the wipe path is exercised, not just the empty-dir
+    /// rmdir.
+    fn seed_mailbox_storage(tmp: &TempDir, domain: &str, local: &str) {
+        for folder in ["inbox", "sent"] {
+            let dir = tmp.path().join(domain).join(folder).join(local);
+            std::fs::create_dir_all(&dir).unwrap();
+        }
+        let stub = tmp
+            .path()
+            .join(domain)
+            .join("inbox")
+            .join(local)
+            .join("2026-05-23-fake.md");
+        std::fs::write(&stub, "+++\nid = \"fake\"\n+++\n\nhi\n").unwrap();
+    }
+
+    /// Removing a domain with no mailboxes on it (`force = false`) is
+    /// the clean-remove happy path. Asserts: config rewritten, DKIM map
+    /// entry dropped, per-domain sub-table dropped.
+    #[tokio::test]
+    async fn remove_clean_no_blockers_drops_domain_and_dkim_entry() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        let (state_ctx, mb_ctx, keys) =
+            contexts_with_config(&tmp, two_domain_config(tmp.path(), &[]));
+
+        // Pre-seed the DKIM map for b.com so we can assert the entry is
+        // dropped after the cascade.
+        let mut seed_map: DkimKeyMap = (*keys.load_full()).clone();
+        seed_map.insert(
+            "b.com".to_string(),
+            DkimKeyEntry {
+                key: Arc::new(make_test_dkim_key()),
+                selector: "aimx".to_string(),
+            },
+        );
+        keys.store(Arc::new(seed_map));
+
+        let req = DomainRemoveRequest {
+            domain: "b.com".into(),
+            force: false,
+        };
+        let resp =
+            handle_domain_remove(&state_ctx, &mb_ctx, &keys, &req, &Caller::internal_root()).await;
+        match resp {
+            JsonAckResponse::Ok { body } => {
+                let parsed: DomainRemoveResponse = serde_json::from_slice(&body).unwrap();
+                assert_eq!(parsed.outcome, DomainRemoveOutcome::Removed);
+                assert!(parsed.blocking_mailboxes.is_empty());
+                assert!(parsed.cascaded_mailboxes.is_empty());
+                assert!(parsed.dkim_dir.ends_with("/b.com"));
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+
+        // In-memory hot-swap.
+        let after = mb_ctx.config_handle.load();
+        assert_eq!(after.domains, vec!["a.com"]);
+        assert!(!after.per_domain.contains_key("b.com"));
+
+        // On-disk config also rewritten.
+        let reloaded = Config::load_ignore_warnings(&mb_ctx.config_path).unwrap();
+        assert_eq!(reloaded.domains, vec!["a.com"]);
+
+        // DKIM map dropped its b.com entry.
+        let snapshot = keys.load_full();
+        assert!(!snapshot.contains_key("b.com"));
+    }
+
+    /// Removing a domain that still has mailboxes (`force = false`)
+    /// must refuse and return the list of blocking mailboxes
+    /// alphabetically.
+    #[tokio::test]
+    async fn remove_blocked_by_mailboxes_returns_sorted_list_no_state_change() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        let (state_ctx, mb_ctx, keys) = contexts_with_config(
+            &tmp,
+            two_domain_config(tmp.path(), &["zeta", "alpha", "beta"]),
+        );
+
+        let req = DomainRemoveRequest {
+            domain: "b.com".into(),
+            force: false,
+        };
+        let resp =
+            handle_domain_remove(&state_ctx, &mb_ctx, &keys, &req, &Caller::internal_root()).await;
+        match resp {
+            JsonAckResponse::Ok { body } => {
+                let parsed: DomainRemoveResponse = serde_json::from_slice(&body).unwrap();
+                assert_eq!(parsed.outcome, DomainRemoveOutcome::BlockedByMailboxes);
+                assert_eq!(
+                    parsed.blocking_mailboxes,
+                    vec![
+                        "alpha@b.com".to_string(),
+                        "beta@b.com".to_string(),
+                        "zeta@b.com".to_string(),
+                    ],
+                    "blockers must be sorted alphabetically",
+                );
+                assert!(parsed.cascaded_mailboxes.is_empty());
+                assert!(!parsed.storage_tree_removed);
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+
+        // No state change.
+        let after = mb_ctx.config_handle.load();
+        assert_eq!(after.domains, vec!["a.com", "b.com"]);
+        assert!(after.mailboxes.contains_key("alpha@b.com"));
+    }
+
+    /// The last remaining domain is hard-blocked from removal even
+    /// with `force = true` — operators wanting a full teardown must
+    /// use `aimx uninstall`.
+    #[tokio::test]
+    async fn remove_last_domain_is_hard_blocked_even_with_force() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        let (state_ctx, mb_ctx, keys) = contexts(&tmp); // single-domain a.com
+
+        for force in [false, true] {
+            let req = DomainRemoveRequest {
+                domain: "a.com".into(),
+                force,
+            };
+            let resp =
+                handle_domain_remove(&state_ctx, &mb_ctx, &keys, &req, &Caller::internal_root())
+                    .await;
+            match resp {
+                JsonAckResponse::Err { code, reason } => {
+                    assert_eq!(code, ErrCode::Domain, "force={force}");
+                    assert!(
+                        reason.contains("last configured domain"),
+                        "force={force}, reason={reason}",
+                    );
+                    assert!(
+                        reason.contains("aimx uninstall"),
+                        "force={force}, reason={reason}",
+                    );
+                }
+                other => panic!("expected Err Domain, got {other:?} (force={force})"),
+            }
+        }
+    }
+
+    /// `--force` cascade: configure b.com with three mailboxes (each
+    /// with on-disk storage), invoke remove with force, assert all
+    /// three mailboxes are dropped, the storage tree is gone, the DKIM
+    /// map entry is gone, and the DKIM keypair on disk is preserved.
+    #[tokio::test]
+    async fn force_cascade_wipes_mailboxes_storage_and_keeps_dkim_keys() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        let (state_ctx, mb_ctx, keys) = contexts_with_config(
+            &tmp,
+            two_domain_config(tmp.path(), &["info", "support", "alice"]),
+        );
+
+        // Provision on-disk storage for every b.com mailbox so the
+        // cascade has real work to do.
+        for local in ["info", "support", "alice"] {
+            seed_mailbox_storage(&tmp, "b.com", local);
+        }
+        // Also provision a.com storage so we can assert the cascade
+        // doesn't accidentally touch the surviving domain.
+        seed_mailbox_storage(&tmp, "a.com", "info");
+
+        // Pre-seed b.com DKIM keys at the canonical per-domain layout
+        // so we can verify they're preserved after the cascade.
+        let dkim_root = crate::config::dkim_dir();
+        let b_dkim_dir = dkim_root.join("b.com");
+        std::fs::create_dir_all(&b_dkim_dir).unwrap();
+        std::fs::write(b_dkim_dir.join("private.key"), b"FAKE_PRIVATE_KEY").unwrap();
+        std::fs::write(b_dkim_dir.join("public.key"), b"FAKE_PUBLIC_KEY").unwrap();
+
+        // Pre-seed the DKIM map entry for b.com.
+        let mut seed_map: DkimKeyMap = (*keys.load_full()).clone();
+        seed_map.insert(
+            "b.com".to_string(),
+            DkimKeyEntry {
+                key: Arc::new(make_test_dkim_key()),
+                selector: "s2025".to_string(),
+            },
+        );
+        keys.store(Arc::new(seed_map));
+
+        let req = DomainRemoveRequest {
+            domain: "b.com".into(),
+            force: true,
+        };
+        let resp =
+            handle_domain_remove(&state_ctx, &mb_ctx, &keys, &req, &Caller::internal_root()).await;
+
+        match resp {
+            JsonAckResponse::Ok { body } => {
+                let parsed: DomainRemoveResponse = serde_json::from_slice(&body).unwrap();
+                assert_eq!(parsed.outcome, DomainRemoveOutcome::Removed);
+                assert!(parsed.storage_tree_removed);
+                assert_eq!(
+                    parsed.cascaded_mailboxes,
+                    vec![
+                        "alice@b.com".to_string(),
+                        "info@b.com".to_string(),
+                        "support@b.com".to_string(),
+                    ],
+                    "cascaded mailboxes must be sorted by FQDN",
+                );
+            }
+            other => panic!("expected Ok, got {other:?}"),
+        }
+
+        // Config rewritten in memory and on disk.
+        let after = mb_ctx.config_handle.load();
+        assert_eq!(after.domains, vec!["a.com"]);
+        assert!(!after.per_domain.contains_key("b.com"));
+        assert!(after.mailboxes.keys().all(|k| !k.ends_with("@b.com")));
+        let reloaded = Config::load_ignore_warnings(&mb_ctx.config_path).unwrap();
+        assert_eq!(reloaded.domains, vec!["a.com"]);
+
+        // Per-domain b.com storage tree is gone.
+        let b_root = tmp.path().join("b.com");
+        assert!(
+            !b_root.exists(),
+            "b.com storage tree must be removed, still at {}",
+            b_root.display()
+        );
+
+        // a.com storage is untouched.
+        let a_info = tmp.path().join("a.com").join("inbox").join("info");
+        assert!(
+            a_info.is_dir(),
+            "a.com mailbox storage must survive the b.com cascade",
+        );
+        // a.com seeded stub file is also still there.
+        assert!(a_info.join("2026-05-23-fake.md").is_file());
+
+        // DKIM map dropped b.com.
+        let snapshot = keys.load_full();
+        assert!(!snapshot.contains_key("b.com"));
+
+        // DKIM keypair on disk is preserved.
+        assert!(
+            b_dkim_dir.join("private.key").is_file(),
+            "DKIM private.key must be preserved after --force cascade",
+        );
+        assert!(
+            b_dkim_dir.join("public.key").is_file(),
+            "DKIM public.key must be preserved after --force cascade",
+        );
+        let private_after = std::fs::read(b_dkim_dir.join("private.key")).unwrap();
+        assert_eq!(
+            private_after, b"FAKE_PRIVATE_KEY",
+            "DKIM private key bytes must be untouched after cascade",
+        );
+    }
+
+    /// Non-root caller is denied with EACCES.
+    #[tokio::test]
+    async fn remove_non_root_caller_denied_with_eacces() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        let (state_ctx, mb_ctx, keys) =
+            contexts_with_config(&tmp, two_domain_config(tmp.path(), &[]));
+
+        let req = DomainRemoveRequest {
+            domain: "b.com".into(),
+            force: false,
+        };
+        let stranger = Caller::new(1000, 1000, None);
+        let resp = handle_domain_remove(&state_ctx, &mb_ctx, &keys, &req, &stranger).await;
+        match resp {
+            JsonAckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Eaccess),
+            other => panic!("expected Err EACCES, got {other:?}"),
+        }
+        let after = mb_ctx.config_handle.load();
+        assert_eq!(after.domains, vec!["a.com", "b.com"]);
+    }
+
+    /// Removing a domain that isn't configured surfaces a canonical
+    /// `ErrCode::Domain` error.
+    #[tokio::test]
+    async fn remove_unknown_domain_rejected() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        let (state_ctx, mb_ctx, keys) =
+            contexts_with_config(&tmp, two_domain_config(tmp.path(), &[]));
+
+        let req = DomainRemoveRequest {
+            domain: "c.com".into(),
+            force: false,
+        };
+        let resp =
+            handle_domain_remove(&state_ctx, &mb_ctx, &keys, &req, &Caller::internal_root()).await;
+        match resp {
+            JsonAckResponse::Err { code, reason } => {
+                assert_eq!(code, ErrCode::Domain);
+                assert!(reason.contains("not configured"), "{reason}");
+            }
+            other => panic!("expected Err Domain, got {other:?}"),
+        }
+    }
+
+    /// Invalid domain syntax is rejected with `ErrCode::Validation`.
+    #[tokio::test]
+    async fn remove_invalid_domain_syntax_rejected() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        let (state_ctx, mb_ctx, keys) =
+            contexts_with_config(&tmp, two_domain_config(tmp.path(), &[]));
+
+        let req = DomainRemoveRequest {
+            domain: "not a domain".into(),
+            force: false,
+        };
+        let resp =
+            handle_domain_remove(&state_ctx, &mb_ctx, &keys, &req, &Caller::internal_root()).await;
+        match resp {
+            JsonAckResponse::Err { code, .. } => assert_eq!(code, ErrCode::Validation),
+            other => panic!("expected Err Validation, got {other:?}"),
+        }
+    }
+
+    /// The non-force clean-remove path (no blockers) succeeds even
+    /// when the DKIM key files are still on disk: the handler MUST
+    /// NOT delete them.
+    #[tokio::test]
+    async fn clean_remove_preserves_dkim_keys_on_disk() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        let (state_ctx, mb_ctx, keys) =
+            contexts_with_config(&tmp, two_domain_config(tmp.path(), &[]));
+
+        let dkim_root = crate::config::dkim_dir();
+        let b_dkim_dir = dkim_root.join("b.com");
+        std::fs::create_dir_all(&b_dkim_dir).unwrap();
+        std::fs::write(b_dkim_dir.join("private.key"), b"FAKE").unwrap();
+        std::fs::write(b_dkim_dir.join("public.key"), b"FAKE").unwrap();
+
+        let req = DomainRemoveRequest {
+            domain: "b.com".into(),
+            force: false,
+        };
+        let _ =
+            handle_domain_remove(&state_ctx, &mb_ctx, &keys, &req, &Caller::internal_root()).await;
+
+        assert!(b_dkim_dir.join("private.key").is_file());
+        assert!(b_dkim_dir.join("public.key").is_file());
+    }
+
+    /// `run_direct_remove` (root daemon-stopped fallback) writes the
+    /// new config and wipes b.com storage without touching the
+    /// in-memory handle. Also preserves the DKIM keys on disk.
+    #[test]
+    fn direct_remove_writes_config_wipes_storage_and_preserves_dkim() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        std::fs::write(tmp.path().join(".layout-version"), "2\n").unwrap();
+        let config = two_domain_config(tmp.path(), &["info"]);
+        let config_path = tmp.path().join("config.toml");
+        crate::config::write_atomic(&config_path, &config).unwrap();
+        seed_mailbox_storage(&tmp, "b.com", "info");
+        let b_dkim_dir = crate::config::dkim_dir().join("b.com");
+        std::fs::create_dir_all(&b_dkim_dir).unwrap();
+        std::fs::write(b_dkim_dir.join("private.key"), b"FAKE").unwrap();
+
+        let response = run_direct_remove(&config_path, &config, "b.com", true).unwrap();
+        assert_eq!(response.outcome, DomainRemoveOutcome::Removed);
+        assert!(response.storage_tree_removed);
+        assert_eq!(response.cascaded_mailboxes, vec!["info@b.com".to_string()]);
+
+        let reloaded = Config::load_ignore_warnings(&config_path).unwrap();
+        assert_eq!(reloaded.domains, vec!["a.com"]);
+        assert!(!tmp.path().join("b.com").exists());
+        assert!(b_dkim_dir.join("private.key").is_file());
+    }
+
+    /// `run_direct_remove` rejects the last-domain hard-block.
+    #[test]
+    fn direct_remove_last_domain_hard_block() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        let config = base_config(tmp.path());
+        let config_path = tmp.path().join("config.toml");
+        crate::config::write_atomic(&config_path, &config).unwrap();
+
+        let err = run_direct_remove(&config_path, &config, "a.com", true)
+            .expect_err("last-domain must hard-block");
+        assert!(err.to_string().contains("last configured domain"));
+        assert!(err.to_string().contains("aimx uninstall"));
+    }
+
+    /// `run_direct_remove` refuses non-force with the blocker list
+    /// populated.
+    #[test]
+    fn direct_remove_blocked_when_mailboxes_present_no_force() {
+        let _r = install_resolver();
+        let tmp = TempDir::new().unwrap();
+        let _override = ConfigDirOverride::set(tmp.path());
+        std::fs::write(tmp.path().join(".layout-version"), "2\n").unwrap();
+        let config = two_domain_config(tmp.path(), &["info", "alice"]);
+        let config_path = tmp.path().join("config.toml");
+        crate::config::write_atomic(&config_path, &config).unwrap();
+
+        let response = run_direct_remove(&config_path, &config, "b.com", false).unwrap();
+        assert_eq!(response.outcome, DomainRemoveOutcome::BlockedByMailboxes);
+        assert_eq!(
+            response.blocking_mailboxes,
+            vec!["alice@b.com".to_string(), "info@b.com".to_string()],
+        );
+
+        // Config unchanged on disk.
+        let reloaded = Config::load_ignore_warnings(&config_path).unwrap();
+        assert_eq!(reloaded.domains, vec!["a.com", "b.com"]);
     }
 }

--- a/src/mcp.rs
+++ b/src/mcp.rs
@@ -1506,6 +1506,72 @@ async fn submit_domain_add_request(
     Ok(parse_ack_response(&buf))
 }
 
+/// Submit an `AIMX/1 DOMAIN-REMOVE` request over UDS. Returns the
+/// daemon's JSON response body on success (which the CLI parses into
+/// a [`crate::domain_handler::DomainRemoveResponse`]) or a
+/// [`MailboxLifecycleFallback`] on failure so the CLI can decide
+/// whether to fall back to the direct on-disk edit (root) or hard-
+/// error (non-root).
+pub(crate) fn submit_domain_remove_via_daemon(
+    domain: &str,
+    force: bool,
+) -> Result<String, MailboxLifecycleFallback> {
+    let request = send_protocol::DomainRemoveRequest {
+        domain: domain.to_string(),
+        force,
+    };
+    let socket = crate::serve::aimx_socket_path();
+
+    let rt = tokio::runtime::Handle::try_current();
+    let io_result: Result<Vec<u8>, std::io::Error> = match rt {
+        Ok(handle) => tokio::task::block_in_place(|| {
+            handle.block_on(submit_domain_remove_request(&socket, &request))
+        }),
+        Err(_) => {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .map_err(|e| {
+                    MailboxLifecycleFallback::Daemon(format!("Failed to create tokio runtime: {e}"))
+                })?;
+            rt.block_on(submit_domain_remove_request(&socket, &request))
+        }
+    };
+
+    let raw = io_result.map_err(|e| {
+        if is_socket_missing(&e) {
+            MailboxLifecycleFallback::SocketMissing
+        } else {
+            MailboxLifecycleFallback::Daemon(format!(
+                "Failed to connect to aimx daemon at {}: {e}",
+                socket.display()
+            ))
+        }
+    })?;
+
+    // Reuse the MAILBOX-LIST / DOMAIN-LIST JSON ack decoder — wire
+    // shape is identical (status line + Content-Length + JSON body on
+    // OK; ERR <code> <reason> on failure).
+    decode_mailbox_list_response(&raw).map_err(MailboxLifecycleFallback::Daemon)
+}
+
+async fn submit_domain_remove_request(
+    socket_path: &std::path::Path,
+    request: &send_protocol::DomainRemoveRequest,
+) -> Result<Vec<u8>, std::io::Error> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let stream = tokio::net::UnixStream::connect(socket_path).await?;
+    let (mut reader, mut writer) = stream.into_split();
+
+    send_protocol::write_domain_remove_request(&mut writer, request).await?;
+    writer.shutdown().await.ok();
+
+    let mut buf = Vec::with_capacity(1024);
+    reader.read_to_end(&mut buf).await?;
+    Ok(buf)
+}
+
 fn submit_mailbox_list_raw() -> Result<String, MailboxLifecycleFallback> {
     let socket = crate::serve::aimx_socket_path();
 

--- a/src/send_protocol.rs
+++ b/src/send_protocol.rs
@@ -206,6 +206,24 @@ pub struct DomainAddRequest {
     pub selector: Option<String>,
 }
 
+/// Decoded `AIMX/1 DOMAIN-REMOVE` request. The daemon-side handler
+/// runs `auth::authorize(.., Action::DomainCrud)` (root-only) before
+/// doing anything else.
+///
+/// `force = false` (default) refuses when the domain still has
+/// mailboxes — the daemon returns the JSON list of blocking mailbox
+/// FQDNs so the CLI can show them. `force = true` cascades to per-
+/// mailbox wipe + storage-tree rmdir + config rewrite under the
+/// lock hierarchy documented in `book/multi-domain.md`.
+///
+/// Removing the last domain is hard-blocked regardless of `force`:
+/// an AIMX install must have at least one domain to be functional.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DomainRemoveRequest {
+    pub domain: String,
+    pub force: bool,
+}
+
 // `AIMX/1 HOOK-LIST` carries no payload; the daemon resolves the
 // caller via `SO_PEERCRED` and returns the hooks visible to the
 // caller's uid (root sees every hook on every mailbox; non-root sees
@@ -256,6 +274,12 @@ pub enum Request {
     /// `AIMX/1 DOMAIN-ADD` carries the `Domain:` header (required) plus
     /// an optional `Selector:` header. Root-only.
     DomainAdd(DomainAddRequest),
+    /// `AIMX/1 DOMAIN-REMOVE` carries the `Domain:` header (required)
+    /// plus the `Force: true|false` header (also required — the
+    /// cascade flag is intentionally explicit on the wire, not a
+    /// boolean default, so a stale client cannot accidentally request
+    /// a cascade by omission). Root-only.
+    DomainRemove(DomainRemoveRequest),
 }
 
 /// Error codes reported on the wire in `AIMX/1 ERR <code> <reason>`.
@@ -501,6 +525,9 @@ where
         "DOMAIN-ADD" => parse_domain_add_headers(reader)
             .await
             .map(Request::DomainAdd),
+        "DOMAIN-REMOVE" => parse_domain_remove_headers(reader)
+            .await
+            .map(Request::DomainRemove),
         other => Err(ParseError::UnknownVerb(other.to_string())),
     }
 }
@@ -530,9 +557,9 @@ where
         Request::Version => Err(ParseError::Malformed(
             "expected SEND verb, got VERSION".to_string(),
         )),
-        Request::DomainList | Request::DomainAdd(_) => Err(ParseError::Malformed(
-            "expected SEND verb, got DOMAIN-*".to_string(),
-        )),
+        Request::DomainList | Request::DomainAdd(_) | Request::DomainRemove(_) => Err(
+            ParseError::Malformed("expected SEND verb, got DOMAIN-*".to_string()),
+        ),
     }
 }
 
@@ -1067,6 +1094,95 @@ where
         domain.ok_or_else(|| ParseError::Malformed("missing required header: Domain".into()))?;
     let _ = content_length;
     Ok(DomainAddRequest { domain, selector })
+}
+
+/// Parse `AIMX/1 DOMAIN-REMOVE` headers: `Domain:` (required) and
+/// `Force: true|false` (required — explicit on the wire so a stale
+/// client cannot accidentally request a cascade by omission).
+/// `Content-Length:` is allowed but must be 0 (the verb carries no
+/// body).
+async fn parse_domain_remove_headers<R>(reader: &mut R) -> Result<DomainRemoveRequest, ParseError>
+where
+    R: AsyncRead + Unpin,
+{
+    let mut domain: Option<String> = None;
+    let mut force: Option<bool> = None;
+    let mut content_length: Option<usize> = None;
+
+    loop {
+        let line = read_line(reader)
+            .await?
+            .ok_or_else(|| ParseError::Malformed("unexpected EOF in headers".into()))?;
+        let line = line.trim_end_matches('\r');
+        if line.is_empty() {
+            break;
+        }
+
+        let (n, v) = line
+            .split_once(':')
+            .ok_or_else(|| ParseError::Malformed(format!("invalid header line: {line:?}")))?;
+
+        if !n.is_ascii() {
+            return Err(ParseError::Malformed(format!(
+                "non-ascii header name: {n:?}"
+            )));
+        }
+        let name_norm = n.trim().to_ascii_lowercase();
+        let value = v.trim().to_string();
+
+        match name_norm.as_str() {
+            "domain" => {
+                if domain.is_some() {
+                    return Err(ParseError::Malformed("duplicate Domain header".into()));
+                }
+                if value.is_empty() {
+                    return Err(ParseError::Malformed("empty Domain value".into()));
+                }
+                domain = Some(value);
+            }
+            "force" => {
+                if force.is_some() {
+                    return Err(ParseError::Malformed("duplicate Force header".into()));
+                }
+                let v_lower = value.to_ascii_lowercase();
+                force = match v_lower.as_str() {
+                    "true" => Some(true),
+                    "false" => Some(false),
+                    _ => {
+                        return Err(ParseError::Malformed(format!(
+                            "invalid Force value: {value:?} (expected 'true' or 'false')"
+                        )));
+                    }
+                };
+            }
+            "content-length" => {
+                if content_length.is_some() {
+                    return Err(ParseError::Malformed(
+                        "duplicate Content-Length header".into(),
+                    ));
+                }
+                let n: usize = value.parse().map_err(|_| {
+                    ParseError::Malformed(format!("non-integer Content-Length: {value:?}"))
+                })?;
+                if n != 0 {
+                    return Err(ParseError::Malformed(format!(
+                        "DOMAIN-REMOVE must have Content-Length: 0, got {n}"
+                    )));
+                }
+                content_length = Some(n);
+            }
+            _ => {
+                // Unknown headers ignored.
+            }
+        }
+    }
+
+    let domain =
+        domain.ok_or_else(|| ParseError::Malformed("missing required header: Domain".into()))?;
+    let force =
+        force.ok_or_else(|| ParseError::Malformed("missing required header: Force".into()))?;
+    let _ = content_length;
+    Ok(DomainRemoveRequest { domain, force })
 }
 
 async fn parse_hook_create_headers_and_body<R>(
@@ -1659,6 +1775,26 @@ where
     Ok(())
 }
 
+/// Write an `AIMX/1 DOMAIN-REMOVE` request frame. `Domain:` is
+/// required; `Force:` is always emitted (`true` / `false`) so a stale
+/// peer cannot infer a cascade by omission.
+pub async fn write_domain_remove_request<W>(
+    writer: &mut W,
+    request: &DomainRemoveRequest,
+) -> Result<(), std::io::Error>
+where
+    W: AsyncWrite + Unpin,
+{
+    let header = format!(
+        "AIMX/1 DOMAIN-REMOVE\nDomain: {}\nForce: {}\nContent-Length: 0\n\n",
+        sanitize_inline(&request.domain),
+        if request.force { "true" } else { "false" },
+    );
+    writer.write_all(header.as_bytes()).await?;
+    writer.flush().await?;
+    Ok(())
+}
+
 /// Strip CR/LF from a single-line wire field. Callers must never emit bare
 /// LF inside a reason or message-ID or the framer ambiguates the next line.
 fn sanitize_inline(s: &str) -> String {
@@ -1794,6 +1930,94 @@ mod mailbox_list_codec_tests {
     #[tokio::test]
     async fn domain_add_rejects_nonzero_content_length() {
         let frame = b"AIMX/1 DOMAIN-ADD\nDomain: b.com\nContent-Length: 5\n\n";
+        let mut reader = std::io::Cursor::new(frame.to_vec());
+        match parse_request(&mut reader).await {
+            Err(ParseError::Malformed(_)) => {}
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    /// Round-trip a `DOMAIN-REMOVE` frame without force: the parser
+    /// decodes back the same struct.
+    #[tokio::test]
+    async fn round_trip_domain_remove_request_without_force() {
+        let req = DomainRemoveRequest {
+            domain: "b.com".into(),
+            force: false,
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        write_domain_remove_request(&mut buf, &req).await.unwrap();
+        let text = std::str::from_utf8(&buf).unwrap();
+        assert!(text.starts_with("AIMX/1 DOMAIN-REMOVE\n"), "{text}");
+        assert!(text.contains("Domain: b.com\n"), "{text}");
+        assert!(text.contains("Force: false\n"), "{text}");
+
+        let mut reader = std::io::Cursor::new(buf);
+        let parsed = parse_request(&mut reader).await.unwrap();
+        assert_eq!(parsed, Request::DomainRemove(req));
+    }
+
+    /// Round-trip a `DOMAIN-REMOVE` frame with force enabled.
+    #[tokio::test]
+    async fn round_trip_domain_remove_request_with_force() {
+        let req = DomainRemoveRequest {
+            domain: "b.com".into(),
+            force: true,
+        };
+        let mut buf: Vec<u8> = Vec::new();
+        write_domain_remove_request(&mut buf, &req).await.unwrap();
+        let text = std::str::from_utf8(&buf).unwrap();
+        assert!(text.contains("Force: true\n"), "{text}");
+
+        let mut reader = std::io::Cursor::new(buf);
+        let parsed = parse_request(&mut reader).await.unwrap();
+        assert_eq!(parsed, Request::DomainRemove(req));
+    }
+
+    /// Missing the required `Domain:` header is a parse error.
+    #[tokio::test]
+    async fn domain_remove_rejects_missing_domain_header() {
+        let frame = b"AIMX/1 DOMAIN-REMOVE\nForce: false\nContent-Length: 0\n\n";
+        let mut reader = std::io::Cursor::new(frame.to_vec());
+        match parse_request(&mut reader).await {
+            Err(ParseError::Malformed(reason)) => {
+                assert!(reason.contains("Domain"), "{reason}");
+            }
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    /// Missing the required `Force:` header is a parse error — the
+    /// cascade flag is intentionally explicit on the wire.
+    #[tokio::test]
+    async fn domain_remove_rejects_missing_force_header() {
+        let frame = b"AIMX/1 DOMAIN-REMOVE\nDomain: b.com\nContent-Length: 0\n\n";
+        let mut reader = std::io::Cursor::new(frame.to_vec());
+        match parse_request(&mut reader).await {
+            Err(ParseError::Malformed(reason)) => {
+                assert!(reason.contains("Force"), "{reason}");
+            }
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    /// An invalid `Force:` value is a parse error.
+    #[tokio::test]
+    async fn domain_remove_rejects_invalid_force_value() {
+        let frame = b"AIMX/1 DOMAIN-REMOVE\nDomain: b.com\nForce: yes\nContent-Length: 0\n\n";
+        let mut reader = std::io::Cursor::new(frame.to_vec());
+        match parse_request(&mut reader).await {
+            Err(ParseError::Malformed(reason)) => {
+                assert!(reason.contains("Force"), "{reason}");
+            }
+            other => panic!("expected Malformed, got {other:?}"),
+        }
+    }
+
+    /// A non-zero `Content-Length:` on DOMAIN-REMOVE is a parse error.
+    #[tokio::test]
+    async fn domain_remove_rejects_nonzero_content_length() {
+        let frame = b"AIMX/1 DOMAIN-REMOVE\nDomain: b.com\nForce: false\nContent-Length: 5\n\n";
         let mut reader = std::io::Cursor::new(frame.to_vec());
         match parse_request(&mut reader).await {
             Err(ParseError::Malformed(_)) => {}

--- a/src/serve.rs
+++ b/src/serve.rs
@@ -1139,6 +1139,19 @@ async fn handle_uds_connection_with_timeout(
                 ),
                 false,
             ),
+            Ok(Ok(Request::DomainRemove(req))) => (
+                Reply::Json(
+                    crate::domain_handler::handle_domain_remove(
+                        &state_ctx,
+                        &mb_ctx,
+                        &send_ctx.dkim_keys,
+                        &req,
+                        &caller,
+                    )
+                    .await,
+                ),
+                false,
+            ),
             Ok(Ok(Request::Version)) => (
                 Reply::Version(crate::version_handler::current_version_response()),
                 false,

--- a/tests/domains_remove.rs
+++ b/tests/domains_remove.rs
@@ -1,0 +1,624 @@
+//! End-to-end integration tests for the `DOMAIN-REMOVE` UDS verb and
+//! the `aimx domains remove` CLI.
+//!
+//! Setup mirrors `tests/domains_uds.rs`: spin up `aimx serve` against
+//! a multi-domain v2 install, exercise the CLI as a separate
+//! subprocess, and assert the expected wire / on-disk effects.
+//!
+//! Every test here requires root because `Action::DomainCrud` is
+//! root-only. Non-root local runs skip with a single stderr line.
+
+use std::io::{BufRead, Write};
+use std::net::TcpStream;
+use std::path::Path;
+use std::process::{Command as StdCommand, Stdio};
+use std::sync::LazyLock;
+use std::time::{Duration, Instant};
+
+use tempfile::TempDir;
+use wait_timeout::ChildExt;
+
+fn aimx_binary_path() -> std::path::PathBuf {
+    let target_dir = std::env::var("CARGO_TARGET_DIR")
+        .map(std::path::PathBuf::from)
+        .unwrap_or_else(|_| std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("target"));
+    let profile = if cfg!(debug_assertions) {
+        "debug"
+    } else {
+        "release"
+    };
+    target_dir.join(profile).join("aimx")
+}
+
+/// `DOMAIN-CRUD` is root-only. Tests that route through the daemon
+/// need to bail out on a non-root local run.
+fn skip_if_not_root() -> bool {
+    if unsafe { libc::geteuid() } == 0 {
+        return false;
+    }
+    eprintln!("skipping DOMAIN-REMOVE UDS test: requires root; DOMAIN-CRUD is root-only");
+    true
+}
+
+/// One-shot DKIM keypair cache shared across tests. Avoids re-running
+/// `aimx dkim-keygen` (~200ms) per test.
+static DR_DKIM_CACHE: LazyLock<TempDir> = LazyLock::new(|| {
+    let cache = TempDir::new().expect("create DKIM cache");
+    let config = format!(
+        "domain = \"dr-cache.example.com\"\ndata_dir = \"{}\"\n\n[mailboxes.catchall]\naddress = \"*@dr-cache.example.com\"\nowner = \"aimx-catchall\"\n",
+        cache.path().display()
+    );
+    std::fs::write(cache.path().join("config.toml"), config).unwrap();
+    let status = StdCommand::new(aimx_binary_path())
+        .env("AIMX_CONFIG_DIR", cache.path())
+        .arg("dkim-keygen")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .expect("failed to spawn dkim-keygen");
+    assert!(status.success(), "dkim-keygen exited non-zero");
+    cache
+});
+
+fn install_dkim_under(domain_dir: &Path) {
+    std::fs::create_dir_all(domain_dir).unwrap();
+    let cache_dkim = DR_DKIM_CACHE
+        .path()
+        .join("dkim")
+        .join("dr-cache.example.com");
+    for name in ["private.key", "public.key"] {
+        let src = cache_dkim.join(name);
+        let dst = domain_dir.join(name);
+        if src.exists() {
+            std::fs::copy(&src, &dst).unwrap();
+        }
+    }
+}
+
+fn current_username() -> String {
+    unsafe {
+        let uid = libc::geteuid();
+        if uid == 0 {
+            if let Some(sudo_user) = std::env::var_os("SUDO_USER") {
+                let name = sudo_user.to_string_lossy().into_owned();
+                if !name.is_empty() && name != "root" {
+                    return name;
+                }
+            }
+            return "nobody".to_string();
+        }
+        let pw = libc::getpwuid(uid);
+        if pw.is_null() {
+            return format!("uid{uid}");
+        }
+        let cstr = std::ffi::CStr::from_ptr((*pw).pw_name);
+        cstr.to_string_lossy().to_string()
+    }
+}
+
+/// Provision a two-domain v2 install (a.com + b.com) under `tmp`.
+/// `b_mailboxes` is the list of local-parts to create on b.com so
+/// each individual test can pick its preferred blocker scenario.
+fn setup_two_domain_env(tmp: &Path, b_mailboxes: &[&str]) {
+    let owner = current_username();
+    let mut cfg = format!(
+        r#"domains = ["a.com", "b.com"]
+data_dir = "{tmp_path}"
+
+[mailboxes."info@a.com"]
+address = "info@a.com"
+owner = "{owner}"
+"#,
+        tmp_path = tmp.display(),
+    );
+    for name in b_mailboxes {
+        cfg.push_str(&format!(
+            "\n[mailboxes.\"{name}@b.com\"]\naddress = \"{name}@b.com\"\nowner = \"{owner}\"\n",
+        ));
+    }
+    std::fs::write(tmp.join("config.toml"), cfg).unwrap();
+    std::fs::write(tmp.join(".layout-version"), "2\n").unwrap();
+
+    install_dkim_under(&tmp.join("dkim").join("a.com"));
+    install_dkim_under(&tmp.join("dkim").join("b.com"));
+
+    // Per-domain dirs + a.com info mailbox storage.
+    for domain in ["a.com", "b.com"] {
+        let domain_root = tmp.join(domain);
+        std::fs::create_dir_all(&domain_root).unwrap();
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&domain_root, std::fs::Permissions::from_mode(0o755)).unwrap();
+        }
+    }
+    for folder in ["inbox", "sent"] {
+        let p = tmp.join("a.com").join(folder).join("info");
+        std::fs::create_dir_all(&p).unwrap();
+    }
+    for name in b_mailboxes {
+        for folder in ["inbox", "sent"] {
+            let p = tmp.join("b.com").join(folder).join(name);
+            std::fs::create_dir_all(&p).unwrap();
+        }
+    }
+}
+
+/// Single-domain install (a.com only) so the last-domain hard-block
+/// can be exercised end-to-end.
+fn setup_single_domain_env(tmp: &Path) {
+    let owner = current_username();
+    let cfg = format!(
+        r#"domains = ["a.com"]
+data_dir = "{tmp_path}"
+
+[mailboxes."info@a.com"]
+address = "info@a.com"
+owner = "{owner}"
+"#,
+        tmp_path = tmp.display(),
+    );
+    std::fs::write(tmp.join("config.toml"), cfg).unwrap();
+    std::fs::write(tmp.join(".layout-version"), "2\n").unwrap();
+    install_dkim_under(&tmp.join("dkim").join("a.com"));
+    for folder in ["inbox", "sent"] {
+        std::fs::create_dir_all(tmp.join("a.com").join(folder).join("info")).unwrap();
+    }
+}
+
+/// Seed a `.md` stub into the named mailbox so the cascade wipe path
+/// has something to remove.
+fn seed_mailbox_message(tmp: &Path, domain: &str, local: &str) {
+    let dir = tmp.join(domain).join("inbox").join(local);
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(
+        dir.join("2026-05-23-stub.md"),
+        "+++\nid = \"stub\"\n+++\n\nhello\n",
+    )
+    .unwrap();
+}
+
+fn find_free_port() -> u16 {
+    let listener = std::net::TcpListener::bind("127.0.0.1:0").unwrap();
+    listener.local_addr().unwrap().port()
+}
+
+fn wait_for_listener(port: u16) {
+    let started = Instant::now();
+    while started.elapsed() < Duration::from_secs(30) {
+        if TcpStream::connect(format!("127.0.0.1:{port}")).is_ok() {
+            return;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    panic!("aimx serve did not start within 30s on port {port}");
+}
+
+fn start_serve(tmp: &Path, port: u16) -> std::process::Child {
+    let runtime = tmp.join("run");
+    std::fs::create_dir_all(&runtime).ok();
+    StdCommand::new(aimx_binary_path())
+        .env("AIMX_CONFIG_DIR", tmp)
+        .env("AIMX_RUNTIME_DIR", &runtime)
+        .arg("--data-dir")
+        .arg(tmp)
+        .arg("serve")
+        .arg("--bind")
+        .arg(format!("127.0.0.1:{port}"))
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("failed to spawn aimx serve")
+}
+
+fn shutdown(child: &mut std::process::Child) {
+    unsafe {
+        libc::kill(child.id() as libc::pid_t, libc::SIGTERM);
+    }
+    let _ = child.wait_timeout(Duration::from_secs(10));
+}
+
+fn run_domains_remove(tmp: &Path, domain: &str, force: bool) -> std::process::Output {
+    let runtime = tmp.join("run");
+    let mut cmd = StdCommand::new(aimx_binary_path());
+    cmd.env("AIMX_CONFIG_DIR", tmp)
+        .env("AIMX_RUNTIME_DIR", &runtime)
+        .env("NO_COLOR", "1")
+        .arg("--data-dir")
+        .arg(tmp)
+        .arg("domains")
+        .arg("remove")
+        .arg(domain);
+    if force {
+        cmd.arg("--force");
+    }
+    cmd.output().expect("failed to spawn aimx domains remove")
+}
+
+fn smtp_rcpt_status(port: u16, from: &str, rcpt: &str) -> String {
+    let stream = TcpStream::connect(format!("127.0.0.1:{port}")).unwrap();
+    stream
+        .set_read_timeout(Some(Duration::from_secs(10)))
+        .unwrap();
+    let mut reader = std::io::BufReader::new(stream.try_clone().unwrap());
+    let mut writer = stream;
+
+    let mut buf = String::new();
+    reader.read_line(&mut buf).unwrap();
+    assert!(buf.starts_with("220"), "banner: {buf}");
+
+    buf.clear();
+    write!(writer, "EHLO test.local\r\n").unwrap();
+    loop {
+        reader.read_line(&mut buf).unwrap();
+        if buf.contains("250 ") {
+            break;
+        }
+    }
+
+    buf.clear();
+    write!(writer, "MAIL FROM:<{from}>\r\n").unwrap();
+    reader.read_line(&mut buf).unwrap();
+    assert!(buf.starts_with("250"), "MAIL FROM: {buf}");
+
+    buf.clear();
+    write!(writer, "RCPT TO:<{rcpt}>\r\n").unwrap();
+    reader.read_line(&mut buf).unwrap();
+    let rcpt_response = buf.clone();
+
+    let _ = write!(writer, "QUIT\r\n");
+    let mut sink = String::new();
+    let _ = reader.read_line(&mut sink);
+
+    rcpt_response
+}
+
+/// Clean remove (no mailboxes on b.com, no `--force` needed). The CLI
+/// exits 0, config drops b.com, the DKIM keypair is preserved on
+/// disk, and the running daemon hot-reloads (SMTP RCPT to `@b.com`
+/// is now rejected).
+#[test]
+fn remove_clean_no_blockers_drops_domain_and_preserves_dkim() {
+    if skip_if_not_root() {
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_two_domain_env(tmp.path(), &[]); // no b.com mailboxes
+    let port = find_free_port();
+    let mut child = start_serve(tmp.path(), port);
+    wait_for_listener(port);
+
+    let out = run_domains_remove(tmp.path(), "b.com", false);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "clean remove must succeed: stdout={stdout} stderr={stderr}",
+    );
+    assert!(
+        stdout.contains("Removed domain"),
+        "missing success line; stdout={stdout}"
+    );
+    assert!(
+        stdout.contains("DKIM keypair preserved"),
+        "missing DKIM-preserved hint; stdout={stdout}",
+    );
+
+    // Config rewritten on disk.
+    let cfg = std::fs::read_to_string(tmp.path().join("config.toml")).unwrap();
+    assert!(!cfg.contains("\"b.com\""), "config still has b.com: {cfg}");
+    assert!(cfg.contains("\"a.com\""), "config lost a.com: {cfg}");
+
+    // DKIM keypair preserved on disk.
+    let dkim_b = tmp.path().join("dkim").join("b.com");
+    assert!(
+        dkim_b.join("private.key").is_file(),
+        "DKIM private.key must be preserved after remove",
+    );
+    assert!(
+        dkim_b.join("public.key").is_file(),
+        "DKIM public.key must be preserved after remove",
+    );
+
+    // Hot-reload: RCPT to a b.com address now rejected with 5.7.x.
+    let resp = smtp_rcpt_status(port, "sender@example.com", "info@b.com");
+    assert!(
+        !resp.starts_with("250"),
+        "RCPT to removed domain must NOT be accepted post-remove (got: {resp})",
+    );
+
+    shutdown(&mut child);
+}
+
+/// Default refusal: b.com still has mailboxes; remove without
+/// `--force` exits non-zero, prints the numbered blocker list, and
+/// suggests `--force`. State on disk is unchanged.
+#[test]
+fn remove_blocked_lists_mailboxes_and_suggests_force() {
+    if skip_if_not_root() {
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_two_domain_env(tmp.path(), &["info", "alice", "support"]);
+    let port = find_free_port();
+    let mut child = start_serve(tmp.path(), port);
+    wait_for_listener(port);
+
+    let out = run_domains_remove(tmp.path(), "b.com", false);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        !out.status.success(),
+        "blocked remove must exit non-zero; stdout={stdout} stderr={stderr}",
+    );
+    // All three blocker FQDNs must appear in the printed list.
+    for fqdn in ["info@b.com", "alice@b.com", "support@b.com"] {
+        assert!(
+            stdout.contains(fqdn),
+            "missing blocker {fqdn} in stdout: {stdout}"
+        );
+    }
+    assert!(
+        stdout.contains("--force"),
+        "missing --force suggestion: stdout={stdout}",
+    );
+
+    // Config on disk unchanged.
+    let cfg = std::fs::read_to_string(tmp.path().join("config.toml")).unwrap();
+    assert!(cfg.contains("\"b.com\""), "config lost b.com: {cfg}");
+    assert!(
+        cfg.contains("\"info@b.com\""),
+        "config lost a b.com mailbox: {cfg}"
+    );
+
+    shutdown(&mut child);
+}
+
+/// Last-domain hard-block: the single-domain install refuses both
+/// `aimx domains remove a.com` and `... --force a.com`, and the
+/// error message points operators at `aimx uninstall`.
+#[test]
+fn remove_last_domain_hard_blocks_even_with_force() {
+    if skip_if_not_root() {
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_single_domain_env(tmp.path());
+    let port = find_free_port();
+    let mut child = start_serve(tmp.path(), port);
+    wait_for_listener(port);
+
+    for force in [false, true] {
+        let out = run_domains_remove(tmp.path(), "a.com", force);
+        let stdout = String::from_utf8_lossy(&out.stdout);
+        let stderr = String::from_utf8_lossy(&out.stderr);
+        let combined = format!("stdout={stdout}\nstderr={stderr}");
+        assert!(
+            !out.status.success(),
+            "last-domain hard-block must reject (force={force}); {combined}"
+        );
+        assert!(
+            combined.contains("last configured domain"),
+            "last-domain wording missing (force={force}); {combined}"
+        );
+        assert!(
+            combined.contains("aimx uninstall"),
+            "aimx uninstall hint missing (force={force}); {combined}"
+        );
+    }
+
+    // Config on disk unchanged.
+    let cfg = std::fs::read_to_string(tmp.path().join("config.toml")).unwrap();
+    assert!(cfg.contains("\"a.com\""));
+
+    shutdown(&mut child);
+}
+
+/// `--force` cascade: three mailboxes on b.com (with seeded mail),
+/// run remove with --force, assert config dropped b.com + every
+/// mailbox, storage tree gone, DKIM keypair preserved on disk.
+#[test]
+fn remove_force_cascade_wipes_mailboxes_and_keeps_dkim() {
+    if skip_if_not_root() {
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_two_domain_env(tmp.path(), &["info", "alice", "support"]);
+    for local in ["info", "alice", "support"] {
+        seed_mailbox_message(tmp.path(), "b.com", local);
+    }
+    // Also seed a.com so we can verify it survives the cascade.
+    seed_mailbox_message(tmp.path(), "a.com", "info");
+
+    let port = find_free_port();
+    let mut child = start_serve(tmp.path(), port);
+    wait_for_listener(port);
+
+    let out = run_domains_remove(tmp.path(), "b.com", true);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "force cascade must succeed: stdout={stdout} stderr={stderr}",
+    );
+    assert!(stdout.contains("Removed domain (cascade)"));
+    assert!(stdout.contains("info@b.com"));
+    assert!(stdout.contains("alice@b.com"));
+    assert!(stdout.contains("support@b.com"));
+    assert!(stdout.contains("Storage tree removed"));
+    assert!(stdout.contains("DKIM keypair preserved"));
+
+    // Config dropped b.com and all its mailboxes.
+    let cfg = std::fs::read_to_string(tmp.path().join("config.toml")).unwrap();
+    assert!(!cfg.contains("\"b.com\""), "config still has b.com: {cfg}");
+    assert!(
+        !cfg.contains("@b.com"),
+        "config still has b.com mailboxes: {cfg}"
+    );
+
+    // b.com storage tree gone.
+    assert!(!tmp.path().join("b.com").exists());
+
+    // DKIM keypair preserved on disk.
+    let dkim_b = tmp.path().join("dkim").join("b.com");
+    assert!(dkim_b.join("private.key").is_file());
+    assert!(dkim_b.join("public.key").is_file());
+
+    // a.com mailbox storage untouched.
+    let a_stub = tmp
+        .path()
+        .join("a.com")
+        .join("inbox")
+        .join("info")
+        .join("2026-05-23-stub.md");
+    assert!(a_stub.is_file(), "a.com message must survive b.com cascade",);
+
+    // Hot-reload: SMTP RCPT to a.com still accepted, b.com rejected.
+    let resp_a = smtp_rcpt_status(port, "ext@example.com", "info@a.com");
+    assert!(
+        resp_a.starts_with("250"),
+        "a.com RCPT must still be accepted post-cascade: {resp_a}"
+    );
+    let resp_b = smtp_rcpt_status(port, "ext@example.com", "info@b.com");
+    assert!(
+        !resp_b.starts_with("250"),
+        "b.com RCPT must be rejected post-cascade: {resp_b}"
+    );
+
+    shutdown(&mut child);
+}
+
+/// Concurrent-ingest stress: while a background thread hammers SMTP
+/// RCPT to a.com (the surviving domain), invoke
+/// `domains remove b.com --force` on the main thread. Both must
+/// complete within a reasonable time without blocking each other and
+/// without deadlocking.
+///
+/// This pins the lock-hierarchy invariant: the per-mailbox locks the
+/// cascade acquires are scoped to b.com mailboxes, so ingest into
+/// `info@a.com` (a different mailbox key) must not contend with the
+/// cascade.
+#[test]
+fn remove_force_does_not_block_concurrent_ingest_on_surviving_domain() {
+    if skip_if_not_root() {
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_two_domain_env(tmp.path(), &["info"]);
+    seed_mailbox_message(tmp.path(), "b.com", "info");
+
+    let port = find_free_port();
+    let mut child = start_serve(tmp.path(), port);
+    wait_for_listener(port);
+
+    let stop = std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let stop_clone = std::sync::Arc::clone(&stop);
+    let port_for_thread = port;
+    // Spawn the ingest stressor — hammers RCPT TO info@a.com in a
+    // tight loop until told to stop. We count accepted RCPTs as a
+    // sanity signal.
+    let handle = std::thread::spawn(move || {
+        let mut accepted: u32 = 0;
+        while !stop_clone.load(std::sync::atomic::Ordering::Relaxed) {
+            let resp = smtp_rcpt_status(port_for_thread, "ext@example.com", "info@a.com");
+            if resp.starts_with("250") {
+                accepted += 1;
+            }
+            std::thread::sleep(Duration::from_millis(5));
+        }
+        accepted
+    });
+
+    // Give the stressor a moment to ramp up.
+    std::thread::sleep(Duration::from_millis(100));
+
+    // Run the cascade with a generous timeout. If the lock hierarchy
+    // is wrong this either deadlocks (we'd hit our outer harness
+    // timeout) or blocks long enough that the test surfaces the bug.
+    let cascade_started = Instant::now();
+    let out = run_domains_remove(tmp.path(), "b.com", true);
+    let cascade_duration = cascade_started.elapsed();
+
+    stop.store(true, std::sync::atomic::Ordering::Relaxed);
+    let accepted = handle.join().expect("stressor thread did not join");
+
+    assert!(
+        out.status.success(),
+        "cascade must succeed under concurrent ingest; stdout={} stderr={}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    // Whatever the actual wall-clock is, it must fit comfortably
+    // inside the timeout that catches a deadlock — 10 s is plenty
+    // for an empty-ish install on a CI runner.
+    assert!(
+        cascade_duration < Duration::from_secs(10),
+        "cascade took too long ({cascade_duration:?}) — likely lock contention",
+    );
+    // The stressor should have managed at least one accepted RCPT
+    // during the cascade window — if every attempt during the
+    // cascade were blocked, the inversion would be obvious.
+    assert!(
+        accepted > 0,
+        "ingest stressor must have completed at least one RCPT during cascade",
+    );
+
+    // Post-cascade: a.com survives, b.com is gone.
+    assert!(tmp.path().join("a.com").is_dir());
+    assert!(!tmp.path().join("b.com").exists());
+
+    shutdown(&mut child);
+}
+
+/// Daemon-stopped fallback: non-root must hard-error with the
+/// canonical hint.
+#[test]
+fn remove_daemon_stopped_non_root_hard_errors() {
+    if unsafe { libc::geteuid() } == 0 {
+        eprintln!("skipping non-root fallback test: running as root");
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_two_domain_env(tmp.path(), &[]);
+
+    // Daemon never started.
+    let out = run_domains_remove(tmp.path(), "b.com", false);
+    assert!(!out.status.success(), "non-root must hard-error");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("daemon must be running"),
+        "expected canonical hint; got: {stderr}"
+    );
+}
+
+/// Daemon-stopped fallback: root falls back to direct config edit.
+#[test]
+fn remove_daemon_stopped_root_falls_back_to_direct_edit() {
+    if skip_if_not_root() {
+        return;
+    }
+    let tmp = TempDir::new().unwrap();
+    setup_two_domain_env(tmp.path(), &[]);
+
+    // Do NOT start the daemon. Root should fall back to direct edit.
+    let out = run_domains_remove(tmp.path(), "b.com", false);
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        out.status.success(),
+        "root fallback must succeed: stdout={stdout} stderr={stderr}",
+    );
+
+    let cfg = std::fs::read_to_string(tmp.path().join("config.toml")).unwrap();
+    assert!(!cfg.contains("\"b.com\""), "config still has b.com: {cfg}");
+
+    // DKIM keypair preserved on disk.
+    let dkim_b = tmp.path().join("dkim").join("b.com");
+    assert!(dkim_b.join("private.key").is_file());
+
+    // CLI surfaced the restart hint.
+    let combined = format!("stdout={stdout} stderr={stderr}");
+    assert!(
+        combined.contains("restart") || combined.contains("daemon"),
+        "missing restart hint: {combined}"
+    );
+}


### PR DESCRIPTION
## Sprint Goal
Land `aimx domains remove <domain>` with the `AIMX/1 DOMAIN-REMOVE` UDS verb: default refuses with the list of blocking mailboxes; `--force` cascades to mailbox deletion + per-domain storage tree removal atomically under the daemon's lock hierarchy; last-domain removal is hard-blocked; DKIM key files are preserved on disk with a hint about their location.

## Stories Implemented

### S5-1 — `DOMAIN-REMOVE` UDS verb (default, no `--force`)
- [x] `AIMX/1 DOMAIN-REMOVE` verb in `send_protocol.rs` with `Domain:` + `Force:` headers (both required — explicit on the wire so a stale client cannot accidentally request a cascade by omission).
- [x] Default path (no blocking mailboxes, `Force: false`) removes the domain from `config.domains` and any `[domain."<d>"]` sub-table; hot-swaps `Arc<Config>`.
- [x] Default path with blocking mailboxes returns the sorted JSON list of blocking mailbox FQDNs so the CLI can pretty-print them.
- [x] Last-domain remove rejected with `ErrCode::Domain` regardless of `Force:`, with the canonical "use `aimx uninstall` for a full teardown" hint.
- [x] `aimx domains remove b.com` CLI surface prints the blocking mailbox list (numbered) and suggests `--force` to cascade.
- [x] Authz via `Action::DomainCrud` (root-only — added in the previous sprint, reused unchanged).
- [x] Integration tests cover each branch.

### S5-2 — `--force` cascade with lock hierarchy + atomic storage wipe
- [x] `domain_handler::handle_domain_remove` implements the cascade.
- [x] Per-mailbox locks acquired in sorted FQDN order BEFORE the cascade body runs; `CONFIG_WRITE_LOCK` taken inside that (matches NFR-2 and the upgrade migration's existing ordering — see "Technical Decisions" below).
- [x] `rmdir <data_dir>/<domain>/` (never `remove_dir_all`) succeeds only after all mailbox wipes complete; non-empty tree at that point surfaces a loud IO error.
- [x] DKIM key files at `<dkim_dir>/<domain>/` are NEVER deleted; the path is echoed back in the response so the CLI prints the preservation hint.
- [x] DKIM map (`ArcSwap`) hot-swap drops the per-domain entry BEFORE `ConfigHandle::store` so any reader who sees the domain gone from `config.domains` also sees the matching DKIM map entry gone (mirrors the DOMAIN-ADD insertion ordering in reverse).
- [x] Crash mid-cascade leaves a re-runnable state — the per-mailbox locks gate any other handler from observing a half-cascaded view.
- [x] Integration test seeds two domains with 3 mailboxes on b.com, runs `domains remove b.com --force`, asserts config dropped b.com, mailboxes gone, `<data_dir>/b.com/` removed, DKIM keypair still at `<dkim_dir>/b.com/`, SMTP RCPT to `@b.com` rejected post-cascade.
- [x] Concurrent-ingest stress test: background thread hammers SMTP RCPT to `info@a.com` while `domains remove b.com --force` runs. Cascade completes within 10s, the stressor accepts at least one RCPT during the cascade window, no deadlock.

### S5-3 — `aimx domains remove` CLI surface + DKIM-preservation hint
- [x] No-force, no-blockers: "Removed domain from config" + DKIM preserved hint.
- [x] No-force, with blockers: numbered list of blocking mailbox FQDNs + `--force` suggestion; CLI exits non-zero.
- [x] `--force` cascade: bulleted per-mailbox deletion summary + storage-tree-removed line + DKIM preserved hint.
- [x] Last-domain remove: daemon's verbatim hard-block error reaches the operator, including the `aimx uninstall` pointer.
- [x] All output routes through `term.rs` semantic helpers (no raw color calls).
- [x] Daemon-stopped fallback: root → direct `config.toml` edit + storage wipe + restart hint; non-root → canonical "daemon must be running" hard-error.

## Technical Decisions

**Lock-order discrepancy in the PRD.** PRD §8 sketch reads `CONFIG_WRITE_LOCK outer → per-mailbox inner`, but NFR-2 says `outer per-mailbox locks → inner CONFIG_WRITE_LOCK`, and the rest of the codebase (`MAILBOX-CREATE/DELETE`, `HOOK-CREATE/DELETE`, the upgrade migration, ingest, `MARK-*`) all take per-mailbox lock first then CONFIG_WRITE_LOCK. Inverting here would deadlock against any of those handlers. The implementation follows the NFR-2 convention; doc comments at the lock-acquisition site capture the rationale. The §8 sketch should be revised to match NFR-2 in a follow-up doc PR.

**Response shape.** `DOMAIN-REMOVE` returns a `JsonAckResponse::Ok { body }` carrying a structured `DomainRemoveResponse` for every non-error outcome (clean remove, blocked-by-mailboxes, force cascade complete). The CLI exit code is decided client-side from the `outcome` field. `JsonAckResponse::Err` is reserved for authz, validation, last-domain hard-block, unknown-domain, and IO failures. This keeps the blocker list shippable as a real JSON array (sorted, structured) rather than packed into a reason string the CLI would have to parse out.

**`rmdir`, not `remove_dir_all`.** Per the brief: explicitly walk through the per-mailbox wipes first (each removes `inbox/<local>/` and `sent/<local>/` content + the directory itself), then `rmdir <data_dir>/<domain>/inbox`, `<data_dir>/<domain>/sent`, and finally `<data_dir>/<domain>`. A `rmdir(2)` failure at the per-domain root means a wipe missed something or an unmanaged file leaked into the tree — that's surfaced as a loud `ErrCode::Io` rather than silently recursing.

**DKIM map hot-swap ordering.** `dkim_keys.store(new_map_without_b)` happens **before** `config_handle.store(new_config_without_b)`. Same invariant as `DOMAIN-ADD`'s reverse ordering: any concurrent SEND that picks up the post-swap `config.domains` (which no longer lists b.com) is guaranteed to find no DKIM entry either, so there's no microsecond window where a SEND could match a configured domain but find no DKIM key.

**Force header is required, not optional.** The wire `Force:` header is mandatory on `DOMAIN-REMOVE` (rejected at the codec layer if absent). This is deliberate: a stale client that omits the header would otherwise default to one of {force, no-force} silently, and "no-force" was deemed the safer default but still surprising. Forcing explicit on-the-wire encoding means a client always has to make a choice.

**Test coverage of the lock hierarchy.** The concurrent-ingest stress test pins the invariant operationally: the cascade completes inside 10 seconds while a tight SMTP RCPT loop hammers the surviving domain. If the lock ordering were wrong the test either deadlocks (catches the bug) or takes far longer than 10s (also catches it). A future hardening would add a property-based test that exercises arbitrary acquisition orders across all the lock-using handlers.

## Deferred Items
None — all S5-1..S5-3 acceptance criteria covered.

## Review Focus Areas

- **`src/domain_handler.rs::handle_domain_remove` (~lines 350-720)** — the lock acquisition sequence, the re-snapshot under the locks, and the response-shape branching. The function is the most consequential piece of this PR. Pay particular attention to the per-mailbox lock set vs. live blocker set re-check under the lock (the `live_blocker_fqdns != lock_keys` guard).

- **`src/domain_handler.rs::run_direct_remove`** — the daemon-stopped fallback path mirrors the daemon handler's logic. The two paths must stay in sync; an integration test covers them both.

- **`tests/domains_remove.rs::remove_force_does_not_block_concurrent_ingest_on_surviving_domain`** — the concurrent-ingest stress test. Confirm the test actually exercises the contention by reading the loop's sleep + ramp-up timing.

- **`src/send_protocol.rs::parse_domain_remove_headers`** — the `Force:` header is required (not defaulted). Make sure the rationale lands clearly.

- **Lock-ordering note in the doc-comment on `handle_domain_remove`** — should match the codebase-wide convention (per-mailbox outer, CONFIG_WRITE_LOCK inner). Flag if the wording could be sharper.