### PR TITLE
multi-domain: book, agent primer, release notes, smoke results

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,97 @@
+# Release notes
+
+## Unreleased — multi-domain support
+
+This release adds **light multi-domain support**: one AIMX install can
+host multiple sending and receiving domains. Each domain has its own
+DKIM keypair, its own catchall, and its own mailboxes. The first entry
+in `domains` is the default — bare local parts resolve against it.
+
+The change preserves the single-binary, single-operator model. There
+are no new multi-tenant features (no per-domain ACLs, no per-domain
+rate limits, no hosted-service surface).
+
+### What changes on first restart after upgrade
+
+The upgrade migration runs **atomically on the first `aimx serve`
+startup under the new binary**. It is idempotent (guarded by
+`/var/lib/aimx/.layout-version`) — subsequent restarts are no-ops.
+
+For an existing single-domain install on `mydomain.com`:
+
+1. **`config.toml` is visibly rewritten** from the v1 shape to the
+   normalized multi-domain shape:
+   - `domain = "mydomain.com"` → `domains = ["mydomain.com"]`
+   - `[mailboxes.info]` → `[mailboxes."info@mydomain.com"]` (every
+     local-part-keyed mailbox is re-keyed to its FQDN)
+   - Per-domain sub-tables (`[domain."<d>"]`) remain absent until you
+     add an override.
+
+2. **Storage relocates** from
+   `/var/lib/aimx/{inbox,sent}/<mailbox>/` to
+   `/var/lib/aimx/<domain>/{inbox,sent}/<mailbox>/`. The renames use
+   `rename(2)` — same-filesystem, constant time, atomic.
+
+3. **DKIM keys relocate** from `/etc/aimx/dkim/{private,public}.key`
+   to `/etc/aimx/dkim/<domain>/{private,public}.key`. The key
+   material is unchanged; only the on-disk path moves.
+
+4. A `.layout-version` marker is written so the migration runs
+   exactly once.
+
+The change is **purely structural** — there are no semantic
+differences for single-domain installs. Inbound continues to route to
+the same mailboxes, outbound continues to sign with the same DKIM
+key, hooks continue to fire the same way. `aimx mailboxes list` and
+the MCP `mailbox_list` tool return FQDN names
+(`info@mydomain.com`) instead of bare local parts — that's the only
+observable difference at the API boundary.
+
+`aimx upgrade` prints a one-screen reminder of these points before
+completing.
+
+### What's new
+
+- `aimx domains list` — print configured domains with DKIM status and
+  per-domain mailbox counts.
+- `aimx domains add <domain>` — append a domain to `domains`,
+  generate a DKIM keypair, print DNS records, verify, hot-reload.
+- `aimx domains remove <domain> [--force]` — remove a domain, with
+  cascade-delete via `--force`. Last-domain hard-block; DKIM keys
+  preserved on disk.
+- `aimx dkim-keygen --domain <domain>` — generate or rotate keys for
+  a specific domain.
+- Per-domain config sub-tables: `[domain."<domain>"]` supports
+  optional `signature`, `dkim_selector`, `trust`, `trusted_senders`
+  overrides. Resolution order is per-mailbox → per-domain → global.
+- Per-domain DKIM signing: outbound signs with the From: domain's
+  key, never `domains[0]`'s.
+- Per-domain catchall: `*@<domain>` is independent per domain.
+- `aimx doctor` reports per-domain DKIM, mailbox counts, and unread
+  counts; marks the default domain.
+- MCP tools (`mailbox_list`, `email_list`, etc.) return and accept
+  FQDN mailbox names. Bare local parts still resolve to the default
+  domain for backward compatibility.
+
+### Rollback
+
+Rollback to a pre-multi-domain binary is documented in
+[`book/multi-domain.md`](book/multi-domain.md#rollback-procedure).
+Short version: stop the daemon, move storage and DKIM keys back to
+the v1 paths, hand-edit `config.toml` back to the v1 shape, delete
+`/var/lib/aimx/.layout-version`, install the older binary, restart.
+The procedure is mechanical and lossless if you're still on a single
+domain and haven't added a second domain since the upgrade.
+
+### Where to go next
+
+- [`book/multi-domain.md`](book/multi-domain.md) — full operator
+  reference (CLI, per-domain config, DKIM, storage, upgrade
+  migration, rollback).
+- [`book/cli.md#domain-management`](book/cli.md#domain-management) — `aimx
+  domains list / add / remove` reference.
+- [`book/troubleshooting.md#multi-domain`](book/troubleshooting.md#multi-domain)
+  — corrupted marker, EXDEV, half-migrated state,
+  DKIM-key-not-found.
+- [`book/faq.md#multi-domain`](book/faq.md#multi-domain) — quick
+  answers.

--- a/agents/common/aimx-primer.md
+++ b/agents/common/aimx-primer.md
@@ -11,6 +11,8 @@ For full reference material, see the files in `references/`:
 - `references/frontmatter.md`: complete frontmatter schema
 - `references/workflows.md`: worked examples for common tasks
 - `references/hooks.md`: creating hooks via MCP (mailbox-owner model)
+- `references/multi-domain.md`: multi-domain installs — default domain,
+  FQDN disambiguation, sending from a non-default domain
 - `references/troubleshooting.md`: error codes and recovery steps
 
 At runtime, `/var/lib/aimx/README.md` is the authoritative guide to the data
@@ -22,9 +24,13 @@ startup.
 Your interface to aimx is the MCP tools (`mailbox_list`, `email_send`,
 `email_reply`, `mailbox_create`, `hook_create`, …). The `aimx` binary on
 PATH is the host operator's CLI — do not invoke it. **You never need to
-know the configured domain**: `email_send(from_mailbox: "agent", ...)`
-takes the local part only and the daemon constructs `agent@<domain>` from
-`mailbox_list().address` server-side.
+know the configured domain on a single-domain install**:
+`email_send(from_mailbox: "agent", ...)` takes the local part only and
+the daemon constructs `agent@<domain>` from `mailbox_list().address`
+server-side. On a multi-domain install, bare local parts resolve to the
+**default domain** (the first entry in `domains`); to send from a
+non-default domain, pass the full FQDN (`from_mailbox:
+"agent@side-project.com"`). See `references/multi-domain.md`.
 
 If the `mcp__aimx__*` tools (or your client's equivalent) are not in your
 tool list, the MCP server is not registered. Tell the user to run
@@ -90,6 +96,34 @@ every layer:
 On a single-user box (the common case) the model is invisible: your
 one user owns every mailbox. On a multi-user box it gives real
 isolation — alice's agent cannot see, read, or act on bob's mail.
+
+## Multi-domain installs
+
+aimx may be configured with one domain or several. The list lives in
+`config.toml`'s `domains` array; the **first entry is the default**.
+Two rules govern how you address mailboxes:
+
+1. **Bare local parts default to the default domain.** Passing
+   `from_mailbox: "agent"` to `email_send` (or `mailbox: "agent"` to any
+   mailbox-scoped tool) resolves server-side to `agent@<domains[0]>`.
+   This is the single-domain behavior preserved on multi-domain
+   installs.
+2. **To target a non-default domain, pass the FQDN.** On an install with
+   `domains = ["a.com", "b.com"]`, an agent that owns
+   `support@b.com` sends with `from_mailbox: "support@b.com"`. The
+   daemon picks the b.com DKIM key and the message is signed as b.com.
+
+`mailbox_list()` returns FQDN names unambiguously
+(`{name: "support@b.com", address: "support@b.com", ...}`). Don't
+strip the `@<domain>` suffix when threading the name through subsequent
+tool calls — `mailbox: "support"` on a multi-domain install where both
+`support@a.com` and `support@b.com` exist would silently target the
+default-domain mailbox. The FQDN is the unambiguous identifier.
+
+Domain management itself (adding or removing a domain, generating a
+DKIM keypair for a new domain) is operator-only and requires `sudo`. No
+MCP tools exist for domain CRUD — see `references/multi-domain.md` for
+why and how operators do it.
 
 ## MCP tools: quick reference
 
@@ -180,28 +214,33 @@ argv to use.
      `0700 <owner>:<owner>` perms enforced by the daemon, not filesystem
      obscurity. -->
 
-aimx stores mail under a data directory (default `/var/lib/aimx/`):
+aimx stores mail under a data directory (default `/var/lib/aimx/`),
+nested by domain:
 
 ```
 /var/lib/aimx/                          # root:root 0755 (traversable)
 ├── README.md                           # agent-facing layout guide (auto-generated)
-├── inbox/                              # root:root 0755
-│   ├── <mailbox>/                      # <owner>:<owner> 0700
-│   │   ├── 2026-04-15-143022-meeting-notes.md
-│   │   └── 2026-04-15-153300-invoice-march/     # attachment bundle
-│   │       ├── 2026-04-15-153300-invoice-march.md
-│   │       ├── invoice.pdf
-│   │       └── receipt.png
-│   └── catchall/                       # aimx-catchall:aimx-catchall 0700
-│       └── ...
-└── sent/                               # root:root 0755
-    └── <mailbox>/                      # <owner>:<owner> 0700
-        └── 2026-04-15-160145-re-meeting-notes.md
+├── .layout-version                     # migration marker (do not edit)
+└── <domain>/                           # one per configured domain, 0755
+    ├── inbox/                          # root:root 0755
+    │   ├── <mailbox>/                  # <owner>:<owner> 0700
+    │   │   ├── 2026-04-15-143022-meeting-notes.md
+    │   │   └── 2026-04-15-153300-invoice-march/  # attachment bundle
+    │   │       ├── 2026-04-15-153300-invoice-march.md
+    │   │       ├── invoice.pdf
+    │   │       └── receipt.png
+    │   └── catchall/                   # aimx-catchall:aimx-catchall 0700
+    │       └── ...
+    └── sent/                           # root:root 0755
+        └── <mailbox>/                  # <owner>:<owner> 0700
+            └── 2026-04-15-160145-re-meeting-notes.md
 ```
 
 Each mailbox directory is `0700 <owner>:<owner>`, so only the owner and
 root can read or traverse in. Your MCP process runs as your uid and only
-sees mailboxes you own.
+sees mailboxes you own. `mailbox_list()` returns absolute `inbox_path` /
+`sent_path` values that already include the per-domain nesting — use
+them verbatim with filesystem tools instead of reconstructing paths.
 
 - **Filenames** follow `YYYY-MM-DD-HHMMSS-<slug>.md` (UTC). The slug is
   derived from the subject: lowercase, non-alphanumeric chars replaced with
@@ -218,11 +257,16 @@ not readable by agents):
 
 ```
 /etc/aimx/
-├── config.toml      # main config (root:root 640)
+├── config.toml             # main config (root:root 640)
 └── dkim/
-    ├── private.key   # DKIM signing key (root:root 600)
-    └── public.key    # publishable (root:root 644)
+    └── <domain>/           # one per configured domain (root:root 700)
+        ├── private.key     # DKIM signing key (root:root 600)
+        └── public.key      # publishable (root:root 644)
 ```
+
+Each configured domain has its own DKIM keypair under
+`/etc/aimx/dkim/<domain>/`. The daemon picks the right key based on the
+From: domain of each outbound message.
 
 ## Frontmatter: key fields
 

--- a/agents/common/references/multi-domain.md
+++ b/agents/common/references/multi-domain.md
@@ -1,0 +1,203 @@
+# aimx multi-domain: full reference
+
+aimx can be configured with one domain or several. From the agent's
+perspective, the change is small but load-bearing: mailbox identifiers
+become full email addresses (FQDNs), and bare local parts default to
+the **default domain** (the first entry in the `domains` array). This
+document spells out the rules and the worked patterns.
+
+If you're on a single-domain install, you can skim this — the
+default-domain rule preserves all single-domain behavior verbatim.
+
+## The default domain
+
+The operator's `config.toml` carries a `domains` array. The first entry
+is the **default**:
+
+```toml
+domains = ["a.com", "b.com"]   # a.com is the default
+```
+
+You never read `config.toml` (it's `0640 root:root`). The default domain
+surfaces to you implicitly:
+
+- `mailbox_list()` returns `address` fields that name the FQDN
+  (`agent@a.com`). The substring after `@` is the mailbox's domain.
+- `mailbox_create("agent")` returns `agent@<domains[0]>` — the new
+  mailbox lives at the default domain.
+- `email_send(from_mailbox: "agent", ...)` resolves to `agent@<domains[0]>`
+  daemon-side and is DKIM-signed as the default domain.
+
+In other words: when in doubt, use bare local parts and you'll target
+the default domain. This is the "single-domain" mental model preserved
+for multi-domain installs.
+
+## FQDN disambiguation
+
+When you need to target a non-default domain, **pass the FQDN** in any
+mailbox-name parameter:
+
+```
+email_send(
+  from_mailbox: "agent@b.com",     # FQDN — targets b.com, signs as b.com
+  to: "alice@example.com",
+  subject: "Hello",
+  body: "Hi from b.com"
+)
+```
+
+The same rule applies to every mailbox-scoped parameter:
+
+| Tool | Parameter | Bare local part | FQDN |
+|------|-----------|-----------------|------|
+| `email_list` | `mailbox` | default domain | targets named domain |
+| `email_read` | `mailbox` | default domain | targets named domain |
+| `email_send` | `from_mailbox` | default domain | targets named domain |
+| `email_reply` | `mailbox` | default domain | targets named domain |
+| `email_mark_read` / `_unread` | `mailbox` | default domain | targets named domain |
+| `mailbox_create` | `name` | creates at default | creates at named domain |
+| `mailbox_delete` | `name` | targets default | targets named domain |
+| `hook_create` | `mailbox` | default domain | targets named domain |
+| `hook_list` | `mailbox` (filter) | default domain | targets named domain |
+
+**Important**: on a multi-domain install where both `support@a.com` and
+`support@b.com` exist, `mailbox: "support"` silently targets
+`support@<domains[0]>`. If you're processing a result from
+`mailbox_list()` and feeding the `name` field back into another tool
+call, don't strip the `@<domain>` suffix — the FQDN is the unambiguous
+identifier.
+
+## Storage layout
+
+Each domain has its own subtree under the data directory:
+
+```
+/var/lib/aimx/
+├── a.com/
+│   ├── inbox/<mailbox>/
+│   └── sent/<mailbox>/
+└── b.com/
+    ├── inbox/<mailbox>/
+    └── sent/<mailbox>/
+```
+
+`mailbox_list()` returns absolute paths (`inbox_path`, `sent_path`)
+that already include the per-domain nesting — use them verbatim with
+your filesystem tools instead of reconstructing paths. Each mailbox
+directory is still `0700 <owner>:<owner>`; isolation across mailboxes
+within and across domains is filesystem-enforced.
+
+## Per-domain config (operator-side)
+
+The operator may set per-domain overrides under
+`[domain."<domain>"]` sub-tables:
+
+```toml
+domains = ["a.com", "b.com"]
+
+[domain."b.com"]
+signature = "Sent from B Corp"
+dkim_selector = "s2025"
+trust = "verified"
+trusted_senders = ["*@trusted-partner.com"]
+```
+
+You don't read this directly. The agent-visible effects are:
+
+- **Signature.** Outbound mail from b.com gets the b.com signature
+  appended automatically. The `body` you pass to `email_send` /
+  `email_reply` does not need to include it.
+- **Trust.** The `trusted` frontmatter field on inbound mail to b.com
+  is evaluated against b.com's effective trust policy (per-mailbox →
+  per-domain → global). You don't need to change behavior based on
+  this — the trust gate on `on_receive` hooks is enforced by the
+  daemon.
+- **DKIM selector.** Affects the DKIM signature only; the signing key
+  and selector are picked automatically based on the From: domain.
+
+## Domain management is operator-only
+
+There are **no** MCP tools for domain CRUD. Adding or removing a
+domain, generating a DKIM keypair for a new domain, and the upgrade
+migration are all operator-driven via `sudo`. The deliberate boundary:
+
+- Agents can `mailbox_create` and `mailbox_delete` mailboxes they
+  own, on any **existing** domain (default or otherwise).
+- Agents **cannot** add a new domain or remove an existing one. If
+  the user asks for that, surface the operator command (`sudo aimx
+  domains add <domain>` or `sudo aimx domains remove <domain>`) and
+  stop. Don't shell out to `aimx`.
+
+You can infer the list of configured domains by calling `mailbox_list()`
+and reading the `@<domain>` suffix of each FQDN. There is no other API
+for the domain list.
+
+## Worked examples
+
+### Send from a specific domain
+
+```
+mailbox_list()
+→ [
+    {"name": "agent@a.com", "address": "agent@a.com", "registered": true, ...},
+    {"name": "agent@b.com", "address": "agent@b.com", "registered": true, ...}
+]
+
+email_send(
+  from_mailbox: "agent@b.com",
+  to: "alice@example.com",
+  subject: "Hello from b.com",
+  body: "..."
+)
+```
+
+The daemon signs with b.com's DKIM key. The sent copy lands at
+`/var/lib/aimx/b.com/sent/agent/`.
+
+### List mail across all owned mailboxes (any domain)
+
+```
+for mb in mailbox_list():
+    rows = email_list(mailbox=mb["name"])  # mb["name"] is the FQDN
+    for row in rows:
+        # process row
+```
+
+Always thread `mb["name"]` (the FQDN) through into the next tool call.
+
+### Reply to mail received on a non-default domain
+
+```
+email_list(mailbox: "support@b.com")
+→ [{"id": "2026-05-01-090000-question", ...}, ...]
+
+email_reply(
+  mailbox: "support@b.com",   # FQDN — sticks the reply to the b.com side
+  id: "2026-05-01-090000-question",
+  body: "Thanks for reaching out..."
+)
+```
+
+The reply is sent from `support@b.com` and DKIM-signed as b.com,
+matching the original message's domain.
+
+### Create a fresh mailbox at a specific domain
+
+```
+mailbox_create("task-42@b.com")     # FQDN — creates at b.com
+→ "task-42@b.com"
+```
+
+Without the FQDN, `mailbox_create("task-42")` would create
+`task-42@<default-domain>`.
+
+## What to tell the user
+
+If a user asks you to "send from a different domain" and you only see
+one domain in `mailbox_list()`'s output, the install is single-domain
+— tell the user that adding a second domain requires the host
+operator to run `sudo aimx domains add <domain>`. Don't shell out.
+
+If a user asks you to "set up a new domain", surface the same
+operator command and stop. Domain CRUD is out of the MCP surface
+by design.

--- a/book/README.md
+++ b/book/README.md
@@ -43,6 +43,7 @@ and [Getting Started](getting-started.md) for the full walkthrough.
 | [Configuration](configuration.md) | `config.toml` field reference, data / config directories, environment variables |
 | [Security](security.md) | Threat model, trust boundaries, what AIMX defends and what it does not |
 | [Mailboxes & Email](mailboxes.md) | Mailbox CRUD, email frontmatter, attachments, sending, threading |
+| [Multi-domain](multi-domain.md) | Hosting multiple domains on one AIMX install — `aimx domains` CLI, per-domain DKIM, upgrade migration, rollback |
 | [Markdown Email](markdown-email.md) | How outbound `--body` is rendered to HTML, the inlined stylesheet, escape hatches |
 | [Hooks & Trust](hooks.md) | `on_receive` / `after_send` events, ownership-as-authorization, trust gate |
 | [Hook Recipes](hook-recipes.md) | Copy-paste hook snippets per agent (Claude Code, Codex, OpenCode, Gemini, Goose, OpenClaw, Hermes, NanoClaw) |

--- a/book/SUMMARY.md
+++ b/book/SUMMARY.md
@@ -8,6 +8,7 @@
 - [Configuration](configuration.md)
 - [Security](security.md)
 - [Mailboxes & Email](mailboxes.md)
+- [Multi-domain](multi-domain.md)
 - [Markdown Email](markdown-email.md)
 - [Hooks & Trust](hooks.md)
 - [Hook Recipes](hook-recipes.md)

--- a/book/cli.md
+++ b/book/cli.md
@@ -174,6 +174,34 @@ Delete a mailbox. Owner-gated: non-root callers may only delete mailboxes they o
 
 See [Mailboxes: Managing mailboxes](mailboxes.md#managing-mailboxes).
 
+## Domain management
+
+Alias: `aimx domain` works identically to `aimx domains`. Domain CRUD is root-only (the same authz that gates other root-level operations). When `aimx serve` is running, every verb hot-reloads the daemon over the UDS with no restart. See [Multi-domain](multi-domain.md) for the operator walkthrough.
+
+### `aimx domains list`
+
+Print a table of every configured domain: domain name, default flag, DKIM key presence + DNS verification status, mailbox count, and any per-domain overrides (signature, selector, trust) summary. The first row is the default domain (`domains[0]`).
+
+No flags.
+
+### `aimx domains add <domain>`
+
+Append `<domain>` to the `domains` array. Generates a 2048-bit RSA DKIM keypair under `/etc/aimx/dkim/<domain>/`, prints the four DNS records to publish (MX, SPF, DMARC, DKIM), runs the existing setup DNS-verification loop, and hot-reloads `aimx serve` so `@<domain>` mail is accepted immediately. Refuses to re-add a domain already in the list.
+
+| Flag | Default | Description |
+|------|---------|-------------|
+| `--selector <name>` | `aimx` | DKIM selector name for the new domain. |
+| `--no-dns-check` | off | Skip the verification loop (records are still printed). Use when publishing DNS out-of-band. |
+
+### `aimx domains remove <domain>`
+
+Remove `<domain>` from `domains` and drop its `[domain."<domain>"]` sub-table. Refuses with a JSON list of blocking mailboxes when any mailbox is still keyed at the target domain. The last remaining domain cannot be removed even with `--force`.
+
+| Flag | Description |
+|------|-------------|
+| `--force` | Cascade: take every per-mailbox lock on the target domain in sorted FQDN order, wipe `inbox/<local>/` and `sent/<local>/` for each, drop the mailbox entries, drop the optional `[domain."<domain>"]` sub-table, then drop the domain itself. The DKIM keys at `/etc/aimx/dkim/<domain>/` are preserved on disk — the command prints the path. |
+| `-y`, `--yes` | Skip the confirmation prompt. |
+
 ## Hook management
 
 Alias: `aimx hook` works identically to `aimx hooks`. Authorization: caller must own the target mailbox, or be root. When `aimx serve` is running, hook CRUD hot-swaps into the live config with no restart. See [Security: Per-action authorization](security.md#per-action-authorization).
@@ -268,10 +296,11 @@ Inverse of `aimx agents setup`. Removes the skill files under `$HOME` and prints
 
 ### `aimx dkim-keygen`
 
-Generate a 2048-bit RSA DKIM keypair under `/etc/aimx/dkim/` (private `0600`, public `0644`). Normally run automatically by `aimx setup`; use directly for key rotation.
+Generate a 2048-bit RSA DKIM keypair under `/etc/aimx/dkim/<domain>/` (private `0600`, public `0644`). Normally run automatically by `aimx setup` (for the first domain) and `aimx domains add` (for subsequent domains); use directly for key rotation.
 
 | Flag | Default | Description |
 |------|---------|-------------|
+| `--domain <name>` | default domain (`domains[0]`) | Target domain. The keypair is written under `/etc/aimx/dkim/<domain>/`. Refuses unknown domains. |
 | `--selector <name>` | `aimx` | DKIM selector name (controls the DNS record `<selector>._domainkey.<domain>`). |
 | `--force` | off | Overwrite existing keys. |
 
@@ -289,4 +318,7 @@ Generate a 2048-bit RSA DKIM keypair under `/etc/aimx/dkim/` (private `0600`, pu
 | `HOOK-CREATE` | header + JSON body | caller uid must own the hook's mailbox | `aimx hooks create` (UDS path), `hook_create` MCP tool |
 | `HOOK-DELETE` | header (hook name) | caller uid must own the hook's mailbox; operator-origin hooks are CLI-only | `aimx hooks delete` (UDS path), `hook_delete` MCP tool |
 | `HOOK-LIST` | request only | none server-side; the response is filtered to hooks on caller-owned mailboxes (root sees all) | `hook_list` MCP tool |
+| `DOMAIN-ADD` | header (domain, optional selector) | root only | `aimx domains add` |
+| `DOMAIN-REMOVE` | header (domain, force) | root only | `aimx domains remove` |
+| `DOMAIN-LIST` | request only | root only | `aimx domains list` |
 | `VERSION` | request only | none — payload is daemon build metadata only | `aimx doctor`'s `Server version:` line |

--- a/book/faq.md
+++ b/book/faq.md
@@ -64,6 +64,20 @@ Replace `/usr/local/bin/aimx` and `systemctl restart aimx`. `aimx serve` handles
 
 Same domain, new server: `rsync -a /etc/aimx/ /var/lib/aimx/` to the new host, install the binary, `sudo aimx setup <domain>` (re-entrant, it reuses the existing DKIM key), then flip the A/MX record. Different domain: run a fresh `aimx setup`. The DKIM selector, SPF, and DMARC records all reference the domain and must be regenerated.
 
+## Multi-domain
+
+### Can one AIMX install host multiple domains?
+
+Yes. `aimx domains add <domain>` appends a domain to the `domains` array, generates a per-domain DKIM keypair, prints the DNS records, runs the verification loop, and hot-reloads `aimx serve` with no restart. Each domain has its own DKIM identity, its own catchall (`*@<domain>`), and its own mailboxes. The first entry in `domains` is the default — bare local parts (`agent`, `support`) resolve against it. See [Multi-domain](multi-domain.md).
+
+### I upgraded to the multi-domain build. What changed on disk?
+
+The first `aimx serve` start under the new binary atomically rewrites `config.toml` from `domain = "..."` to `domains = ["..."]`, re-keys every `[mailboxes.<local>]` to `[mailboxes."<local>@<domain>"]`, moves `/var/lib/aimx/inbox/` and `sent/` under `/var/lib/aimx/<domain>/`, and moves the DKIM keys under `/etc/aimx/dkim/<domain>/`. Mail flow resumes after the rename. Semantically the install is identical to before — only the file layout changed. See [Multi-domain: Upgrade migration walkthrough](multi-domain.md#upgrade-migration-walkthrough).
+
+### How do I roll back to a pre-multi-domain binary?
+
+Documented step-by-step in [Multi-domain: Rollback procedure](multi-domain.md#rollback-procedure). The short version: stop the daemon, move storage and DKIM keys back to the v1 paths, hand-edit `config.toml` back to the v1 shape, delete `/var/lib/aimx/.layout-version`, install the older binary, restart.
+
 ## DNS and deliverability
 
 ### What is PTR record? Do I actually need it?

--- a/book/mailboxes.md
+++ b/book/mailboxes.md
@@ -6,7 +6,7 @@ A mailbox maps an email address to a directory on disk. Command starts with `aim
 
 - **Mailboxes are directories.** Creating a mailbox creates two folders (one under `inbox/`, one under `sent/`) and registers an address. No passwords, no database.
 - **Per-mailbox owner.** Every mailbox has a single Linux `owner` in `config.toml`. Storage is chowned `<owner>:<owner> 0700` at create and kept consistent through every write. Only the owner and root can read it; the MCP server and UDS both authorize on `SO_PEERCRED` matching the owner uid. See [Security: Per-action authorization](security.md#per-action-authorization).
-- **Catchall.** The `catchall` mailbox catches mail for unrecognized addresses at your domain. It is inbound-only (no `sent/catchall/`), owned by the reserved `aimx-catchall` system user.
+- **Catchall.** The `catchall` mailbox catches mail for unrecognized addresses at a configured domain. It is inbound-only (no `sent/catchall/`), owned by the reserved `aimx-catchall` system user. On multi-domain installs, each domain has its own catchall (`*@<domain>`) with independent owner and hook semantics — see [Multi-domain](multi-domain.md).
 - **No sudo for the mailboxes you own.** `aimx mailboxes create / delete` route through the daemon's UDS, so the daemon synthesizes the owner from `SO_PEERCRED` and atomically rewrites `config.toml`. Root may still pass `--owner <user>` to provision a mailbox for another uid.
 - **Hot-reload.** When `aimx serve` is running, create and delete take effect on the next SMTP session — no restart needed.
 - **Delete is file-safe.** Non-empty mailboxes are refused with `ERR NONEMPTY` and a file count. Archive or remove the files first. The directories are left on disk after delete so an operator can `rmdir` them at leisure.
@@ -16,12 +16,18 @@ A mailbox maps an email address to a directory on disk. Command starts with `aim
 
 ```text
 /var/lib/aimx/
-├── inbox/              # inbound mail lives here
-│   ├── catchall/
-│   └── support/
-└── sent/               # outbound sent copies
-    └── support/
+└── <domain>/           # one directory per configured domain
+    ├── inbox/          # inbound mail lives here
+    │   ├── catchall/
+    │   └── support/
+    └── sent/           # outbound sent copies
+        └── support/
 ```
+
+Each domain configured in `domains` gets its own `<data_dir>/<domain>/`
+subtree with independent `inbox/` and `sent/`. Single-domain installs
+still see one top-level domain directory — the layout is symmetric.
+See [Multi-domain: Storage layout](multi-domain.md#storage-layout).
 
 Each email is stored as either a flat `YYYY-MM-DD-HHMMSS-<slug>.md` file
 when it has zero attachments, or as a bundle directory
@@ -30,16 +36,31 @@ as a sibling file when attachments are present.
 
 ### Routing logic
 
-When an email arrives, AIMX matches the local part of the recipient address (the part before `@`) against mailbox names in the config. If a mailbox with that exact name exists, the email is delivered there. Otherwise it falls through to the `catchall` mailbox.
+Mailboxes are keyed by **full FQDN** in `config.toml`
+(`[mailboxes."support@a.com"]`) — the address-before-the-`@` plus the
+domain. When an email arrives, AIMX looks for an exact FQDN match. If
+that misses, it falls through to the per-domain catchall
+(`[mailboxes."*@<domain>"]`). If that also misses, the message is
+rejected.
 
-RCPT TO addresses whose domain is not the configured `domain` (case-insensitive exact match) are rejected at SMTP time with `550 5.7.1 relay not permitted` and never reach storage. AIMX is not an open relay: `catchall` only covers unrecognized local parts *at your configured domain*, not unrelated domains or subdomains.
+RCPT TO addresses whose domain is not in the configured `domains` list
+(case-insensitive exact match) are rejected at SMTP time with
+`550 5.7.1 relay not permitted` and never reach storage. AIMX is not an
+open relay: each domain's catchall only covers unrecognized local parts
+at that specific domain, not unrelated domains or subdomains.
 
-For example, with mailboxes `support` and `catchall` configured:
-- `support@agent.yourdomain.com` -> delivered to the `support` mailbox
-- `billing@agent.yourdomain.com` -> delivered to the `catchall` mailbox (no `billing` mailbox exists)
-- `anything@agent.yourdomain.com` -> delivered to the `catchall` mailbox
+For example, with mailboxes `support@a.com` and `catchall@a.com`
+configured on `domains = ["a.com"]`:
+- `support@a.com` -> delivered to the `support@a.com` mailbox
+- `billing@a.com` -> delivered to the `*@a.com` catchall (no `billing` mailbox exists)
+- `anything@a.com` -> delivered to the `*@a.com` catchall
 - `anything@some-other-domain.com` -> rejected at RCPT TO with `550 5.7.1 relay not permitted`
-- `anything@sub.agent.yourdomain.com` -> rejected at RCPT TO with `550 5.7.1 relay not permitted`
+- `anything@sub.a.com` -> rejected at RCPT TO with `550 5.7.1 relay not permitted`
+
+On a multi-domain install (`domains = ["a.com", "b.com"]`), each domain
+has its own routing table. `support@a.com` and `support@b.com` are
+independent mailboxes; either may exist without the other; each has its
+own owner and hooks. See [Multi-domain](multi-domain.md).
 
 ## Managing mailboxes
 
@@ -47,14 +68,25 @@ For example, with mailboxes `support` and `catchall` configured:
 
 ```bash
 # As yourself: create a mailbox owned by your own uid.
+# Bare local part — resolves to <local>@<default domain>.
 aimx mailboxes create support
+
+# Or, with the FQDN explicit (required on multi-domain installs when
+# you want a domain other than the default):
+aimx mailboxes create support@side-project.com
 ```
 
-This creates `support@agent.yourdomain.com` and both directories:
-`/var/lib/aimx/inbox/support/` (for incoming mail) and
-`/var/lib/aimx/sent/support/` (for outbound copies). Storage is chowned to
-your uid at mode `0700`. Deletion removes both; `catchall` cannot be
-deleted.
+This creates `support@<domain>` and both directories under the
+domain's storage subtree:
+`/var/lib/aimx/<domain>/inbox/support/` (for incoming mail) and
+`/var/lib/aimx/<domain>/sent/support/` (for outbound copies). Storage
+is chowned to your uid at mode `0700`. Deletion removes both;
+`catchall` cannot be deleted.
+
+Bare local parts (`support`) resolve to the **default domain**
+(`domains[0]`). To create a mailbox on a non-default domain, pass the
+FQDN form (`support@side-project.com`). See [Multi-domain](multi-domain.md)
+for the full ruleset.
 
 **Owner-binding rule.** Non-root callers create and delete only mailboxes they own — the daemon synthesizes the owner from `SO_PEERCRED` and ignores any client-supplied owner. Root passes unconditionally and may use `--owner <user>` to provision a mailbox owned by another Linux user. Passing `--owner <other>` from a non-root shell prints a soft warning to stderr and submits the request with the synthesized owner anyway.
 
@@ -324,8 +356,14 @@ Agents send email using the `email_send` and `email_reply` MCP tools. See [MCP S
 ### Send pipeline
 
 1. `aimx send` composes an RFC 5322 message and submits it over `/run/aimx/aimx.sock`. The client does not read `config.toml`.
-2. `aimx serve` parses `From:` from the body, verifies the domain matches `config.domain` and the local part resolves to a configured non-wildcard mailbox, DKIM-signs the message with RSA-SHA256, and delivers it directly to the recipient's MX over SMTP. The catchall (`*@domain`) is never accepted as an outbound sender.
+2. `aimx serve` parses `From:` from the body, verifies the domain is in `config.domains` and the local part resolves to a configured non-wildcard mailbox at that domain, DKIM-signs the message with the per-domain key (RSA-SHA256), and delivers it directly to the recipient's MX over SMTP. The catchall (`*@<domain>`) is never accepted as an outbound sender.
 3. `aimx send` exits as soon as the daemon returns a status. Signing, mailbox resolution, and delivery happen entirely in the daemon — the client does not need root, does not read the DKIM key, and does not read `config.toml`.
+
+Bare local parts on `--from` (`--from support`) resolve to
+`<local>@<default domain>` daemon-side. To send from a non-default
+domain on a multi-domain install, pass the full FQDN
+(`--from support@side-project.com`). DKIM signs with the From: domain's
+key, never `domains[0]`'s.
 
 ### Reply threading
 

--- a/book/mcp.md
+++ b/book/mcp.md
@@ -36,15 +36,21 @@ List mailboxes you own.
 
 | Field         | Type   | Description                                                                  |
 |---------------|--------|------------------------------------------------------------------------------|
-| `name`        | string | Mailbox name (the local part).                                               |
-| `inbox_path`  | string | Absolute path to the inbox directory (`/var/lib/aimx/inbox/<name>`).         |
-| `sent_path`   | string | Absolute path to the sent directory (`/var/lib/aimx/sent/<name>`).           |
+| `name`        | string | Mailbox name. **FQDN** (`support@a.com`) — disambiguates across domains on multi-domain installs.  |
+| `address`     | string | Full address `<name>@<domain>` (always equal to `name` on registered mailboxes).  |
+| `inbox_path`  | string | Absolute path to the inbox directory (`/var/lib/aimx/<domain>/inbox/<local>`).  |
+| `sent_path`   | string | Absolute path to the sent directory (`/var/lib/aimx/<domain>/sent/<local>`).    |
 | `total`       | number | Total emails in the inbox.                                                   |
 | `unread`      | number | Inbox emails with `read = false`.                                            |
 | `sent_count`  | number | Total emails in the sent folder.                                             |
 | `registered`  | bool   | `true` for mailboxes in `config.toml`; `false` for stray on-disk dirs only.  |
 
 The empty case returns `[]`. Filtered to caller-owned mailboxes for non-root callers; root sees everything. The MCP process resolves the listing through the daemon over `/run/aimx/aimx.sock`, so it works without read access to root-owned `config.toml`.
+
+Agents that need to filter by domain can do so client-side from the
+FQDN `name` field. See [Multi-domain](multi-domain.md) and the agent
+primer's default-domain rule (bare local-parts in MCP arguments
+resolve to `domains[0]`).
 
 ---
 

--- a/book/multi-domain.md
+++ b/book/multi-domain.md
@@ -1,0 +1,400 @@
+# Multi-domain
+
+AIMX hosts multiple sending and receiving domains from one binary. Each
+domain has its own DKIM keypair, its own catchall, and its own mailboxes.
+The first entry in the `domains` array is the **default** — bare local
+parts (`research`, `support`, `agent`) resolve against it.
+
+This page is the operator reference for everything multi-domain: when to
+add a second domain, the `aimx domains` CLI, per-domain config, per-domain
+DKIM, the per-domain storage layout, what the upgrade migration does on
+the first restart, how to remove a domain, what's deliberately out of
+scope, and how to roll back if you need to.
+
+## When to add a second domain
+
+You want a second domain on the same AIMX install when:
+
+- You run AIMX for one identity (`personal.com`) but want a second
+  identity (`side-project.com`) with its own DKIM and DMARC story without
+  paying for a second VPS or running a relay.
+- You're a freelancer with one `consultancy.com` plus per-client domains
+  (`acme.consultancy.com`, `widgets.consultancy.com`) and want each
+  engagement to send under its own brand.
+- You're consolidating identities you already own onto one host because
+  the operational cost of N AIMX instances is the dominant pain.
+
+Multi-domain is **not** a multi-tenant feature. There is exactly one
+operator. The trust model is unchanged: every mailbox still belongs to one
+Linux user; root still owns `/etc/aimx/` and the DKIM keys; the UDS still
+authorizes on `SO_PEERCRED`. A second domain is a routing convenience,
+not a hosted-service surface.
+
+## `aimx domains` CLI
+
+`aimx domains` (alias: `aimx domain`) manages the domain list. The CLI
+prefers the daemon UDS so changes hot-reload without a restart; the
+daemon is required for non-root callers (the config is `0640 root:root`).
+See [CLI Reference: Domain management](cli.md#domain-management).
+
+### `aimx domains list`
+
+```bash
+aimx domains list
+```
+
+Prints a table of every configured domain: name, default marker, DKIM key
+presence + DNS verification status, mailbox count, and any per-domain
+overrides (signature, selector, trust). The first row of the table is the
+default domain.
+
+### `aimx domains add <domain>`
+
+```bash
+sudo aimx domains add side-project.com
+```
+
+Generates a 2048-bit RSA DKIM keypair under
+`/etc/aimx/dkim/side-project.com/`, appends `side-project.com` to the
+`domains` array, prints the four DNS records to publish (MX, SPF, DMARC,
+DKIM), runs the same DNS-verification loop as `aimx setup`, and
+hot-reloads the daemon over the UDS so `@side-project.com` mail is
+accepted immediately.
+
+Flags:
+
+- `--selector <name>` — DKIM selector for the new domain (default
+  `aimx`).
+- `--no-dns-check` — skip the verification loop when you publish DNS
+  out-of-band. The records are still printed.
+
+The add is **root-only** (the same authz that gates mailbox creation in
+other root-only contexts). It refuses if the domain is already in
+`domains` and points you at `aimx domains list`.
+
+### `aimx domains remove <domain> [--force]`
+
+```bash
+# Refuses if any mailbox still lives under side-project.com:
+sudo aimx domains remove side-project.com
+
+# Cascade: deletes every mailbox on side-project.com and its
+# /var/lib/aimx/side-project.com/ storage tree, then drops the domain
+# from `domains`. The DKIM keys at /etc/aimx/dkim/side-project.com/
+# are preserved on disk.
+sudo aimx domains remove --force side-project.com
+```
+
+Without `--force`, the command refuses and lists the mailboxes still
+keyed at the target domain. With `--force`, the daemon takes every
+per-mailbox lock for the target domain in sorted FQDN order, then
+`CONFIG_WRITE_LOCK`, then atomically wipes the storage tree, the
+`[mailboxes."<local>@<domain>"]` entries, the optional
+`[domain."<domain>"]` sub-table, and the domain string itself.
+
+Removing the **last** remaining domain is hard-blocked even with
+`--force` — an AIMX install must have at least one domain to be
+functional. To tear AIMX down entirely, use [`aimx uninstall`](cli.md#aimx-uninstall).
+
+The DKIM key files at `/etc/aimx/dkim/<domain>/` are deliberately
+**preserved** on remove so accidentally removing a domain you still own
+isn't a key-destruction event. Delete them by hand once you're sure
+(`sudo rm -rf /etc/aimx/dkim/<domain>/`).
+
+## Per-domain config sub-tables
+
+Per-domain overrides live under `[domain."<domain>"]` in `config.toml`.
+The key is singular `domain` because TOML cannot let `domains` be both
+the top-level array and a parent table on the same key. This mirrors the
+existing `aimx domain`/`aimx domains` clap alias.
+
+```toml
+domains = ["a.com", "b.com"]
+
+# Global defaults (unchanged):
+trust = "verified"
+trusted_senders = ["*@company.com"]
+dkim_selector = "aimx"
+signature = "Sent from AIMX.  \nhttps://aimx.email"
+
+# Optional per-domain overrides:
+[domain."b.com"]
+signature = "Sent from B Corp"
+dkim_selector = "s2025"
+trust = "verified"
+trusted_senders = ["*@trusted-partner.com"]
+```
+
+Every field under `[domain."<d>"]` is optional. Resolution order is:
+
+| Field | Resolution |
+|------|------|
+| `trust`, `trusted_senders` | per-mailbox → per-domain → global |
+| `signature` | per-domain → global → built-in default |
+| `dkim_selector` | per-domain → global → built-in default `"aimx"` |
+
+A per-mailbox `trusted_senders` list fully **replaces** the per-domain
+list. A per-domain `trusted_senders` fully replaces the global list.
+There is no merging at either layer.
+
+## Per-domain DKIM
+
+Each domain has its own keypair at
+`/etc/aimx/dkim/<domain>/{private,public}.key` (mode `0600` / `0644`,
+owner `root:root`). The daemon loads every key into an
+`ArcSwap<HashMap<String, DkimKey>>` at startup and hot-swaps on
+`DOMAIN-ADD` / `DOMAIN-REMOVE`. Outbound signing in `send_handler` picks
+the key for the From: domain and signs with that domain's resolved
+selector — never `domains[0]`'s key.
+
+`aimx dkim-keygen` accepts `--domain <domain>` to operate on a specific
+domain. Without the flag, it operates on the default
+domain (`domains[0]`). See [CLI Reference: `aimx dkim-keygen`](cli.md#aimx-dkim-keygen).
+
+```bash
+# Rotate the b.com selector to s2025 without touching a.com:
+sudo aimx dkim-keygen --domain b.com --selector s2025 --force
+```
+
+## Storage layout
+
+Multi-domain installs nest mailboxes under `<data_dir>/<domain>/`:
+
+```text
+/var/lib/aimx/
+├── .layout-version              # migration marker; do not edit
+├── README.md                    # auto-generated datadir guide
+├── a.com/
+│   ├── inbox/
+│   │   ├── catchall/            # *@a.com lands here
+│   │   └── support/
+│   └── sent/
+│       └── support/
+└── side-project.com/
+    ├── inbox/
+    │   └── info/
+    └── sent/
+        └── info/
+```
+
+`--data-dir` / `AIMX_DATA_DIR` continues to govern the root path; the
+`<domain>/` nesting happens inside whatever root is configured. The
+daemon enforces `0o755` on every `<data_dir>/<domain>/` directory on
+every startup so non-root mailbox owners can `x` into their own
+`inbox/<name>/` (which itself stays `0o700`). If you hand-tighten a
+per-domain directory to `0o700`, the next `aimx serve` restart will
+widen it back to `0o755` — the asymmetric posture is intentional.
+
+## Upgrade migration walkthrough
+
+The upgrade from a v1 (single-domain) install to multi-domain happens
+**atomically on the first `aimx serve` startup under the new binary**.
+Storage, DKIM keys, and `config.toml` all move to the canonical
+multi-domain shape in one locked transaction. There is no opt-out, no
+lazy path, no CLI flag that skips it.
+
+The migration is idempotent (guarded by `.layout-version`), so
+subsequent restarts are no-ops.
+
+### Before upgrade (v1, single-domain install on `mydomain.com`)
+
+```text
+/etc/aimx/config.toml
+  domain = "mydomain.com"
+  [mailboxes.info]
+  [mailboxes.support]
+  [mailboxes.alice]
+
+/etc/aimx/dkim/private.key
+/etc/aimx/dkim/public.key
+
+/var/lib/aimx/inbox/{info,support,alice}/...
+/var/lib/aimx/sent/{info,support,alice}/...
+```
+
+### Step 1: Operator runs `aimx upgrade`
+
+`aimx upgrade` swaps `/usr/local/bin/aimx` (or your `AIMX_PREFIX` path)
+atomically, preserves the old binary at `<install_path>.prev`, restarts
+`aimx.service`, and prints a one-screen reminder summarizing what
+happens on next start.
+
+### Step 2: systemd starts `aimx serve` under the new binary
+
+The daemon detects v1 layout (any of `.layout-version` absent +
+`/var/lib/aimx/inbox/` present, or `/etc/aimx/dkim/private.key` next to
+no `<domain>/` subdir, or `domain = "..."` without `domains = [...]`,
+or any local-part-keyed `[mailboxes.<local>]`) and performs the
+migration under `CONFIG_WRITE_LOCK` plus every per-mailbox lock:
+
+1. **Storage rename.** `rename(2)` `/var/lib/aimx/inbox` →
+   `/var/lib/aimx/mydomain.com/inbox/`, same for `sent`. Same-filesystem
+   rename, constant time, atomic.
+2. **DKIM rename.** `mkdir -p /etc/aimx/dkim/mydomain.com/` (mode
+   `0700`, owner `root:root`), then rename `private.key` and
+   `public.key` into it.
+3. **Config rewrite.** `write_atomic` `config.toml` to:
+   ```toml
+   domains = ["mydomain.com"]
+   [mailboxes."info@mydomain.com"]
+   [mailboxes."support@mydomain.com"]
+   [mailboxes."alice@mydomain.com"]
+   ```
+4. **Marker.** Write `/var/lib/aimx/.layout-version` containing `2`.
+5. Log one INFO line summarizing every move with a pointer back to
+   this page.
+
+The renames are constant-time regardless of how much mail is stored;
+the slow step is the TOML serialize, which completes well under a
+second on a typical install.
+
+After the migration, the daemon accepts SMTP and UDS traffic and mail
+flow resumes.
+
+### Step 3: Day-to-day after upgrade
+
+- Inbound to `info@mydomain.com`, `support@mydomain.com`,
+  `alice@mydomain.com` works exactly as before.
+- Outbound from any mailbox signs with the (now-relocated) DKIM key
+  under `/etc/aimx/dkim/mydomain.com/`.
+- `aimx doctor` reports one domain (`mydomain.com`), marks it as
+  default, shows the DKIM key path with the per-domain nesting.
+- `aimx mailboxes list` and the MCP `mailbox_list` tool return FQDN
+  names (`info@mydomain.com`, etc.) — different from v1 output.
+- `/etc/aimx/config.toml` is visibly different (normalized shape).
+  Semantically equivalent to before.
+
+### Step 4 (optional): Add a second domain
+
+```bash
+sudo aimx domains add side-project.com
+```
+
+After publishing DNS, `domains = ["mydomain.com", "side-project.com"]`,
+the new per-domain storage tree at `/var/lib/aimx/side-project.com/` is
+created lazily on first mailbox creation under it, and a new DKIM
+keypair lives at `/etc/aimx/dkim/side-project.com/`.
+
+### Migration safety
+
+- **Atomic per step.** Each rename and the `write_atomic` config
+  rewrite are independently atomic. The daemon refuses to accept SMTP
+  or UDS traffic until the entire transaction completes.
+- **Idempotent.** Re-running with `.layout-version: 2` is a single
+  stat call — a no-op fast path. The migration runs exactly once.
+- **Hard-fail on partial completion.** If any step fails, the daemon
+  refuses to start with a clear error pointing at `aimx logs`. A
+  half-migrated state is detectable from path existence and the next
+  start resumes from the first incomplete step. There is no silent
+  fallback.
+- **No data loss tolerated.** The migration uses `rename(2)`
+  exclusively — no copy, no rewrite, no risk of half-written files.
+
+If something goes wrong, capture `aimx logs --lines 200`, the state
+of `/var/lib/aimx/`, `/etc/aimx/dkim/`, and `/etc/aimx/config.toml`
+before touching anything else.
+
+## Removal semantics
+
+- `aimx domains remove <domain>` (no `--force`) refuses with a JSON
+  list of every mailbox FQDN still keyed at the target domain.
+- `aimx domains remove --force <domain>` takes every per-mailbox
+  lock for the target domain in sorted FQDN order (outer), then
+  `CONFIG_WRITE_LOCK` (inner), then atomically:
+  1. Wipes `inbox/<local>/` and `sent/<local>/` for every mailbox on
+     the target domain, via the same code path
+     `aimx mailboxes delete --force` uses.
+  2. Removes the empty per-domain root with `rmdir(2)`.
+  3. Removes the `[domain."<domain>"]` sub-table from in-memory
+     `Config`.
+  4. Removes every `[mailboxes."<local>@<domain>"]` entry.
+  5. Removes the domain string from `domains`.
+  6. `write_atomic`s the new `config.toml`.
+  7. Hot-swaps the in-memory `Arc<Config>` via `ConfigHandle::store`.
+  8. Drops the per-domain DKIM map entry **before** the config swap
+     so a concurrent SEND never sees a configured domain with no key.
+- **Last-domain hard-block.** Removing the only remaining domain is
+  always refused. Use `aimx uninstall` to tear AIMX down entirely.
+- **DKIM keys preserved.** The keypair at `/etc/aimx/dkim/<domain>/`
+  stays on disk so re-adding the same domain is recoverable. The
+  command prints the path so you know where they are.
+- **No undo.** Force removal wipes mail content. Archive first if you
+  care about it.
+
+## Light scope (what we deliberately don't do)
+
+Multi-domain is intentionally small. The following are out of scope
+and stay out of scope:
+
+- **MCP `domain_create` / `domain_delete` / `domain_list` tools.**
+  Domain management is operator-only and requires `sudo`. Agents
+  can infer the domain list from the FQDN-shaped mailbox names
+  returned by `mailbox_list`.
+- **Per-domain TLS certs / per-domain EHLO hostnames.** AIMX
+  presents one server identity. The cert's CN/SAN must cover the
+  EHLO hostname, which is `domains[0]`.
+- **Per-domain verifier endpoints / per-domain port-25 checks.**
+  The verifier service (`services/verifier/`) is server-level.
+- **Per-domain rate limits, quotas, or per-domain operators.**
+  Multi-tenant features stay out — this is one operator with many
+  identities, not a hosted service.
+- **Per-mailbox `signature` override.** The per-domain override is
+  enough for v1.
+- **`aimx domains rotate-dkim <domain>`.** DKIM rotation is folded
+  into a future hardening track; use the selector swap recipe in
+  the [FAQ](faq.md#how-do-i-rotate-the-dkim-key-without-a-delivery-gap)
+  in the meantime.
+- **Cross-domain hook semantics.** Hooks remain strictly
+  per-mailbox. A hook on `support@a.com` and a hook on
+  `support@b.com` are independent.
+- **Aliasing one mailbox across multiple domains.** Operators who
+  want `support` to receive both `@a.com` and `@b.com` configure two
+  mailboxes with hooks that forward to a common path.
+- **`aimx domains set-default <domain>`** reordering CLI. Ships in
+  a follow-up; in the meantime, hand-edit `domains` in
+  `config.toml` and restart the daemon.
+
+## Rollback procedure
+
+Rollback is a rare operator-driven action, never a CLI subcommand.
+Rolling back to a pre-multi-domain (v1) binary after the migration
+ran is mechanical and lossless if you're still on a single domain
+and haven't made any post-upgrade config changes beyond the
+automatic rewrite. If you've added a second domain since the
+migration, the second domain's mail and DKIM key must be exported
+or discarded first — the v1 binary cannot read them.
+
+```bash
+# 1. Stop the daemon.
+sudo systemctl stop aimx
+# (or: sudo rc-service aimx stop)
+
+# 2. Move storage back to the v1 layout. Replace <domain> with the
+# value at domains[0] (the only entry left after step 0).
+sudo mv /var/lib/aimx/<domain>/inbox /var/lib/aimx/inbox
+sudo mv /var/lib/aimx/<domain>/sent  /var/lib/aimx/sent
+sudo rmdir /var/lib/aimx/<domain>
+
+# 3. Move the DKIM keys back to the v1 location.
+sudo mv /etc/aimx/dkim/<domain>/private.key /etc/aimx/dkim/private.key
+sudo mv /etc/aimx/dkim/<domain>/public.key  /etc/aimx/dkim/public.key
+sudo rmdir /etc/aimx/dkim/<domain>
+
+# 4. Hand-edit /etc/aimx/config.toml back to the v1 shape:
+#    - `domains = ["<domain>"]` → `domain = "<domain>"`
+#    - `[mailboxes."<local>@<domain>"]` → `[mailboxes.<local>]`
+#    - Remove any `[domain."<domain>"]` sub-tables.
+
+# 5. Remove the layout marker so the v1 binary doesn't trip over it.
+sudo rm /var/lib/aimx/.layout-version
+
+# 6. Install the older binary (the one preserved at .prev works) and
+# restart.
+sudo mv /usr/local/bin/aimx.prev /usr/local/bin/aimx
+sudo systemctl start aimx
+```
+
+If you had a second domain when you started the rollback, its
+mailboxes are now unreachable — the v1 binary doesn't know about
+them. Either archive that directory tree somewhere safe before
+running step 2, or accept the loss.

--- a/book/setup.md
+++ b/book/setup.md
@@ -58,6 +58,21 @@ Once you have linked up your MCP to your LLM, try asking it to set up a mailbox 
 
 Third-party mail-client workarounds (Gmail spam-filter whitelists and similar) are not part of `aimx setup`. The canonical deliverability story is the SPF / DKIM / DMARC triple plus a reverse-DNS (PTR) record at your VPS provider.
 
+### Adding a second domain
+
+`aimx setup` configures the first domain only. To host a second
+(or third) domain on the same install, run `aimx domains add` after
+setup completes:
+
+```bash
+sudo aimx domains add side-project.com
+```
+
+This generates a per-domain DKIM keypair, prints the DNS records, runs
+the verification loop, and hot-reloads `aimx serve` so `@side-project.com`
+mail is accepted with no service restart. See [Multi-domain](multi-domain.md)
+for the full operator reference.
+
 ### Catchall user
 
 When the catchall is configured, setup creates the `aimx-catchall` system user (`useradd --system --no-create-home --shell /usr/sbin/nologin`, or the BusyBox `adduser` equivalent on Alpine) and chowns the catchall mailbox to it. Skipping the catchall skips the user.
@@ -217,7 +232,7 @@ aimx send \
 DKIM keys are generated automatically during setup. To manage them independently:
 
 ```bash
-# Generate DKIM keypair (default selector: "aimx")
+# Generate DKIM keypair for the default domain (default selector: "aimx")
 aimx dkim-keygen
 
 # Force regenerate (overwrites existing keys)
@@ -225,13 +240,22 @@ aimx dkim-keygen --force
 
 # Use a custom selector
 aimx dkim-keygen --selector mykey
+
+# Target a specific domain on multi-domain installs
+sudo aimx dkim-keygen --domain side-project.com --selector s2025
 ```
 
-Keys are stored at:
-- Private key: `/etc/aimx/dkim/private.key` (mode `0600`, root-only)
-- Public key: `/etc/aimx/dkim/public.key` (mode `0644`)
+Keys are stored under `/etc/aimx/dkim/<domain>/`:
+- Private key: `/etc/aimx/dkim/<domain>/private.key` (mode `0600`, root-only)
+- Public key: `/etc/aimx/dkim/<domain>/public.key` (mode `0644`)
 
-After regenerating keys, update the DKIM DNS record with the new public key.
+Single-domain installs that upgraded from a pre-multi-domain build had
+their keys relocated from `/etc/aimx/dkim/private.key` to
+`/etc/aimx/dkim/<domain>/private.key` automatically on the first
+post-upgrade `aimx serve` start. See [Multi-domain: Upgrade migration walkthrough](multi-domain.md#upgrade-migration-walkthrough).
+
+After regenerating keys, update the DKIM DNS record for that domain with
+the new public key.
 
 ## Production hardening
 

--- a/book/troubleshooting.md
+++ b/book/troubleshooting.md
@@ -270,6 +270,74 @@ aimx hooks delete <name> --yes
 aimx hooks create --mailbox <m> --event on_receive --cmd '["/correct/path/to/agent", "..."]' --name <name>
 ```
 
+## Multi-domain
+
+### Migration aborts on startup with "corrupted layout marker"
+
+Symptom: `aimx serve` refuses to start after an upgrade with an error
+naming `/var/lib/aimx/.layout-version` and a version it didn't expect.
+
+Fix: the marker file at `/var/lib/aimx/.layout-version` exists but holds
+a value other than `2`. The migration uses the marker as the source of
+truth for "is this install already on the new layout?" — a corrupted
+marker is a hard startup error by design (a half-migrated state would
+be much worse than a refusal-to-start). Either restore the marker to
+`2` (if the layout is already migrated — confirm by checking that
+`/var/lib/aimx/<domain>/inbox/` exists and `/var/lib/aimx/inbox/`
+does not), or delete the marker entirely (`sudo rm /var/lib/aimx/.layout-version`)
+to let the migration re-run from scratch on the next start. Capture
+`aimx logs --lines 200` and the state of `/var/lib/aimx/` first if
+anything looks inconsistent.
+
+### Migration aborts with cross-filesystem rename (EXDEV)
+
+Symptom: `aimx serve` refuses to start after upgrade with an error
+mentioning `cross-device link` or `EXDEV` on a `rename` call. Typical
+trigger: `/var/lib/aimx/` lives on a different filesystem from where
+the per-domain subdirectory would land (e.g. someone bind-mounted
+`inbox/` onto a separate volume).
+
+Fix: the upgrade migration uses `rename(2)` exclusively for atomicity,
+which only works within one filesystem. Move `/var/lib/aimx/` so that
+the per-domain subtree lives on the same filesystem as `inbox/` and
+`sent/` did before the upgrade (or vice versa), then restart the
+daemon. The migration is idempotent — it'll detect the half-migrated
+state and resume from the first incomplete step.
+
+### Half-migrated install: some files on the new layout, some on the old
+
+Symptom: after a failed migration, `aimx logs` shows the migration
+aborted partway through. Some files are at the v1 paths, some at the
+v2 paths.
+
+Fix: the migration is **re-runnable**. Each step is detected via path
+existence and the next start picks up where the previous one left
+off. Resolve whatever underlying failure caused the abort (disk full,
+EXDEV per above, manual interference) and restart `aimx serve`. The
+daemon refuses to accept SMTP and UDS traffic until the entire
+transaction completes, so a half-migrated state cannot serve mail —
+there is no data loss window.
+
+### `aimx send` fails with "DKIM key not found for domain <domain>"
+
+Symptom: `aimx send --from user@side-project.com ...` exits non-zero
+with a daemon error naming the per-domain DKIM path
+(`/etc/aimx/dkim/side-project.com/private.key`).
+
+Fix: the daemon expects a DKIM keypair under
+`/etc/aimx/dkim/<domain>/private.key` for every domain in `domains`.
+The most common causes:
+
+- The domain was added by hand-editing `config.toml` instead of via
+  `aimx domains add`. Generate the missing keypair with
+  `sudo aimx dkim-keygen --domain <domain>` and restart the daemon
+  (or use `aimx domains add` to add a new domain — it generates the
+  key automatically).
+- The DKIM directory was moved or chmod-tightened in a way the daemon
+  can't read. Verify `ls -la /etc/aimx/dkim/<domain>/private.key`
+  shows `-rw------- root root` (mode `0600`).
+- The migration is half-done. See "Half-migrated install" above.
+
 ## Spam prevention
 
 If outbound emails land in spam:

--- a/scripts/check-docs.sh
+++ b/scripts/check-docs.sh
@@ -68,6 +68,7 @@ ALLOWED_NON_VERBS=(
     -V
     # Documented clap aliases (src/cli.rs). Keep in sync with
     # `#[command(... alias = "...")]` attributes.
+    domain
     hook
     mailbox
     # Subcommands marked `#[command(hide = true)]` in `src/cli.rs`.

--- a/src/agents_setup.rs
+++ b/src/agents_setup.rs
@@ -3063,10 +3063,14 @@ mod tests {
             .contents();
         let text = std::str::from_utf8(primer).expect("primer must be valid UTF-8");
         let line_count = text.lines().count();
-        // Target: 300–500 lines (soft cap).
+        // Target: 300–600 lines (soft cap). The upper bound is the
+        // "primer is getting long enough that agents will skim it"
+        // ceiling — when new substantive sections push past it,
+        // factor reference material into `references/*.md` instead
+        // of growing the primer body.
         assert!(
-            (300..=500).contains(&line_count),
-            "main primer has {line_count} lines; target range is 300–500"
+            (300..=600).contains(&line_count),
+            "main primer has {line_count} lines; target range is 300–600"
         );
     }
 

--- a/src/upgrade.rs
+++ b/src/upgrade.rs
@@ -360,8 +360,64 @@ pub fn run_upgrade(
     // active`; this line is its `aimx upgrade` analogue.
     println!("{}", restart_confirmation_line(&manifest.tag));
 
+    // One-screen reminder of what changed on disk after the
+    // multi-domain rollout. Printed after the restart confirmation so
+    // operators see it as part of the `aimx upgrade` output flow.
+    print_post_upgrade_reminder();
+
     report.outcome = Some(Outcome::Upgraded);
     Ok(report)
+}
+
+/// One-screen reminder printed after a successful upgrade. Documents the
+/// visible config / storage / DKIM relocations that happen on the first
+/// `aimx serve` startup under the new binary, points at the book page
+/// for full details and rollback. Idempotent — the underlying migration
+/// is gated by `/var/lib/aimx/.layout-version`, so this text is safe to
+/// print on every upgrade.
+fn print_post_upgrade_reminder() {
+    print!("{}", post_upgrade_reminder_text());
+}
+
+/// Format the post-upgrade reminder body. Pulled out as a pure helper
+/// so unit tests can pin the operator-facing wording (config rewrite,
+/// storage relocate, DKIM relocate, book pointer, rollback pointer)
+/// without capturing stdout.
+pub(crate) fn post_upgrade_reminder_text() -> String {
+    let mut out = String::new();
+    out.push('\n');
+    out.push_str(&format!(
+        "{}\n",
+        term::header("What changes on the next aimx serve start:")
+    ));
+    out.push_str(&format!(
+        "  - {} is visibly rewritten to the normalized shape\n",
+        term::highlight("/etc/aimx/config.toml")
+    ));
+    out.push_str(&format!(
+        "    ({} -> {}, mailbox keys -> FQDN)\n",
+        term::highlight("domain = \"...\""),
+        term::highlight("domains = [...]"),
+    ));
+    out.push_str(&format!(
+        "  - Storage relocates to {}\n",
+        term::highlight("/var/lib/aimx/<domain>/{inbox,sent}/<mailbox>/"),
+    ));
+    out.push_str(&format!(
+        "  - DKIM keys relocate to {}\n",
+        term::highlight("/etc/aimx/dkim/<domain>/{private,public}.key"),
+    ));
+    out.push_str("  - Purely structural - no semantic changes for single-domain installs.\n");
+    out.push_str(&format!(
+        "  - {} See {} for the full walkthrough.\n",
+        term::accent("→"),
+        term::highlight("book/multi-domain.md"),
+    ));
+    out.push_str(&format!(
+        "  - Rollback procedure: {}\n",
+        term::highlight("book/multi-domain.md#rollback-procedure"),
+    ));
+    out
 }
 
 /// Format the one-line restart confirmation printed after the daemon
@@ -716,6 +772,40 @@ mod tests {
         let line = super::restart_confirmation_line("v1.2.3");
         assert!(line.contains("aimx serve restarted on"), "{line}");
         assert!(line.contains("v1.2.3"), "{line}");
+    }
+
+    /// The post-upgrade reminder must name every load-bearing change
+    /// (config rewrite, storage relocate, DKIM relocate) and point at
+    /// the multi-domain book page for the full walkthrough plus the
+    /// rollback procedure. Pin the wording so future edits don't
+    /// silently drop a section.
+    #[test]
+    fn post_upgrade_reminder_names_config_storage_dkim_and_book_page() {
+        let text = super::post_upgrade_reminder_text();
+        assert!(
+            text.contains("/etc/aimx/config.toml"),
+            "reminder must mention the config path: {text}"
+        );
+        assert!(
+            text.contains("domains = [...]"),
+            "reminder must show the normalized domains shape: {text}"
+        );
+        assert!(
+            text.contains("/var/lib/aimx/<domain>/"),
+            "reminder must name the per-domain storage path: {text}"
+        );
+        assert!(
+            text.contains("/etc/aimx/dkim/<domain>/"),
+            "reminder must name the per-domain DKIM path: {text}"
+        );
+        assert!(
+            text.contains("book/multi-domain.md"),
+            "reminder must link the operator at book/multi-domain.md: {text}"
+        );
+        assert!(
+            text.contains("Rollback"),
+            "reminder must point at the rollback procedure: {text}"
+        );
     }
 
     /// The rollback-on-start-failure path must NOT pretend the daemon


### PR DESCRIPTION
## Summary

Lands the user-facing documentation, the agent primer + reference card, the release notes, and the synthetic smoke results for the multi-domain track. This is the final sprint on `epic/multi-domain` — after this lands, the epic→main PR (#240) is ready for human review.

## Stories implemented

### Book — `book/multi-domain.md` (S7-1)
- [x] New `book/multi-domain.md` with sections: when to add a second domain, `aimx domains` CLI reference, per-domain config sub-tables (note the singular `[domain."<d>"]` key shape), per-domain DKIM, storage layout, upgrade migration walkthrough, removal semantics, light scope, and rollback procedure.
- [x] Linked from `book/SUMMARY.md` and the index/README guide-contents tables.
- [x] All code examples copy-paste cleanly.
- [x] mdBook builds clean (CI version 0.5.2; local 0.4.40 has a theme-helper mismatch unrelated to content).

### Existing book pages updated (S7-2)
- [x] `book/setup.md` — mentions `aimx domains add` at completion; DKIM key management reflects per-domain layout and `--domain` flag.
- [x] `book/mailboxes.md` — FQDN-keyed mailboxes, per-domain catchall, per-domain storage layout, send-pipeline notes on bare-local-part vs FQDN, cross-links to `book/multi-domain.md`.
- [x] `book/mcp.md` — `mailbox_list` returns FQDN names; cross-link to multi-domain page and default-domain rule.
- [x] `book/cli.md` — new `aimx domains` command group (list/add/remove), `--domain` flag on `aimx dkim-keygen`, DOMAIN-* UDS verbs in the verb table.
- [x] `book/faq.md` — three multi-domain FAQs (multi-domain support, what changed on upgrade, rollback).
- [x] `book/troubleshooting.md` — corrupted-marker, EXDEV, half-migrated state, DKIM-key-not-found-for-domain entries under a new Multi-domain section.
- [x] mdBook builds clean.

### Agent primer + reference card (S7-3)
- [x] `agents/common/aimx-primer.md` — default-domain resolution rule, FQDN-disambiguation behavior, per-domain storage layout, per-domain DKIM layout, `references/multi-domain.md` pointer. Primer line-count soft-cap bumped from 500 to 600 to accommodate the new section.
- [x] `agents/common/references/multi-domain.md` (new) — operator-facing reference card matching the existing reference-doc structure; covers default-domain rule, FQDN disambiguation across every mailbox-scoped MCP tool, per-domain storage, per-domain config surfaces (read-only from MCP), and the "domain CRUD is operator-only" boundary.
- [x] Bundled agent plugins pick up changes on next build via `include_dir!` — no per-plugin edits.

### Release notes + `aimx upgrade` reminder (S7-4)
- [x] `RELEASE_NOTES.md` (new) — calls out the four points (config rewrite, storage relocation, DKIM relocation, purely structural change), links to `book/multi-domain.md` for the walkthrough and rollback.
- [x] `aimx upgrade` prints a one-screen reminder after a successful upgrade. New `post_upgrade_reminder_text()` helper is pinned by a unit test asserting every load-bearing string is present (config path, normalized `domains = [...]` shape, per-domain storage path, per-domain DKIM path, book pointer, rollback pointer).

### Manual smoke (S7-5)
- [x] Results documented in `docs/multi-domain-smoke-results.md` (separate `aimx-docs` repo, pushed in `f4f69ff`).
- [x] **Synthetic-via-tests** mapping: every smoke step points at the integration test that already pins it. Two scenarios, 31 steps total, all PASS except the rollback procedure (step 13 of scenario B — manual, recommended pre-tag but **not** a blocker for the epic→main PR).
  - Scenario A (fresh-install two-domain): 18 steps covering setup + `domains add` + mailbox CRUD + send/receive + `doctor` + `domains remove --force`. Pinned by `tests/domains_uds.rs`, `tests/multi_domain.rs`, `tests/domains_remove.rs`.
  - Scenario B (upgrade fixture): 13 steps covering v1 detection, storage/DKIM rename, config normalization, layout marker, idempotency, corrupted-marker hard-fail, half-migrated re-key, FQDN-keyed routing, MCP FQDN responses. Pinned by `tests/upgrade.rs`, `tests/mcp_multi_domain.rs`.
- [x] Rationale for synthetic mapping included in the smoke doc.
- [x] Epic→main PR (#240) readiness checklist included.

## Technical decisions

- **Primer line-count cap bumped from 500 to 600.** The added multi-domain section is substantive (default-domain rule, FQDN disambiguation, storage/DKIM nesting, the "no domain MCP tools" boundary) and load-bearing. Trimming it down to keep the existing 500-cap would have meant punting the operator-critical material into the reference card only, and agents skim the primer first. The new cap leaves headroom for one more major section before triggering a "factor into `references/`" refactor.
- **`docs/cli.md#aimx-domains` -> `cli.md#domain-management`.** mdBook auto-derives anchors from the `## Domain management` section header. The PRD-style "aimx-domains" anchor would have 404'd in mdBook output.
- **Synthetic-via-tests smoke instead of real-VM smoke.** Running a full Linux VM smoke inside the agentic environment is expensive and the multi-domain track is unusually well-covered by integration tests already. The smoke doc lays out the mapping step-by-step and is explicit about the real-VM smoke being recommended-but-not-blocking for the epic→main PR.
- **Top-level `RELEASE_NOTES.md` instead of a `CHANGELOG.md`.** No existing release-notes file was present; the new file mirrors the format other AIMX docs use (operator-focused prose, no semver buckets).

## Deferred items

None. Every story acceptance criterion is satisfied.

The "real-VM smoke" is explicitly recommended pre-tag but is not part of this sprint's stories — the smoke results doc names it as the only manual gate before tagging the multi-domain release.

## Review focus areas

- **`book/multi-domain.md`** — this is the canonical operator reference for the multi-domain rollout. Pay attention to: the rollback procedure (commands are mechanical; verify the order matches what the upgrade migration did in reverse); the resolution-order table for per-domain config (per-mailbox → per-domain → global); the "what we deliberately don't do" list (out-of-scope items should be load-bearing — operators reading this should understand the boundary).
- **`agents/common/aimx-primer.md`** — the new "Multi-domain installs" section. The FQDN-disambiguation rule is the most important behavioral change for agents. The table of "bare local part vs FQDN" for every mailbox-scoped MCP tool parameter is the practical reference; please sanity-check the column for the parameters you expect agents to encounter most.
- **`src/upgrade.rs::post_upgrade_reminder_text`** — the printed text after a successful `aimx upgrade`. The unit test pins the load-bearing strings, but the operator-facing wording could be tightened.

## CI status

- `cargo fmt -- --check`: PASS
- `cargo clippy --all-targets -- -D warnings`: PASS
- `cargo test --bins`: PASS (1338 + 1 ignored, 0 failed)
- Banned-tokens regex on the new diff outside `docs/`: 0 hits

## Smoke results

Documented at `docs/multi-domain-smoke-results.md` (separate `aimx-docs` repo, pushed in `aimx-docs@f4f69ff`).