### PR TITLE
cargo(deps): upgrade sparkv 0.1 → 0.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2742,9 +2742,9 @@ dependencies = [
 
 [[package]]
 name = "sparkv"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e3eef4e6fb0a66200df893d1292b96cb92e4f8a43864fd938ba2f96cd345c40"
+checksum = "98a10d99f717743724a8bbf127db24ba4281104dde9534ebcae81c2c8e06219e"
 
 [[package]]
 name = "spin"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ flate2 = { version = "1", default-features = false, features = ["rust_backend"] 
 comrak = { version = "=0.52.0", default-features = false }
 lol_html = "3"
 tempfile = "3"
-sparkv = "0.1"
+sparkv = "0.2"
 
 [dev-dependencies]
 assert_cmd = "2"

--- a/src/ingest.rs
+++ b/src/ingest.rs
@@ -369,7 +369,7 @@ pub fn ingest_email(
             .lock()
             .unwrap_or_else(|p| p.into_inner());
         let cache = cache_guard.get_or_insert_with(|| build_dedup_cache_from_disk(&inbox_dir));
-        if cache.get(&message_id).is_some() {
+        if cache.contains_key(&message_id) {
             tracing::info!(
                 target: "aimx::ingest",
                 "duplicate message_id, skipping rcpt={rcpt} mailbox={mailbox} message_id={message_id}",
@@ -506,13 +506,13 @@ pub fn ingest_email(
             // check is belt-and-braces against the cache's `set_with_ttl`
             // returning `Err(ItemSizeExceeded)` and silently dropping the
             // dedup record.
-            let value: &str = if meta.id.len() <= DEDUP_MAX_VALUE_SIZE {
-                meta.id.as_str()
+            let value: String = if meta.id.len() <= DEDUP_MAX_VALUE_SIZE {
+                meta.id.clone()
             } else {
-                ""
+                String::new()
             };
             if let Err(e) = cache.set_with_ttl(&meta.message_id, value, DEDUP_TTL) {
-                // Failure mode at scale: SparKV returns `Err(MaxItemsExceeded)`
+                // Failure mode at scale: SparKV returns `Err(CapacityExceeded)`
                 // when this mailbox accumulates more than `DEDUP_MAX_ITEMS`
                 // (100k) live entries inside the 24h window — roughly 1.2
                 // sustained inbound messages/second per mailbox, which is
@@ -659,7 +659,11 @@ fn build_dedup_cache_from_disk(inbox_dir: &Path) -> sparkv::SparKV {
         }
         let remaining = total - elapsed;
         let remaining_secs = remaining.num_seconds().max(1) as u64;
-        let _ = kv.set_with_ttl(&msg_id, "loaded", Duration::from_secs(remaining_secs));
+        let _ = kv.set_with_ttl(
+            &msg_id,
+            "loaded".to_string(),
+            Duration::from_secs(remaining_secs),
+        );
     }
     kv
 }
@@ -757,7 +761,7 @@ fn parse_toml_string_value(after_key: &str) -> Option<String> {
 fn make_dedup_sparkv() -> sparkv::SparKV {
     let mut config = sparkv::Config::new();
     config.max_items = DEDUP_MAX_ITEMS;
-    config.max_item_size = DEDUP_MAX_VALUE_SIZE;
+    config.max_item_size = Some(DEDUP_MAX_VALUE_SIZE);
     config.max_ttl = DEDUP_TTL;
     config.default_ttl = DEDUP_TTL;
     config.auto_clear_expired = true;

--- a/src/mailbox_locks.rs
+++ b/src/mailbox_locks.rs
@@ -83,7 +83,7 @@ pub struct MailboxState {
     /// Message-Id dedup cache. `None` until the first ingest into this
     /// mailbox after daemon startup; populated lazily from disk on
     /// first use. Wrapped in `std::sync::Mutex` because `SparKV`
-    /// mutates on every read/write.
+    /// writes take `&mut self`.
     pub seen_message_ids: Mutex<Option<sparkv::SparKV>>,
 }
 


### PR DESCRIPTION
## Summary

Upgrade the `sparkv` dependency from `0.1` (locked `0.1.1`) to `0.2.0`. sparkv is the per-mailbox Message-Id dedup cache that stops `on_receive` hooks from re-firing on legitimate SMTP retries. 0.2.0 has three breaking API changes, so a handful of call sites in `src/ingest.rs` adapt. Dedup behavior stays byte-for-byte identical. The verifier crate (`services/verifier/`) does NOT use sparkv and is untouched.

## Requirements

- [x] `Cargo.toml` pins `sparkv = "0.2"` and `Cargo.lock` resolves `sparkv` to `0.2.0` (was `0.1.1`).
- [x] `src/ingest.rs`: dedup existence check `cache.get(&message_id).is_some()` → `cache.contains_key(&message_id)` (0.2.0 `get` returns owned `Option<V>` requiring `V: Clone`; `contains_key` is the allocation-free existence test).
- [x] `src/ingest.rs`: insert value passed by ownership — truncation branch produces an owned `String` (`meta.id.clone()` / `String::new()`) passed by value to `set_with_ttl`.
- [x] `src/ingest.rs` disk-rebuild path: `set_with_ttl(&msg_id, "loaded", …)` → owned `"loaded".to_string()`.
- [x] `src/ingest.rs`: `config.max_item_size = DEDUP_MAX_VALUE_SIZE;` → `config.max_item_size = Some(DEDUP_MAX_VALUE_SIZE);` (field is now `Option<usize>`).
- [x] `src/ingest.rs`: comment referencing `Err(MaxItemsExceeded)` updated to `Err(CapacityExceeded)` (renamed 0.2.0 variant). `ItemSizeExceeded` references unchanged.
- [x] `src/mailbox_locks.rs`: doc comment trimmed from "`SparKV` mutates on every read/write" to reflect that only writes take `&mut self` in 0.2.0; the `Mutex<Option<sparkv::SparKV>>` type annotation needs no change (`SparKV<V = String>` defaults to `String`).

## Out of scope

- The verifier crate (`services/verifier/`) — no sparkv dependency, not touched.
- Any change to dedup semantics, the 24h TTL window, item caps (`DEDUP_MAX_ITEMS` / `DEDUP_MAX_VALUE_SIZE`), or on-disk storage format. Behavior is identical.
- Adopting other new 0.2.0 surface (`get_item`, `delete`, custom `ValueSize` impls) — not needed.

## Technical approach

0.2.0 breaking changes and their mapping:

| 0.2.0 change | Call-site impact |
|---|---|
| `set`/`set_with_ttl` take value by ownership (`V`, default `String`) instead of `&str` | owned-`String` insert values |
| `Config::max_item_size` is now `Option<usize>` (was `usize`) | `Some(...)` wrap |
| `get(&self) -> Option<V> where V: Clone` (0.1 read no longer matches) | switch existence check to `contains_key` |
| Error variant `MaxItemsExceeded` renamed `CapacityExceeded`; `ItemSizeExceeded` unchanged | comment-only update |
| `SparKV<V = String>` now generic with `String` default | no type-annotation change needed |

Verified 0.2.0 signatures: `SparKV<V = String>`, `contains_key(&self, key: &str) -> bool`, `get(&self, key: &str) -> Option<V> where V: Clone`, `set_with_ttl(&mut self, key: &str, value: V, ttl: Duration) -> Result<(), Error> where V: ValueSize`, `Config { max_items: usize, max_item_size: Option<usize>, ... }`. Keys remain `&str`, so existing `&String` call args coerce fine. Error handling only debug-formats `{err:?}` and never matches variants, so the rename is comment-only.

## Test plan

- sparkv is not referenced directly by any test; dedup behavior is exercised transitively through inbound ingest tests in `src/ingest.rs` (`with_fresh_message_id` helper, the `ingest_skips_duplicate_message_id` / `ingest_allows_distinct_message_ids` / `ingest_dedup_cache_loads_from_disk` / `ingest_dedup_cache_excludes_expired` tests) and `tests/integration.rs`.
- Full gate run and green: `cargo build` OK, `cargo clippy -- -D warnings` clean, `cargo fmt --check` clean, `cargo test` all pass (1151 lib/unit + 120 integration + others; 0 failed).
- `grep -rn sparkv src/` confirms every call site migrated — no remaining `&str`-value `set_with_ttl`, no bare-`usize` `max_item_size`.

## Notes

Existing dedup test coverage (same Message-Id ingested twice → second skipped, no second `.md`, hook not re-fired; plus the disk-rebuild and TTL-expiry paths) is comprehensive and serves as the regression guard. Per the plan's guidance to not over-build tests for a mechanical version bump, no new test was added.